### PR TITLE
Fix pnpm version conflict in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
## Summary
- remove the duplicate pnpm version declaration from the GitHub Actions workflow
- let pnpm/action-setup read the exact version from package.json

## Why
The CI job failed before install because the workflow declared  while  already pins  via . pnpm/action-setup treats that as a conflict and aborts.