### PR TITLE
fix: emit serial progress after each fragment

### DIFF
--- a/src/progress/tracker.ts
+++ b/src/progress/tracker.ts
@@ -119,7 +119,7 @@ export class SerialProgressTracker {
 
   public async complete(finalWordsCount = 0): Promise<void> {
     this.#completedWords += finalWordsCount;
-    if (this.#completedWords > 0) {
+    if (finalWordsCount > 0) {
       this.#completedFragments += 1;
     }
 

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -162,21 +162,16 @@ export class SerialGeneration {
     options: GenerateSerialOptions,
     progressTracker?: SerialProgressTracker,
   ): Promise<Serial> {
-    let finalWordsCount = 0;
-
     await this.#buildTopology(
       serialId,
       stream,
       options.extractionPrompt,
       options.userLanguage,
       progressTracker,
-      (wordsCount) => {
-        finalWordsCount = wordsCount;
-      },
     );
 
     const summary = await this.#buildSummary(serialId, options.userLanguage);
-    await progressTracker?.complete(finalWordsCount);
+    await progressTracker?.complete();
 
     return new Serial(this.#document, serialId, summary);
   }
@@ -235,7 +230,6 @@ export class SerialGeneration {
     extractionPrompt: string,
     userLanguage: Language | undefined,
     progressTracker?: SerialProgressTracker,
-    setFinalWordsCount?: (wordsCount: number) => void,
   ): Promise<void> {
     const reader = new Reader({
       attention: {
@@ -265,48 +259,24 @@ export class SerialGeneration {
     );
     const allChunks: ReaderChunk[] = [];
     const successorIdsByChunkId = createNumberListRecord();
-    let finalFragment:
-      | {
-          readonly sentences: ReadonlyArray<{
-            readonly text: string;
-            readonly wordsCount: number;
-          }>;
-          readonly wordsCount: number;
-        }
-      | undefined;
-
     for await (const fragment of streamFragments({
       maxWordsCount: this.#fragmentWordsCount,
       stream: reader.segment(stream),
     })) {
-      if (finalFragment !== undefined) {
-        await this.#processFragment({
-          allChunks,
-          fragment: finalFragment,
-          reader,
-          serialId,
-          successorIdsByChunkId,
-          topology,
-        });
-        await progressTracker?.advance(finalFragment.wordsCount);
-      }
+      const wordsCount = countFragmentWords(fragment.sentences);
 
-      finalFragment = {
-        sentences: fragment.sentences,
-        wordsCount: countFragmentWords(fragment.sentences),
-      };
-    }
-
-    if (finalFragment !== undefined) {
       await this.#processFragment({
         allChunks,
-        fragment: finalFragment,
+        fragment: {
+          sentences: fragment.sentences,
+          wordsCount,
+        },
         reader,
         serialId,
         successorIdsByChunkId,
         topology,
       });
-      setFinalWordsCount?.(finalFragment.wordsCount);
+      await progressTracker?.advance(wordsCount);
     }
 
     await this.#writeSemaphore.use(async () => {

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -269,13 +269,13 @@ export class SerialGeneration {
         allChunks,
         fragment: {
           sentences: fragment.sentences,
-          wordsCount,
         },
         reader,
         serialId,
         successorIdsByChunkId,
         topology,
       });
+      // Progress only advances after the fragment is fully persisted and indexed.
       await progressTracker?.advance(wordsCount);
     }
 
@@ -292,7 +292,6 @@ export class SerialGeneration {
         readonly text: string;
         readonly wordsCount: number;
       }>;
-      readonly wordsCount: number;
     };
     readonly reader: Reader<ReaderProgressScope>;
     readonly serialId: number;

