### PR TITLE
feat: support CLI prompt override

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm install -g spinedigest
 Digest an EPUB into Markdown:
 
 ```bash
-spinedigest --input ./book.epub --output ./digest.md
+spinedigest --input ./book.epub --output ./digest.md --prompt "Preserve emotional shifts for both major and supporting characters."
 ```
 
 Save a reusable archive first, then export later:

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -37,7 +37,7 @@ npm install -g spinedigest
 把一本 EPUB 摘要成 Markdown：
 
 ```bash
-spinedigest --input ./book.epub --output ./digest.md
+spinedigest --input ./book.epub --output ./digest.md --prompt "重点保留主主角、配角的情绪变化细节"
 ```
 
 先保存归档，之后再导出：

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -9,14 +9,14 @@ SpineDigest is designed to be used from the command line first.
 Installed CLI:
 
 ```bash
-spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--verbose]
+spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--prompt <text>] [--verbose]
 spinedigest sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>]
 ```
 
 From a source checkout:
 
 ```bash
-pnpm dev -- [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--verbose]
+pnpm dev -- [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--prompt <text>] [--verbose]
 pnpm dev -- sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>]
 ```
 
@@ -27,6 +27,7 @@ pnpm dev -- sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>]
 - `--input-format <format>`: input format override
 - `--output-format <format>`: output format override
 - `--digest-dir <path>`: keep the digest workspace; the directory is cleared before each run
+- `--prompt <text>`: one-off extraction prompt override for the current digest run
 - `--verbose`: write diagnostic logs to `stderr`
 - `-h`, `--help`: print help text
 
@@ -35,6 +36,8 @@ The main conversion command does not support positional arguments.
 The `sdpub` inspection interface uses positional subcommands: `spinedigest sdpub <subcommand>`.
 
 The `sdpub` inspection subcommands only accept `--input`, and `cat` also requires `--serial`.
+
+`--prompt` only affects digest generation from source inputs. It does not apply when reopening `.sdpub` archives or using `spinedigest sdpub ...`.
 
 ## Formats
 
@@ -119,6 +122,12 @@ Use pipes:
 cat ./chapter.txt | spinedigest --input-format txt --output-format markdown
 ```
 
+Use a one-off extraction prompt:
+
+```bash
+spinedigest --input ./book.md --output ./digest.md --prompt "Preserve named entities and decisive transitions."
+```
+
 ## Configuration
 
 Default config path:
@@ -159,6 +168,8 @@ Config fields:
   }
 }
 ```
+
+For the main digest command, `--prompt` has the highest priority for the current run. Otherwise, `SPINEDIGEST_PROMPT` overrides `config.json`, and missing values fall back to the built-in default prompt.
 
 ## Environment Variables
 
@@ -207,7 +218,7 @@ Expect a plain-text error message on `stderr` and a non-zero exit code when:
 - `--verbose` is used while writing output to `stdout`
 - no LLM configuration is available for a digest operation
 - `spinedigest sdpub cat` is used without `--serial`
-- `sdpub` inspection subcommands are used with unsupported flags such as `--output`, `--output-format`, or `--verbose`
+- `sdpub` inspection subcommands are used with unsupported flags such as `--output`, `--output-format`, `--prompt`, or `--verbose`
 - `spinedigest sdpub cover` tries to write binary data to an interactive terminal
 - `spinedigest sdpub cover` is used on an archive without a cover
 - provider-specific configuration is invalid

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -154,7 +154,13 @@ cat ./chapter.txt | spinedigest --input-format txt --output-format markdown
 
 ## 8. Add A Custom Extraction Prompt
 
-You can customize the extraction prompt in config:
+For a one-off run, pass `--prompt`:
+
+```bash
+spinedigest --input ./book.md --output ./digest.md --prompt "Preserve key arguments, named entities, and decisive transitions."
+```
+
+For a persistent default, set it in config:
 
 ```json
 {
@@ -162,7 +168,9 @@ You can customize the extraction prompt in config:
 }
 ```
 
-This prompt is applied when digesting source files or text streams.
+For the main digest command, `--prompt` overrides `SPINEDIGEST_PROMPT`, which overrides `config.json`. If none is set, SpineDigest uses its built-in default prompt.
+
+This prompt is applied when digesting source files or text streams. It is not used when reopening an existing `.sdpub`.
 
 ## 9. Troubleshooting
 

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -9,14 +9,14 @@ SpineDigest 的设计重心是命令行使用。
 已安装 CLI 时：
 
 ```bash
-spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--verbose]
+spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--prompt <text>] [--verbose]
 spinedigest sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>]
 ```
 
 在源码仓库中运行时：
 
 ```bash
-pnpm dev -- [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--verbose]
+pnpm dev -- [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--prompt <text>] [--verbose]
 pnpm dev -- sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>]
 ```
 
