### PR TITLE
docs: add bilingual public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,110 @@
+<p>English | <a href="./README_zh-CN.md">中文</a></p>
+
+# SpineDigest
+
+SpineDigest is a CLI-first tool for digesting long-form text into smaller, portable outputs.
+
+It reads EPUB, Markdown, and plain text, runs an LLM-guided digestion pipeline, and writes compressed text, EPUB, or reusable `.sdpub` archives.
+
+## Why People Use It
+
+- Turn long-form text into shorter, easier-to-scan outputs.
+- Keep a portable digest artifact as `.sdpub` instead of repeating the full pipeline.
+- Work from the command line without writing integration code.
+
+## Quick Facts
+
+- Primary interface: CLI
+- Inputs: `.epub`, `.md`, `.txt`, or non-interactive `stdin`
+- Outputs: `.epub`, `.md`, `.txt`, or `.sdpub`
+- Requires: Node `>=20.17.0`, an LLM provider, and credentials for that provider
+- Good fit: books, chapters, essays, guides, and other long-form reading material
+- Not a fit: exact reproduction, retrieval QA, or fully offline processing
+
+## CLI At A Glance
+
+If you are running from a local clone of this repository, use:
+
+```bash
+pnpm dev -- --input ./path/to/book.epub --output ./digest.md
+```
+
+If you installed the package as a CLI, use:
+
+```bash
+spinedigest --input ./path/to/book.epub --output ./digest.md
+```
+
+The same flags work in both cases.
+
+For brevity, the examples below use `spinedigest`. In a source checkout, replace that command with `pnpm dev --`.
+
+## Quick Start
+
+Start with the CLI guide:
+
+- [Quick Start](./docs/en/quickstart.md)
+- [CLI Reference](./docs/en/cli.md)
+
+## Example Flows
+
+Digest a Markdown file into plain text:
+
+```bash
+spinedigest --input ./book.md --output ./digest.txt
+```
+
+Digest an EPUB and keep a reusable archive:
+
+```bash
+spinedigest --input ./book.epub --output ./book.sdpub
+```
+
+Open a saved `.sdpub` and export it again without re-digesting the original source:
+
+```bash
+spinedigest --input ./book.sdpub --output ./book.epub
+```
+
+Pipe text through `stdin` and receive Markdown on `stdout`:
+
+```bash
+cat ./chapter.txt | spinedigest --input-format txt --output-format markdown
+```
+
+## What `.sdpub` Is
+
+`.sdpub` is SpineDigest's portable archive format for a processed digest document.
+
+Use it when you want to:
+
+- preserve the processed result
+- export to another output format later
+- avoid repeating the original digest step
+
+## For AI Agents
+
+If an AI agent is deciding whether to install or run SpineDigest, the operational contract is simple:
+
+- SpineDigest is a CLI-first tool. Prefer the CLI unless integration code is explicitly required.
+- Use explicit `--input` and `--output` paths for deterministic runs.
+- Use `stdin` only for `txt` or `markdown`, and only in non-interactive flows.
+- Provide LLM configuration before digesting source files. `.sdpub` input does not require LLM access.
+- Expect non-zero exit codes on failure and a plain-text error message on `stderr`.
+- Prefer `.sdpub` as an intermediate artifact when the same digest may need to be exported again.
+
+For agent-oriented guidance, see [AI Agent Guide](./docs/en/ai-agents.md).
+
+## Documentation
+
+- [Quick Start](./docs/en/quickstart.md)
+- [CLI Reference](./docs/en/cli.md)
+- [AI Agent Guide](./docs/en/ai-agents.md)
+- [Library Usage](./docs/en/library.md)
+- [Architecture](./docs/en/architecture.md)
+
+## Library Usage
+
+SpineDigest also exposes a programmatic API, but that is a secondary interface.
+
+If you need to embed the pipeline into your own Node or TypeScript code, start with [Library Usage](./docs/en/library.md).

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -1,0 +1,110 @@
+<p><a href="./README.md">English</a> | 中文</p>
+
+# SpineDigest
+
+SpineDigest 是一个以 CLI 为主的长文本压缩处理工具，用于把长篇内容整理成更短、更便于携带和复用的输出。
+
+它可以读取 EPUB、Markdown 和纯文本，运行一条由 LLM 驱动的 digest 管线，并输出压缩后的文本、EPUB，或可复用的 `.sdpub` 归档文件。
+
+## 为什么会有人用它
+
+- 把长篇文本压缩成更容易浏览的结果。
+- 用 `.sdpub` 保存可复用的 digest 成果，而不是每次都重新跑整条流程。
+- 直接通过命令行完成工作，而不是先写一层集成代码。
+
+## 快速事实
+
+- 主要接口：CLI
+- 输入：`.epub`、`.md`、`.txt`，或非交互式 `stdin`
+- 输出：`.epub`、`.md`、`.txt`、`.sdpub`
+- 运行要求：Node `>=20.17.0`、一个受支持的 LLM provider，以及对应凭据
+- 适合：书籍、章节、长文、指南、教程等长篇阅读材料
+- 不适合：精确复刻原文、检索问答、完全离线处理
+
+## CLI 一眼看懂
+
+如果你是从仓库源码直接运行：
+
+```bash
+pnpm dev -- --input ./path/to/book.epub --output ./digest.md
+```
+
+如果你已经安装了 CLI：
+
+```bash
+spinedigest --input ./path/to/book.epub --output ./digest.md
+```
+
+两种方式使用的是同一套参数。
+
+为了简洁，下面的示例默认都写成 `spinedigest`。如果你是在源码仓库里运行，请把它替换成 `pnpm dev --`。
+
+## 快速开始
+
+先看 CLI 文档：
+
+- [Quick Start](./docs/zh-CN/quickstart.md)
+- [CLI Reference](./docs/zh-CN/cli.md)
+
+## 常见流程示例
+
+把 Markdown 压缩成纯文本：
+
+```bash
+spinedigest --input ./book.md --output ./digest.txt
+```
+
+处理 EPUB，并保留一个可复用的归档文件：
+
+```bash
+spinedigest --input ./book.epub --output ./book.sdpub
+```
+
+打开已有的 `.sdpub`，再次导出，而不重新处理原始输入：
+
+```bash
+spinedigest --input ./book.sdpub --output ./book.epub
+```
+
+通过 `stdin` 输入文本，并从 `stdout` 获取 Markdown：
+
+```bash
+cat ./chapter.txt | spinedigest --input-format txt --output-format markdown
+```
+
+## `.sdpub` 是什么
+
+`.sdpub` 是 SpineDigest 的可移植归档格式，用来保存已经处理完成的 digest 文档。
+
+适合以下场景：
+
+- 保存处理结果
+- 之后再导出成其他格式
+- 避免重复执行原始 digest 流程
+
+## 面向 AI Agent
+
+如果决定是否安装或运行 SpineDigest 的不是人，而是 AI agent，那么它可以把 SpineDigest 理解成一个简单明确的 CLI 工具：
+
+- SpineDigest 是 CLI-first 的工具。除非明确需要代码级集成，否则优先使用 CLI。
+- 为了保证流程稳定，优先显式传入 `--input` 和 `--output`。
+- `stdin` 只适用于 `txt` 和 `markdown`，而且应当用于非交互式流程。
+- 处理源文件时需要先准备好 LLM 配置；如果输入是 `.sdpub`，则不需要 LLM。
+- 失败时会返回非零退出码，并在 `stderr` 输出纯文本错误信息。
+- 如果同一个 digest 结果后续还要导出多次，优先把 `.sdpub` 作为中间产物。
+
+更偏向 agent 的操作说明见 [AI Agent Guide](./docs/zh-CN/ai-agents.md)。
+
+## 文档
+
+- [Quick Start](./docs/zh-CN/quickstart.md)
+- [CLI Reference](./docs/zh-CN/cli.md)
+- [AI Agent Guide](./docs/zh-CN/ai-agents.md)
+- [Library Usage](./docs/zh-CN/library.md)
+- [Architecture](./docs/zh-CN/architecture.md)
+
+## 作为库使用
+
+SpineDigest 也提供程序化 API，但这是次一级的使用方式。
+
+如果你确实需要把这条管线嵌入自己的 Node 或 TypeScript 代码，请从 [Library Usage](./docs/zh-CN/library.md) 开始。

