### PR TITLE
fix: improve cli progress feedback

### DIFF
--- a/src/cli/progress.ts
+++ b/src/cli/progress.ts
@@ -129,8 +129,8 @@ class TerminalProgressRenderer implements CLIProgressRenderer {
       return;
     }
 
-    if (this.#renderedLineCount > 0) {
-      moveCursor(this.#stream, 0, -this.#renderedLineCount);
+    if (this.#renderedLineCount > 1) {
+      moveCursor(this.#stream, 0, -(this.#renderedLineCount - 1));
     }
 
     const renderLineCount = Math.max(lines.length, this.#renderedLineCount);
@@ -150,7 +150,7 @@ class TerminalProgressRenderer implements CLIProgressRenderer {
       }
     }
 
-    this.#renderedLineCount = lines.length;
+    this.#renderedLineCount = renderLineCount;
   }
 
   #buildLines(): string[] {

--- a/src/progress/tracker.ts
+++ b/src/progress/tracker.ts
@@ -13,6 +13,7 @@ export interface CreateDigestProgressTrackerOptions {
 export class DigestProgressTracker {
   readonly #reporter: ProgressReporter;
   #completedWords = 0;
+  readonly #completedWordsBySerial = new Map<number, number>();
   #totalWords = 0;
   #discoverySettled = false;
 
@@ -56,10 +57,17 @@ export class DigestProgressTracker {
   }
 
   public async completeSerial(words: number): Promise<void> {
-    this.#completedWords += words;
-    if (this.#completedWords > this.#totalWords) {
-      this.#totalWords = this.#completedWords;
+    const nextTotalWords = Math.max(
+      this.#totalWords,
+      this.#completedWords,
+      words,
+    );
+
+    if (nextTotalWords === this.#totalWords) {
+      return;
     }
+
+    this.#totalWords = nextTotalWords;
     await this.#emitDigestProgress();
   }
 
@@ -68,12 +76,28 @@ export class DigestProgressTracker {
     readonly completedWords: number;
     readonly id: number;
   }): Promise<void> {
+    const previousCompletedWords =
+      this.#completedWordsBySerial.get(input.id) ?? 0;
+
+    if (input.completedWords !== previousCompletedWords) {
+      this.#completedWordsBySerial.set(input.id, input.completedWords);
+      this.#completedWords += input.completedWords - previousCompletedWords;
+
+      if (this.#completedWords > this.#totalWords) {
+        this.#totalWords = this.#completedWords;
+      }
+    }
+
     await this.#reporter.emit({
       completedFragments: input.completedFragments,
       completedWords: input.completedWords,
       id: input.id,
       type: "serial-progress",
     });
+
+    if (input.completedWords !== previousCompletedWords) {
+      await this.#emitDigestProgress();
+    }
   }
 
   async #emitDigestProgress(): Promise<void> {

--- a/test/cli/progress.test.ts
+++ b/test/cli/progress.test.ts
@@ -90,12 +90,88 @@ describe("cli/progress", () => {
       "#2        [##########..] 1,576 / 1,820 words (2/3 fragments)",
     ]);
   });
