### PR TITLE
fix: extract leading system messages for AI SDK calls

### DIFF
--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -367,7 +367,19 @@ function normalizeGenerationInput(input: {
   system?: string | SystemModelMessage | SystemModelMessage[];
   timeout: number;
 } {
-  const { messages, systemMessages } = splitLeadingSystemMessages(input.messages);
+  const systemMessages: SystemModelMessage[] = [];
+  let firstNonSystemIndex = 0;
+
+  while (firstNonSystemIndex < input.messages.length) {
+    const message = input.messages[firstNonSystemIndex];
+
+    if (message.role !== "system") {
+      break;
+    }
+
+    systemMessages.push(message);
+    firstNonSystemIndex += 1;
+  }
 
   if (systemMessages.length === 0) {
     return input;
@@ -375,33 +387,9 @@ function normalizeGenerationInput(input: {
 
   return {
     ...input,
-    messages,
+    messages: input.messages.slice(firstNonSystemIndex),
     system:
       systemMessages.length === 1 ? systemMessages[0] : systemMessages,
-  };
-}
-
-function splitLeadingSystemMessages(messages: readonly ModelMessage[]): {
-  messages: ModelMessage[];
-  systemMessages: SystemModelMessage[];
-} {
-  const systemMessages: SystemModelMessage[] = [];
-  let index = 0;
-
-  while (index < messages.length) {
-    const message = messages[index];
-
-    if (message.role !== "system") {
-      break;
-    }
-
-    systemMessages.push(message);
-    index += 1;
-  }
-
-  return {
-    messages: messages.slice(index),
-    systemMessages,
   };
 }
 

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -8,6 +8,7 @@ import {
   streamText,
   type LanguageModel,
   type ModelMessage,
+  type SystemModelMessage,
 } from "ai";
 import type { Environment } from "nunjucks";
 
@@ -271,15 +272,16 @@ export class LLM<S extends string> {
             maxRetries: number;
             messages: ModelMessage[];
             model: LanguageModel;
+            system?: string | SystemModelMessage | SystemModelMessage[];
             temperature?: number;
             timeout?: number;
             topP?: number;
-          } = {
+          } = normalizeGenerationInput({
             maxRetries: 0,
             messages: [...input.messages],
             model: this.#model,
             timeout: this.#timeoutMs,
-          };
+          });
 
           if (resolvedTemperature !== undefined) {
             generationInput.temperature = resolvedTemperature;
@@ -351,6 +353,56 @@ export class LLM<S extends string> {
 
     return response;
   }
+}
+
+function normalizeGenerationInput(input: {
+  maxRetries: number;
+  messages: ModelMessage[];
+  model: LanguageModel;
+  timeout: number;
+}): {
+  maxRetries: number;
+  messages: ModelMessage[];
+  model: LanguageModel;
+  system?: string | SystemModelMessage | SystemModelMessage[];
+  timeout: number;
+} {
+  const { messages, systemMessages } = splitLeadingSystemMessages(input.messages);
+
+  if (systemMessages.length === 0) {
+    return input;
+  }
+
+  return {
+    ...input,
+    messages,
+    system:
+      systemMessages.length === 1 ? systemMessages[0] : systemMessages,
+  };
+}
+
+function splitLeadingSystemMessages(messages: readonly ModelMessage[]): {
+  messages: ModelMessage[];
+  systemMessages: SystemModelMessage[];
+} {
+  const systemMessages: SystemModelMessage[] = [];
+  let index = 0;
+
+  while (index < messages.length) {
+    const message = messages[index];
+
+    if (message.role !== "system") {
+      break;
+    }
+
+    systemMessages.push(message);
+    index += 1;
+  }
+
+  return {
+    messages: messages.slice(index),
+    systemMessages,
+  };
 }
 
 function ensureDirectoryPath(dirPath?: string): string | undefined {

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -373,7 +373,7 @@ function normalizeGenerationInput(input: {
   while (firstNonSystemIndex < input.messages.length) {
     const message = input.messages[firstNonSystemIndex];
 
-    if (message.role !== "system") {
+    if (message === undefined || message.role !== "system") {
       break;
     }
 
@@ -385,11 +385,24 @@ function normalizeGenerationInput(input: {
     return input;
   }
 
+  if (systemMessages.length === 1) {
+    const [systemMessage] = systemMessages;
+
+    if (systemMessage === undefined) {
+      return input;
+    }
+
+    return {
+      ...input,
+      messages: input.messages.slice(firstNonSystemIndex),
+      system: systemMessage,
+    };
+  }
+
   return {
     ...input,
     messages: input.messages.slice(firstNonSystemIndex),
-    system:
-      systemMessages.length === 1 ? systemMessages[0] : systemMessages,
+    system: systemMessages,
   };
 }
 

--- a/test/llm/client.test.ts
+++ b/test/llm/client.test.ts
@@ -175,6 +175,34 @@ describe("llm/client", () => {
     });
   });
 
+  it("keeps cache keys based on the original messages", async () => {
+    const llm = new LLM({
+      cacheDirPath: process.cwd(),
+      dataDirPath: process.cwd(),
+      model: {
+        modelId: "test-model",
+        provider: "test-provider",
+      } as never,
+    });
+    const messages = [
+      {
+        content: "follow the style guide",
+        role: "system",
+      },
+      {
+        content: "hello",
+        role: "user",
+      },
+    ] as const;
+
+    await expect(llm.request(messages)).resolves.toBe("generated response");
+    aiMockState.generateTextResponse = "cached response should not be used";
+
+    await expect(llm.request(messages)).resolves.toBe("generated response");
+
+    expect(aiMockState.generateTextCalls).toHaveLength(1);
+  });
+
   it("preserves non-leading system messages in the messages array", async () => {
     const llm = new LLM({
       dataDirPath: process.cwd(),

--- a/test/llm/client.test.ts
+++ b/test/llm/client.test.ts
@@ -242,7 +242,8 @@ describe("llm/client", () => {
       ],
     });
     expect(
-      (aiMockState.generateTextCalls[0] as { readonly system?: unknown }).system,
+      (aiMockState.generateTextCalls[0] as { readonly system?: unknown })
+        .system,
     ).toBeUndefined();
   });
 

--- a/test/llm/client.test.ts
+++ b/test/llm/client.test.ts
@@ -135,6 +135,89 @@ describe("llm/client", () => {
     expect(aiMockState.streamTextCalls).toHaveLength(0);
   });
 
+  it("moves a leading system message to the top-level system field", async () => {
+    const llm = new LLM({
+      dataDirPath: process.cwd(),
+      model: {
+        modelId: "test-model",
+        provider: "test-provider",
+      } as never,
+    });
+
+    await llm.request([
+      {
+        content: "follow the style guide",
+        role: "system",
+      },
+      {
+        content: "hello",
+        role: "user",
+      },
+    ]);
+
+    expect(aiMockState.generateTextCalls).toHaveLength(1);
+    expect(
+      aiMockState.generateTextCalls[0] as {
+        readonly messages: readonly unknown[];
+        readonly system?: unknown;
+      },
+    ).toMatchObject({
+      messages: [
+        {
+          content: "hello",
+          role: "user",
+        },
+      ],
+      system: {
+        content: "follow the style guide",
+        role: "system",
+      },
+    });
+  });
+
+  it("preserves non-leading system messages in the messages array", async () => {
+    const llm = new LLM({
+      dataDirPath: process.cwd(),
+      model: {
+        modelId: "test-model",
+        provider: "test-provider",
+      } as never,
+    });
+
+    await llm.request([
+      {
+        content: "hello",
+        role: "user",
+      },
+      {
+        content: "follow the style guide",
+        role: "system",
+      },
+    ]);
+
+    expect(aiMockState.generateTextCalls).toHaveLength(1);
+    expect(
+      aiMockState.generateTextCalls[0] as {
+        readonly messages: readonly unknown[];
+        readonly system?: unknown;
+      },
+    ).toMatchObject({
+      messages: [
+        {
+          content: "hello",
+          role: "user",
+        },
+        {
+          content: "follow the style guide",
+          role: "system",
+        },
+      ],
+    });
+    expect(
+      (aiMockState.generateTextCalls[0] as { readonly system?: unknown }).system,
+    ).toBeUndefined();
+  });
+
   it("uses streamText when stream mode is enabled", async () => {
     const llm = new LLM({
       dataDirPath: process.cwd(),


### PR DESCRIPTION
## Summary
- extract leading `system` messages only at AI SDK call construction time
- pass extracted system prompts through the top-level `system` field for `generateText` and `streamText`
- add coverage for top-level system extraction, non-leading system preservation, and cache-key stability

## Why
AI SDK warns when `system` messages are passed inside `messages`. This change keeps the original request messages intact for cache-key calculation, and only rewrites the outbound `generationInput` shape before calling the SDK.

## Verification
- `pnpm --dir ./project test:run -- test/llm/client.test.ts`
- `pnpm --dir ./project typecheck`