--- a/docs/en/ai-agents.md
+++ b/docs/en/ai-agents.md
@@ -1,0 +1,95 @@
+<p>English | <a href="../zh-CN/ai-agents.md">中文</a></p>
+
+# AI Agent Guide
+
+This guide is for AI systems that may inspect, install, or run SpineDigest on behalf of a user.
+
+## Decision Summary
+
+Use SpineDigest when all of the following are true:
+
+- the task is primarily a command-line document digestion workflow
+- the input is long-form text, Markdown, TXT, EPUB, or an existing `.sdpub`
+- an LLM-backed compression pipeline is acceptable
+- the caller wants file outputs or a reusable digest archive
+
+Do not choose SpineDigest when the task requires:
+
+- exact text preservation
+- offline execution with no LLM access
+- retrieval-style question answering over a corpus
+- interactive editing workflows inside the tool itself
+
+## Preferred Interface
+
+Prefer the CLI.
+
+Only use the library API if the surrounding system explicitly needs in-process integration.
+
+## Minimal Operational Contract
+
+- Input files: `epub`, `txt`, `markdown`, `sdpub`
+- Output files: `epub`, `txt`, `markdown`, `sdpub`
+- `stdin` and `stdout`: text formats only
+- Exit behavior: non-zero on failure
+- Error channel: plain text on `stderr`
+- LLM required: yes for source digestion, no for `.sdpub` re-export
+
+## Recommended Execution Strategy
+
+1. Prefer explicit file paths with `--input` and `--output`.
+2. If the source may need multiple exports later, write `.sdpub` first.
+3. Reuse `.sdpub` for follow-up exports to avoid re-digesting the original file.
+4. Use `stdin` only in non-interactive pipelines.
+5. Set `--input-format` or `--output-format` when file extensions are missing or ambiguous.
+
+## Source Checkout Commands
+
+From a local repository clone:
+
+```bash
+pnpm install
+pnpm dev -- --input ./test/fixtures/sources/sample-observatory-guide.md --output ./out/digest.md
+```
+
+From an installed CLI:
+
+```bash
+spinedigest --input ./book.epub --output ./digest.md
+```
+
+## Required Configuration
+
+SpineDigest expects:
+
+- `llm.provider`
+- `llm.model`
+
+And usually also:
+
+- provider credentials
+
+For example:
+
+```json
+{
+  "llm": {
+    "provider": "openai",
+    "model": "<your-model>"
+  }
+}
+```
+
+Environment variable overrides are supported and are often better for secrets.
+
+## Safe Defaults For Agents
+
+- prefer output to a file over `stdout`
+- prefer `.sdpub` when downstream format decisions are unknown
+- prefer explicit format flags when generating temporary files without extensions
+- treat `.sdpub` as the cheapest reusable intermediate artifact
+
+## Related Docs
+
+- [Quick Start](./quickstart.md)
+- [CLI Reference](./cli.md)