--- a/test/common/progress-tracker.test.ts
+++ b/test/common/progress-tracker.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { createDigestProgressTracker } from "../../src/progress/index.js";
+
+describe("progress/tracker", () => {
+  it("does not add an extra fragment when completion only finalizes digest totals", async () => {
+    const events: Array<{
+      readonly completedFragments?: number;
+      readonly completedWords?: number;
+      readonly id?: number;
+      readonly totalWords?: number;
+      readonly type: string;
+    }> = [];
+    const digestTracker = createDigestProgressTracker({
+      onProgress: (event) => {
+        switch (event.type) {
+          case "serial-progress":
+            events.push({
+              completedFragments: event.completedFragments,
+              completedWords: event.completedWords,
+              id: event.id,
+              type: event.type,
+            });
+            return;
+          case "digest-progress":
+            events.push({
+              completedWords: event.completedWords,
+              totalWords: event.totalWords,
+              type: event.type,
+            });
+        }
+      },
+      operation: "digest-text-stream",
+    });
+    const serialTracker = digestTracker.createSerialTracker({
+      id: 7,
+    });
+
+    await serialTracker.advance(3);
+    await serialTracker.complete();
+
+    expect(events).toStrictEqual([
+      {
+        completedFragments: 1,
+        completedWords: 3,
+        id: 7,
+        type: "serial-progress",
+      },
+      {
+        completedFragments: 1,
+        completedWords: 3,
+        id: 7,
+        type: "serial-progress",
+      },
+      {
+        completedWords: 3,
+        totalWords: 3,
+        type: "digest-progress",
+      },
+    ]);
+  });
+});

