### PR TITLE
fix: restore fragment-to-fragment topology continuity

### DIFF
--- a/docs/fragment-sizing.md
+++ b/docs/fragment-sizing.md
@@ -1,0 +1,12 @@
+# Fragment Sizing Units
+
+The reader and topology pipeline currently applies fragment, snake, and group
+limits with `wordsCount`, not tokenizer token counts.
+
+That difference is semantically significant. Token-based thresholds must not be
+copied directly into `wordsCount`-based thresholds as if they were equivalent.
+Doing so materially changes fragment boundaries, attention generations, graph
+connectivity, and the final snake structure.
+
+Any change between token-based sizing and `wordsCount`-based sizing should be
+treated as a behavior change and revalidated with topology-level outputs.

--- a/src/reader/attention/attention.ts
+++ b/src/reader/attention/attention.ts
@@ -45,8 +45,12 @@ export class Attention {
   public createChunkBatchContext(input?: {
     includeCurrentFragment?: boolean;
   }): ChunkBatchContext {
+    const chunks = this.#workingMemory.getChunksForPrompt(
+      input?.includeCurrentFragment ?? true,
+    );
+
     return {
-      visibleChunkIds: this.#workingMemory.getChunks().map((chunk) => chunk.id),
+      visibleChunkIds: chunks.map((chunk) => chunk.id),
       workingMemoryPrompt: this.#workingMemory.formatForPrompt(
         input?.includeCurrentFragment ?? true,
       ),
@@ -72,9 +76,8 @@ export class Attention {
     allChunks: readonly CognitiveChunk[];
     getSuccessorChunkIds: (chunkId: number) => readonly number[];
   }): void {
-    const latestChunkIds = this.#workingMemory
-      .getAllChunksForSaving()
-      .map((chunk) => chunk.id);
+    const previousFragmentChunks = this.#workingMemory.getAllChunksForSaving();
+    const latestChunkIds = previousFragmentChunks.map((chunk) => chunk.id);
     const extraChunks = this.#waveReflection.selectTopChunks({
       allChunks: input.allChunks,
       capacity: this.#workingMemory.capacity,
@@ -82,7 +85,10 @@ export class Attention {
       latestChunkIds,
     });
 
-    this.#workingMemory.setExtraChunks(extraChunks);
+    this.#workingMemory.setRetainedChunks({
+      extraChunks,
+      previousFragmentChunks,
+    });
     this.#workingMemory.finalizeFragment();
   }
 