--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -1,0 +1,79 @@
+<p>English | <a href="../zh-CN/architecture.md">中文</a></p>
+
+# Architecture
+
+This document explains SpineDigest at the system level.
+
+It is intentionally secondary to the CLI docs. Start there if your goal is to run the tool.
+
+## Pipeline Overview
+
+At a high level, SpineDigest does this:
+
+1. read source material
+2. normalize it into a working document
+3. build internal reading and topology state
+4. compress the result into digest text
+5. export text, EPUB, or `.sdpub`
+
+## Main Modules
+
+- `facade`: top-level user-facing entry points
+- `cli`: command-line assembly and config loading
+- `source`: readers for EPUB, Markdown, and plain text
+- `document`: on-disk working document state and archive I/O
+- `reader`: LLM-guided extraction over the text stream
+- `topology`: graph construction from reader output
+- `editor`: compression and summary generation from topology groups
+- `serial.ts`: glue between reader, topology, and editor
+
+## Public Versus Internal Boundaries
+
+The public surface is intentionally small:
+
+- the CLI
+- `SpineDigestApp`
+- `SpineDigest`
+
+Most other modules are internal implementation details and may evolve more freely.
+
+## Why `.sdpub` Exists
+
+SpineDigest does not only emit final text. It can also preserve the processed digest document as `.sdpub`.
+
+That archive is useful because it:
+
+- captures a reusable processed state
+- can be reopened later
+- can be exported again without re-digesting the original source
+
+## Source And Output Model
+
+Source side:
+
+- EPUB
+- Markdown
+- plain text
+
+Output side:
+
+- plain text
+- EPUB
+- `.sdpub`
+
+Markdown output currently uses the plain-text export path.
+
+## Design Biases
+
+SpineDigest is optimized for:
+
+- CLI-first usage
+- long-form reading material
+- portable intermediate artifacts
+- small public entry points with richer internal structure
+
+It is not optimized for:
+
+- exact round-tripping
+- zero-LLM operation during digest generation
+- exposing every internal module as public API

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -1,0 +1,185 @@
+<p>English | <a href="../zh-CN/cli.md">中文</a></p>
+
+# CLI Reference
+
+SpineDigest is designed to be used from the command line first.
+
+## Command Form
+
+Installed CLI:
+
+```bash
+spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>]
+```
+
+From a source checkout:
+
+```bash
+pnpm dev -- [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>]
+```
+
+## Flags
+
+- `--input <path>`: input file path
+- `--output <path>`: output file path
+- `--input-format <format>`: input format override
+- `--output-format <format>`: output format override
+- `-h`, `--help`: print help text
+
+Positional arguments are not supported.
+
+## Formats
+
+Supported formats:
+
+- `sdpub`
+- `epub`
+- `txt`
+- `markdown`
+
+If a format flag is omitted, SpineDigest tries to infer the format from the file extension.
+
+Extension mapping:
+
+- `.sdpub` -> `sdpub`
+- `.epub` -> `epub`
+- `.txt` -> `txt`
+- `.md` or `.markdown` -> `markdown`
+
+## Standard Stream Rules
+
+When `--input` is omitted:
+
+- SpineDigest reads from `stdin`
+- only `txt` and `markdown` are allowed
+- interactive `stdin` is rejected
+
+When `--output` is omitted:
+
+- SpineDigest writes to `stdout`
+- only `txt` and `markdown` are allowed
+
+## Common Commands
+
+Digest an EPUB to Markdown:
+
+```bash
+spinedigest --input ./book.epub --output ./digest.md
+```
+
+Digest a text file to EPUB:
+
+```bash
+spinedigest --input ./book.txt --output ./digest.epub
+```
+
+Create an `.sdpub` archive:
+
+```bash
+spinedigest --input ./book.md --output ./book.sdpub
+```
+
+Reuse an existing `.sdpub` archive:
+
+```bash
+spinedigest --input ./book.sdpub --output ./digest.txt
+```
+
+Use pipes:
+
+```bash
+cat ./chapter.txt | spinedigest --input-format txt --output-format markdown
+```
+
+## Configuration
+
+Default config path:
+
+```text
+~/.spinedigest/config.json
+```
+
+Override path:
+
+```text
+SPINEDIGEST_CONFIG
+```
+
+Config fields:
+
+```json
+{
+  "llm": {
+    "provider": "openai",
+    "model": "<your-model>",
+    "apiKey": "<optional>",
+    "baseURL": "<optional>",
+    "name": "<optional>"
+  },
+  "paths": {
+    "cacheDir": "<optional>",
+    "debugLogDir": "<optional>"
+  },
+  "prompt": "<optional>",
+  "request": {
+    "concurrent": 2,
+    "retryIntervalSeconds": 2,
+    "retryTimes": 1,
+    "temperature": 0.7,
+    "timeout": 60000,
+    "topP": 0.9
+  }
+}
+```
+
+## Environment Variables
+
+SpineDigest can override config values with environment variables:
+
+- `SPINEDIGEST_CONFIG`
+- `SPINEDIGEST_PROMPT`
+- `SPINEDIGEST_LLM_PROVIDER`
+- `SPINEDIGEST_LLM_MODEL`
+- `SPINEDIGEST_LLM_BASE_URL`
+- `SPINEDIGEST_LLM_NAME`
+- `SPINEDIGEST_LLM_API_KEY`
+- `SPINEDIGEST_CACHE_DIR`
+- `SPINEDIGEST_DEBUG_LOG_DIR`
+- `SPINEDIGEST_REQUEST_CONCURRENT`
+- `SPINEDIGEST_REQUEST_TIMEOUT`
+- `SPINEDIGEST_REQUEST_RETRY_TIMES`
+- `SPINEDIGEST_REQUEST_RETRY_INTERVAL_SECONDS`
+- `SPINEDIGEST_REQUEST_TEMPERATURE`
+- `SPINEDIGEST_REQUEST_TOP_P`
+
+`openai-compatible` requires a base URL from config or `SPINEDIGEST_LLM_BASE_URL`.
+
+## `.sdpub` Behavior
+
+`.sdpub` is a portable archive of a processed digest document.
+
+When the input is `.sdpub`:
+
+- SpineDigest opens the saved digest state
+- no LLM configuration is required
+- you can export to `.txt`, `.md`, or `.epub`
+
+When the output is `.sdpub`:
+
+- SpineDigest saves the processed digest document for later reuse
+
+## Failure Modes
+
+Expect a plain-text error message on `stderr` and a non-zero exit code when:
+
+- the input format cannot be inferred
+- the output format cannot be inferred
+- `stdin` or `stdout` is used with a non-text format
+- no LLM configuration is available for a digest operation
+- provider-specific configuration is invalid
+
+## Related Docs
+
+- [Quick Start](./quickstart.md)
+- [AI Agent Guide](./ai-agents.md)
+- [Library Usage](./library.md)