--- a/test/serial.test.ts
+++ b/test/serial.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { compressTextMock, readerSegmentMock } = vi.hoisted(() => ({
+  compressTextMock: vi.fn(),
+  readerSegmentMock: vi.fn(),
+}));
+
+vi.mock("../src/editor/index.js", () => ({
+  compressText: compressTextMock,
+}));
+
+vi.mock("../src/reader/index.js", () => ({
+  Reader: class {
+    public segment(stream: unknown): AsyncIterable<unknown> {
+      return readerSegmentMock(stream);
+    }
+
+    public extractUserFocused() {
+      return Promise.resolve({
+        delta: {
+          chunks: [],
+          edges: [],
+        },
+        fragmentSummary: "",
+      });
+    }
+
+    public extractBookCoherence() {
+      return Promise.resolve({
+        chunks: [],
+        edges: [],
+      });
+    }
+
+    public completeFragment(): void {}
+  },
+  segmentTextStream: (stream: unknown) => stream,
+}));
+
+vi.mock("../src/topology/index.js", () => ({
+  Topology: class {
+    public accept(): void {}
+
+    public finalize(): Promise<void> {
+      return Promise.resolve();
+    }
+  },
+}));
+
+import { DirectoryDocument } from "../src/document/index.js";
+import { SerialGeneration } from "../src/serial.js";
+import { withTempDir } from "./helpers/temp.js";
+
+describe("serial", () => {
+  beforeEach(() => {
+    compressTextMock.mockReset();
+    readerSegmentMock.mockReset();
+    compressTextMock.mockResolvedValue("");
+  });
+
+  it("emits advance for a single fragment before completion", async () => {
+    await withTempDir("spinedigest-serial-", async (path) => {
+      const document = await DirectoryDocument.open(path);
+      const progressTracker = {
+        advance: vi.fn(async (_wordsCount: number) => undefined),
+        complete: vi.fn(async (_finalWordsCount?: number) => undefined),
+      };
+
+      readerSegmentMock.mockReturnValueOnce(
+        createSentenceStream([
+          {
+            text: "Alpha beta.",
+            wordsCount: 2,
+          },
+        ]),
+      );
+
+      try {
+        await new SerialGeneration({
+          document,
+          llm: {} as never,
+        }).generateInto(
+          1,
+          [],
+          {
+            extractionPrompt: "Keep key beats",
+          },
+          progressTracker as never,
+        );
+
+        expect(progressTracker.advance).toHaveBeenCalledTimes(1);
+        expect(progressTracker.advance).toHaveBeenCalledWith(2);
+        expect(progressTracker.complete).toHaveBeenCalledTimes(1);
+        expect(progressTracker.complete).toHaveBeenCalledWith();
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("emits advance for every processed fragment", async () => {
+    await withTempDir("spinedigest-serial-", async (path) => {
+      const document = await DirectoryDocument.open(path);
+      const progressTracker = {
+        advance: vi.fn(async (_wordsCount: number) => undefined),
+        complete: vi.fn(async (_finalWordsCount?: number) => undefined),
+      };
+
+      readerSegmentMock.mockReturnValueOnce(
+        createSentenceStream([
+          {
+            text: "Alpha beta.",
+            wordsCount: 200,
+          },
+          {
+            text: "Gamma delta epsilon.",
+            wordsCount: 160,
+          },
+        ]),
+      );
+
+      try {
+        await new SerialGeneration({
+          document,
+          llm: {} as never,
+        }).generateInto(
+          1,
+          [],
+          {
+            extractionPrompt: "Keep key beats",
+          },
+          progressTracker as never,
+        );
+
+        expect(progressTracker.advance).toHaveBeenCalledTimes(2);
+        expect(progressTracker.advance).toHaveBeenNthCalledWith(1, 200);
+        expect(progressTracker.advance).toHaveBeenNthCalledWith(2, 160);
+        expect(progressTracker.complete).toHaveBeenCalledWith();
+      } finally {
+        await document.release();
+      }
+    });
+  });
+});
+
+async function* createSentenceStream(
+  sentences: ReadonlyArray<{
+    readonly text: string;
+    readonly wordsCount: number;
+  }>,
+): AsyncIterable<{
+  readonly text: string;
+  readonly wordsCount: number;
+}> {
+  for (const sentence of sentences) {
+    yield sentence;
+  }
+}

--- a/test/serial.test.ts
+++ b/test/serial.test.ts
@@ -1,8 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  ReaderChunk,
+  ReaderGraphDelta,
+  ReaderSegment,
+  ReaderSentence,
+  ReaderTextStream,
+} from "../src/reader/index.js";
+
+const EMPTY_DELTA: ReaderGraphDelta = {
+  chunks: [],
+  edges: [],
+};
 
 const { compressTextMock, readerSegmentMock } = vi.hoisted(() => ({
   compressTextMock: vi.fn(),
-  readerSegmentMock: vi.fn<(stream: unknown) => AsyncIterable<unknown>>(),
+  readerSegmentMock:
+    vi.fn<(stream: ReaderTextStream) => AsyncIterable<ReaderSegment>>(),
 }));
 
 vi.mock("../src/editor/index.js", () => ({
@@ -11,30 +24,37 @@ vi.mock("../src/editor/index.js", () => ({
 
 vi.mock("../src/reader/index.js", () => ({
   Reader: class {
-    public segment(stream: unknown): AsyncIterable<unknown> {
+    public segment(stream: ReaderTextStream): AsyncIterable<ReaderSegment> {
       return readerSegmentMock(stream);
     }
 
-    public extractUserFocused() {
+    public extractUserFocused(_input: {
+      readonly sentences: readonly ReaderSentence[];
+      readonly text: string;
+    }): Promise<{
+      readonly delta: ReaderGraphDelta;
+      readonly fragmentSummary: string;
+    }> {
       return Promise.resolve({
-        delta: {
-          chunks: [],
-          edges: [],
-        },
+        delta: EMPTY_DELTA,
         fragmentSummary: "",
       });
     }
 
-    public extractBookCoherence() {
-      return Promise.resolve({
-        chunks: [],
-        edges: [],
-      });
+    public extractBookCoherence(_input: {
+      readonly sentences: readonly ReaderSentence[];
+      readonly text: string;
+      readonly userFocusedChunks: readonly ReaderChunk[];
+    }): Promise<ReaderGraphDelta> {
+      return Promise.resolve(EMPTY_DELTA);
     }
 
-    public completeFragment(): void {}
+    public completeFragment(_input: {
+      readonly allChunks: readonly ReaderChunk[];
+      readonly getSuccessorChunkIds: (chunkId: number) => readonly number[];
+    }): void {}
   },
-  segmentTextStream: (stream: unknown) => stream,
+  segmentTextStream: (stream: ReaderTextStream): ReaderTextStream => stream,
 }));
 
 vi.mock("../src/topology/index.js", () => ({
@@ -69,6 +89,7 @@ describe("serial", () => {
       readerSegmentMock.mockReturnValueOnce(
         createSentenceStream([
           {
+            offset: 0,
             text: "Alpha beta.",
             wordsCount: 2,
           },
@@ -109,10 +130,12 @@ describe("serial", () => {
       readerSegmentMock.mockReturnValueOnce(
         createSentenceStream([
           {
+            offset: 0,
             text: "Alpha beta.",
             wordsCount: 200,
           },
           {
+            offset: 11,
             text: "Gamma delta epsilon.",
             wordsCount: 160,
           },
@@ -144,19 +167,10 @@ describe("serial", () => {
 });
 
 function createSentenceStream(
-  sentences: ReadonlyArray<{
-    readonly text: string;
-    readonly wordsCount: number;
-  }>,
-): AsyncIterable<{
-  readonly text: string;
-  readonly wordsCount: number;
-}> {
+  sentences: ReadonlyArray<ReaderSegment>,
+): AsyncIterable<ReaderSegment> {
   return {
-    [Symbol.asyncIterator](): AsyncIterator<{
-      readonly text: string;
-      readonly wordsCount: number;
-    }> {
+    [Symbol.asyncIterator](): AsyncIterator<ReaderSegment> {
       const iterator = sentences[Symbol.iterator]();
 
       return {

--- a/test/serial.test.ts
+++ b/test/serial.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { compressTextMock, readerSegmentMock } = vi.hoisted(() => ({
   compressTextMock: vi.fn(),
-  readerSegmentMock: vi.fn(),
+  readerSegmentMock: vi.fn<(stream: unknown) => AsyncIterable<unknown>>(),
 }));
 
 vi.mock("../src/editor/index.js", () => ({
@@ -62,8 +62,8 @@ describe("serial", () => {
     await withTempDir("spinedigest-serial-", async (path) => {
       const document = await DirectoryDocument.open(path);
       const progressTracker = {
-        advance: vi.fn(async (_wordsCount: number) => undefined),
-        complete: vi.fn(async (_finalWordsCount?: number) => undefined),
+        advance: vi.fn((_wordsCount: number) => Promise.resolve()),
+        complete: vi.fn((_finalWordsCount?: number) => Promise.resolve()),
       };
 
       readerSegmentMock.mockReturnValueOnce(
@@ -102,8 +102,8 @@ describe("serial", () => {
     await withTempDir("spinedigest-serial-", async (path) => {
       const document = await DirectoryDocument.open(path);
       const progressTracker = {
-        advance: vi.fn(async (_wordsCount: number) => undefined),
-        complete: vi.fn(async (_finalWordsCount?: number) => undefined),
+        advance: vi.fn((_wordsCount: number) => Promise.resolve()),
+        complete: vi.fn((_finalWordsCount?: number) => Promise.resolve()),
       };
 
       readerSegmentMock.mockReturnValueOnce(
@@ -143,7 +143,7 @@ describe("serial", () => {
   });
 });
 
-async function* createSentenceStream(
+function createSentenceStream(
   sentences: ReadonlyArray<{
     readonly text: string;
     readonly wordsCount: number;
@@ -152,7 +152,18 @@ async function* createSentenceStream(
   readonly text: string;
   readonly wordsCount: number;
 }> {
-  for (const sentence of sentences) {
-    yield sentence;
-  }
+  return {
+    [Symbol.asyncIterator](): AsyncIterator<{
+      readonly text: string;
+      readonly wordsCount: number;
+    }> {
+      const iterator = sentences[Symbol.iterator]();
+
+      return {
+        next() {
+          return Promise.resolve(iterator.next());
+        },
+      };
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- emit serial progress as soon as each fragment finishes instead of waiting for the next fragment boundary
- avoid counting an extra completed fragment when serial completion only finalizes totals
- add regression tests for serial progress timing and tracker fragment counting

## Testing
- pnpm vitest run test/serial.test.ts test/common/progress-tracker.test.ts test/facade/digest.test.ts test/facade/import.test.ts