--- a/src/reader/attention/working-memory.ts
+++ b/src/reader/attention/working-memory.ts
@@ -3,6 +3,7 @@ import type { CognitiveChunk } from "../chunk-batch/types.js";
 export class WorkingMemory {
   readonly #capacity: number;
   readonly #currentFragmentChunks: CognitiveChunk[] = [];
+  readonly #previousFragmentChunks: CognitiveChunk[] = [];
   readonly #extraChunks: CognitiveChunk[] = [];
   #generation = 0;
 
@@ -22,8 +23,16 @@ export class WorkingMemory {
     this.#currentFragmentChunks.push(...chunks);
   }
 
-  public setExtraChunks(extraChunks: readonly CognitiveChunk[]): void {
-    this.#extraChunks.splice(0, this.#extraChunks.length, ...extraChunks);
+  public setRetainedChunks(input: {
+    readonly extraChunks: readonly CognitiveChunk[];
+    readonly previousFragmentChunks: readonly CognitiveChunk[];
+  }): void {
+    this.#previousFragmentChunks.splice(
+      0,
+      this.#previousFragmentChunks.length,
+      ...input.previousFragmentChunks,
+    );
+    this.#extraChunks.splice(0, this.#extraChunks.length, ...input.extraChunks);
   }
 
   public finalizeFragment(): CognitiveChunk[] {
@@ -36,49 +45,38 @@ export class WorkingMemory {
   }
 
   public getChunks(): CognitiveChunk[] {
-    return [...this.#currentFragmentChunks, ...this.#extraChunks];
+    return [
+      ...this.#currentFragmentChunks,
+      ...this.#previousFragmentChunks,
+      ...this.#extraChunks,
+    ];
   }
 
   public getAllChunksForSaving(): CognitiveChunk[] {
     return [...this.#currentFragmentChunks];
   }
 
-  public formatForPrompt(includeCurrentFragment = true): string {
-    const chunks = includeCurrentFragment
+  public getChunksForPrompt(includeCurrentFragment = true): CognitiveChunk[] {
+    return includeCurrentFragment
       ? this.getChunks()
-      : [...this.#extraChunks];
+      : [...this.#previousFragmentChunks, ...this.#extraChunks];
+  }
+
+  public formatForPrompt(includeCurrentFragment = true): string {
+    const chunks = this.getChunksForPrompt(includeCurrentFragment);
 
     if (chunks.length === 0) {
       return "(empty)";
     }
 
-    const sortedChunks = [...chunks].sort((left, right) => {
-      if (left.generation !== right.generation) {
-        return left.generation - right.generation;
-      }
-
-      if (left.sentenceId[0] !== right.sentenceId[0]) {
-        return left.sentenceId[0] - right.sentenceId[0];
-      }
-
-      if (left.sentenceId[1] !== right.sentenceId[1]) {
-        return left.sentenceId[1] - right.sentenceId[1];
-      }
-
-      if (left.sentenceId[2] !== right.sentenceId[2]) {
-        return left.sentenceId[2] - right.sentenceId[2];
-      }
-
-      return left.id - right.id;
-    });
-
-    return sortedChunks
+    return chunks
       .map((chunk) => `${chunk.id}. [${chunk.label}] - ${chunk.content}`)
       .join("\n");
   }
 
   public clear(): void {
     this.#currentFragmentChunks.splice(0, this.#currentFragmentChunks.length);
+    this.#previousFragmentChunks.splice(0, this.#previousFragmentChunks.length);
     this.#extraChunks.splice(0, this.#extraChunks.length);
   }
 }

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -39,9 +39,9 @@ import { compressText, type EditorOptions } from "./editor/index.js";
 import { Topology } from "./topology/index.js";
 
 const DEFAULT_COMPRESSION_RATIO = 0.2;
-const DEFAULT_FRAGMENT_WORDS_COUNT = 800;
+const DEFAULT_FRAGMENT_WORDS_COUNT = 320;
 const DEFAULT_GENERATION_DECAY_FACTOR = 0.5;
-const DEFAULT_GROUP_WORDS_COUNT = 9600;
+const DEFAULT_GROUP_WORDS_COUNT = 3840;
 const DEFAULT_MAX_CLUES = 10;
 const DEFAULT_MAX_ITERATIONS = 5;
 const DEFAULT_WORKING_MEMORY_CAPACITY = 7;

--- a/src/topology/snake-detector.ts
+++ b/src/topology/snake-detector.ts
@@ -3,7 +3,7 @@ import { getKnowledgeEdgeKey } from "./weights.js";
 
 const ATTRIBUTE_BONUS_WEIGHT = 3;
 const DEFAULT_LINK_STRENGTH_WEIGHT = 1;
-const DEFAULT_SNAKE_WORDS_COUNT = 700;
+const DEFAULT_SNAKE_WORDS_COUNT = 280;
 const DECAY_FACTOR = 0.75;
 const MIN_EDGE_WEIGHT = 0.1;
 

--- a/src/topology/topology.ts
+++ b/src/topology/topology.ts
@@ -17,7 +17,7 @@ import {
   getKnowledgeEdgeKey,
 } from "./weights.js";
 
-const DEFAULT_SNAKE_WORDS_COUNT = 700;
+const DEFAULT_SNAKE_WORDS_COUNT = 280;
 
 export class Topology {
   readonly #chunkIds: number[] = [];

--- a/test/reader/attention.test.ts
+++ b/test/reader/attention.test.ts
@@ -55,7 +55,7 @@ describe("reader/attention", () => {
     });
   });
 
-  it("retains reflected historical chunks after fragment completion and clears them", async () => {
+  it("keeps the previous fragment visible for one round and also retains reflected history", async () => {
     const attention = new Attention(2, 1, createIdGenerator([10, 11]));
 
     const firstDelta = await attention.acceptChunkBatch({
@@ -83,8 +83,11 @@ describe("reader/attention", () => {
     });
 
     expect(attention.createChunkBatchContext()).toStrictEqual({
-      visibleChunkIds: [10],
-      workingMemoryPrompt: "10. [Earlier] - Earlier content",
+      visibleChunkIds: [11, 10],
+      workingMemoryPrompt: [
+        "11. [Latest] - Latest content",
+        "10. [Earlier] - Earlier content",
+      ].join("\n"),
     });
 
     attention.clear();
@@ -94,6 +97,36 @@ describe("reader/attention", () => {
       workingMemoryPrompt: "(empty)",
     });
   });
+
+  it("keeps all latest chunks even when they exceed capacity", async () => {
+    const attention = new Attention(2, 1, createIdGenerator([10, 11, 12]));
+
+    const firstDelta = await attention.acceptChunkBatch({
+      chunks: [
+        createChunk(0, 0, [1, 0, 0], "Alpha", "Alpha content"),
+        createChunk(0, 0, [1, 0, 1], "Beta", "Beta content"),
+        createChunk(0, 0, [1, 0, 2], "Gamma", "Gamma content"),
+      ],
+      links: [],
+      orderCorrect: true,
+      tempIds: ["temp-a", "temp-b", "temp-c"],
+    });
+
+    attention.completeFragment({
+      allChunks: firstDelta.chunks,
+      getSuccessorChunkIds: () => [],
+    });
+
+    expect(attention.createChunkBatchContext()).toStrictEqual({
+      visibleChunkIds: [10, 11, 12],
+      workingMemoryPrompt: [
+        "10. [Alpha] - Alpha content",
+        "11. [Beta] - Beta content",
+        "12. [Gamma] - Gamma content",
+      ].join("\n"),
+    });
+  });
+
 });
 
 function createChunk(

--- a/test/reader/attention.test.ts
+++ b/test/reader/attention.test.ts
@@ -126,7 +126,6 @@ describe("reader/attention", () => {
       ].join("\n"),
     });
   });
-
 });
 
 function createChunk(

--- a/test/reader/reader.test.ts
+++ b/test/reader/reader.test.ts
@@ -20,11 +20,11 @@ vi.mock("../../src/reader/segment/segment.js", () => ({
 }));
 
 import { Reader } from "../../src/reader/reader.js";
+import { Language } from "../../src/common/language.js";
 import {
   SPINE_DIGEST_READER_SCOPES,
   SpineDigestScope,
 } from "../../src/common/llm-scope.js";
-import { Language } from "../../src/common/language.js";
 import { ChunkImportance, ChunkRetention } from "../../src/document/index.js";
 import type {
   SentenceStreamAdapter,
@@ -183,7 +183,7 @@ describe("reader/reader", () => {
         ],
         text: "Beta sentence.",
         userFocusedChunks: userFocused.delta.chunks,
-        visibleChunkIds: [1],
+        visibleChunkIds: [],
         workingMemoryPrompt: "(empty)",
       },
     );
@@ -201,6 +201,11 @@ describe("reader/reader", () => {
         importance: ChunkImportance.Important,
       },
     ]);
+
+    reader.completeFragment({
+      allChunks: [...userFocused.delta.chunks, ...coherenceDelta.chunks],
+      getSuccessorChunkIds: (chunkId) => (chunkId === 1 ? [2] : []),
+    });
 
     reader.clear();
 
@@ -233,6 +238,113 @@ describe("reader/reader", () => {
     );
     expect(afterClear.delta.chunks.map((chunk) => chunk.id)).toStrictEqual([3]);
   });
+
+  it("shows the previous fragment to the next fragment user-focused stage", async () => {
+    extractUserFocusedChunkBatchMock
+      .mockResolvedValueOnce({
+        chunkBatch: {
+          chunks: [
+            createChunk(0, 0, [1, 0, 0], "Alpha", "Alpha content", {
+              retention: ChunkRetention.Focused,
+            }),
+          ],
+          links: [],
+          orderCorrect: true,
+          tempIds: ["temp-a"],
+        },
+        fragmentSummary: "Fragment summary",
+      })
+      .mockResolvedValueOnce({
+        chunkBatch: {
+          chunks: [
+            createChunk(0, 0, [1, 1, 0], "Gamma", "Gamma content", {
+              retention: ChunkRetention.Relevant,
+            }),
+          ],
+          links: [],
+          orderCorrect: true,
+          tempIds: ["temp-c"],
+        },
+        fragmentSummary: "Next fragment",
+      });
+    extractBookCoherenceChunkBatchMock
+      .mockResolvedValueOnce({
+        chunks: [
+          createChunk(0, 0, [1, 0, 1], "Beta", "Beta content", {
+            importance: ChunkImportance.Important,
+          }),
+        ],
+        links: [],
+        orderCorrect: true,
+        tempIds: ["temp-b"],
+      })
+      .mockResolvedValueOnce({
+        chunks: [],
+        links: [],
+        orderCorrect: true,
+        tempIds: [],
+      });
+
+    const reader = createReader();
+    const firstUserFocused = await reader.extractUserFocused({
+      sentences: [
+        {
+          sentenceId: [1, 0, 0],
+          text: "Alpha sentence.",
+          wordsCount: 2,
+        },
+      ],
+      text: "Alpha sentence.",
+    });
+    const firstCoherence = await reader.extractBookCoherence({
+      sentences: [
+        {
+          sentenceId: [1, 0, 1],
+          text: "Beta sentence.",
+          wordsCount: 3,
+        },
+      ],
+      text: "Beta sentence.",
+      userFocusedChunks: firstUserFocused.delta.chunks,
+    });
+
+    reader.completeFragment({
+      allChunks: [...firstUserFocused.delta.chunks, ...firstCoherence.chunks],
+      getSuccessorChunkIds: (chunkId) => (chunkId === 1 ? [2] : []),
+    });
+
+    await reader.extractUserFocused({
+      sentences: [
+        {
+          sentenceId: [1, 1, 0],
+          text: "Gamma sentence.",
+          wordsCount: 4,
+        },
+      ],
+      text: "Gamma sentence.",
+    });
+
+    expect(extractUserFocusedChunkBatchMock).toHaveBeenNthCalledWith(
+      2,
+      expect.any(Object),
+      {
+        sentences: [
+          {
+            sentenceId: [1, 1, 0],
+            text: "Gamma sentence.",
+            wordsCount: 4,
+          },
+        ],
+        text: "Gamma sentence.",
+        visibleChunkIds: [1, 2],
+        workingMemoryPrompt: [
+          "1. [Alpha] - Alpha content",
+          "2. [Beta] - Beta content",
+        ].join("\n"),
+      },
+    );
+  });
+
 });
 
 function createReader(input?: { readonly segmenter?: SentenceStreamAdapter }) {

--- a/test/reader/reader.test.ts
+++ b/test/reader/reader.test.ts
@@ -344,7 +344,6 @@ describe("reader/reader", () => {
       },
     );
   });