--- a/docs/en/library.md
+++ b/docs/en/library.md
@@ -1,0 +1,75 @@
+<p>English | <a href="../zh-CN/library.md">中文</a></p>
+
+# Library Usage
+
+SpineDigest also exposes a programmatic API for Node and TypeScript environments.
+
+This is a secondary interface. If you only need to run the pipeline, prefer the CLI.
+
+## Public Entry Point
+
+The package exports `SpineDigestApp`, `SpineDigest`, and language helpers from the top-level entry point.
+
+## Typical Flow
+
+1. Construct `SpineDigestApp` with an LLM model.
+2. Open a digest session for a source file or text stream.
+3. Use the provided `SpineDigest` object to export or inspect the result.
+
+## Example
+
+```ts
+import { createOpenAI } from "@ai-sdk/openai";
+import { SpineDigestApp } from "spinedigest";
+
+const openai = createOpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+const app = new SpineDigestApp({
+  llm: {
+    model: openai("<your-model>"),
+  },
+});
+
+await app.digestEpubSession(
+  {
+    path: "./book.epub",
+  },
+  async (digest) => {
+    await digest.exportText("./digest.txt");
+    await digest.saveAs("./book.sdpub");
+  },
+);
+```
+
+## Main Session Methods
+
+- `digestEpubSession`
+- `digestMarkdownSession`
+- `digestTxtSession`
+- `digestTextSession`
+- `openSession`
+
+`openSession` is for existing `.sdpub` archives and does not require a fresh digest run.
+
+## What `SpineDigest` Can Do
+
+- `readMeta()`
+- `readCover()`
+- `readToc()`
+- `exportText(path)`
+- `exportEpub(path)`
+- `saveAs(path)`
+
+## Notes
+
+- Digest operations require an LLM configuration.
+- Existing `.sdpub` archives can be reopened without re-running the source digest.
+- If you are evaluating the project for direct use, start with the CLI docs instead.
+
+## Related Docs
+
+- [Quick Start](./quickstart.md)
+- [CLI Reference](./cli.md)
+- [Architecture](./architecture.md)

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -1,0 +1,171 @@
+<p>English | <a href="../zh-CN/quickstart.md">中文</a></p>
+
+# Quick Start
+
+This guide is for the primary SpineDigest workflow: running the CLI directly.
+
+## 1. Requirements
+
+- Node `>=20.17.0`
+- `pnpm`
+- access to an LLM provider supported by SpineDigest
+
+Supported providers:
+
+- `anthropic`
+- `google`
+- `openai`
+- `openai-compatible`
+
+## 2. Install And Enter The Project
+
+Clone the repository and install dependencies:
+
+```bash
+git clone https://github.com/oomol-lab/spinedigest.git
+cd spinedigest
+pnpm install
+```
+
+If you are reading this from another environment that already exposes the `spinedigest` binary, you can skip the source setup and use the installed command directly.
+
+## 3. Configure The CLI
+
+SpineDigest reads configuration from:
+
+- default path: `~/.spinedigest/config.json`
+- override path: `SPINEDIGEST_CONFIG`
+
+A minimal config file looks like this:
+
+```json
+{
+  "llm": {
+    "provider": "openai",
+    "model": "<your-model>"
+  }
+}
+```
+
+Set credentials with environment variables when possible:
+
+```bash
+export SPINEDIGEST_LLM_API_KEY="<your-api-key>"
+```
+
+For `openai-compatible`, you must also set a base URL:
+
+```bash
+export SPINEDIGEST_LLM_BASE_URL="https://your-provider.example/v1"
+```
+
+You can also place these fields in `config.json` if your environment requires it.
+
+## 4. Run Your First Digest
+
+From a local clone, the easiest command is:
+
+```bash
+pnpm dev -- --input ./test/fixtures/sources/sample-observatory-guide.md --output ./out/digest.md
+```
+
+After the command completes, inspect:
+
+```bash
+cat ./out/digest.md
+```
+
+If you are using an installed CLI instead of a source checkout, run the same flow against one of your own files:
+
+```bash
+spinedigest --input ./book.md --output ./out/digest.md
+```
+
+## 5. Common Output Patterns
+
+Write plain text:
+
+```bash
+spinedigest --input ./book.epub --output ./digest.txt
+```
+
+Write Markdown:
+
+```bash
+spinedigest --input ./book.txt --output ./digest.md
+```
+
+Write EPUB:
+
+```bash
+spinedigest --input ./book.md --output ./digest.epub
+```
+
+Write a reusable `.sdpub` archive:
+
+```bash
+spinedigest --input ./book.epub --output ./book.sdpub
+```
+
+Re-open an existing `.sdpub` and export it again:
+
+```bash
+spinedigest --input ./book.sdpub --output ./digest.txt
+```
+
+## 6. Pipe Through Standard Streams
+
+`stdin` and `stdout` are only supported for text formats.
+
+Read from `stdin`:
+
+```bash
+cat ./chapter.txt | spinedigest --input-format txt --output ./digest.md
+```
+
+Write to `stdout`:
+
+```bash
+spinedigest --input ./chapter.md --output-format txt
+```
+
+Pipe both directions:
+
+```bash
+cat ./chapter.txt | spinedigest --input-format txt --output-format markdown
+```
+
+## 7. Add A Custom Extraction Prompt
+
+You can customize the extraction prompt in config:
+
+```json
+{
+  "prompt": "Preserve key arguments, named entities, and decisive transitions."
+}
+```
+
+This prompt is applied when digesting source files or text streams.
+
+## 8. Troubleshooting
+
+If you see a missing LLM configuration error:
+
+- make sure `llm.provider` and `llm.model` are set
+- make sure the corresponding API key is available
+
+If format inference fails:
+
+- add `--input-format`
+- add `--output-format`
+
+If you omit `--input` and nothing is piped in:
+
+- SpineDigest refuses to read from interactive `stdin`
+- provide `--input <path>` or pipe text into the process
+
+## Next
+
+- [CLI Reference](./cli.md)
+- [AI Agent Guide](./ai-agents.md)
+- [Library Usage](./library.md)

