### PR TITLE
fix: skip empty epub sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spinedigest",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "CLI-first tool for digesting long-form text and ebooks into compressed text, EPUB, or reusable .sdpub archives.",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/cli/progress.ts
+++ b/src/cli/progress.ts
@@ -95,8 +95,10 @@ class TerminalProgressRenderer implements CLIProgressRenderer {
           this.#serials.set(serial.id, {
             completedFragments: 0,
             completedWords: 0,
-            fragments: serial.fragments,
             words: serial.words,
+            ...(serial.fragments === undefined
+              ? {}
+              : { fragments: serial.fragments }),
           });
         }
         return;
@@ -157,8 +159,8 @@ class TerminalProgressRenderer implements CLIProgressRenderer {
       ([leftId], [rightId]) => leftId - rightId,
     );
     const discoveredSerials = serials.filter(
-      (entry): entry is [number, KnownSerialState] =>
-        hasDiscoveryTotals(entry[1]),
+      (entry): entry is [number, SerialState & { words: number }] =>
+        hasDiscoveryWords(entry[1]),
     );
     const totalSerialWords = discoveredSerials.reduce(
       (sum, [, serial]) => sum + serial.words,
@@ -216,7 +218,7 @@ class TerminalProgressRenderer implements CLIProgressRenderer {
         `${formatSerialLabel(`#${serialId}`)}${renderBar(
           serial.completedWords,
           serial.words,
-        )} ${wordsLabel.padEnd(wordsLabelWidth)} (${fragmentsLabel})`,
+        )} ${wordsLabel.padEnd(wordsLabelWidth)}${fragmentsLabel === undefined ? "" : ` (${fragmentsLabel})`}`,
       );
     }
 
@@ -228,8 +230,10 @@ function swallowRenderError(): undefined {
   return undefined;
 }
 
