### PR TITLE
refactor: simplify public language model

### DIFF
--- a/src/common/language.ts
+++ b/src/common/language.ts
@@ -1,111 +1,26 @@
-export const ARABIC = "Arabic";
-export const DANISH = "Danish";
-export const DUTCH = "Dutch";
-export const ENGLISH = "English";
-export const FINNISH = "Finnish";
-export const FRENCH = "French";
-export const GERMAN = "German";
-export const HINDI = "Hindi";
-export const INDONESIAN = "Indonesian";
-export const ITALIAN = "Italian";
-export const JAPANESE = "Japanese";
-export const KOREAN = "Korean";
-export const NORWEGIAN = "Norwegian";
-export const POLISH = "Polish";
-export const PORTUGUESE = "Portuguese";
-export const RUSSIAN = "Russian";
-export const SIMPLIFIED_CHINESE = "Simplified Chinese";
-export const SPANISH = "Spanish";
-export const SWEDISH = "Swedish";
-export const THAI = "Thai";
-export const TRADITIONAL_CHINESE = "Traditional Chinese";
-export const TURKISH = "Turkish";
-export const VIETNAMESE = "Vietnamese";
-
-export const LANGUAGES = [
-  ARABIC,
-  DANISH,
-  DUTCH,
-  ENGLISH,
-  FINNISH,
-  FRENCH,
-  GERMAN,
-  HINDI,
-  INDONESIAN,
-  ITALIAN,
-  JAPANESE,
-  KOREAN,
-  NORWEGIAN,
-  POLISH,
-  PORTUGUESE,
-  RUSSIAN,
-  SIMPLIFIED_CHINESE,
-  SPANISH,
-  SWEDISH,
-  THAI,
-  TRADITIONAL_CHINESE,
-  TURKISH,
-  VIETNAMESE,
-] as const;
-
-export type Language = (typeof LANGUAGES)[number];
-
-const LANGUAGE_TAGS = new Map<Language, string>([
-  [ARABIC, "ar"],
-  [DANISH, "da"],
-  [DUTCH, "nl"],
-  [ENGLISH, "en"],
-  [FINNISH, "fi"],
-  [FRENCH, "fr"],
-  [GERMAN, "de"],
-  [HINDI, "hi"],
-  [INDONESIAN, "id"],
-  [ITALIAN, "it"],
-  [JAPANESE, "ja"],
-  [KOREAN, "ko"],
-  [NORWEGIAN, "no"],
-  [POLISH, "pl"],
-  [PORTUGUESE, "pt"],
-  [RUSSIAN, "ru"],
-  [SIMPLIFIED_CHINESE, "zh-CN"],
-  [SPANISH, "es"],
-  [SWEDISH, "sv"],
-  [THAI, "th"],
-  [TRADITIONAL_CHINESE, "zh-TW"],
-  [TURKISH, "tr"],
-  [VIETNAMESE, "vi"],
-]);
-
-const LANGUAGE_DETECTION_CODES = new Map<Language, string>([
-  [ARABIC, "ar"],
-  [DANISH, "da"],
-  [DUTCH, "nl"],
-  [ENGLISH, "en"],
-  [FINNISH, "fi"],
-  [FRENCH, "fr"],
-  [GERMAN, "de"],
-  [HINDI, "hi"],
-  [INDONESIAN, "id"],
-  [ITALIAN, "it"],
-  [JAPANESE, "ja"],
-  [KOREAN, "ko"],
-  [NORWEGIAN, "no"],
-  [POLISH, "pl"],
-  [PORTUGUESE, "pt"],
-  [RUSSIAN, "ru"],
-  [SIMPLIFIED_CHINESE, "zh"],
-  [SPANISH, "es"],
-  [SWEDISH, "sv"],
-  [THAI, "th"],
-  [TRADITIONAL_CHINESE, "zh"],
-  [TURKISH, "tr"],
-  [VIETNAMESE, "vi"],
-]);
-
-export function getLanguageTag(language: Language): string {
-  return LANGUAGE_TAGS.get(language) ?? "";
+export enum Language {
+  Arabic = "Arabic",
+  Danish = "Danish",
+  Dutch = "Dutch",
+  English = "English",
+  Finnish = "Finnish",
+  French = "French",
+  German = "German",
+  Hindi = "Hindi",
+  Indonesian = "Indonesian",
+  Italian = "Italian",
+  Japanese = "Japanese",
+  Korean = "Korean",
+  Norwegian = "Norwegian",
+  Polish = "Polish",
+  Portuguese = "Portuguese",
+  Russian = "Russian",
+  SimplifiedChinese = "Simplified Chinese",
+  Spanish = "Spanish",
+  Swedish = "Swedish",
+  Thai = "Thai",
+  TraditionalChinese = "Traditional Chinese",
+  Turkish = "Turkish",
+  Vietnamese = "Vietnamese",
 }
 
-export function getLanguageDetectionCode(language: Language): string {
-  return LANGUAGE_DETECTION_CODES.get(language) ?? "";
-}

--- a/src/common/language.ts
+++ b/src/common/language.ts
@@ -23,4 +23,3 @@ export enum Language {
   Turkish = "Turkish",
   Vietnamese = "Vietnamese",
 }
-

--- a/src/common/tinyld-language.ts
+++ b/src/common/tinyld-language.ts
@@ -1,0 +1,68 @@
+import { detect, validateISO2 } from "tinyld";
+
+import { Language } from "./language.js";
+
+const LANGUAGE_DETECTION_CODES = {
+  [Language.Arabic]: "ar",
+  [Language.Danish]: "da",
+  [Language.Dutch]: "nl",
+  [Language.English]: "en",
+  [Language.Finnish]: "fi",
+  [Language.French]: "fr",
+  [Language.German]: "de",
+  [Language.Hindi]: "hi",
+  [Language.Indonesian]: "id",
+  [Language.Italian]: "it",
+  [Language.Japanese]: "ja",
+  [Language.Korean]: "ko",
+  [Language.Norwegian]: "no",
+  [Language.Polish]: "pl",
+  [Language.Portuguese]: "pt",
+  [Language.Russian]: "ru",
+  [Language.SimplifiedChinese]: "zh",
+  [Language.Spanish]: "es",
+  [Language.Swedish]: "sv",
+  [Language.Thai]: "th",
+  [Language.TraditionalChinese]: "zh",
+  [Language.Turkish]: "tr",
+  [Language.Vietnamese]: "vi",
+} satisfies Record<Language, string>;
+
+export function detectLanguageCode(text: string): string | undefined {
+  const normalizedText = text.trim();
+
+  if (normalizedText === "") {
+    return undefined;
+  }
+
+  try {
+    return normalizeLanguageCode(detect(normalizedText));
+  } catch {
+    return undefined;
+  }
+}
+
+export function getLanguageDetectionCode(language: Language): string {
+  return LANGUAGE_DETECTION_CODES[language];
+}
+
+function normalizeLanguageCode(languageCode: string): string | undefined {
+  const normalizedLanguageCode = languageCode.trim().toLowerCase();
+  const directLanguageCode = validateISO2(normalizedLanguageCode);
+
+  if (directLanguageCode !== "") {
+    return directLanguageCode;
+  }
+
+  const baseLanguageCode = normalizedLanguageCode.split("-")[0];
+
+  if (baseLanguageCode === undefined) {
+    return undefined;
+  }
+
+  const validatedBaseLanguageCode = validateISO2(baseLanguageCode);
+
+  return validatedBaseLanguageCode === ""
+    ? undefined
+    : validatedBaseLanguageCode;
+}

--- a/src/editor/language-review.ts
+++ b/src/editor/language-review.ts
@@ -1,6 +1,8 @@
-import { detect, validateISO2 } from "tinyld";
-
-import { getLanguageDetectionCode, type Language } from "../common/language.js";
+import {
+  detectLanguageCode,
+  getLanguageDetectionCode,
+} from "../common/tinyld-language.js";
+import { type Language } from "../common/language.js";
 import { ReviewSeverity, type ReviewResult } from "./types.js";
 
 export interface LanguageReview {
@@ -18,10 +20,6 @@ export function checkOutputLanguage(input: {
   }
 
   const targetLanguageCode = getLanguageDetectionCode(input.userLanguage);
-
-  if (targetLanguageCode === "") {
-    return undefined;
-  }
 
   const detectedLanguageCode = detectLanguageCode(input.compressedText);
 
@@ -47,39 +45,4 @@ export function checkOutputLanguage(input: {
     },
     targetLanguageCode,
   };
-}
-
-function detectLanguageCode(text: string): string | undefined {
-  const normalizedText = text.trim();
-
-  if (normalizedText === "") {
-    return undefined;
-  }
-
-  try {
-    return normalizeLanguageCode(detect(normalizedText));
-  } catch {
-    return undefined;
-  }
-}
-
-function normalizeLanguageCode(languageCode: string): string | undefined {
-  const normalizedLanguageCode = languageCode.trim().toLowerCase();
-  const directLanguageCode = validateISO2(normalizedLanguageCode);
-
-  if (directLanguageCode !== "") {
-    return directLanguageCode;
-  }
-
-  const baseLanguageCode = normalizedLanguageCode.split("-")[0];
-
-  if (baseLanguageCode === undefined) {
-    return undefined;
-  }
-
-  const validatedBaseLanguageCode = validateISO2(baseLanguageCode);
-
-  return validatedBaseLanguageCode === ""
-    ? undefined
-    : validatedBaseLanguageCode;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { LANGUAGES, type Language } from "./common/language.js";
+export { Language } from "./common/language.js";
 export {
   type DigestProgressEvent,
   type SerialDiscoveryItem,

--- a/src/reader/chunk-batch/language.ts
+++ b/src/reader/chunk-batch/language.ts
@@ -1,9 +1,8 @@
-import { detect, validateISO2 } from "tinyld";
-
 import {
+  detectLanguageCode,
   getLanguageDetectionCode,
-  type Language,
-} from "../../common/language.js";
+} from "../../common/tinyld-language.js";
+import { type Language } from "../../common/language.js";
 
 export function needsTranslation(input: {
   content: string;
@@ -33,39 +32,4 @@ function fieldNeedsTranslation(
   }
 
   return detectedLanguageCode !== targetLanguageCode;
-}
-
-function detectLanguageCode(text: string): string | undefined {
-  const normalizedText = text.trim();
-
-  if (normalizedText === "") {
-    return undefined;
-  }
-
-  try {
-    return validateLanguageCode(detect(normalizedText));
-  } catch {
-    return undefined;
-  }
-}
-
-function validateLanguageCode(languageCode: string): string | undefined {
-  const normalizedLanguageCode = languageCode.trim().toLowerCase();
-  const directLanguageCode = validateISO2(normalizedLanguageCode);
-
-  if (directLanguageCode !== "") {
-    return directLanguageCode;
-  }
-
-  const baseLanguageCode = normalizedLanguageCode.split("-")[0];
-
-  if (baseLanguageCode === undefined) {
-    return undefined;
-  }
-
-  const validatedBaseLanguageCode = validateISO2(baseLanguageCode);
-
-  return validatedBaseLanguageCode === ""
-    ? undefined
-    : validatedBaseLanguageCode;
 }

--- a/test/common/language.test.ts
+++ b/test/common/language.test.ts
@@ -1,24 +1,19 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  ENGLISH,
-  LANGUAGES,
-  SIMPLIFIED_CHINESE,
-  getLanguageDetectionCode,
-  getLanguageTag,
-} from "../../src/common/language.js";
+import { Language } from "../../src/common/language.js";
+import { getLanguageDetectionCode } from "../../src/common/tinyld-language.js";
 
 describe("common/language", () => {
   it("exposes a stable language list", () => {
-    expect(LANGUAGES).toContain(ENGLISH);
-    expect(LANGUAGES).toContain(SIMPLIFIED_CHINESE);
-    expect(new Set(LANGUAGES).size).toBe(LANGUAGES.length);
+    const languages = Object.values(Language);
+
+    expect(languages).toContain(Language.English);
+    expect(languages).toContain(Language.SimplifiedChinese);
+    expect(new Set(languages).size).toBe(languages.length);
   });
 
-  it("maps languages to tags and detection codes", () => {
-    expect(getLanguageTag(ENGLISH)).toBe("en");
-    expect(getLanguageTag(SIMPLIFIED_CHINESE)).toBe("zh-CN");
-    expect(getLanguageDetectionCode(ENGLISH)).toBe("en");
-    expect(getLanguageDetectionCode(SIMPLIFIED_CHINESE)).toBe("zh");
+  it("maps languages to detection codes", () => {
+    expect(getLanguageDetectionCode(Language.English)).toBe("en");
+    expect(getLanguageDetectionCode(Language.SimplifiedChinese)).toBe("zh");
   });
 });

--- a/test/editor/editor.test.ts
+++ b/test/editor/editor.test.ts
@@ -18,6 +18,7 @@ import {
   SPINE_DIGEST_EDITOR_SCOPES,
   SpineDigestScope,
 } from "../../src/common/llm-scope.js";
+import { Language } from "../../src/common/language.js";
 import type {
   ChunkRecord,
   FragmentGroupRecord,
@@ -133,7 +134,7 @@ describe("editor/editor", () => {
       maxIterations: 3,
       scopes: SPINE_DIGEST_EDITOR_SCOPES,
       serialId: 1,
-      userLanguage: "English",
+      userLanguage: Language.English,
       workspace: document,
     });
 

--- a/test/editor/language-review.test.ts
+++ b/test/editor/language-review.test.ts
@@ -12,6 +12,7 @@ vi.mock("tinyld", () => ({
 
 import { checkOutputLanguage } from "../../src/editor/language-review.js";
 import { ReviewSeverity } from "../../src/editor/types.js";
+import { Language } from "../../src/common/language.js";
 
 describe("editor/language-review", () => {
   beforeEach(() => {
@@ -28,7 +29,7 @@ describe("editor/language-review", () => {
     expect(
       checkOutputLanguage({
         compressedText: "English summary",
-        userLanguage: "English",
+        userLanguage: Language.English,
       }),
     ).toBeUndefined();
   });
@@ -38,7 +39,7 @@ describe("editor/language-review", () => {
 
     const result = checkOutputLanguage({
       compressedText: "こんにちは世界",
-      userLanguage: "English",
+      userLanguage: Language.English,
     });
 
     expect(result).toMatchObject({

--- a/test/editor/log.test.ts
+++ b/test/editor/log.test.ts
@@ -2,6 +2,7 @@ import { readdir, readFile } from "fs/promises";
 
 import { describe, expect, it } from "vitest";
 
+import { Language } from "../../src/common/language.js";
 import { ChunkRetention, type ChunkRecord } from "../../src/document/index.js";
 import { CompressionLog } from "../../src/editor/log.js";
 import { ReviewSeverity } from "../../src/editor/types.js";
@@ -28,7 +29,7 @@ describe("editor/log", () => {
         weight: 1,
       },
       targetLanguageCode: "en",
-      userLanguage: "English",
+      userLanguage: Language.English,
     });
     await log.appendFinalSelection(
       {
@@ -83,7 +84,7 @@ describe("editor/log", () => {
           weight: 1,
         },
         targetLanguageCode: "en",
-        userLanguage: "English",
+        userLanguage: Language.English,
       });
       await log.appendFinalSelection(
         {

--- a/test/editor/review.test.ts
+++ b/test/editor/review.test.ts
@@ -4,6 +4,7 @@ import {
   SPINE_DIGEST_EDITOR_SCOPES,
   SpineDigestScope,
 } from "../../src/common/llm-scope.js";
+import { Language } from "../../src/common/language.js";
 import type { ReadonlySerialFragments } from "../../src/document/index.js";
 import type { ChunkRecord, FragmentRecord } from "../../src/document/types.js";
 import {
@@ -25,7 +26,7 @@ describe("editor/review", () => {
         review: SPINE_DIGEST_EDITOR_SCOPES.review,
         reviewGuide: SPINE_DIGEST_EDITOR_SCOPES.reviewGuide,
       },
-      "English",
+      Language.English,
     );
 
     const reviewers = await reviewer.generateClueReviewers([
@@ -59,7 +60,7 @@ describe("editor/review", () => {
         review: SPINE_DIGEST_EDITOR_SCOPES.review,
         reviewGuide: SPINE_DIGEST_EDITOR_SCOPES.reviewGuide,
       },
-      "English",
+      Language.English,
     );
 
     const result = await reviewer.reviewCompression(

--- a/test/facade/app.test.ts
+++ b/test/facade/app.test.ts
@@ -50,7 +50,7 @@ vi.mock("../../src/facade/digest.js", () => ({
 import { SpineDigestScope } from "../../src/common/llm-scope.js";
 import { DirectoryDocument } from "../../src/document/index.js";
 import { SpineDigest } from "../../src/facade/spine-digest.js";
-import { SpineDigestApp } from "../../src/index.js";
+import { Language, SpineDigestApp } from "../../src/index.js";
 import { withTempDir } from "../helpers/temp.js";
 
 describe("facade/app", () => {
@@ -93,7 +93,7 @@ describe("facade/app", () => {
         extractionPrompt: "   ",
         onProgress,
         path: "/tmp/source.txt",
-        userLanguage: "Simplified Chinese",
+        userLanguage: Language.SimplifiedChinese,
       },
       () => "done",
     );
@@ -134,7 +134,7 @@ describe("facade/app", () => {
     expect(digestCall.logDirPath).toBe("/tmp/spinedigest-debug");
     expect(digestCall.onProgress).toBe(onProgress);
     expect(digestCall.path).toBe("/tmp/source.txt");
-    expect(digestCall.userLanguage).toBe("Simplified Chinese");
+    expect(digestCall.userLanguage).toBe(Language.SimplifiedChinese);
     expect(digestCall.llm).toBeTruthy();
     expect(digestCall.extractionPrompt).toContain(
       "main storyline and key character developments",
@@ -162,7 +162,7 @@ describe("facade/app", () => {
         sourceFormat: "markdown",
         stream: ["alpha", "beta"],
         title: "  Session Title  ",
-        userLanguage: "English",
+        userLanguage: Language.English,
       },
       () => undefined,
     );
@@ -215,7 +215,7 @@ describe("facade/app", () => {
     expect(digestCall.sourceFormat).toBe("markdown");
     expect(digestCall.stream).toStrictEqual(["alpha", "beta"]);
     expect(digestCall.title).toBe("  Session Title  ");
-    expect(digestCall.userLanguage).toBe("English");
+    expect(digestCall.userLanguage).toBe(Language.English);
     expect(digestCall.extractionPrompt).toBe("Keep dialogue only");
   });
 

--- a/test/facade/digest.test.ts
+++ b/test/facade/digest.test.ts
@@ -131,6 +131,7 @@ import {
   digestTextStreamSession,
   digestTxtSession,
 } from "../../src/facade/digest.js";
+import { Language } from "../../src/common/language.js";
 import { withTempDir } from "../helpers/temp.js";
 
 describe("facade/digest", () => {
@@ -148,7 +149,7 @@ describe("facade/digest", () => {
         llm: {} as never,
         stream: ["alpha ", "beta"],
         title: "  Digest Title  ",
-        userLanguage: "Simplified Chinese",
+        userLanguage: Language.SimplifiedChinese,
       },
       async (digest) => {
         expect(await digest.readMeta()).toMatchObject({
@@ -176,7 +177,7 @@ describe("facade/digest", () => {
       {
         options: {
           extractionPrompt: "Keep beats",
-          userLanguage: "Simplified Chinese",
+          userLanguage: Language.SimplifiedChinese,
         },
         serialId: 1,
         streamText: "alpha beta",
@@ -306,7 +307,7 @@ describe("facade/digest", () => {
           extractionPrompt: "Prompt",
           llm: {} as never,
           path: "/tmp/book.epub",
-          userLanguage: "Japanese",
+          userLanguage: Language.Japanese,
         },
         async (digest) => {
           return (await digest.readMeta())?.title;
@@ -345,7 +346,7 @@ describe("facade/digest", () => {
         adapterFormat: "epub",
         extractionPrompt: "Prompt",
         path: "/tmp/book.epub",
-        userLanguage: "Japanese",
+        userLanguage: Language.Japanese,
       });
       expect(digestMockState.importCalls[0]?.documentPath).toContain("/epub");
       expect(digestMockState.importCalls[1]).toMatchObject({

--- a/test/facade/import.test.ts
+++ b/test/facade/import.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { Language } from "../../src/common/language.js";
 import { DirectoryDocument } from "../../src/document/index.js";
 import type { SourceDocument } from "../../src/source/adapter.js";
 import { createDigestProgressTracker } from "../../src/progress/index.js";
@@ -112,7 +113,7 @@ describe("facade/import", () => {
           document,
           extractionPrompt: "Keep key beats",
           llm: {} as never,
-          userLanguage: "Simplified Chinese",
+          userLanguage: Language.SimplifiedChinese,
         });
 
         expect(imported.meta).toBe(meta);
@@ -152,7 +153,7 @@ describe("facade/import", () => {
           {
             options: {
               extractionPrompt: "Keep key beats",
-              userLanguage: "Simplified Chinese",
+              userLanguage: Language.SimplifiedChinese,
             },
             serialId: 1,
             streamText: "Nested summary",
@@ -160,7 +161,7 @@ describe("facade/import", () => {
           {
             options: {
               extractionPrompt: "Keep key beats",
-              userLanguage: "Simplified Chinese",
+              userLanguage: Language.SimplifiedChinese,
             },
             serialId: 2,
             streamText: "Second summary",

--- a/test/hello-world.test.ts
+++ b/test/hello-world.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { LANGUAGES } from "../src/index.js";
+import { Language } from "../src/index.js";
 
 describe("test framework", () => {
   it("runs a hello world smoke test", () => {
-    expect(LANGUAGES).toContain("English");
+    expect(Object.values(Language)).toContain(Language.English);
   });
 });

--- a/test/reader/chunk-batch/extractor.test.ts
+++ b/test/reader/chunk-batch/extractor.test.ts
@@ -14,6 +14,7 @@ import {
   SPINE_DIGEST_READER_SCOPES,
   SpineDigestScope,
 } from "../../../src/common/llm-scope.js";
+import { Language } from "../../../src/common/language.js";
 import { ChunkImportance } from "../../../src/document/index.js";
 import { ChunkExtractor } from "../../../src/reader/chunk-batch/extractor.js";
 import {
@@ -271,7 +272,7 @@ describe("reader/chunk-batch/extractor", () => {
       sentenceTextSource: {
         getSentence: (sentenceId) => Promise.resolve(sentenceId.join(":")),
       },
-      userLanguage: "English",
+      userLanguage: Language.English,
     });
 
     const result = await extractor.extractUserFocused({
@@ -323,7 +324,7 @@ describe("reader/chunk-batch/extractor", () => {
       sentenceTextSource: {
         getSentence: (sentenceId) => Promise.resolve(sentenceId.join(":")),
       },
-      userLanguage: "English",
+      userLanguage: Language.English,
     });
 
     const result = await extractor.extractUserFocused({
@@ -390,7 +391,7 @@ describe("reader/chunk-batch/extractor", () => {
       sentenceTextSource: {
         getSentence: (sentenceId) => Promise.resolve(sentenceId.join(":")),
       },
-      userLanguage: "English",
+      userLanguage: Language.English,
     });
 
     const result = await extractor.extractUserFocused({

--- a/test/reader/reader.test.ts
+++ b/test/reader/reader.test.ts
@@ -24,6 +24,7 @@ import {
   SPINE_DIGEST_READER_SCOPES,
   SpineDigestScope,
 } from "../../src/common/llm-scope.js";
+import { Language } from "../../src/common/language.js";
 import { ChunkImportance, ChunkRetention } from "../../src/document/index.js";
 import type {
   SentenceStreamAdapter,
@@ -142,7 +143,7 @@ describe("reader/reader", () => {
           choice: SpineDigestScope.ReaderChoice,
           extraction: SpineDigestScope.ReaderExtraction,
         },
-        userLanguage: "English",
+        userLanguage: Language.English,
       }),
       {
         sentences: [
@@ -249,7 +250,7 @@ function createReader(input?: { readonly segmenter?: SentenceStreamAdapter }) {
     sentenceTextSource: {
       getSentence: (sentenceId) => Promise.resolve(sentenceId.join(":")),
     },
-    userLanguage: "English",
+    userLanguage: Language.English,
     ...(input?.segmenter === undefined
       ? {}
       : {


### PR DESCRIPTION
## Summary
- replace the public language string union helpers with a single exported `Language` enum
- move tinyld-specific detection and normalization into a dedicated common adapter
- update tests to use enum values directly instead of a duplicated language list

## Testing
- pnpm typecheck
- pnpm test:run test/common/language.test.ts test/hello-world.test.ts test/editor/language-review.test.ts test/reader/chunk-batch/extractor.test.ts