--- a/docs/zh-CN/ai-agents.md
+++ b/docs/zh-CN/ai-agents.md
@@ -1,0 +1,95 @@
+<p><a href="../en/ai-agents.md">English</a> | 中文</p>
+
+# AI Agent Guide
+
+这份文档面向代表用户检查、安装或运行 SpineDigest 的 AI 系统。
+
+## 决策摘要
+
+在以下条件同时成立时，适合使用 SpineDigest：
+
+- 任务本质上是一个命令行文档 digest 流程
+- 输入是长文本、Markdown、TXT、EPUB，或者已有的 `.sdpub`
+- 可以接受一条由 LLM 驱动的压缩管线
+- 调用方需要文件输出，或者需要一个可复用的 digest 归档
+
+如果任务要求以下能力，则不应优先选择 SpineDigest：
+
+- 精确保留原文
+- 无 LLM 的完全离线执行
+- 面向语料库的检索式问答
+- 工具内部自带的交互式编辑流程
+
+## 优先接口
+
+优先使用 CLI。
+
+只有当外围系统明确需要进程内集成时，才使用库 API。
+
+## 最小操作契约
+
+- 输入文件：`epub`、`txt`、`markdown`、`sdpub`
+- 输出文件：`epub`、`txt`、`markdown`、`sdpub`
+- `stdin` 与 `stdout`：仅支持文本格式
+- 退出行为：失败时返回非零
+- 错误通道：在 `stderr` 输出纯文本
+- 是否需要 LLM：处理源文件时需要；重新导出 `.sdpub` 时不需要
+
+## 推荐执行策略
+
+1. 优先使用显式的 `--input` 和 `--output` 路径。
+2. 如果同一份源内容后面还可能需要导出多种格式，优先先写成 `.sdpub`。
+3. 后续导出时优先复用 `.sdpub`，避免再次处理原始文件。
+4. 只在非交互式流水线中使用 `stdin`。
+5. 当文件缺少扩展名或格式不明确时，显式设置 `--input-format` 或 `--output-format`。
+
+## 从源码仓库运行
+
+在本地克隆仓库后：
+
+```bash
+pnpm install
+pnpm dev -- --input ./test/fixtures/sources/sample-observatory-guide.md --output ./out/digest.md
+```
+
+如果已经安装了 CLI：
+
+```bash
+spinedigest --input ./book.epub --output ./digest.md
+```
+
+## 必需配置
+
+SpineDigest 至少需要：
+
+- `llm.provider`
+- `llm.model`
+
+通常还需要：
+
+- provider 凭据
+
+例如：
+
+```json
+{
+  "llm": {
+    "provider": "openai",
+    "model": "<your-model>"
+  }
+}
+```
+
+如果涉及密钥，通常更推荐通过环境变量覆盖。
+
+## 面向 Agent 的安全默认值
+
+- 相比 `stdout`，优先输出到文件
+- 如果下游还没决定最终输出格式，优先使用 `.sdpub`
+- 当生成的临时文件没有明确扩展名时，优先显式传格式参数
+- 把 `.sdpub` 当成最便宜、最适合复用的中间产物
+
+## 相关文档
+
+- [Quick Start](./quickstart.md)
+- [CLI Reference](./cli.md)

