### PR TITLE
fix: bypass compression for short serials

### DIFF
--- a/src/serial.ts
+++ b/src/serial.ts
@@ -18,6 +18,7 @@ import type {
   ReadonlyDocument,
   ReadonlyFragmentGroupStore,
   ReadonlyKnowledgeEdgeStore,
+  ReadonlySerialFragments,
   ReadonlySnakeChunkStore,
   ReadonlySnakeEdgeStore,
   ReadonlySnakeStore,
@@ -199,6 +200,21 @@ export class SerialGeneration {
 
     if (existingSummary !== undefined) {
       return existingSummary;
+    }
+    const serialFragments = this.#getSerialFragments(serialId);
+    const fragmentIds = await serialFragments.listFragmentIds();
+
+    if (fragmentIds.length <= 1) {
+      const summary = await readSerialPassthroughSummary(
+        serialFragments,
+        fragmentIds,
+      );
+
+      await this.#writeSemaphore.use(
+        async () => await this.#document.writeSummary(serialId, summary),
+      );
+
+      return summary;
     }
     const groupIds = await this.#fragmentGroups.listGroupIdsForSerial(serialId);
     const summaryParts: string[] = [];
@@ -598,4 +614,24 @@ function countFragmentWords(
   }>,
 ): number {
   return sentences.reduce((sum, sentence) => sum + sentence.wordsCount, 0);
+}
+
+async function readSerialPassthroughSummary(
+  fragments: ReadonlySerialFragments,
+  fragmentIds: readonly number[],
+): Promise<string> {
+  if (fragmentIds.length === 0) {
+    return "";
+  }
+
+  const records = await Promise.all(
+    fragmentIds.map(async (fragmentId) => await fragments.getFragment(fragmentId)),
+  );
+
+  return records
+    .flatMap((fragment: Awaited<ReturnType<typeof fragments.getFragment>>) =>
+      fragment.sentences.map((sentence) => sentence.text),
+    )
+    .join(" ")
+    .trim();
 }

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -625,7 +625,9 @@ async function readSerialPassthroughSummary(
   }
 
   const records = await Promise.all(
-    fragmentIds.map(async (fragmentId) => await fragments.getFragment(fragmentId)),
+    fragmentIds.map(
+      async (fragmentId) => await fragments.getFragment(fragmentId),
+    ),
   );
 
   return records

--- a/test/serial.test.ts
+++ b/test/serial.test.ts
@@ -164,6 +164,65 @@ describe("serial", () => {
       }
     });
   });
+
+  it("uses the original text as summary when a serial has one fragment", async () => {
+    await withTempDir("spinedigest-serial-", async (path) => {
+      const document = await DirectoryDocument.open(path);
+
+      readerSegmentMock.mockReturnValueOnce(
+        createSentenceStream([
+          {
+            offset: 0,
+            text: "Alpha beta.",
+            wordsCount: 2,
+          },
+          {
+            offset: 11,
+            text: "Gamma delta.",
+            wordsCount: 2,
+          },
+        ]),
+      );
+
+      try {
+        const serial = await new SerialGeneration({
+          document,
+          llm: {} as never,
+        }).generateInto(1, [], {
+          extractionPrompt: "Keep key beats",
+        });
+
+        expect(serial.getSummary()).toBe("Alpha beta. Gamma delta.");
+        expect(await document.readSummary(1)).toBe("Alpha beta. Gamma delta.");
+        expect(compressTextMock).not.toHaveBeenCalled();
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("writes an empty summary when a serial has no fragments", async () => {
+    await withTempDir("spinedigest-serial-", async (path) => {
+      const document = await DirectoryDocument.open(path);
+
+      readerSegmentMock.mockReturnValueOnce(createSentenceStream([]));
+
+      try {
+        const serial = await new SerialGeneration({
+          document,
+          llm: {} as never,
+        }).generateInto(1, [], {
+          extractionPrompt: "Keep key beats",
+        });
+
+        expect(serial.getSummary()).toBe("");
+        expect(await document.readSummary(1)).toBe("");
+        expect(compressTextMock).not.toHaveBeenCalled();
+      } finally {
+        await document.release();
+      }
+    });
+  });
 });
 
 function createSentenceStream(


### PR DESCRIPTION
## Summary
- bypass summary compression when a serial has zero or one fragment
- persist passthrough summaries directly from fragment text before the editor stage
- add serial-level coverage for zero-fragment and single-fragment cases

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test:run