-function hasDiscoveryTotals(serial: SerialState): serial is KnownSerialState {
-  return serial.fragments !== undefined && serial.words !== undefined;
+function hasDiscoveryWords(
+  serial: SerialState,
+): serial is SerialState & { words: number } {
+  return serial.words !== undefined;
 }
 
 function formatStageLabel(label: string): string {
@@ -244,7 +248,14 @@ function buildWordsLabel(completed: number, total: number): string {
   return `${formatNumber(completed)} / ${formatNumber(total)} words`;
 }
 
-function buildFragmentsLabel(completed: number, total: number): string {
+function buildFragmentsLabel(
+  completed: number,
+  total: number | undefined,
+): string | undefined {
+  if (total === undefined) {
+    return undefined;
+  }
+
   return `${formatNumber(completed)}/${formatNumber(total)} fragments`;
 }
 
@@ -259,9 +270,4 @@ function renderBar(completed: number, total: number): string {
 
 function formatNumber(value: number): string {
   return new Intl.NumberFormat("en-US").format(value);
-}
-
-interface KnownSerialState extends SerialState {
-  fragments: number;
-  words: number;
 }

--- a/src/facade/import.ts
+++ b/src/facade/import.ts
@@ -90,19 +90,11 @@ export async function importSourceDocument(
   const serials: Serial[] = [];
 
   if (options.digestProgressTracker !== undefined) {
-    const discoveries = [];
-
-    for (const plannedSection of plannedSections) {
-      discoveries.push({
-        id: plannedSection.serialId,
-        ...(await discoverSerial({
-          ...(options.segmenter === undefined
-            ? {}
-            : { segmenter: options.segmenter }),
-          stream: await plannedSection.section.open(),
-        })),
-      });
-    }
+    const discoveries = await discoverPlannedSections(plannedSections, {
+      ...(options.segmenter === undefined
+        ? {}
+        : { segmenter: options.segmenter }),
+    });
 
     await options.digestProgressTracker.discoverSerials(discoveries);
   }
@@ -234,4 +226,44 @@ async function assertImportTargetIsEmpty(document: Document): Promise<void> {
   if (serialIds.length > 0) {
     throw new Error("Document already contains serials");
   }
+}
+
+async function discoverPlannedSections(
+  plannedSections: readonly PlannedSection[],
+  options: {
+    readonly segmenter?: NonNullable<ImportSourceOptions["segmenter"]>;
+  },
+): Promise<
+  readonly {
+    readonly fragments?: number;
+    readonly id: number;
+    readonly words: number;
+  }[]
+> {
+  if (
+    plannedSections.every(
+      (plannedSection) => plannedSection.section.wordsCount !== undefined,
+    )
+  ) {
+    return plannedSections.map((plannedSection) => ({
+      id: plannedSection.serialId,
+      words: plannedSection.section.wordsCount ?? 0,
+    }));
+  }
+
+  const discoveries = [];
+
+  for (const plannedSection of plannedSections) {
+    discoveries.push({
+      id: plannedSection.serialId,
+      ...(await discoverSerial({
+        ...(options.segmenter === undefined
+          ? {}
+          : { segmenter: options.segmenter }),
+        stream: await plannedSection.section.open(),
+      })),
+    });
+  }
+
+  return discoveries;
 }

--- a/src/progress/reporter.ts
+++ b/src/progress/reporter.ts
@@ -67,7 +67,7 @@ function buildLogBindings(
         available: Number(event.available),
         serials: event.serials.length,
         totalFragments: event.serials.reduce(
-          (sum, serial) => sum + serial.fragments,
+          (sum, serial) => sum + (serial.fragments ?? 0),
           0,
         ),
         totalWords: event.serials.reduce(

--- a/src/progress/types.ts
+++ b/src/progress/types.ts
@@ -6,7 +6,7 @@ export type SpineDigestOperation =
 
 export interface SerialDiscoveryItem {
   readonly id: number;
-  readonly fragments: number;
+  readonly fragments?: number | undefined;
   readonly words: number;
 }
 

--- a/src/source/epub/content.ts
+++ b/src/source/epub/content.ts
@@ -48,6 +48,11 @@ export interface EpubSectionTarget {
   readonly fragment: string | undefined;
 }
 
+export interface EpubSectionAnalysis {
+  readonly hasContent: boolean;
+  readonly wordsCount: number;
+}
+
 export class EpubContentLoader {
   readonly #archive: EpubArchive;
   readonly #targetsBySectionId: ReadonlyMap<
@@ -89,6 +94,30 @@ export class EpubContentLoader {
   }
 }
 
+export async function analyzeSectionTargets(
+  archive: Pick<EpubArchive, "openReadStream">,
+  targetsByPath: ReadonlyMap<string, readonly EpubSectionTarget[]>,
+): Promise<ReadonlyMap<string, EpubSectionAnalysis>> {
+  const analyses = new Map<string, EpubSectionAnalysis>();
+
+  for (const [path, targets] of targetsByPath.entries()) {
+    const stream = await archive.openReadStream(path);
+    stream.setEncoding("utf8");
+    const sections = await parseHtmlSectionTexts(stream, targets);
+
+    for (const target of targets) {
+      const text = sections.get(target.id) ?? "";
+
+      analyses.set(target.id, {
+        hasContent: text.trim() !== "",
+        wordsCount: countWords(text),
+      });
+    }
+  }
+
+  return analyses;
+}
+
 function createTargetsBySectionId(
   targetsByPath: ReadonlyMap<string, readonly EpubSectionTarget[]>,
 ): ReadonlyMap<
@@ -116,6 +145,13 @@ function createTargetsBySectionId(
 }
 
 async function parseHtmlSections(
+  stream: Readable,
+  targets: readonly EpubSectionTarget[],
+): Promise<ReadonlyMap<string, string>> {
+  return await parseHtmlSectionTexts(stream, targets);
+}
+
+async function parseHtmlSectionTexts(
   stream: Readable,
   targets: readonly EpubSectionTarget[],
 ): Promise<ReadonlyMap<string, string>> {
@@ -222,4 +258,22 @@ function toTextChunk(chunk: unknown): string {
   }
 
   throw new Error("Unexpected HTML stream chunk type");
+}
+
+function countWords(text: string): number {
+  return [...createWordSegmenter().segment(text)].filter(
+    (segment) => segment.isWordLike,
+  ).length;
+}
+
+let WORD_SEGMENTER: Intl.Segmenter | undefined;
+
+function createWordSegmenter(): Intl.Segmenter {
+  if (WORD_SEGMENTER === undefined) {
+    WORD_SEGMENTER = new Intl.Segmenter(undefined, {
+      granularity: "word",
+    });
+  }
+
+  return WORD_SEGMENTER;
 }

--- a/src/source/epub/document.ts
+++ b/src/source/epub/document.ts
@@ -2,15 +2,22 @@ import type { SourceAdapter, SourceDocument } from "../adapter.js";
 import type { SourceAsset, SourceSection, SourceTextStream } from "../types.js";
 import { normalizeFragment } from "./archive.js";
 import { EpubArchive } from "./archive.js";
-import { EpubContentLoader, type EpubSectionTarget } from "./content.js";
+import {
+  analyzeSectionTargets,
+  EpubContentLoader,
+  type EpubSectionAnalysis,
+  type EpubSectionTarget,
+} from "./content.js";
 import { readEpubNavigation, type EpubNavigationItem } from "./navigation.js";
 import { readEpubPackage, type EpubPackageData } from "./package.js";
 
 interface SectionDefinition {
+  readonly hasContent: boolean;
   readonly id: string;
   readonly title: string | undefined;
   readonly path: string | undefined;
   readonly fragment: string | undefined;
+  readonly wordsCount: number;
   readonly children: readonly SectionDefinition[];
 }
 
@@ -31,11 +38,15 @@ class EpubSourceSection implements SourceSection {
   }
 
   public get hasContent(): boolean {
-    return this.#definition.path !== undefined;
+    return this.#definition.hasContent;
   }
 
   public get title(): string | undefined {
     return this.#definition.title;
+  }
+
+  public get wordsCount(): number {
+    return this.#definition.wordsCount;
   }
 
   public get children(): readonly SourceSection[] {
@@ -71,8 +82,10 @@ export class EpubSourceDocument implements SourceDocument {
     assertArchiveIsSupported(archive);
     const packageData = await readEpubPackage(archive);
     const navigation = await readEpubNavigation(archive, packageData);
-    const sections = buildSections(archive, navigation);
-    const targetsByPath = groupTargetsByPath(sections);
+    const rawSections = buildSections(archive, navigation);
+    const targetsByPath = groupTargetsByPath(rawSections);
+    const sectionAnalyses = await analyzeSectionTargets(archive, targetsByPath);
+    const sections = hydrateSectionAnalyses(rawSections, sectionAnalyses);
     const cover = await readCoverAsset(archive, packageData);
 
     return new EpubSourceDocument(
@@ -178,14 +191,32 @@ function buildSection(
   const id = createUniqueId(baseId, idCounts);
 
   return {
+    hasContent: item.path !== undefined,
     id,
     title: item.title,
     path: item.path,
     fragment,
+    wordsCount: 0,
     children: item.children.map((child, index) =>
       buildSection(archive, child, [...indexPath, index], idCounts),
     ),
   };
+}
+
+function hydrateSectionAnalyses(
+  sections: readonly SectionDefinition[],
+  sectionAnalyses: ReadonlyMap<string, EpubSectionAnalysis>,
+): readonly SectionDefinition[] {
+  return sections.map((section) => {
+    const analysis = sectionAnalyses.get(section.id);
+
+    return {
+      ...section,
+      hasContent: analysis?.hasContent ?? false,
+      wordsCount: analysis?.wordsCount ?? 0,
+      children: hydrateSectionAnalyses(section.children, sectionAnalyses),
+    };
+  });
 }
 
 function createUniqueId(baseId: string, idCounts: Map<string, number>): string {

--- a/src/source/types.ts
+++ b/src/source/types.ts
@@ -10,6 +10,7 @@ export interface SourceSection {
   readonly hasContent: boolean;
   readonly id: string;
   readonly title?: string | undefined;
+  readonly wordsCount?: number | undefined;
   readonly children: readonly SourceSection[];
   open(): Promise<SourceTextStream>;
 }

--- a/test/facade/digest.test.ts
+++ b/test/facade/digest.test.ts
@@ -237,7 +237,7 @@ describe("facade/digest", () => {
       readonly completedFragments?: number;
       readonly completedWords?: number;
       readonly serials?: readonly {
-        readonly fragments: number;
+        readonly fragments?: number | undefined;
         readonly id: number;
         readonly words: number;
       }[];

--- a/test/facade/import.test.ts
+++ b/test/facade/import.test.ts
@@ -317,6 +317,78 @@ describe("facade/import", () => {
     });
   });
 
+  it("reuses source-provided words counts for discovery", async () => {
+    await withTempDir("spinedigest-import-", async (path) => {
+      const document = await DirectoryDocument.open(`${path}/document`);
+      const openCounts = new Map<string, number>();
+      const events: unknown[] = [];
+
+      try {
+        await importSourceDocument(
+          createSourceDocument({
+            meta: createBookMeta({
+              title: "Discovery Fixture",
+            }),
+            sections: [
+              createSourceSection({
+                hasContent: true,
+                openCounts,
+                streamText: "alpha beta",
+                title: "Chapter 1",
+                wordsCount: 2,
+              }),
+              createSourceSection({
+                hasContent: false,
+                openCounts,
+                streamText: "",
+                title: "Spacer",
+                wordsCount: 0,
+              }),
+              createSourceSection({
+                hasContent: true,
+                openCounts,
+                streamText: "gamma delta epsilon",
+                title: "Chapter 2",
+                wordsCount: 3,
+              }),
+            ],
+          }),
+          {
+            digestProgressTracker: createDigestProgressTracker({
+              onProgress: (event) => {
+                events.push(event);
+              },
+              operation: "digest-epub",
+            }),
+            document,
+            extractionPrompt: "Keep key beats",
+            llm: {} as never,
+          },
+        );
+
+        expect(events).toContainEqual({
+          available: true,
+          serials: [
+            {
+              id: 1,
+              words: 2,
+            },
+            {
+              id: 2,
+              words: 3,
+            },
+          ],
+          type: "serials-discovered",
+        });
+        expect(openCounts.get("Chapter 1")).toBe(1);
+        expect(openCounts.get("Spacer")).toBeUndefined();
+        expect(openCounts.get("Chapter 2")).toBe(1);
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
   it("rejects imports when the target document already has content", async () => {
     await withTempDir("spinedigest-import-", async (path) => {
       const sourceDocument = createSourceDocument({
@@ -412,6 +484,7 @@ function createSourceSection(input: {
   readonly openCounts?: Map<string, number>;
   readonly streamText?: string;
   readonly title?: string;
+  readonly wordsCount?: number;
 }): SourceSection {
   const id = crypto.randomUUID();
 
@@ -435,6 +508,7 @@ function createSourceSection(input: {
       );
     },
     title: input.title,
+    wordsCount: input.wordsCount,
   };
 }
 

--- a/test/source/epub-source-adapter.test.ts
+++ b/test/source/epub-source-adapter.test.ts
@@ -2,7 +2,10 @@ import { Readable } from "stream";
 
 import { describe, expect, it } from "vitest";
 
-import { EpubContentLoader } from "../../src/source/epub/content.js";
+import {
+  analyzeSectionTargets,
+  EpubContentLoader,
+} from "../../src/source/epub/content.js";
 import { EPUB_SOURCE_ADAPTER } from "../../src/source/index.js";
 import {
   collectSectionTitles,
@@ -106,6 +109,50 @@ describe("source/epub", () => {
       await readStreamText(await loader.openSection("chapter.xhtml")),
     ).toBe("Alpha beta.");
     expect(openReadStreamCount).toBe(2);
+  });
+
+  it("marks empty section targets as structure-only during analysis", async () => {
+    const analyses = await analyzeSectionTargets(
+      {
+        openReadStream: () =>
+          Promise.resolve(
+            Readable.from([
+              [
+                "<html><body>",
+                '<section id="empty"></section>',
+                '<section id="filled"><p>Alpha beta.</p></section>',
+                "</body></html>",
+              ].join(""),
+            ]),
+          ),
+      } as never,
+      new Map([
+        [
+          "chapter.xhtml",
+          [
+            {
+              fragment: "empty",
+              id: "empty",
+              path: "chapter.xhtml",
+            },
+            {
+              fragment: "filled",
+              id: "filled",
+              path: "chapter.xhtml",
+            },
+          ],
+        ],
+      ]),
+    );
+
+    expect(analyses.get("empty")).toStrictEqual({
+      hasContent: false,
+      wordsCount: 0,
+    });
+    expect(analyses.get("filled")).toStrictEqual({
+      hasContent: true,
+      wordsCount: 2,
+    });
   });
 
   it("rejects encrypted epub inputs", async () => {


### PR DESCRIPTION
## Summary
- treat empty EPUB sections as structure-only nodes during source analysis
- reuse source-provided section word counts for discovery reporting without rescanning
- bump the package version

## Testing
- pnpm test:run
- pnpm typecheck