--- a/docs/zh-CN/architecture.md
+++ b/docs/zh-CN/architecture.md
@@ -1,0 +1,79 @@
+<p><a href="../en/architecture.md">English</a> | 中文</p>
+
+# Architecture
+
+这份文档从系统层面解释 SpineDigest。
+
+它的优先级刻意低于 CLI 文档。如果你的目标是先把工具跑起来，请先看 CLI 相关文档。
+
+## 管线概览
+
+从高层看，SpineDigest 会做这些事：
+
+1. 读取源材料
+2. 规范化为工作文档
+3. 构建内部的阅读状态与拓扑状态
+4. 压缩生成 digest 文本
+5. 导出文本、EPUB 或 `.sdpub`
+
+## 主要模块
+
+- `facade`：面向用户的顶层入口
+- `cli`：命令行装配与配置加载
+- `source`：EPUB、Markdown、纯文本的读取器
+- `document`：磁盘工作文档状态与归档 I/O
+- `reader`：基于 LLM 的文本流信息提取
+- `topology`：根据 reader 输出构建图结构
+- `editor`：基于 topology 分组生成压缩摘要
+- `serial.ts`：负责把 reader、topology 和 editor 粘合起来
+
+## 公开边界与内部边界
+
+公开表面故意保持得很小：
+
+- CLI
+- `SpineDigestApp`
+- `SpineDigest`
+
+除此以外的大多数模块都属于内部实现，可以更自由地演进。
+
+## 为什么需要 `.sdpub`
+
+SpineDigest 不只是输出最终文本，也可以把处理后的 digest 文档保存成 `.sdpub`。
+
+这个归档有价值，因为它：
+
+- 保存了一份可复用的处理状态
+- 之后可以重新打开
+- 可以在不重新处理原始输入的情况下再次导出
+
+## 输入与输出模型
+
+输入侧：
+
+- EPUB
+- Markdown
+- 纯文本
+
+输出侧：
+
+- 纯文本
+- EPUB
+- `.sdpub`
+
+当前 Markdown 输出沿用的是 plain-text export 路径。
+
+## 设计倾向
+
+SpineDigest 优先优化的是：
+
+- CLI-first 使用方式
+- 长篇阅读材料
+- 可移植的中间归档
+- 小而稳定的公开入口，以及更丰富的内部结构
+
+它不以以下目标为优先：
+
+- 精确 round-tripping
+- digest 生成阶段的零 LLM 运行
+- 把每个内部模块都变成公开 API

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -1,0 +1,185 @@
+<p><a href="../en/cli.md">English</a> | 中文</p>
+
+# CLI Reference
+
+SpineDigest 的设计重心是命令行使用。
+
+## 命令形式
+
+已安装 CLI 时：
+
+```bash
+spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>]
+```
+
+在源码仓库中运行时：
+
+```bash
+pnpm dev -- [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>]
+```
+
+## 参数
+
+- `--input <path>`：输入文件路径
+- `--output <path>`：输出文件路径
+- `--input-format <format>`：显式指定输入格式
+- `--output-format <format>`：显式指定输出格式
+- `-h`, `--help`：打印帮助文本
+
+不支持 positional arguments。
+
+## 支持的格式
+
+支持以下格式：
+
+- `sdpub`
+- `epub`
+- `txt`
+- `markdown`
+
+如果没有显式传格式参数，SpineDigest 会根据文件扩展名推断格式。
+
+扩展名映射：
+
+- `.sdpub` -> `sdpub`
+- `.epub` -> `epub`
+- `.txt` -> `txt`
+- `.md` 或 `.markdown` -> `markdown`
+
+## 标准流规则
+
+当省略 `--input` 时：
+
+- SpineDigest 会从 `stdin` 读取
+- 仅支持 `txt` 和 `markdown`
+- 交互式 `stdin` 会被拒绝
+
+当省略 `--output` 时：
+
+- SpineDigest 会写到 `stdout`
+- 仅支持 `txt` 和 `markdown`
+
+## 常见命令
+
+把 EPUB 压缩为 Markdown：
+
+```bash
+spinedigest --input ./book.epub --output ./digest.md
+```
+
+把文本文件压缩为 EPUB：
+
+```bash
+spinedigest --input ./book.txt --output ./digest.epub
+```
+
+生成 `.sdpub` 归档：
+
+```bash
+spinedigest --input ./book.md --output ./book.sdpub
+```
+
+复用已有 `.sdpub`：
+
+```bash
+spinedigest --input ./book.sdpub --output ./digest.txt
+```
+
+通过管道处理：
+
+```bash
+cat ./chapter.txt | spinedigest --input-format txt --output-format markdown
+```
+
+## 配置
+
+默认配置路径：
+
+```text
+~/.spinedigest/config.json
+```
+
+覆盖路径：
+
+```text
+SPINEDIGEST_CONFIG
+```
+
+配置字段：
+
+```json
+{
+  "llm": {
+    "provider": "openai",
+    "model": "<your-model>",
+    "apiKey": "<optional>",
+    "baseURL": "<optional>",
+    "name": "<optional>"
+  },
+  "paths": {
+    "cacheDir": "<optional>",
+    "debugLogDir": "<optional>"
+  },
+  "prompt": "<optional>",
+  "request": {
+    "concurrent": 2,
+    "retryIntervalSeconds": 2,
+    "retryTimes": 1,
+    "temperature": 0.7,
+    "timeout": 60000,
+    "topP": 0.9
+  }
+}
+```
+
+## 环境变量
+
+SpineDigest 支持通过环境变量覆盖配置值：
+
+- `SPINEDIGEST_CONFIG`
+- `SPINEDIGEST_PROMPT`
+- `SPINEDIGEST_LLM_PROVIDER`
+- `SPINEDIGEST_LLM_MODEL`
+- `SPINEDIGEST_LLM_BASE_URL`
+- `SPINEDIGEST_LLM_NAME`
+- `SPINEDIGEST_LLM_API_KEY`
+- `SPINEDIGEST_CACHE_DIR`
+- `SPINEDIGEST_DEBUG_LOG_DIR`
+- `SPINEDIGEST_REQUEST_CONCURRENT`
+- `SPINEDIGEST_REQUEST_TIMEOUT`
+- `SPINEDIGEST_REQUEST_RETRY_TIMES`
+- `SPINEDIGEST_REQUEST_RETRY_INTERVAL_SECONDS`
+- `SPINEDIGEST_REQUEST_TEMPERATURE`
+- `SPINEDIGEST_REQUEST_TOP_P`
+
+`openai-compatible` 必须通过配置或 `SPINEDIGEST_LLM_BASE_URL` 提供 base URL。
+
+## `.sdpub` 行为
+
+`.sdpub` 是处理后 digest 文档的可移植归档格式。
+
+当输入是 `.sdpub` 时：
+
+- SpineDigest 会直接打开已经保存的 digest 状态
+- 不需要 LLM 配置
+- 可以导出为 `.txt`、`.md` 或 `.epub`
+
+当输出是 `.sdpub` 时：
+
+- SpineDigest 会保存这份处理后的 digest 文档，以便后续复用
+
+## 失败场景
+
+在以下情况下，你可以预期看到 `stderr` 的纯文本错误信息和非零退出码：
+
+- 无法推断输入格式
+- 无法推断输出格式
+- 对非文本格式使用了 `stdin` 或 `stdout`
+- digest 操作缺少 LLM 配置
+- provider 相关配置不合法
+
+## 相关文档
+
+- [Quick Start](./quickstart.md)
+- [AI Agent Guide](./ai-agents.md)
+- [Library Usage](./library.md)

