### PR TITLE
refactor: rename text stream digest session

### DIFF
--- a/docs/en/library.md
+++ b/docs/en/library.md
@@ -67,7 +67,7 @@ const { SpineDigestApp } = require("spinedigest");
 - `digestEpubSession`
 - `digestMarkdownSession`
 - `digestTxtSession`
-- `digestTextSession`
+- `digestTextStreamSession`
 - `openSession`
 
 `openSession` is for existing `.sdpub` archives and does not require a fresh digest run.

--- a/docs/zh-CN/library.md
+++ b/docs/zh-CN/library.md
@@ -67,7 +67,7 @@ const { SpineDigestApp } = require("spinedigest");
 - `digestEpubSession`
 - `digestMarkdownSession`
 - `digestTxtSession`
-- `digestTextSession`
+- `digestTextStreamSession`
 - `openSession`
 
 `openSession` 面向已有的 `.sdpub` 归档，不需要重新执行一轮新的 digest。

--- a/src/cli/convert.ts
+++ b/src/cli/convert.ts
@@ -96,7 +96,7 @@ export async function runConvertCommand(args: CLIArguments): Promise<void> {
         );
       }
 
-      await app.digestTextSession(
+      await app.digestTextStreamSession(
         {
           ...(digestDirPath === undefined
             ? {}

--- a/src/facade/app.ts
+++ b/src/facade/app.ts
@@ -17,11 +17,11 @@ import type {
 import {
   digestEpubSession,
   digestMarkdownSession,
-  digestTextSession,
+  digestTextStreamSession,
   digestTxtSession,
   type DigestDocumentSessionOptions,
   type DigestSourceSessionOptions,
-  type DigestTextSessionOptions,
+  type DigestTextStreamSessionOptions,
 } from "./digest.js";
 import { SpineDigestFile } from "./spine-digest-file.js";
 import type { SpineDigest } from "./spine-digest.js";
@@ -59,7 +59,7 @@ export interface SpineDigestSourceSessionOptions extends DigestDocumentSessionOp
   readonly userLanguage?: Language;
 }
 
-export interface SpineDigestTextSessionOptions extends DigestDocumentSessionOptions {
+export interface SpineDigestTextStreamSessionOptions extends DigestDocumentSessionOptions {
   readonly bookLanguage?: string | null;
   readonly extractionPrompt?: string;
   readonly onProgress?: SpineDigestProgressCallback;
@@ -111,14 +111,14 @@ export class SpineDigestApp {
     );
   }
 
-  public async digestTextSession<T>(
-    options: SpineDigestTextSessionOptions,
+  public async digestTextStreamSession<T>(
+    options: SpineDigestTextStreamSessionOptions,
     operation: (digest: SpineDigest) => Promise<T> | T,
   ): Promise<T> {
     return await this.#withLogging(
-      "digest-text",
+      "digest-text-stream",
       async () =>
-        await digestTextSession(
+        await digestTextStreamSession(
           {
             extractionPrompt: resolveExtractionPrompt(options.extractionPrompt),
             llm: this.#requireLLM(),
@@ -142,7 +142,7 @@ export class SpineDigestApp {
             ...(options.userLanguage === undefined
               ? {}
               : { userLanguage: options.userLanguage }),
-          } satisfies DigestTextSessionOptions,
+          } satisfies DigestTextStreamSessionOptions,
           operation,
         ),
     );

--- a/src/facade/digest.ts
+++ b/src/facade/digest.ts
@@ -41,7 +41,7 @@ export interface DigestSourceSessionOptions extends DigestSessionOptions {
   readonly path: string;
 }
 
-export interface DigestTextSessionOptions extends DigestSessionOptions {
+export interface DigestTextStreamSessionOptions extends DigestSessionOptions {
   readonly bookLanguage?: string | null;
   readonly sourceFormat?: Extract<SourceFormat, "markdown" | "txt">;
   readonly stream: ReaderTextStream;
@@ -72,12 +72,12 @@ export async function digestMarkdownSession<T>(
   );
 }
 
-export async function digestTextSession<T>(
-  options: DigestTextSessionOptions,
+export async function digestTextStreamSession<T>(
+  options: DigestTextStreamSessionOptions,
   operation: (digest: SpineDigest) => Promise<T> | T,
 ): Promise<T> {
   const progressTracker = createDigestProgressTracker({
-    operation: "digest-text",
+    operation: "digest-text-stream",
     ...(options.onProgress === undefined
       ? {}
       : { onProgress: options.onProgress }),

--- a/src/facade/index.ts
+++ b/src/facade/index.ts
@@ -11,6 +11,6 @@ export {
   type SerialDiscoveredEvent,
   type SerialProgressEvent,
   type SpineDigestSourceSessionOptions,
-  type SpineDigestTextSessionOptions,
+  type SpineDigestTextStreamSessionOptions,
 } from "./app.js";
 export { SpineDigest } from "./spine-digest.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,5 +13,5 @@ export {
   type SerialDiscoveredEvent,
   type SerialProgressEvent,
   type SpineDigestSourceSessionOptions,
-  type SpineDigestTextSessionOptions,
+  type SpineDigestTextStreamSessionOptions,
 } from "./facade/index.js";

--- a/src/progress/types.ts
+++ b/src/progress/types.ts
@@ -1,7 +1,7 @@
 export type SpineDigestOperation =
   | "digest-epub"
   | "digest-markdown"
-  | "digest-text"
+  | "digest-text-stream"
   | "digest-txt";
 
 export interface SerialDiscoveredEvent {

--- a/test/cli/convert.test.ts
+++ b/test/cli/convert.test.ts
@@ -19,7 +19,7 @@ const cliMockState = vi.hoisted(() => ({
   digestCalls: {
     epub: [] as unknown[],
     markdown: [] as unknown[],
-    text: [] as unknown[],
+    textStream: [] as unknown[],
     txt: [] as unknown[],
   },
   exportCalls: [] as Array<{
@@ -78,11 +78,11 @@ vi.mock("../../src/index.js", () => ({
       return await operation(createMockDigest());
     }
 
-    public async digestTextSession(
+    public async digestTextStreamSession(
       options: unknown,
       operation: (digest: MockDigest) => Promise<unknown>,
     ): Promise<unknown> {
-      cliMockState.digestCalls.text.push(options);
+      cliMockState.digestCalls.textStream.push(options);
       await emitMockProgress(options);
       return await operation(createMockDigest());
     }
@@ -153,7 +153,7 @@ describe("cli/convert", () => {
     cliMockState.createTemporaryOutputPathCalls.length = 0;
     cliMockState.digestCalls.epub.length = 0;
     cliMockState.digestCalls.markdown.length = 0;
-    cliMockState.digestCalls.text.length = 0;
+    cliMockState.digestCalls.textStream.length = 0;
     cliMockState.digestCalls.txt.length = 0;
     cliMockState.exportCalls.length = 0;
     cliMockState.openCalls.length = 0;
@@ -229,14 +229,16 @@ describe("cli/convert", () => {
     expect(cliMockState.resetDigestDirCalls).toStrictEqual([
       "/tmp/kept-digest",
     ]);
-    expect(cliMockState.digestCalls.text).toHaveLength(1);
-    expect(cliMockState.digestCalls.text[0]).toStrictEqual({
+    expect(cliMockState.digestCalls.textStream).toHaveLength(1);
+    expect(cliMockState.digestCalls.textStream[0]).toStrictEqual({
       documentDirPath: "/tmp/kept-digest",
       extractionPrompt: "Keep the main beats",
       sourceFormat: "txt",
       stream: mockStdinStream,
     });
-    expect(cliMockState.digestCalls.text[0]).not.toHaveProperty("onProgress");
+    expect(cliMockState.digestCalls.textStream[0]).not.toHaveProperty(
+      "onProgress",
+    );
     expect(cliMockState.stderrWrites).toStrictEqual([]);
     expect(cliMockState.createTemporaryOutputPathCalls).toStrictEqual([
       {
@@ -278,7 +280,7 @@ describe("cli/convert", () => {
       "Missing --input. Refusing to read from interactive stdin. Use --input <path> or pipe text into stdin.",
     );
 
-    expect(cliMockState.digestCalls.text).toHaveLength(0);
+    expect(cliMockState.digestCalls.textStream).toHaveLength(0);
   });
 
   it("routes epub inputs through digestEpubSession and saves sdpub output", async () => {

--- a/test/common/progress.test.ts
+++ b/test/common/progress.test.ts
@@ -4,7 +4,7 @@ import { ProgressReporter } from "../../src/progress/index.js";
 
 describe("progress/reporter", () => {
   it("does not fail the pipeline when the progress callback throws", async () => {
-    const reporter = new ProgressReporter("digest-text", () => {
+    const reporter = new ProgressReporter("digest-text-stream", () => {
       throw new Error("UI disconnected");
     });
 
@@ -19,7 +19,7 @@ describe("progress/reporter", () => {
 
   it("delivers structured events to the callback", async () => {
     const callback = vi.fn();
-    const reporter = new ProgressReporter("digest-text", callback);
+    const reporter = new ProgressReporter("digest-text-stream", callback);
 
     await reporter.emit({
       fragments: 4,

--- a/test/facade/app.test.ts
+++ b/test/facade/app.test.ts
@@ -6,7 +6,7 @@ const appMockState = vi.hoisted(() => ({
   digestCalls: {
     epub: [] as unknown[],
     markdown: [] as unknown[],
-    text: [] as unknown[],
+    textStream: [] as unknown[],
     txt: [] as unknown[],
   },
   llmOptions: [] as unknown[],
@@ -33,9 +33,9 @@ vi.mock("../../src/facade/digest.js", () => ({
       return await operation();
     },
   ),
-  digestTextSession: vi.fn(
+  digestTextStreamSession: vi.fn(
     async (options: unknown, operation: () => unknown) => {
-      appMockState.digestCalls.text.push(options);
+      appMockState.digestCalls.textStream.push(options);
       return await operation();
     },
   ),
@@ -56,7 +56,7 @@ describe("facade/app", () => {
   beforeEach(() => {
     appMockState.digestCalls.epub.length = 0;
     appMockState.digestCalls.markdown.length = 0;
-    appMockState.digestCalls.text.length = 0;
+    appMockState.digestCalls.textStream.length = 0;
     appMockState.digestCalls.txt.length = 0;
     appMockState.llmOptions.length = 0;
   });
@@ -129,7 +129,7 @@ describe("facade/app", () => {
     );
   });
 
-  it("forwards text session options and preserves explicit extraction prompts", async () => {
+  it("forwards text-stream session options and preserves explicit extraction prompts", async () => {
     const fakeModel = {
       provider: "test-model",
     };
@@ -142,7 +142,7 @@ describe("facade/app", () => {
       },
     });
 
-    await app.digestTextSession(
+    await app.digestTextStreamSession(
       {
         bookLanguage: "ja",
         documentDirPath: "/tmp/custom-document",
@@ -170,8 +170,8 @@ describe("facade/app", () => {
     expect(llmOptions.model).toBe(fakeModel);
     expect(llmOptions.stream).toBe(true);
     expect(llmOptions.temperature).toBe(0.3);
-    expect(appMockState.digestCalls.text).toHaveLength(1);
-    const digestCall = appMockState.digestCalls.text[0] as {
+    expect(appMockState.digestCalls.textStream).toHaveLength(1);
+    const digestCall = appMockState.digestCalls.textStream[0] as {
       readonly bookLanguage: string;
       readonly documentDirPath: string;
       readonly extractionPrompt: string;

--- a/test/facade/digest.test.ts
+++ b/test/facade/digest.test.ts
@@ -128,7 +128,7 @@ vi.mock("../../src/facade/import.js", () => ({
 import {
   digestEpubSession,
   digestMarkdownSession,
-  digestTextSession,
+  digestTextStreamSession,
   digestTxtSession,
 } from "../../src/facade/digest.js";
 import { withTempDir } from "../helpers/temp.js";
@@ -140,8 +140,8 @@ describe("facade/digest", () => {
     digestMockState.tempDocumentPaths.length = 0;
   });
 
-  it("creates text-session documents and removes temporary directories by default", async () => {
-    const title = await digestTextSession(
+  it("creates text-stream session documents and removes temporary directories by default", async () => {
+    const title = await digestTextStreamSession(
       {
         bookLanguage: "fr",
         extractionPrompt: "Keep beats",
@@ -188,11 +188,11 @@ describe("facade/digest", () => {
     ).rejects.toThrow();
   });
 
-  it("keeps custom text-session directories and uses a fallback toc title", async () => {
+  it("keeps custom text-stream session directories and uses a fallback toc title", async () => {
     await withTempDir("spinedigest-digest-", async (path) => {
       const documentDirPath = `${path}/custom-document`;
 
-      await digestTextSession(
+      await digestTextStreamSession(
         {
           bookLanguage: null,
           documentDirPath,
@@ -230,7 +230,7 @@ describe("facade/digest", () => {
     });
   });
 
-  it("emits discovered and progress events for text digest", async () => {
+  it("emits discovered and progress events for text-stream digest", async () => {
     const events: Array<{
       readonly completedFragments?: number;
       readonly completedWords?: number;
@@ -242,7 +242,7 @@ describe("facade/digest", () => {
     }> = [];
 
     await withTempDir("spinedigest-digest-", async () => {
-      await digestTextSession(
+      await digestTextStreamSession(
         {
           extractionPrompt: "Keep beats",
           llm: {} as never,


### PR DESCRIPTION
## Summary
- rename the stream-based digest API to digestTextStreamSession and remove the old digestTextSession name
- update CLI stdin handling, exported option types, progress operation names, and public docs to match the new naming
- refresh tests to cover the renamed API and text-stream terminology

## Testing
- pnpm verify
- pnpm test:run