@@ -27,6 +27,7 @@ pnpm dev -- sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>]
 - `--input-format <format>`：显式指定输入格式
 - `--output-format <format>`：显式指定输出格式
 - `--digest-dir <path>`：保留 digest 中间工作目录；每次运行前会先清空该目录
+- `--prompt <text>`：为当前这次 digest 临时覆盖 extraction prompt
 - `--verbose`：把诊断日志输出到 `stderr`
 - `-h`, `--help`：打印帮助文本
 
@@ -35,6 +36,8 @@ pnpm dev -- sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>]
 `sdpub` 检查接口本身使用 positional subcommands：`spinedigest sdpub <subcommand>`。
 
 `sdpub` 检查子命令只接受 `--input`，其中 `cat` 还要求提供 `--serial`。
+
+`--prompt` 只影响从源输入生成 digest 的过程，不适用于重新打开 `.sdpub` 或使用 `spinedigest sdpub ...`。
 
 ## 支持的格式
 
@@ -119,6 +122,12 @@ spinedigest sdpub cover --input ./book.sdpub > ./cover.png
 cat ./chapter.txt | spinedigest --input-format txt --output-format markdown
 ```
 
+临时覆盖 extraction prompt：
+
+```bash
+spinedigest --input ./book.md --output ./digest.md --prompt "Preserve named entities and decisive transitions."
+```
+
 ## 配置
 
 默认配置路径：
@@ -159,6 +168,8 @@ SPINEDIGEST_CONFIG
   }
 }
 ```
+
+对于主 digest 命令，`--prompt` 的优先级最高，只影响当前这次运行。否则，`SPINEDIGEST_PROMPT` 会覆盖 `config.json`，再没有时使用内置默认 prompt。
 
 ## 环境变量
 
@@ -207,7 +218,7 @@ SpineDigest 支持通过环境变量覆盖配置值：
 - 在写入 `stdout` 时同时使用了 `--verbose`
 - digest 操作缺少 LLM 配置
 - `spinedigest sdpub cat` 缺少 `--serial`
-- `sdpub` 检查子命令使用了不支持的参数，例如 `--output`、`--output-format` 或 `--verbose`
+- `sdpub` 检查子命令使用了不支持的参数，例如 `--output`、`--output-format`、`--prompt` 或 `--verbose`
 - `spinedigest sdpub cover` 试图向交互式终端输出二进制数据
 - `spinedigest sdpub cover` 针对一个没有封面的归档运行
 - provider 相关配置不合法

--- a/docs/zh-CN/quickstart.md
+++ b/docs/zh-CN/quickstart.md
@@ -154,7 +154,13 @@ cat ./chapter.txt | spinedigest --input-format txt --output-format markdown
 
 ## 8. 添加自定义 extraction prompt
 
-你可以在配置中自定义 extraction prompt：
+如果只是临时跑一次，可以直接传 `--prompt`：
+
+```bash
+spinedigest --input ./book.md --output ./digest.md --prompt "Preserve key arguments, named entities, and decisive transitions."
+```
+
+如果希望作为长期默认值，可以写进配置：
 
 ```json
 {
@@ -162,7 +168,9 @@ cat ./chapter.txt | spinedigest --input-format txt --output-format markdown
 }
 ```
 
-这个 prompt 会用于处理源文件或文本流时的 digest 过程。
+对于主 digest 命令，`--prompt` 会覆盖 `SPINEDIGEST_PROMPT`，后者再覆盖 `config.json`。如果都没有设置，则使用内置默认 prompt。
+
+这个 prompt 会用于处理源文件或文本流时的 digest 过程，不会用于重新打开已有 `.sdpub`。
 
 ## 9. 故障排查
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -9,6 +9,7 @@ export interface CLIArguments {
   readonly inputFormat?: CLIFormat;
   readonly outputPath?: string;
   readonly outputFormat?: CLIFormat;
+  readonly prompt?: string;
   readonly verbose: boolean;
 }
 