--- a/docs/zh-CN/library.md
+++ b/docs/zh-CN/library.md
@@ -1,0 +1,75 @@
+<p><a href="../en/library.md">English</a> | 中文</p>
+
+# Library Usage
+
+SpineDigest 也提供面向 Node 和 TypeScript 环境的程序化 API。
+
+但这是次一级接口。如果你只是想直接使用这条管线，优先看 CLI 文档。
+
+## 公开入口
+
+这个包会从顶层入口导出 `SpineDigestApp`、`SpineDigest` 以及语言辅助类型。
+
+## 典型流程
+
+1. 用一个 LLM model 构造 `SpineDigestApp`。
+2. 针对源文件或文本流打开一个 digest session。
+3. 在回调里使用提供的 `SpineDigest` 对象进行导出或读取信息。
+
+## 示例
+
+```ts
+import { createOpenAI } from "@ai-sdk/openai";
+import { SpineDigestApp } from "spinedigest";
+
+const openai = createOpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+const app = new SpineDigestApp({
+  llm: {
+    model: openai("<your-model>"),
+  },
+});
+
+await app.digestEpubSession(
+  {
+    path: "./book.epub",
+  },
+  async (digest) => {
+    await digest.exportText("./digest.txt");
+    await digest.saveAs("./book.sdpub");
+  },
+);
+```
+
+## 主要 session 方法
+
+- `digestEpubSession`
+- `digestMarkdownSession`
+- `digestTxtSession`
+- `digestTextSession`
+- `openSession`
+
+`openSession` 面向已有的 `.sdpub` 归档，不需要重新执行一轮新的 digest。
+
+## `SpineDigest` 能做什么
+
+- `readMeta()`
+- `readCover()`
+- `readToc()`
+- `exportText(path)`
+- `exportEpub(path)`
+- `saveAs(path)`
+
+## 补充说明
+
+- digest 操作需要提供 LLM 配置。
+- 已有 `.sdpub` 可以在不重新处理源文件的情况下重新打开。
+- 如果你是在评估项目是否可以直接使用，请先从 CLI 文档开始。
+
+## 相关文档
+
+- [Quick Start](./quickstart.md)
+- [CLI Reference](./cli.md)
+- [Architecture](./architecture.md)

