### PR TITLE
feat: batch serial discovery progress

### DIFF
--- a/docs/en/library.md
+++ b/docs/en/library.md
@@ -78,9 +78,9 @@ Digest session options accept an optional `onProgress` callback.
 
 The callback reports three event shapes during digest generation:
 
-- `serial-discovered`, which reports a serial id plus its fragment count and total word count
+- `serials-discovered`, which reports all discovered serial ids plus their fragment counts and total word counts in one batch; when discovery cannot be done up front, it is emitted once with `available: false` and an empty `serials` array
 - `serial-progress`, which reports completed word count and completed fragment count for a specific serial id
-- `digest-progress`, which reports completed word count against the current total discovered word count
+- `digest-progress`, which reports completed word count against the current known total word count
 
 ## What `SpineDigest` Can Do
 

--- a/docs/zh-CN/library.md
+++ b/docs/zh-CN/library.md
@@ -78,9 +78,9 @@ digest session 的 option 现在可以传入可选的 `onProgress` 回调。
 
 这个回调在 digest 过程中会提供三种事件：
 
-- `serial-discovered`：报告某个 serial 的 id、fragment 数量和总词数
+- `serials-discovered`：一次性报告所有已发现 serial 的 id、fragment 数量和总词数；如果当前输入无法提前发现，则会发出一次 `available: false` 且 `serials` 为空数组的事件
 - `serial-progress`：报告某个 serial 当前已经完成的词数和 fragment 数量
-- `digest-progress`：报告整个 digest 当前已完成词数，以及目前已发现 serial 的总词数
+- `digest-progress`：报告整个 digest 当前已完成词数，以及当前已知的总词数
 
 ## `SpineDigest` 能做什么
 

--- a/src/cli/progress.ts
+++ b/src/cli/progress.ts
@@ -7,9 +7,9 @@ import type {
 
 interface SerialState {
   completedFragments: number;
-  readonly fragments: number;
   completedWords: number;
-  readonly words: number;
+  fragments?: number;
+  words?: number;
 }
 
 export interface CLIProgressRenderer {
@@ -86,21 +86,29 @@ class TerminalProgressRenderer implements CLIProgressRenderer {
 
   #applyEvent(event: SpineDigestProgressEvent): void {
     switch (event.type) {
-      case "serial-discovered":
-        this.#serials.set(event.id, {
-          completedFragments: 0,
-          completedWords: 0,
-          fragments: event.fragments,
-          words: event.words,
-        });
+      case "serials-discovered":
+        if (!event.available) {
+          return;
+        }
+
+        for (const serial of event.serials) {
+          this.#serials.set(serial.id, {
+            completedFragments: 0,
+            completedWords: 0,
+            fragments: serial.fragments,
+            words: serial.words,
+          });
+        }
         return;
       case "serial-progress": {
-        const serial = this.#serials.get(event.id);
+        const serial = this.#serials.get(event.id) ?? {
+          completedFragments: 0,
+          completedWords: 0,
+        };
 
-        if (serial !== undefined) {
-          serial.completedFragments = event.completedFragments;
-          serial.completedWords = event.completedWords;
-        }
+        serial.completedFragments = event.completedFragments;
+        serial.completedWords = event.completedWords;
+        this.#serials.set(event.id, serial);
         return;
       }
       case "digest-progress":