@@ -44,7 +45,7 @@ export type ParsedCLIArguments =
 
 export const CLI_HELP_TEXT = `
 Usage:
-  spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--verbose]
+  spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--prompt <text>] [--verbose]
   spinedigest sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>]
 
 Behavior:
@@ -55,6 +56,7 @@ Behavior:
   - If a format flag is omitted, the format is inferred from the file extension.
   - --digest-dir keeps the intermediate digest workspace for digest inputs.
   - --digest-dir clears the target directory before each run.
+  - --prompt overrides config/env extraction prompts for the current digest run.
   - --verbose writes diagnostic logs to stderr.
 
 Formats:
@@ -124,6 +126,9 @@ export function parseCLIArguments(
       "output-format": {
         type: "string",
       },
+      prompt: {
+        type: "string",
+      },
       serial: {
         type: "string",
       },
@@ -169,6 +174,7 @@ export function parseCLIArguments(
               "--output-format",
             ),
           }),
+      ...(values.prompt === undefined ? {} : { prompt: values.prompt }),
       verbose: values.verbose ?? false,
     },
     help: values.help ?? false,
@@ -186,6 +192,7 @@ function parseSdpubArguments(
     readonly "input-format"?: string;
     readonly output?: string;
     readonly "output-format"?: string;
+    readonly prompt?: string;
     readonly serial?: string;
     readonly verbose?: boolean;
   },
@@ -239,6 +246,11 @@ function parseSdpubArguments(
   if (values["output-format"] !== undefined) {
     throw new Error(
       "The `sdpub` subcommands do not support --output-format. Their output format is fixed by the subcommand.",
+    );
+  }
+  if (values.prompt !== undefined) {
+    throw new Error(
+      "The `sdpub` subcommands do not support --prompt. It only applies to digest generation from source inputs.",
     );
   }
   if (values.verbose) {

--- a/src/cli/convert.ts
+++ b/src/cli/convert.ts
@@ -86,7 +86,7 @@ export async function runConvertCommand(args: CLIArguments): Promise<void> {
     }
   }
 
-  const extractionPrompt = config.prompt;
+  const extractionPrompt = args.prompt ?? config.prompt;
 
   try {
     if (input.path === undefined) {

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -21,6 +21,8 @@ describe("cli/args", () => {
         "out.txt",
         "--output-format",
         "markdown",
+        "--prompt",
+        "Keep named entities",
       ]),
     ).toStrictEqual({
       args: {
@@ -30,6 +32,7 @@ describe("cli/args", () => {
         inputPath: "book.epub",
         outputFormat: "markdown",
         outputPath: "out.txt",
+        prompt: "Keep named entities",
         verbose: false,
       },
       help: true,
@@ -60,6 +63,21 @@ describe("cli/args", () => {
       helpText: CLI_HELP_TEXT,
       kind: "convert",
     });
+  });
+
+  it("parses --prompt for the main convert command", () => {
+    expect(parseCLIArguments(["--prompt", "Keep dialogue only"])).toStrictEqual(
+      {
+        args: {
+          help: false,
+          prompt: "Keep dialogue only",
+          verbose: false,
+        },
+        help: false,
+        helpText: CLI_HELP_TEXT,
+        kind: "convert",
+      },
+    );
   });
 
   it("parses sdpub subcommands", () => {
@@ -120,6 +138,11 @@ describe("cli/args", () => {
       "The `sdpub` subcommands do not support --output. Use stdout redirection or pipes instead.",
     );
     expect(() =>
+      parseCLIArguments(["sdpub", "info", "--prompt", "Keep dialogue only"]),
+    ).toThrow(
+      "The `sdpub` subcommands do not support --prompt. It only applies to digest generation from source inputs.",
+    );
+    expect(() =>
       parseCLIArguments(["sdpub", "cat", "--input", "book.sdpub"]),
     ).toThrow("Missing --serial. `spinedigest sdpub cat` requires it.");
     expect(() =>
@@ -154,6 +177,9 @@ describe("cli/args", () => {
     expect(CLI_HELP_TEXT).toContain("--digest-dir keeps the intermediate");
     expect(CLI_HELP_TEXT).toContain(
       "--digest-dir clears the target directory before each run",
+    );
+    expect(CLI_HELP_TEXT).toContain(
+      "--prompt overrides config/env extraction prompts",
     );
     expect(CLI_HELP_TEXT).toContain(
       "--verbose writes diagnostic logs to stderr",

--- a/test/cli/convert.test.ts
+++ b/test/cli/convert.test.ts
@@ -260,6 +260,31 @@ describe("cli/convert", () => {
     ]);
   });
 
+  it("lets --prompt override the configured extraction prompt", async () => {
+    cliMockState.config = {
+      llm: {
+        model: "gpt-test",
+        provider: "openai",
+      },
+      prompt: "Configured prompt",
+    };
+
+    await runConvertCommand({
+      help: false,
+      inputPath: "/tmp/book.txt",
+      outputPath: "/tmp/output.txt",
+      prompt: "CLI prompt",
+      verbose: false,
+    });
+
+    expect(cliMockState.digestCalls.txt).toStrictEqual([
+      {
+        extractionPrompt: "CLI prompt",
+        path: "/tmp/book.txt",
+      },
+    ]);
+  });
+
   it("refuses to read interactive stdin when input is omitted", async () => {
     cliMockState.config = {
       llm: {


### PR DESCRIPTION
## Summary
- add `--prompt` to the main CLI conversion command
- make `--prompt` override config and env prompt values for the current digest run
- reject `--prompt` for `.sdpub` inspection paths and sync the English/Chinese docs

## Testing
- pnpm exec vitest run test/cli/args.test.ts test/cli/convert.test.ts
- pnpm exec tsc -p tsconfig.json --noEmit
- pnpm exec prettier --check src/cli/args.ts src/cli/convert.ts test/cli/args.test.ts test/cli/convert.test.ts docs/en/cli.md docs/zh-CN/cli.md docs/en/quickstart.md docs/zh-CN/quickstart.md