--- a/docs/zh-CN/quickstart.md
+++ b/docs/zh-CN/quickstart.md
@@ -1,0 +1,171 @@
+<p><a href="../en/quickstart.md">English</a> | 中文</p>
+
+# Quick Start
+
+这份文档面向 SpineDigest 的主要使用方式：直接运行 CLI。
+
+## 1. 环境要求
+
+- Node `>=20.17.0`
+- `pnpm`
+- 一个 SpineDigest 支持的 LLM provider
+
+当前支持的 provider：
+
+- `anthropic`
+- `google`
+- `openai`
+- `openai-compatible`
+
+## 2. 安装并进入项目
+
+克隆仓库并安装依赖：
+
+```bash
+git clone https://github.com/oomol-lab/spinedigest.git
+cd spinedigest
+pnpm install
+```
+
+如果你所在的环境已经提供了可直接调用的 `spinedigest` 命令，可以跳过源码安装，直接使用已安装的 CLI。
+
+## 3. 配置 CLI
+
+SpineDigest 会从以下位置读取配置：
+
+- 默认路径：`~/.spinedigest/config.json`
+- 覆盖路径：`SPINEDIGEST_CONFIG`
+
+最小配置文件示例：
+
+```json
+{
+  "llm": {
+    "provider": "openai",
+    "model": "<your-model>"
+  }
+}
+```
+
+凭据建议优先通过环境变量提供：
+
+```bash
+export SPINEDIGEST_LLM_API_KEY="<your-api-key>"
+```
+
+如果使用 `openai-compatible`，还必须提供 base URL：
+
+```bash
+export SPINEDIGEST_LLM_BASE_URL="https://your-provider.example/v1"
+```
+
+如果你的环境更适合写进 `config.json`，也可以把这些字段写入配置文件。
+
+## 4. 跑第一条命令
+
+在源码仓库里，最直接的命令是：
+
+```bash
+pnpm dev -- --input ./test/fixtures/sources/sample-observatory-guide.md --output ./out/digest.md
+```
+
+执行完成后，可以查看结果：
+
+```bash
+cat ./out/digest.md
+```
+
+如果你用的是已经安装好的 CLI，请对你自己的文件运行同样的流程：
+
+```bash
+spinedigest --input ./book.md --output ./out/digest.md
+```
+
+## 5. 常见输出模式
+
+输出纯文本：
+
+```bash
+spinedigest --input ./book.epub --output ./digest.txt
+```
+
+输出 Markdown：
+
+```bash
+spinedigest --input ./book.txt --output ./digest.md
+```
+
+输出 EPUB：
+
+```bash
+spinedigest --input ./book.md --output ./digest.epub
+```
+
+输出可复用的 `.sdpub` 归档：
+
+```bash
+spinedigest --input ./book.epub --output ./book.sdpub
+```
+
+重新打开已有 `.sdpub` 并再次导出：
+
+```bash
+spinedigest --input ./book.sdpub --output ./digest.txt
+```
+
+## 6. 通过标准流处理
+
+`stdin` 和 `stdout` 只支持文本格式。
+
+从 `stdin` 读取：
+
+```bash
+cat ./chapter.txt | spinedigest --input-format txt --output ./digest.md
+```
+
+写到 `stdout`：
+
+```bash
+spinedigest --input ./chapter.md --output-format txt
+```
+
+双向管道：
+
+```bash
+cat ./chapter.txt | spinedigest --input-format txt --output-format markdown
+```
+
+## 7. 添加自定义 extraction prompt
+
+你可以在配置中自定义 extraction prompt：
+
+```json
+{
+  "prompt": "Preserve key arguments, named entities, and decisive transitions."
+}
+```
+
+这个 prompt 会用于处理源文件或文本流时的 digest 过程。
+
+## 8. 故障排查
+
+如果看到缺少 LLM 配置的错误：
+
+- 确认已经设置 `llm.provider` 和 `llm.model`
+- 确认对应 provider 的 API key 已经可用
+
+如果格式推断失败：
+
+- 添加 `--input-format`
+- 添加 `--output-format`
+
+如果省略了 `--input`，但又没有真正通过管道传入内容：
+
+- SpineDigest 会拒绝从交互式 `stdin` 读取
+- 请显式提供 `--input <path>`，或者通过管道输入文本
+
+## 下一步
+
+- [CLI Reference](./cli.md)
+- [AI Agent Guide](./ai-agents.md)
+- [Library Usage](./library.md)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spinedigest",
   "version": "0.1.0",
-  "description": "Hello world CLI scaffold for spinedigest.",
+  "description": "CLI-first tool for digesting long-form text and ebooks into compressed text, EPUB, or reusable .sdpub archives.",
   "license": "MIT",
   "type": "module",
   "packageManager": "pnpm@10.32.0",


### PR DESCRIPTION
## Summary
- add a CLI-first public README and a paired `README_zh-CN.md`
- organize docs into `docs/en` and `docs/zh-CN` with language switch links on every page
- add quick start, CLI, AI agent, library, and architecture docs in both languages
- update the package description to match the public positioning

## Verification
- pnpm verify