@@ -148,19 +156,23 @@ class TerminalProgressRenderer implements CLIProgressRenderer {
     const serials = [...this.#serials.entries()].sort(
       ([leftId], [rightId]) => leftId - rightId,
     );
-    const totalSerialWords = serials.reduce(
+    const discoveredSerials = serials.filter(
+      (entry): entry is [number, KnownSerialState] =>
+        hasDiscoveryTotals(entry[1]),
+    );
+    const totalSerialWords = discoveredSerials.reduce(
       (sum, [, serial]) => sum + serial.words,
       0,
     );
-    const totalCompletedSerialWords = serials.reduce(
+    const totalCompletedSerialWords = discoveredSerials.reduce(
       (sum, [, serial]) => sum + serial.completedWords,
       0,
     );
-    const activeSerials = serials.filter(
+    const activeSerials = discoveredSerials.filter(
       ([, serial]) => serial.completedWords < serial.words,
     );
 
-    if (serials.length > 0) {
+    if (discoveredSerials.length > 0) {
       lines.push(
         `${formatStageLabel("Serial")}${renderBar(
           totalCompletedSerialWords,
@@ -216,6 +228,10 @@ function swallowRenderError(): undefined {
   return undefined;
 }
 
+function hasDiscoveryTotals(serial: SerialState): serial is KnownSerialState {
+  return serial.fragments !== undefined && serial.words !== undefined;
+}
+
 function formatStageLabel(label: string): string {
   return label.padEnd(8);
 }
@@ -243,4 +259,9 @@ function renderBar(completed: number, total: number): string {
 
 function formatNumber(value: number): string {
   return new Intl.NumberFormat("en-US").format(value);
+}
+
+interface KnownSerialState extends SerialState {
+  fragments: number;
+  words: number;
 }

--- a/src/facade/app.ts
+++ b/src/facade/app.ts
@@ -7,7 +7,8 @@ import { withLoggingContext } from "../common/logging.js";
 import { LLM } from "../llm/index.js";
 import type {
   DigestProgressEvent,
-  SerialDiscoveredEvent,
+  SerialDiscoveryItem,
+  SerialsDiscoveredEvent,
   SerialProgressEvent,
   SpineDigestProgressCallback,
   SpineDigestProgressEvent,
@@ -234,7 +235,8 @@ export class SpineDigestApp {
 
 export type {
   DigestProgressEvent,
-  SerialDiscoveredEvent,
+  SerialDiscoveryItem,
+  SerialsDiscoveredEvent,
   SerialProgressEvent,
   SpineDigestProgressCallback,
   SpineDigestProgressEvent,

--- a/src/facade/digest.ts
+++ b/src/facade/digest.ts
@@ -91,6 +91,7 @@ export async function digestTextStreamSession<T>(
       const serialProgressTracker = progressTracker.createSerialTracker({
         id: serialId,
       });
+      await progressTracker.markDiscoveryUnavailable();
 
       const generation = new SerialGeneration({
         document: openedDocument,

--- a/src/facade/import.ts
+++ b/src/facade/import.ts
@@ -2,6 +2,7 @@ import type { Document } from "../document/index.js";
 import type { DigestProgressTracker } from "../progress/index.js";
 import {
   SerialGeneration,
+  discoverSerial,
   type GenerateSerialOptions,
   type Serial,
   type SerialGenerationOptions,
@@ -87,6 +88,24 @@ export async function importSourceDocument(
       : { segmenter: options.segmenter }),
   });
   const serials: Serial[] = [];
+
+  if (options.digestProgressTracker !== undefined) {
+    const discoveries = [];
+
+    for (const plannedSection of plannedSections) {
+      discoveries.push({
+        id: plannedSection.serialId,
+        ...(await discoverSerial({
+          ...(options.segmenter === undefined
+            ? {}
+            : { segmenter: options.segmenter }),
+          stream: await plannedSection.section.open(),
+        })),
+      });
+    }
+
+    await options.digestProgressTracker.discoverSerials(discoveries);
+  }
 
   for (const plannedSection of plannedSections) {
     const serialProgressTracker =

--- a/src/facade/index.ts
+++ b/src/facade/index.ts
@@ -1,6 +1,7 @@
 export {
   SpineDigestApp,
   type DigestProgressEvent,
+  type SerialDiscoveryItem,
   type SpineDigestAppOptions,
   type SpineDigestLLMOptions,
   type SpineDigestOpenSessionOptions,
@@ -8,7 +9,7 @@ export {
   type SpineDigestProgressEvent,
   type SpineDigestProgressEventType,
   type SpineDigestOperation,
-  type SerialDiscoveredEvent,
+  type SerialsDiscoveredEvent,
   type SerialProgressEvent,
   type SpineDigestSourceSessionOptions,
   type SpineDigestTextStreamSessionOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { LANGUAGES, type Language } from "./common/language.js";
 export {
   type DigestProgressEvent,
+  type SerialDiscoveryItem,
   SpineDigest,
   SpineDigestApp,
   type SpineDigestAppOptions,
@@ -10,7 +11,7 @@ export {
   type SpineDigestProgressEvent,
   type SpineDigestProgressEventType,
   type SpineDigestOperation,
-  type SerialDiscoveredEvent,
+  type SerialsDiscoveredEvent,
   type SerialProgressEvent,
   type SpineDigestSourceSessionOptions,
   type SpineDigestTextStreamSessionOptions,

--- a/src/progress/index.ts
+++ b/src/progress/index.ts
@@ -7,7 +7,8 @@ export {
 export { createProgressReporter, ProgressReporter } from "./reporter.js";
 export type {
   DigestProgressEvent,
-  SerialDiscoveredEvent,
+  SerialDiscoveryItem,
+  SerialsDiscoveredEvent,
   SerialProgressEvent,
   SpineDigestOperation,
   SpineDigestProgressCallback,

--- a/src/progress/reporter.ts
+++ b/src/progress/reporter.ts
@@ -2,7 +2,6 @@ import { getLogger } from "../common/logging.js";
 
 import type {
   DigestProgressEvent,
-  SerialDiscoveredEvent,
   SerialProgressEvent,
   SpineDigestOperation,
   SpineDigestProgressCallback,
@@ -63,12 +62,19 @@ function buildLogBindings(
   event: SpineDigestProgressEvent,
 ): Record<string, number> {
   switch (event.type) {
-    case "serial-discovered":
+    case "serials-discovered":
       return {
-        fragments: event.fragments,
-        id: event.id,
-        words: event.words,
-      } satisfies Record<keyof Omit<SerialDiscoveredEvent, "type">, number>;
+        available: Number(event.available),
+        serials: event.serials.length,
+        totalFragments: event.serials.reduce(
+          (sum, serial) => sum + serial.fragments,
+          0,
+        ),
+        totalWords: event.serials.reduce(
+          (sum, serial) => sum + serial.words,
+          0,
+        ),
+      } satisfies Record<string, number>;
     case "serial-progress":
       return {
         completedFragments: event.completedFragments,
@@ -85,8 +91,10 @@ function buildLogBindings(
 
 function buildLogMessage(event: SpineDigestProgressEvent): string {
   switch (event.type) {
-    case "serial-discovered":
-      return `Discovered serial ${event.id}`;
+    case "serials-discovered":
+      return event.available
+        ? `Discovered ${event.serials.length} serials`
+        : "Serial discovery unavailable";
     case "serial-progress":
       return `Serial ${event.id} progressed`;
     case "digest-progress":

--- a/src/progress/tracker.ts
+++ b/src/progress/tracker.ts
@@ -1,5 +1,6 @@
 import { createProgressReporter, type ProgressReporter } from "./reporter.js";
 import type {
+  SerialDiscoveryItem,
   SpineDigestOperation,
   SpineDigestProgressCallback,
 } from "./types.js";
@@ -13,6 +14,7 @@ export class DigestProgressTracker {
   readonly #reporter: ProgressReporter;
   #completedWords = 0;
   #totalWords = 0;
+  #discoverySettled = false;
 
   public constructor(options: CreateDigestProgressTrackerOptions) {
     this.#reporter = createProgressReporter(
@@ -27,38 +29,38 @@ export class DigestProgressTracker {
     return new SerialProgressTracker(this, input.id);
   }
 
-  public async discoverSerial(input: {
-    readonly fragments: number;
-    readonly id: number;
-    readonly words: number;
-  }): Promise<void> {
-    this.#totalWords += input.words;
+  public async discoverSerials(
+    serials: readonly SerialDiscoveryItem[],
+  ): Promise<void> {
+    this.#ensureDiscoveryOpen();
+    this.#discoverySettled = true;
+    this.#totalWords = serials.reduce((sum, serial) => sum + serial.words, 0);
+
     await this.#reporter.emit({
-      fragments: input.fragments,
-      id: input.id,
-      type: "serial-discovered",
-      words: input.words,
+      available: true,
+      serials,
+      type: "serials-discovered",
     });
+    await this.#emitDigestProgress();
+  }
+
+  public async markDiscoveryUnavailable(): Promise<void> {
+    this.#ensureDiscoveryOpen();
+    this.#discoverySettled = true;
+
     await this.#reporter.emit({
-      completedWords: this.#completedWords,
-      totalWords: this.#totalWords,
-      type: "digest-progress",
+      available: false,
+      serials: [],
+      type: "serials-discovered",
     });
   }
 
-  public async completeSerial(input: {
-    readonly completedWords: number;
-    readonly discoveredWords?: number;
-  }): Promise<void> {
-    this.#completedWords += input.completedWords;
-    if (input.discoveredWords !== undefined) {
-      this.#totalWords += input.discoveredWords;
+  public async completeSerial(words: number): Promise<void> {
+    this.#completedWords += words;
+    if (this.#completedWords > this.#totalWords) {
+      this.#totalWords = this.#completedWords;
     }
-    await this.#reporter.emit({
-      completedWords: this.#completedWords,
-      totalWords: this.#totalWords,
-      type: "digest-progress",
-    });
+    await this.#emitDigestProgress();
   }
 
   public async emitSerialProgress(input: {
@@ -73,6 +75,20 @@ export class DigestProgressTracker {
       type: "serial-progress",
     });
   }
+
+  async #emitDigestProgress(): Promise<void> {
+    await this.#reporter.emit({
+      completedWords: this.#completedWords,
+      totalWords: this.#totalWords,
+      type: "digest-progress",
+    });
+  }
+
+  #ensureDiscoveryOpen(): void {
+    if (this.#discoverySettled) {
+      throw new Error("Serial discovery has already been reported");
+    }
+  }
 }
 
 export class SerialProgressTracker {
@@ -80,34 +96,18 @@ export class SerialProgressTracker {
   readonly #digestTracker: DigestProgressTracker;
   #completedWords = 0;
   readonly #id: number;
-  #started = false;
-  #totalsKnown = false;
-  #totalFragments = 0;
-  #totalWords = 0;
 
   public constructor(digestTracker: DigestProgressTracker, id: number) {
     this.#digestTracker = digestTracker;
     this.#id = id;
   }
 
-  public async begin(input: {
+  public async begin(_input?: {
     readonly fragments: number;
     readonly words: number;
-  }): Promise<void> {
-    this.#started = true;
-    this.#totalsKnown = true;
-    this.#totalFragments = input.fragments;
-    this.#totalWords = input.words;
-    await this.#digestTracker.discoverSerial({
-      fragments: input.fragments,
-      id: this.#id,
-      words: this.#totalWords,
-    });
-  }
+  }): Promise<void> {}
 
   public async advance(wordsCount: number): Promise<void> {
-    this.#started = true;
-
     this.#completedWords += wordsCount;
     this.#completedFragments += 1;
     await this.#digestTracker.emitSerialProgress({
@@ -118,19 +118,9 @@ export class SerialProgressTracker {
   }
 
   public async complete(finalWordsCount = 0): Promise<void> {
-    this.#started = true;
-
     this.#completedWords += finalWordsCount;
-    if (
-      this.#totalsKnown
-        ? this.#completedFragments < this.#totalFragments
-        : this.#completedWords > 0
-    ) {
+    if (this.#completedWords > 0) {
       this.#completedFragments += 1;
-    }
-
-    if (this.#totalsKnown && this.#completedWords > this.#totalWords) {
-      throw new Error(`Serial ${this.#id} completed beyond its total words`);
     }
 
     await this.#digestTracker.emitSerialProgress({
@@ -138,10 +128,7 @@ export class SerialProgressTracker {
       completedWords: this.#completedWords,
       id: this.#id,
     });
-    await this.#digestTracker.completeSerial({
-      completedWords: this.#totalsKnown ? this.#totalWords : this.#completedWords,
-      ...(this.#totalsKnown ? {} : { discoveredWords: this.#completedWords }),
-    });
+    await this.#digestTracker.completeSerial(this.#completedWords);
   }
 }
 

--- a/src/progress/tracker.ts
+++ b/src/progress/tracker.ts
@@ -46,8 +46,14 @@ export class DigestProgressTracker {
     });
   }
 
-  public async completeSerial(words: number): Promise<void> {
-    this.#completedWords += words;
+  public async completeSerial(input: {
+    readonly completedWords: number;
+    readonly discoveredWords?: number;
+  }): Promise<void> {
+    this.#completedWords += input.completedWords;
+    if (input.discoveredWords !== undefined) {
+      this.#totalWords += input.discoveredWords;
+    }
     await this.#reporter.emit({
       completedWords: this.#completedWords,
       totalWords: this.#totalWords,
@@ -75,6 +81,7 @@ export class SerialProgressTracker {
   #completedWords = 0;
   readonly #id: number;
   #started = false;
+  #totalsKnown = false;
   #totalFragments = 0;
   #totalWords = 0;
 
@@ -88,6 +95,7 @@ export class SerialProgressTracker {
     readonly words: number;
   }): Promise<void> {
     this.#started = true;
+    this.#totalsKnown = true;
     this.#totalFragments = input.fragments;
     this.#totalWords = input.words;
     await this.#digestTracker.discoverSerial({
@@ -98,9 +106,7 @@ export class SerialProgressTracker {
   }
 
   public async advance(wordsCount: number): Promise<void> {
-    if (!this.#started) {
-      throw new Error("Serial progress has not started");
-    }
+    this.#started = true;
 
     this.#completedWords += wordsCount;
     this.#completedFragments += 1;
@@ -112,16 +118,18 @@ export class SerialProgressTracker {
   }
 
   public async complete(finalWordsCount = 0): Promise<void> {
-    if (!this.#started) {
-      throw new Error("Serial progress has not started");
-    }
+    this.#started = true;
 
     this.#completedWords += finalWordsCount;
-    if (this.#completedFragments < this.#totalFragments) {
+    if (
+      this.#totalsKnown
+        ? this.#completedFragments < this.#totalFragments
+        : this.#completedWords > 0
+    ) {
       this.#completedFragments += 1;
     }
 
-    if (this.#completedWords > this.#totalWords) {
+    if (this.#totalsKnown && this.#completedWords > this.#totalWords) {
       throw new Error(`Serial ${this.#id} completed beyond its total words`);
     }
 
@@ -130,7 +138,10 @@ export class SerialProgressTracker {
       completedWords: this.#completedWords,
       id: this.#id,
     });
-    await this.#digestTracker.completeSerial(this.#totalWords);
+    await this.#digestTracker.completeSerial({
+      completedWords: this.#totalsKnown ? this.#totalWords : this.#completedWords,
+      ...(this.#totalsKnown ? {} : { discoveredWords: this.#completedWords }),
+    });
   }
 }
 

--- a/src/progress/types.ts
+++ b/src/progress/types.ts
@@ -4,11 +4,16 @@ export type SpineDigestOperation =
   | "digest-text-stream"
   | "digest-txt";
 
-export interface SerialDiscoveredEvent {
-  readonly type: "serial-discovered";
+export interface SerialDiscoveryItem {
   readonly id: number;
   readonly fragments: number;
   readonly words: number;
+}
+
+export interface SerialsDiscoveredEvent {
+  readonly type: "serials-discovered";
+  readonly available: boolean;
+  readonly serials: readonly SerialDiscoveryItem[];
 }
 
 export interface SerialProgressEvent {
@@ -27,7 +32,7 @@ export interface DigestProgressEvent {
 export type SpineDigestProgressEventType = SpineDigestProgressEvent["type"];
 
 export type SpineDigestProgressEvent =
-  | SerialDiscoveredEvent
+  | SerialsDiscoveredEvent
   | SerialProgressEvent
   | DigestProgressEvent;
 

--- a/src/reader/index.ts
+++ b/src/reader/index.ts
@@ -1,4 +1,5 @@
 export { Reader } from "./reader.js";
+export { segmentTextStream } from "./segment/segment.js";
 export type {
   ReaderChunk,
   ReaderGraphDelta,

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -234,67 +234,112 @@ export class SerialGeneration {
     );
     const allChunks: ReaderChunk[] = [];
     const successorIdsByChunkId = createNumberListRecord();
-    const fragments = await collectFragments({
+    let finalFragment:
+      | {
+          readonly sentences: ReadonlyArray<{
+            readonly text: string;
+            readonly wordsCount: number;
+          }>;
+          readonly wordsCount: number;
+        }
+      | undefined;
+
+    for await (const fragment of streamFragments({
       maxWordsCount: this.#fragmentWordsCount,
       stream: reader.segment(stream),
-    });
-    const totalWords = fragments.reduce(
-      (sum, fragment) => sum + fragment.wordsCount,
-      0,
-    );
-
-    await progressTracker?.begin({
-      fragments: fragments.length,
-      words: totalWords,
-    });
-
-    for (const [index, fragment] of fragments.entries()) {
-      const serialFragments = this.#getSerialFragments(serialId);
-      const fragmentDraft = await serialFragments.createDraft();
-      const sentences = fragment.sentences.map((sentence) => ({
-        sentenceId: fragmentDraft.addSentence(
-          sentence.text,
-          sentence.wordsCount,
-        ),
-        text: sentence.text,
-        wordsCount: sentence.wordsCount,
-      }));
-      const fragmentText = sentences.map((sentence) => sentence.text).join(" ");
-      const userFocused = await reader.extractUserFocused({
-        sentences,
-        text: fragmentText,
-      });
-
-      if (userFocused.fragmentSummary.trim() !== "") {
-        fragmentDraft.setSummary(userFocused.fragmentSummary);
+    })) {
+      if (finalFragment !== undefined) {
+        await this.#processFragment({
+          allChunks,
+          fragment: finalFragment,
+          progressTracker,
+          reader,
+          serialId,
+          successorIdsByChunkId,
+          topology,
+        });
+        await progressTracker?.advance(finalFragment.wordsCount);
       }
 
-      const bookCoherence = await reader.extractBookCoherence({
-        sentences,
-        text: fragmentText,
-        userFocusedChunks: userFocused.delta.chunks,
-      });
+      finalFragment = {
+        sentences: fragment.sentences,
+        wordsCount: countFragmentWords(fragment.sentences),
+      };
+    }
 
-      await fragmentDraft.commit();
-      saveDelta(allChunks, successorIdsByChunkId, topology, userFocused.delta);
-      saveDelta(allChunks, successorIdsByChunkId, topology, bookCoherence);
-      reader.completeFragment({
+    if (finalFragment !== undefined) {
+      await this.#processFragment({
         allChunks,
-        getSuccessorChunkIds: (chunkId) =>
-          successorIdsByChunkId[String(chunkId)] ?? [],
+        fragment: finalFragment,
+        reader,
+        serialId,
+        successorIdsByChunkId,
+        topology,
       });
-
-      if (index < fragments.length - 1) {
-        await progressTracker?.advance(fragment.wordsCount);
-        continue;
-      }
-
-      setFinalWordsCount?.(fragment.wordsCount);
+      setFinalWordsCount?.(finalFragment.wordsCount);
     }
 
     await this.#writeSemaphore.use(async () => {
       await topology.finalize();
       await this.#serials.setTopologyReady(serialId);
+    });
+  }
+
+  async #processFragment(input: {
+    readonly allChunks: ReaderChunk[];
+    readonly fragment: {
+      readonly sentences: ReadonlyArray<{
+        readonly text: string;
+        readonly wordsCount: number;
+      }>;
+      readonly wordsCount: number;
+    };
+    readonly progressTracker?: SerialProgressTracker;
+    readonly reader: Reader<SpineDigestScope>;
+    readonly serialId: number;
+    readonly successorIdsByChunkId: Record<string, number[] | undefined>;
+    readonly topology: Topology;
+  }): Promise<void> {
+    const serialFragments = this.#getSerialFragments(input.serialId);
+    const fragmentDraft = await serialFragments.createDraft();
+    const sentences = input.fragment.sentences.map((sentence) => ({
+      sentenceId: fragmentDraft.addSentence(sentence.text, sentence.wordsCount),
+      text: sentence.text,
+      wordsCount: sentence.wordsCount,
+    }));
+    const fragmentText = sentences.map((sentence) => sentence.text).join(" ");
+    const userFocused = await input.reader.extractUserFocused({
+      sentences,
+      text: fragmentText,
+    });
+
+    if (userFocused.fragmentSummary.trim() !== "") {
+      fragmentDraft.setSummary(userFocused.fragmentSummary);
+    }
+
+    const bookCoherence = await input.reader.extractBookCoherence({
+      sentences,
+      text: fragmentText,
+      userFocusedChunks: userFocused.delta.chunks,
+    });
+
+    await fragmentDraft.commit();
+    saveDelta(
+      input.allChunks,
+      input.successorIdsByChunkId,
+      input.topology,
+      userFocused.delta,
+    );
+    saveDelta(
+      input.allChunks,
+      input.successorIdsByChunkId,
+      input.topology,
+      bookCoherence,
+    );
+    input.reader.completeFragment({
+      allChunks: input.allChunks,
+      getSuccessorChunkIds: (chunkId) =>
+        input.successorIdsByChunkId[String(chunkId)] ?? [],
     });
   }
 
@@ -548,38 +593,11 @@ async function* streamFragments(input: {
   }
 }
 
-async function collectFragments(input: {
-  maxWordsCount: number;
-  stream: AsyncIterable<{
+function countFragmentWords(
+  sentences: ReadonlyArray<{
     readonly text: string;
     readonly wordsCount: number;
-  }>;
-}): Promise<
-  ReadonlyArray<{
-    readonly sentences: ReadonlyArray<{
-      readonly text: string;
-      readonly wordsCount: number;
-    }>;
-    readonly wordsCount: number;
-  }>
-> {
-  const fragments: Array<{
-    readonly sentences: ReadonlyArray<{
-      readonly text: string;
-      readonly wordsCount: number;
-    }>;
-    readonly wordsCount: number;
-  }> = [];
-
-  for await (const fragment of streamFragments(input)) {
-    fragments.push({
-      sentences: fragment.sentences,
-      wordsCount: fragment.sentences.reduce(
-        (sum, sentence) => sum + sentence.wordsCount,
-        0,
-      ),
-    });
-  }
-
-  return fragments;
+  }>,
+): number {
+  return sentences.reduce((sum, sentence) => sum + sentence.wordsCount, 0);
 }

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -28,7 +28,7 @@ import type {
   SnakeEdgeRecord,
   SnakeRecord,
 } from "./document/index.js";
-import { Reader } from "./reader/index.js";
+import { Reader, segmentTextStream } from "./reader/index.js";
 import type {
   ReaderChunk,
   ReaderGraphDelta,
@@ -51,6 +51,14 @@ export interface GenerateSerialOptions {
   readonly userLanguage?: Language;
 }
 
+export interface SerialDiscovery {
+  readonly fragments: number;
+  readonly words: number;
+}
+
+type ReaderProgressScope =
+  (typeof SPINE_DIGEST_READER_SCOPES)[keyof typeof SPINE_DIGEST_READER_SCOPES];
+
 export type CreateSerialOptions = GenerateSerialOptions;
 
 export interface SerialGenerationOptions {
@@ -63,6 +71,29 @@ export interface SerialGenerationOptions {
 }
 
 export type SerialHubOptions = SerialGenerationOptions;
+
+export async function discoverSerial(input: {
+  readonly segmenter?: ReaderSegmenter;
+  readonly stream: ReaderTextStream;
+}): Promise<SerialDiscovery> {
+  let fragments = 0;
+  let words = 0;
+
+  for await (const fragment of streamFragments({
+    maxWordsCount: DEFAULT_FRAGMENT_WORDS_COUNT,
+    stream: segmentTextStream(input.stream, {
+      ...(input.segmenter === undefined ? {} : { adapter: input.segmenter }),
+    }),
+  })) {
+    fragments += 1;
+    words += countFragmentWords(fragment.sentences);
+  }
+
+  return {
+    fragments,
+    words,
+  };
+}
 
 export class SerialGeneration {
   readonly #chunks: ChunkStore;
@@ -252,7 +283,6 @@ export class SerialGeneration {
         await this.#processFragment({
           allChunks,
           fragment: finalFragment,
-          progressTracker,
           reader,
           serialId,
           successorIdsByChunkId,
@@ -294,8 +324,7 @@ export class SerialGeneration {
       }>;
       readonly wordsCount: number;
     };
-    readonly progressTracker?: SerialProgressTracker;
-    readonly reader: Reader<SpineDigestScope>;
+    readonly reader: Reader<ReaderProgressScope>;
     readonly serialId: number;
     readonly successorIdsByChunkId: Record<string, number[] | undefined>;
     readonly topology: Topology;

--- a/src/source/epub/content.ts
+++ b/src/source/epub/content.ts
@@ -48,46 +48,34 @@ export interface EpubSectionTarget {
   readonly fragment: string | undefined;
 }
 
-export class EpubContentCache {
+export class EpubContentLoader {
   readonly #archive: EpubArchive;
-  readonly #targetsByPath: ReadonlyMap<string, readonly EpubSectionTarget[]>;
-  readonly #cache = new Map<string, Promise<ReadonlyMap<string, string>>>();
+  readonly #targetsBySectionId: ReadonlyMap<
+    string,
+    {
+      readonly path: string;
+      readonly targets: readonly EpubSectionTarget[];
+    }
+  >;
 
   public constructor(
     archive: EpubArchive,
     targetsByPath: ReadonlyMap<string, readonly EpubSectionTarget[]>,
   ) {
     this.#archive = archive;
-    this.#targetsByPath = targetsByPath;
+    this.#targetsBySectionId = createTargetsBySectionId(targetsByPath);
   }
 
   public async openSection(sectionId: string): Promise<SourceTextStream> {
-    const entry = [...this.#targetsByPath.entries()].find(([, targets]) =>
-      targets.some((target) => target.id === sectionId),
-    );
-    if (entry === undefined) {
+    const target = this.#targetsBySectionId.get(sectionId);
+
+    if (target === undefined) {
       return [];
     }
 
-    const [path, targets] = entry;
-    const sections = await this.#getParsedSections(path, targets);
+    const sections = await this.#parseSections(target.path, target.targets);
 
     return [sections.get(sectionId) ?? ""];
-  }
-
-  async #getParsedSections(
-    path: string,
-    targets: readonly EpubSectionTarget[],
-  ): Promise<ReadonlyMap<string, string>> {
-    const cached = this.#cache.get(path);
-    if (cached !== undefined) {
-      return await cached;
-    }
-
-    const parsing = this.#parseSections(path, targets);
-    this.#cache.set(path, parsing);
-
-    return await parsing;
   }
 
   async #parseSections(
@@ -99,6 +87,32 @@ export class EpubContentCache {
 
     return await parseHtmlSections(stream, targets);
   }
+}
+
+function createTargetsBySectionId(
+  targetsByPath: ReadonlyMap<string, readonly EpubSectionTarget[]>,
+): ReadonlyMap<
+  string,
+  {
+    readonly path: string;
+    readonly targets: readonly EpubSectionTarget[];
+  }
+> {
+  const targetsBySectionId = new Map<
+    string,
+    {
+      readonly path: string;
+      readonly targets: readonly EpubSectionTarget[];
+    }
+  >();
+
+  for (const [path, targets] of targetsByPath.entries()) {
+    for (const target of targets) {
+      targetsBySectionId.set(target.id, { path, targets });
+    }
+  }
+
+  return targetsBySectionId;
 }
 
 async function parseHtmlSections(

--- a/src/source/epub/document.ts
+++ b/src/source/epub/document.ts
@@ -2,7 +2,7 @@ import type { SourceAdapter, SourceDocument } from "../adapter.js";
 import type { SourceAsset, SourceSection, SourceTextStream } from "../types.js";
 import { normalizeFragment } from "./archive.js";
 import { EpubArchive } from "./archive.js";
-import { EpubContentCache, type EpubSectionTarget } from "./content.js";
+import { EpubContentLoader, type EpubSectionTarget } from "./content.js";
 import { readEpubNavigation, type EpubNavigationItem } from "./navigation.js";
 import { readEpubPackage, type EpubPackageData } from "./package.js";
 
@@ -53,18 +53,18 @@ export class EpubSourceDocument implements SourceDocument {
   readonly #packageData: EpubPackageData;
   readonly #cover: SourceAsset | undefined;
   readonly #sections: readonly SectionDefinition[];
-  readonly #contentCache: EpubContentCache;
+  readonly #contentLoader: EpubContentLoader;
 
   public constructor(
     packageData: EpubPackageData,
     cover: SourceAsset | undefined,
     sections: readonly SectionDefinition[],
-    contentCache: EpubContentCache,
+    contentLoader: EpubContentLoader,
   ) {
     this.#packageData = packageData;
     this.#cover = cover;
     this.#sections = sections;
-    this.#contentCache = contentCache;
+    this.#contentLoader = contentLoader;
   }
 
   public static async open(archive: EpubArchive): Promise<EpubSourceDocument> {
@@ -78,7 +78,7 @@ export class EpubSourceDocument implements SourceDocument {
       packageData,
       cover,
       sections,
-      new EpubContentCache(archive, targetsByPath),
+      new EpubContentLoader(archive, targetsByPath),
     );
   }
 
@@ -97,7 +97,7 @@ export class EpubSourceDocument implements SourceDocument {
   }
 
   public async openSection(sectionId: string): Promise<SourceTextStream> {
-    return await this.#contentCache.openSection(sectionId);
+    return await this.#contentLoader.openSection(sectionId);
   }
 }
 

--- a/test/cli/convert.test.ts
+++ b/test/cli/convert.test.ts
@@ -487,10 +487,15 @@ async function emitMockProgress(options: unknown): Promise<void> {
   }
 
   await onProgress({
-    fragments: 6,
-    id: 1,
-    type: "serial-discovered",
-    words: 4800,
+    available: true,
+    serials: [
+      {
+        fragments: 6,
+        id: 1,
+        words: 4800,
+      },
+    ],
+    type: "serials-discovered",
   });
   await onProgress({
     completedWords: 0,

--- a/test/cli/progress.test.ts
+++ b/test/cli/progress.test.ts
@@ -32,16 +32,20 @@ describe("cli/progress", () => {
 
     await Promise.all([
       renderer.onProgress({
-        fragments: 3,
-        id: 2,
-        type: "serial-discovered",
-        words: 1820,
-      }),
-      renderer.onProgress({
-        fragments: 2,
-        id: 1,
-        type: "serial-discovered",
-        words: 882,
+        available: true,
+        serials: [
+          {
+            fragments: 3,
+            id: 2,
+            words: 1820,
+          },
+          {
+            fragments: 2,
+            id: 1,
+            words: 882,
+          },
+        ],
+        type: "serials-discovered",
       }),
       renderer.onProgress({
         completedWords: 0,

--- a/test/common/progress.test.ts
+++ b/test/common/progress.test.ts
@@ -22,18 +22,28 @@ describe("progress/reporter", () => {
     const reporter = new ProgressReporter("digest-text-stream", callback);
 
     await reporter.emit({
-      fragments: 4,
-      id: 7,
-      type: "serial-discovered",
-      words: 1600,
+      available: true,
+      serials: [
+        {
+          fragments: 4,
+          id: 7,
+          words: 1600,
+        },
+      ],
+      type: "serials-discovered",
     });
 
     expect(callback).toHaveBeenCalledTimes(1);
     expect(callback).toHaveBeenCalledWith({
-      fragments: 4,
-      id: 7,
-      type: "serial-discovered",
-      words: 1600,
+      available: true,
+      serials: [
+        {
+          fragments: 4,
+          id: 7,
+          words: 1600,
+        },
+      ],
+      type: "serials-discovered",
     });
   });
 });

--- a/test/facade/digest.test.ts
+++ b/test/facade/digest.test.ts
@@ -232,13 +232,17 @@ describe("facade/digest", () => {
 
   it("emits discovered and progress events for text-stream digest", async () => {
     const events: Array<{
+      readonly available?: boolean;
       readonly completedFragments?: number;
       readonly completedWords?: number;
-      readonly fragments?: number;
+      readonly serials?: readonly {
+        readonly fragments: number;
+        readonly id: number;
+        readonly words: number;
+      }[];
       readonly id?: number;
       readonly totalWords?: number;
       readonly type: string;
-      readonly words?: number;
     }> = [];
 
     await withTempDir("spinedigest-digest-", async () => {
@@ -248,12 +252,11 @@ describe("facade/digest", () => {
           llm: {} as never,
           onProgress: (event) => {
             switch (event.type) {
-              case "serial-discovered":
+              case "serials-discovered":
                 events.push({
-                  fragments: event.fragments,
-                  id: event.id,
+                  available: event.available,
+                  serials: event.serials,
                   type: event.type,
-                  words: event.words,
                 });
                 return;
               case "serial-progress":
@@ -280,12 +283,7 @@ describe("facade/digest", () => {
     });
 
     expect(events).toStrictEqual([
-      { fragments: 1, id: 1, type: "serial-discovered", words: 2 },
-      {
-        completedWords: 0,
-        type: "digest-progress",
-        totalWords: 2,
-      },
+      { available: false, serials: [], type: "serials-discovered" },
       {
         completedFragments: 1,
         completedWords: 2,

--- a/test/facade/import.test.ts
+++ b/test/facade/import.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DirectoryDocument } from "../../src/document/index.js";
 import type { SourceDocument } from "../../src/source/adapter.js";
+import { createDigestProgressTracker } from "../../src/progress/index.js";
 import type {
   BookMeta,
   SourceAsset,
@@ -20,6 +21,23 @@ const serialMockState = vi.hoisted(() => ({
 }));
 
 vi.mock("../../src/serial.js", () => ({
+  discoverSerial: async (input: {
+    readonly stream: AsyncIterable<string> | Iterable<string>;
+  }) => {
+    let streamText = "";
+
+    for await (const chunk of input.stream) {
+      streamText += chunk;
+    }
+
+    return {
+      fragments: streamText.trim() === "" ? 0 : 1,
+      words: streamText
+        .trim()
+        .split(/\s+/)
+        .filter((value) => value !== "").length,
+    };
+  },
   SerialGeneration: class {
     readonly #document: DirectoryDocument;
 
@@ -234,6 +252,70 @@ describe("facade/import", () => {
     });
   });
 
+  it("discovers all serials before generation and reopens sections for import", async () => {
+    await withTempDir("spinedigest-import-", async (path) => {
+      const document = await DirectoryDocument.open(`${path}/document`);
+      const openCounts = new Map<string, number>();
+      const events: unknown[] = [];
+
+      try {
+        await importSourceDocument(
+          createSourceDocument({
+            meta: createBookMeta({
+              title: "Discovery Fixture",
+            }),
+            sections: [
+              createSourceSection({
+                hasContent: true,
+                openCounts,
+                streamText: "alpha beta",
+                title: "Chapter 1",
+              }),
+              createSourceSection({
+                hasContent: true,
+                openCounts,
+                streamText: "gamma delta epsilon",
+                title: "Chapter 2",
+              }),
+            ],
+          }),
+          {
+            digestProgressTracker: createDigestProgressTracker({
+              onProgress: (event) => {
+                events.push(event);
+              },
+              operation: "digest-txt",
+            }),
+            document,
+            extractionPrompt: "Keep key beats",
+            llm: {} as never,
+          },
+        );
+
+        expect(events).toContainEqual({
+          available: true,
+          serials: [
+            {
+              fragments: 1,
+              id: 1,
+              words: 2,
+            },
+            {
+              fragments: 1,
+              id: 2,
+              words: 3,
+            },
+          ],
+          type: "serials-discovered",
+        });
+        expect(openCounts.get("Chapter 1")).toBe(2);
+        expect(openCounts.get("Chapter 2")).toBe(2);
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
   it("rejects imports when the target document already has content", async () => {
     await withTempDir("spinedigest-import-", async (path) => {
       const sourceDocument = createSourceDocument({
@@ -326,15 +408,31 @@ function createSourceDocument(input: {
 function createSourceSection(input: {
   readonly children?: readonly SourceSection[];
   readonly hasContent: boolean;
+  readonly openCounts?: Map<string, number>;
   readonly streamText?: string;
   readonly title?: string;
 }): SourceSection {
+  const id = crypto.randomUUID();
+
   return {
     children: input.children ?? [],
     hasContent: input.hasContent,
-    id: crypto.randomUUID(),
-    open: () =>
-      Promise.resolve(input.streamText === undefined ? [] : [input.streamText]),
+    id,
+    open: () => {
+      if (input.openCounts !== undefined) {
+        input.openCounts.set(id, (input.openCounts.get(id) ?? 0) + 1);
+        if (input.title !== undefined) {
+          input.openCounts.set(
+            input.title,
+            (input.openCounts.get(input.title) ?? 0) + 1,
+          );
+        }
+      }
+
+      return Promise.resolve(
+        input.streamText === undefined ? [] : [input.streamText],
+      );
+    },
     title: input.title,
   };
 }

--- a/test/source/epub-source-adapter.test.ts
+++ b/test/source/epub-source-adapter.test.ts
@@ -1,5 +1,8 @@
+import { Readable } from "stream";
+
 import { describe, expect, it } from "vitest";
 
+import { EpubContentLoader } from "../../src/source/epub/content.js";
 import { EPUB_SOURCE_ADAPTER } from "../../src/source/index.js";
 import {
   collectSectionTitles,
@@ -69,5 +72,39 @@ describe("source/epub", () => {
         expect(stormLedgerText).toContain("west stair sounded hollow");
       },
     );
+  });
+
+  it("reopens the underlying xhtml entry for repeated section reads", async () => {
+    let openReadStreamCount = 0;
+    const loader = new EpubContentLoader(
+      {
+        openReadStream: () => {
+          openReadStreamCount += 1;
+          return Promise.resolve(
+            Readable.from(["<html><body><p>Alpha beta.</p></body></html>"]),
+          );
+        },
+      } as never,
+      new Map([
+        [
+          "chapter.xhtml",
+          [
+            {
+              fragment: undefined,
+              id: "chapter.xhtml",
+              path: "chapter.xhtml",
+            },
+          ],
+        ],
+      ]),
+    );
+
+    expect(
+      await readStreamText(await loader.openSection("chapter.xhtml")),
+    ).toBe("Alpha beta.");
+    expect(
+      await readStreamText(await loader.openSection("chapter.xhtml")),
+    ).toBe("Alpha beta.");
+    expect(openReadStreamCount).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary
- stream serial generation instead of buffering all fragments before processing
- remove EPUB section text caching so repeated reads reopen source content instead of retaining book text in memory
- replace single-serial discovery progress with a batched `serials-discovered` event and make text-stream discovery explicitly unavailable up front

## Testing
- pnpm verify
- pnpm test:run