+
+  it("preserves the terminal row above the progress block while lines shrink", async () => {
+    const stream = new FakeTTYStream({
+      lines: ["shell> "],
+      row: 1,
+    });
+    const renderer = createCLIProgressRenderer({
+      enabled: true,
+      stream: stream as unknown as NodeJS.WriteStream,
+    });
+
+    if (renderer.onProgress === undefined) {
+      throw new Error(
+        "Progress callback should exist when renderer is enabled",
+      );
+    }
+
+    await renderer.onProgress({
+      available: true,
+      serials: [
+        {
+          fragments: 2,
+          id: 1,
+          words: 10,
+        },
+        {
+          fragments: 2,
+          id: 2,
+          words: 10,
+        },
+      ],
+      type: "serials-discovered",
+    });
+    await renderer.onProgress({
+      completedWords: 0,
+      totalWords: 20,
+      type: "digest-progress",
+    });
+    await renderer.onProgress({
+      completedFragments: 1,
+      completedWords: 5,
+      id: 1,
+      type: "serial-progress",
+    });
+    await renderer.onProgress({
+      completedFragments: 2,
+      completedWords: 10,
+      id: 1,
+      type: "serial-progress",
+    });
+    await renderer.onProgress({
+      completedFragments: 1,
+      completedWords: 5,
+      id: 2,
+      type: "serial-progress",
+    });
+
+    await renderer.stop();
+
+    expect(stream.visibleLines()).toStrictEqual([
+      "shell> ",
+      "Serial  [#########...] 15 / 20 words",
+      "Digest  [............] 0 / 20 words",
+      "------------------------",
+      "#2        [######......] 5 / 10 words (1/2 fragments)",
+    ]);
+  });
 });
 
 class FakeTTYStream {
   #column = 0;
-  #lines = [""];
-  #row = 0;
+  #lines: string[];
+  #row: number;
+
+  public constructor(input?: {
+    readonly lines?: readonly string[];
+    readonly row?: number;
+  }) {
+    this.#lines = [...(input?.lines ?? [""])];
+    this.#row = input?.row ?? 0;
+    this.#ensureLine(this.#row);
+  }
 
   public clearLine(): void {
     this.#ensureLine(this.#row);

--- a/test/common/progress-tracker.test.ts
+++ b/test/common/progress-tracker.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { createDigestProgressTracker } from "../../src/progress/index.js";
 
 describe("progress/tracker", () => {
-  it("does not add an extra fragment when completion only finalizes digest totals", async () => {
+  it("updates digest progress as fragment work advances", async () => {
     const events: Array<{
       readonly completedFragments?: number;
       readonly completedWords?: number;
@@ -47,14 +47,81 @@ describe("progress/tracker", () => {
         type: "serial-progress",
       },
       {
+        completedWords: 3,
+        totalWords: 3,
+        type: "digest-progress",
+      },
+      {
         completedFragments: 1,
         completedWords: 3,
         id: 7,
         type: "serial-progress",
       },
+    ]);
+  });
+
+  it("keeps discovered digest totals while serial work is still in flight", async () => {
+    const events: Array<{
+      readonly completedFragments?: number;
+      readonly completedWords?: number;
+      readonly id?: number;
+      readonly totalWords?: number;
+      readonly type: string;
+    }> = [];
+    const digestTracker = createDigestProgressTracker({
+      onProgress: (event) => {
+        switch (event.type) {
+          case "serial-progress":
+            events.push({
+              completedFragments: event.completedFragments,
+              completedWords: event.completedWords,
+              id: event.id,
+              type: event.type,
+            });
+            return;
+          case "digest-progress":
+            events.push({
+              completedWords: event.completedWords,
+              totalWords: event.totalWords,
+              type: event.type,
+            });
+        }
+      },
+      operation: "digest-txt",
+    });
+
+    await digestTracker.discoverSerials([
       {
-        completedWords: 3,
-        totalWords: 3,
+        id: 3,
+        words: 5,
+      },
+      {
+        id: 4,
+        words: 7,
+      },
+    ]);
+
+    const serialTracker = digestTracker.createSerialTracker({
+      id: 3,
+    });
+
+    await serialTracker.advance(2);
+
+    expect(events).toStrictEqual([
+      {
+        completedWords: 0,
+        totalWords: 12,
+        type: "digest-progress",
+      },
+      {
+        completedFragments: 1,
+        completedWords: 2,
+        id: 3,
+        type: "serial-progress",
+      },
+      {
+        completedWords: 2,
+        totalWords: 12,
         type: "digest-progress",
       },
     ]);

--- a/test/facade/digest.test.ts
+++ b/test/facade/digest.test.ts
@@ -375,5 +375,5 @@ describe("facade/digest", () => {
         undefined,
       );
     });
-  });
+  }, 15_000);
 });


### PR DESCRIPTION
## Summary
- fix terminal progress block redraw so shrinking updates do not leave stale serial rows behind
- update digest progress tracking to advance as serial fragments complete instead of waiting for whole serial completion
- add regression tests for terminal redraw behavior and digest progress aggregation

## Testing
- pnpm vitest run --passWithNoTests test/common/progress-tracker.test.ts test/common/progress.test.ts test/facade/digest.test.ts test/facade/import.test.ts test/cli/progress.test.ts test/cli/convert.test.ts
- pnpm prettier --check src/progress/tracker.ts src/cli/progress.ts test/common/progress-tracker.test.ts test/cli/progress.test.ts