-
 });
 
 function createReader(input?: { readonly segmenter?: SentenceStreamAdapter }) {

--- a/test/reader/working-memory.test.ts
+++ b/test/reader/working-memory.test.ts
@@ -3,45 +3,56 @@ import { describe, expect, it } from "vitest";
 import { WorkingMemory } from "../../src/reader/attention/working-memory.js";
 
 describe("reader/working-memory", () => {
-  it("formats current and extra chunks in stable prompt order", () => {
+  it("formats current, previous, and retained chunks in prompt order", () => {
     const memory = new WorkingMemory(3);
 
     memory.addChunks([
       createChunk(7, 1, [1, 1, 0], "Later", "Later content"),
       createChunk(3, 0, [1, 0, 1], "Earlier", "Earlier content"),
     ]);
-    memory.setExtraChunks([
-      createChunk(5, 0, [1, 0, 0], "Extra", "Extra content"),
-    ]);
+    memory.setRetainedChunks({
+      extraChunks: [createChunk(5, 0, [1, 0, 0], "Extra", "Extra content")],
+      previousFragmentChunks: [
+        createChunk(2, 0, [1, 0, 0], "Previous", "Previous content"),
+      ],
+    });
 
     expect(memory.capacity).toBe(3);
     expect(memory.getChunks().map((chunk) => chunk.id)).toStrictEqual([
-      7, 3, 5,
+      7, 3, 2, 5,
     ]);
     expect(memory.formatForPrompt()).toBe(
       [
-        "5. [Extra] - Extra content",
-        "3. [Earlier] - Earlier content",
         "7. [Later] - Later content",
+        "3. [Earlier] - Earlier content",
+        "2. [Previous] - Previous content",
+        "5. [Extra] - Extra content",
       ].join("\n"),
     );
-    expect(memory.formatForPrompt(false)).toBe("5. [Extra] - Extra content");
+    expect(memory.formatForPrompt(false)).toBe(
+      ["2. [Previous] - Previous content", "5. [Extra] - Extra content"].join(
+        "\n",
+      ),
+    );
   });
 
   it("finalizes fragments, increments generation, and clears all state", () => {
     const memory = new WorkingMemory(2);
 
     memory.addChunks([createChunk(1, 0, [1, 0, 0], "Alpha", "Alpha content")]);
-    memory.setExtraChunks([
-      createChunk(2, 1, [1, 1, 0], "Beta", "Beta content"),
-    ]);
+    memory.setRetainedChunks({
+      extraChunks: [createChunk(2, 1, [1, 1, 0], "Beta", "Beta content")],
+      previousFragmentChunks: [
+        createChunk(3, 0, [1, 0, 2], "Gamma", "Gamma content"),
+      ],
+    });
 
     const finalized = memory.finalizeFragment();
 
     expect(finalized.map((chunk) => chunk.id)).toStrictEqual([1]);
     expect(memory.generation).toBe(1);
     expect(memory.getAllChunksForSaving()).toStrictEqual([]);
-    expect(memory.getChunks().map((chunk) => chunk.id)).toStrictEqual([2]);
+    expect(memory.getChunks().map((chunk) => chunk.id)).toStrictEqual([3, 2]);
 
     memory.clear();
 


### PR DESCRIPTION
## Summary
- retain the previous fragment chunks for one round so the next fragment can still see them
- rescale fragment, snake, and group sizing thresholds for the current `wordsCount` unit
- document that token-based and `wordsCount`-based sizing are not interchangeable

## Testing
- pnpm vitest run test/reader/attention.test.ts test/reader/reader.test.ts test/topology/topology.test.ts test/topology/grouping.test.ts test/topology/fragment-incision.test.ts