### PR TITLE
feat: improve CLI progress display and add status command

### DIFF
--- a/data/help/commands/root.jinja
+++ b/data/help/commands/root.jinja
@@ -9,6 +9,7 @@ Purpose:
 
 Usage:
   spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--prompt <text>] [--verbose|-v] [--help|-h]
+  spinedigest status [--help|-h]
   spinedigest sdpub <subcommand> --input <path> [--serial <id>] [--help|-h]
   spinedigest help [topic] [--help|-h]
 
@@ -23,6 +24,7 @@ Flag aliases:
 
 Common paths:
   Source input -> digest -> markdown | txt | epub | .sdpub
+  Config status -> validate config file -> print masked JSON
   .sdpub input -> re-export or inspect without re-running the digest pipeline
 
 Help topics:

--- a/data/help/commands/status.jinja
+++ b/data/help/commands/status.jinja
@@ -1,0 +1,29 @@
+Help Type: command
+Command: spinedigest status
+
+SpineDigest Status
+
+Purpose:
+  Validate and print the currently selected CLI config file.
+
+Usage:
+  spinedigest status [--help|-h]
+
+Behavior:
+  - Resolves the active config path using `SPINEDIGEST_CONFIG` when set, otherwise `~/.spinedigest/config.json`.
+  - If the config file does not exist, prints `{}` to stdout and exits 0.
+  - If the config file exists and is valid, prints the config JSON to stdout.
+  - `llm.apiKey` is masked before printing.
+  - If the file cannot be read, parsed, or validated, prints the error to stderr and exits non-zero.
+
+Notes:
+  - This command does not support digest, I/O, or verbose flags.
+  - Environment variables other than `SPINEDIGEST_CONFIG` do not get merged into the printed JSON.
+
+Where to go next:
+  - Need config precedence and override rules:
+    spinedigest help config
+  - Need the environment variable reference:
+    spinedigest help env
+  - Need the JSON file schema:
+    spinedigest help config-file

--- a/data/help/topics/command.jinja
+++ b/data/help/topics/command.jinja
@@ -6,6 +6,10 @@ Command Reference
 Main convert command:
   spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--prompt <text>] [--verbose|-v] [--help|-h]
 
+Status command:
+  spinedigest status [--help|-h]
+    Validate the active config file and print its masked JSON content.
+
 Main flags:
   --input <path>          Read from a file. If omitted, stdin is used.
   --output <path>         Write to a file. If omitted, stdout is used.

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -10,6 +10,7 @@ import {
   parseHelpTopic,
   renderHelpTopicText,
   renderMainHelpText,
+  renderStatusHelpText,
   renderSdpubHelpText,
   renderSdpubSubcommandHelpText,
   SDPUB_SUBCOMMANDS,
@@ -60,6 +61,15 @@ export type ParsedCLIArguments =
       readonly help: true;
       readonly helpText: string;
       readonly kind: "help";
+    }
+  | {
+      readonly help: false;
+      readonly kind: "status";
+    }
+  | {
+      readonly help: true;
+      readonly helpText: string;
+      readonly kind: "status";
     };
 
 export function parseCLIArguments(
@@ -108,6 +118,10 @@ export function parseCLIArguments(
 
   if (positionals[0] === "sdpub") {
     return parseSdpubArguments(positionals.slice(1), values);
+  }
+
+  if (positionals[0] === "status") {
+    return parseStatusArguments(positionals.slice(1), values);
   }
 
   if (positionals.length > 0) {
@@ -383,6 +397,60 @@ function parseHelpArguments(
   };
 }
 
+function parseStatusArguments(
+  positionals: readonly string[],
+  values: {
+    readonly "digest-dir"?: string;
+    readonly help?: boolean;
+    readonly input?: string;
+    readonly "input-format"?: string;
+    readonly output?: string;
+    readonly "output-format"?: string;
+    readonly prompt?: string;
+    readonly serial?: string;
+    readonly verbose?: boolean;
+  },
+): ParsedCLIArguments {
+  rejectStatusFlag("digest-dir", values["digest-dir"]);
+  rejectStatusFlag("input", values.input);
+  rejectStatusFlag("input-format", values["input-format"]);
+  rejectStatusFlag("output", values.output);
+  rejectStatusFlag("output-format", values["output-format"]);
+  rejectStatusFlag("prompt", values.prompt);
+  rejectStatusFlag("serial", values.serial);
+
+  if (values.verbose) {
+    throw new Error(
+      withHelpRoute(
+        "The `status` command does not support --verbose.",
+        "spinedigest status --help",
+      ),
+    );
+  }
+
+  if (positionals.length > 0) {
+    throw new Error(
+      withHelpRoute(
+        `Unexpected positional arguments: ${positionals.join(" ")}.`,
+        "spinedigest status --help",
+      ),
+    );
+  }
+
+  if (values.help ?? false) {
+    return {
+      help: true,
+      helpText: renderStatusHelpText(),
+      kind: "status",
+    };
+  }
+
+  return {
+    help: false,
+    kind: "status",
+  };
+}
+
 function parseSerialId(value: string, flag: string, helpRoute: string): number {
   const normalized = value.trim();
 
@@ -404,6 +472,17 @@ function rejectHelpFlag(name: string, value: string | undefined): void {
       withHelpRoute(
         `The \`help\` command does not support --${name}.`,
         CLI_HELP_ROUTES.root,
+      ),
+    );
+  }
+}
+
+function rejectStatusFlag(name: string, value: string | undefined): void {
+  if (value !== undefined) {
+    throw new Error(
+      withHelpRoute(
+        `The \`status\` command does not support --${name}.`,
+        "spinedigest status --help",
       ),
     );
   }

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -76,8 +76,8 @@ export interface CLIConfig {
 type CLIConfigFile = z.infer<typeof cliConfigSchema>;
 
 export async function loadCLIConfig(): Promise<CLIConfig> {
-  const configFilePath = resolveConfigFilePath(process.env.SPINEDIGEST_CONFIG);
-  const fileConfig = await readConfigFile(configFilePath);
+  const configFilePath = resolveCLIConfigFilePath();
+  const fileConfig = await readCLIConfigFile(configFilePath);
   const configDirectoryPath = dirname(configFilePath);
 
   const prompt = firstDefined(
@@ -177,7 +177,11 @@ export async function loadCLIConfig(): Promise<CLIConfig> {
   };
 }
 
-async function readConfigFile(path: string): Promise<CLIConfigFile> {
+export function resolveCLIConfigFilePath(): string {
+  return resolveConfigFilePath(process.env.SPINEDIGEST_CONFIG);
+}
+
+export async function readCLIConfigFile(path: string): Promise<CLIConfigFile> {
   if (!existsSync(path)) {
     return {};
   }

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -132,6 +132,10 @@ export function renderMainHelpText(): string {
   return renderHelpTemplate("help/commands/root");
 }
 
+export function renderStatusHelpText(): string {
+  return renderHelpTemplate("help/commands/status");
+}
+
 export function renderHelpTopicText(topic: HelpTopic): string {
   return renderHelpTemplate(HELP_TOPIC_TEMPLATE_NAMES[topic]);
 }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,5 +1,6 @@
 import { parseCLIArguments } from "./args.js";
 import { runConvertCommand } from "./convert.js";
+import { runStatusCommand } from "./status.js";
 import { runSdpubCommand } from "./sdpub.js";
 import { formatError } from "../utils/node-error.js";
 
@@ -22,6 +23,9 @@ export async function main(): Promise<void> {
         }
 
         await runSdpubCommand(parsed.args);
+        return;
+      case "status":
+        await runStatusCommand();
         return;
     }
   } catch (error) {

--- a/src/cli/progress.ts
+++ b/src/cli/progress.ts
@@ -248,7 +248,15 @@ function buildSerialHeading(
   serialId: number,
   title: string | undefined,
 ): string {
-  return title === undefined ? `#${serialId}` : `#${serialId} ${title}`;
+  if (title === undefined) {
+    return `#${serialId}`;
+  }
+
+  const sanitizedTitle = sanitizeSerialTitle(title);
+
+  return sanitizedTitle === ""
+    ? `#${serialId}`
+    : `#${serialId} ${sanitizedTitle}`;
 }
 
 function formatSerialDetailIndent(): string {
@@ -257,6 +265,75 @@ function formatSerialDetailIndent(): string {
 
 function buildWordsLabel(completed: number, total: number): string {
   return `${formatNumber(completed)} / ${formatNumber(total)} words`;
+}
+
+function sanitizeSerialTitle(title: string): string {
+  let sanitized = "";
+
+  for (let index = 0; index < title.length; index += 1) {
+    const current = title[index];
+
+    if (current === "\u001B") {
+      const next = title[index + 1];
+
+      if (next === "[") {
+        index = skipAnsiCSISequence(title, index + 2);
+        continue;
+      }
+
+      if (next === "]") {
+        index = skipAnsiOSCSequence(title, index + 2);
+        continue;
+      }
+
+      continue;
+    }
+
+    if (current !== undefined && /\p{Cc}/u.test(current)) {
+      continue;
+    }
+
+    sanitized += current ?? "";
+  }
+
+  return sanitized.trim();
+}
+
+function skipAnsiCSISequence(title: string, startIndex: number): number {
+  for (let index = startIndex; index < title.length; index += 1) {
+    const current = title[index];
+
+    if (current === undefined) {
+      return title.length;
+    }
+
+    if (current >= "@" && current <= "~") {
+      return index;
+    }
+  }
+
+  return title.length;
+}
+
+function skipAnsiOSCSequence(title: string, startIndex: number): number {
+  for (let index = startIndex; index < title.length; index += 1) {
+    const current = title[index];
+    const next = title[index + 1];
+
+    if (current === undefined) {
+      return title.length;
+    }
+
+    if (current === "\u0007") {
+      return index;
+    }
+
+    if (current === "\u001B" && next === "\\") {
+      return index + 1;
+    }
+  }
+
+  return title.length;
 }
 
 function buildFragmentsLabel(

--- a/src/cli/progress.ts
+++ b/src/cli/progress.ts
@@ -9,6 +9,7 @@ interface SerialState {
   completedFragments: number;
   completedWords: number;
   fragments?: number;
+  title?: string;
   words?: number;
 }
 
@@ -95,6 +96,7 @@ class TerminalProgressRenderer implements CLIProgressRenderer {
           this.#serials.set(serial.id, {
             completedFragments: 0,
             completedWords: 0,
+            ...(serial.title === undefined ? {} : { title: serial.title }),
             words: serial.words,
             ...(serial.fragments === undefined
               ? {}
@@ -171,7 +173,8 @@ class TerminalProgressRenderer implements CLIProgressRenderer {
       0,
     );
     const activeSerials = discoveredSerials.filter(
-      ([, serial]) => serial.completedWords < serial.words,
+      ([, serial]) =>
+        serial.completedWords > 0 && serial.completedWords < serial.words,
     );
 
     if (discoveredSerials.length > 0) {
@@ -214,8 +217,9 @@ class TerminalProgressRenderer implements CLIProgressRenderer {
         serial.fragments,
       );
 
+      lines.push(buildSerialHeading(serialId, serial.title));
       lines.push(
-        `${formatSerialLabel(`#${serialId}`)}${renderBar(
+        `${formatSerialDetailIndent()}${renderBar(
           serial.completedWords,
           serial.words,
         )} ${wordsLabel.padEnd(wordsLabelWidth)}${fragmentsLabel === undefined ? "" : ` (${fragmentsLabel})`}`,
@@ -240,8 +244,15 @@ function formatStageLabel(label: string): string {
   return label.padEnd(8);
 }
 
-function formatSerialLabel(label: string): string {
-  return label.padEnd(10);
+function buildSerialHeading(
+  serialId: number,
+  title: string | undefined,
+): string {
+  return title === undefined ? `#${serialId}` : `#${serialId} ${title}`;
+}
+
+function formatSerialDetailIndent(): string {
+  return " ".repeat(7);
 }
 
 function buildWordsLabel(completed: number, total: number): string {

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -48,19 +48,21 @@ function maskConfigSecrets(value: unknown): JSONLike {
   }
 
   const record = value as Record<string, unknown>;
-  const maskedEntries = Object.entries(record).map(([key, entryValue]) => [
-    key,
-    key === "apiKey" ? maskAPIKey(entryValue) : maskConfigSecrets(entryValue),
-  ]);
+  const maskedRecord: Record<string, unknown> = {};
 
-  const maskedRecord: Record<string, unknown> = Object.fromEntries(maskedEntries);
+  for (const [key, entryValue] of Object.entries(record)) {
+    maskedRecord[key] =
+      key === "apiKey" ? maskAPIKey(entryValue) : maskConfigSecrets(entryValue);
+  }
 
   return maskedRecord;
 }
 
 function maskAPIKey(value: unknown): string | number | boolean | null {
   if (typeof value !== "string") {
-    return value === null || typeof value === "number" || typeof value === "boolean"
+    return value === null ||
+      typeof value === "number" ||
+      typeof value === "boolean"
       ? value
       : null;
   }

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -1,0 +1,76 @@
+import { existsSync } from "fs";
+import { readFile } from "fs/promises";
+
+import { readCLIConfigFile, resolveCLIConfigFilePath } from "./config.js";
+import { writeTextToStdout } from "./io.js";
+
+export async function runStatusCommand(): Promise<void> {
+  const configFilePath = resolveCLIConfigFilePath();
+
+  await readCLIConfigFile(configFilePath);
+
+  if (!existsSync(configFilePath)) {
+    await writeTextToStdout("{}\n");
+    return;
+  }
+
+  const content = await readFile(configFilePath, "utf8");
+  const parsedJson = JSON.parse(content) as Record<string, unknown>;
+  const masked = maskConfigSecrets(parsedJson);
+
+  await writeTextToStdout(`${JSON.stringify(masked, null, 2)}\n`);
+}
+
+type JSONLike =
+  | Record<string, unknown>
+  | readonly unknown[]
+  | string
+  | number
+  | boolean
+  | null;
+
+function maskConfigSecrets(value: unknown): JSONLike {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item): JSONLike => maskConfigSecrets(item));
+  }
+
+  if (typeof value !== "object") {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const maskedEntries = Object.entries(record).map(([key, entryValue]) => [
+    key,
+    key === "apiKey" ? maskAPIKey(entryValue) : maskConfigSecrets(entryValue),
+  ]);
+
+  const maskedRecord: Record<string, unknown> = Object.fromEntries(maskedEntries);
+
+  return maskedRecord;
+}
+
+function maskAPIKey(value: unknown): string | number | boolean | null {
+  if (typeof value !== "string") {
+    return value === null || typeof value === "number" || typeof value === "boolean"
+      ? value
+      : null;
+  }
+
+  const visiblePrefixLength = Math.min(4, value.length);
+  const visibleSuffixLength = value.length > 8 ? 4 : 0;
+  const maskedLength = Math.max(
+    0,
+    value.length - visiblePrefixLength - visibleSuffixLength,
+  );
+
+  return `${value.slice(0, visiblePrefixLength)}${"*".repeat(maskedLength)}${visibleSuffixLength === 0 ? "" : value.slice(-visibleSuffixLength)}`;
+}

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -1,22 +1,9 @@
-import { existsSync } from "fs";
-import { readFile } from "fs/promises";
-
 import { readCLIConfigFile, resolveCLIConfigFilePath } from "./config.js";
 import { writeTextToStdout } from "./io.js";
 
 export async function runStatusCommand(): Promise<void> {
   const configFilePath = resolveCLIConfigFilePath();
-
-  await readCLIConfigFile(configFilePath);
-
-  if (!existsSync(configFilePath)) {
-    await writeTextToStdout("{}\n");
-    return;
-  }
-
-  const content = await readFile(configFilePath, "utf8");
-  const parsedJson = JSON.parse(content) as Record<string, unknown>;
-  const masked = maskConfigSecrets(parsedJson);
+  const masked = maskConfigSecrets(await readCLIConfigFile(configFilePath));
 
   await writeTextToStdout(`${JSON.stringify(masked, null, 2)}\n`);
 }
@@ -65,6 +52,10 @@ function maskAPIKey(value: unknown): string | number | boolean | null {
       typeof value === "boolean"
       ? value
       : null;
+  }
+
+  if (value.length <= 8) {
+    return `${value.slice(0, Math.min(3, value.length))}***`;
   }
 
   const visiblePrefixLength = Math.min(4, value.length);

--- a/src/facade/import.ts
+++ b/src/facade/import.ts
@@ -237,6 +237,7 @@ async function discoverPlannedSections(
   readonly {
     readonly fragments?: number;
     readonly id: number;
+    readonly title?: string | undefined;
     readonly words: number;
   }[]
 > {

--- a/src/facade/import.ts
+++ b/src/facade/import.ts
@@ -247,6 +247,7 @@ async function discoverPlannedSections(
   ) {
     return plannedSections.map((plannedSection) => ({
       id: plannedSection.serialId,
+      title: plannedSection.section.title?.trim() || undefined,
       words: plannedSection.section.wordsCount ?? 0,
     }));
   }
@@ -256,6 +257,7 @@ async function discoverPlannedSections(
   for (const plannedSection of plannedSections) {
     discoveries.push({
       id: plannedSection.serialId,
+      title: plannedSection.section.title?.trim() || undefined,
       ...(await discoverSerial({
         ...(options.segmenter === undefined
           ? {}

--- a/src/progress/types.ts
+++ b/src/progress/types.ts
@@ -7,6 +7,7 @@ export type SpineDigestOperation =
 export interface SerialDiscoveryItem {
   readonly id: number;
   readonly fragments?: number | undefined;
+  readonly title?: string | undefined;
   readonly words: number;
 }
 

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -4,6 +4,7 @@ import { parseCLIArguments } from "../../src/cli/args.js";
 import {
   renderHelpTopicText,
   renderMainHelpText,
+  renderStatusHelpText,
   renderSdpubHelpText,
   renderSdpubSubcommandHelpText,
 } from "../../src/cli/help.js";
@@ -124,6 +125,19 @@ describe("cli/args", () => {
     });
   });
 
+  it("parses status and prints status help text", () => {
+    expect(parseCLIArguments(["status"])).toStrictEqual({
+      help: false,
+      kind: "status",
+    });
+
+    expect(parseCLIArguments(["status", "--help"])).toStrictEqual({
+      help: true,
+      helpText: renderStatusHelpText(),
+      kind: "status",
+    });
+  });
+
   it("prints help topic pages", () => {
     expect(parseCLIArguments(["help", "runtime"])).toStrictEqual({
       help: true,
@@ -227,12 +241,25 @@ describe("cli/args", () => {
     );
   });
 
+  it("rejects invalid status usage", () => {
+    expect(() => parseCLIArguments(["status", "--input", "book.epub"])).toThrow(
+      "The `status` command does not support --input.\nSee: spinedigest status --help",
+    );
+    expect(() => parseCLIArguments(["status", "--verbose"])).toThrow(
+      "The `status` command does not support --verbose.\nSee: spinedigest status --help",
+    );
+    expect(() => parseCLIArguments(["status", "extra"])).toThrow(
+      "Unexpected positional arguments: extra.\nSee: spinedigest status --help",
+    );
+  });
+
   it("documents the layered help contract", () => {
     const rootHelpText = renderMainHelpText();
     const sdpubHelpText = renderSdpubHelpText();
     const commandHelpText = renderHelpTopicText("command");
 
     expect(rootHelpText).toContain("spinedigest help [topic]");
+    expect(rootHelpText).toContain("spinedigest status [--help|-h]");
     expect(rootHelpText).toContain("spinedigest help overview");
     expect(rootHelpText).toContain("spinedigest help env");
     expect(rootHelpText).toContain("spinedigest help config-file");
@@ -251,6 +278,7 @@ describe("cli/args", () => {
     expect(rootHelpText).toContain("Use `spinedigest help troubleshoot`");
     expect(renderHelpTopicText("runtime")).toContain("Runtime Behavior");
     expect(renderHelpTopicText("config")).toContain("Configuration Overview");
+    expect(renderHelpTopicText("command")).toContain("spinedigest status");
     expect(renderHelpTopicText("ai")).toContain("Suggested first pass:");
     expect(renderHelpTopicText("ai")).toContain(
       "Begin at `spinedigest --help`, which acts as the root page",

--- a/test/cli/main.test.ts
+++ b/test/cli/main.test.ts
@@ -12,8 +12,10 @@ const mainMockState = vi.hoisted(() => ({
   } as Record<string, unknown>,
   parseError: undefined as Error | undefined,
   runCalls: [] as unknown[],
+  statusRunCalls: 0,
   sdpubRunCalls: [] as unknown[],
   runError: undefined as Error | undefined,
+  statusRunError: undefined as Error | undefined,
   sdpubRunError: undefined as Error | undefined,
 }));
 
@@ -33,6 +35,18 @@ vi.mock("../../src/cli/convert.js", () => ({
 
     if (mainMockState.runError !== undefined) {
       return Promise.reject(mainMockState.runError);
+    }
+
+    return Promise.resolve();
+  }),
+}));
+
+vi.mock("../../src/cli/status.js", () => ({
+  runStatusCommand: vi.fn(() => {
+    mainMockState.statusRunCalls += 1;
+
+    if (mainMockState.statusRunError !== undefined) {
+      return Promise.reject(mainMockState.statusRunError);
     }
 
     return Promise.resolve();
@@ -71,8 +85,10 @@ describe("cli/main", () => {
     };
     mainMockState.parseError = undefined;
     mainMockState.runCalls.length = 0;
+    mainMockState.statusRunCalls = 0;
     mainMockState.sdpubRunCalls.length = 0;
     mainMockState.runError = undefined;
+    mainMockState.statusRunError = undefined;
     mainMockState.sdpubRunError = undefined;
     process.exitCode = 0;
     stdoutChunks = [];
@@ -109,6 +125,7 @@ describe("cli/main", () => {
     expect(stdoutChunks).toStrictEqual(["CLI HELP\n"]);
     expect(stderrChunks).toStrictEqual([]);
     expect(mainMockState.runCalls).toHaveLength(0);
+    expect(mainMockState.statusRunCalls).toBe(0);
     expect(mainMockState.sdpubRunCalls).toHaveLength(0);
     expect(process.exitCode).toBe(0);
   });
@@ -136,8 +153,23 @@ describe("cli/main", () => {
       },
     ]);
     expect(mainMockState.sdpubRunCalls).toHaveLength(0);
+    expect(mainMockState.statusRunCalls).toBe(0);
     expect(stdoutChunks).toStrictEqual([]);
     expect(stderrChunks).toStrictEqual([]);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("runs the status command for status execution", async () => {
+    mainMockState.argsResult = {
+      help: false,
+      kind: "status",
+    };
+
+    await main();
+
+    expect(mainMockState.runCalls).toHaveLength(0);
+    expect(mainMockState.statusRunCalls).toBe(1);
+    expect(mainMockState.sdpubRunCalls).toHaveLength(0);
     expect(process.exitCode).toBe(0);
   });
 
@@ -170,6 +202,7 @@ describe("cli/main", () => {
 
     expect(stderrChunks).toStrictEqual(["bad args\n"]);
     expect(mainMockState.runCalls).toHaveLength(0);
+    expect(mainMockState.statusRunCalls).toBe(0);
     expect(process.exitCode).toBe(1);
   });
 
@@ -193,6 +226,20 @@ describe("cli/main", () => {
         verbose: false,
       },
     ]);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("writes status command failures to stderr and sets a non-zero exit code", async () => {
+    mainMockState.argsResult = {
+      help: false,
+      kind: "status",
+    };
+    mainMockState.statusRunError = new Error("status failed");
+
+    await main();
+
+    expect(stderrChunks).toStrictEqual(["status failed\n"]);
+    expect(mainMockState.statusRunCalls).toBe(1);
     expect(process.exitCode).toBe(1);
   });
 

--- a/test/cli/progress.test.ts
+++ b/test/cli/progress.test.ts
@@ -229,6 +229,54 @@ describe("cli/progress", () => {
       "       [######......] 10 / 20 words (1/2 fragments)",
     ]);
   });
+
+  it("sanitizes serial titles before rendering", async () => {
+    const stream = new FakeTTYStream();
+    const renderer = createCLIProgressRenderer({
+      enabled: true,
+      stream: stream as unknown as NodeJS.WriteStream,
+    });
+
+    if (renderer.onProgress === undefined) {
+      throw new Error(
+        "Progress callback should exist when renderer is enabled",
+      );
+    }
+
+    await renderer.onProgress({
+      available: true,
+      serials: [
+        {
+          fragments: 2,
+          id: 7,
+          title: "Line 1\n\u001B[31mLine 2\u001B[0m",
+          words: 10,
+        },
+      ],
+      type: "serials-discovered",
+    });
+    await renderer.onProgress({
+      completedFragments: 1,
+      completedWords: 5,
+      id: 7,
+      type: "serial-progress",
+    });
+    await renderer.onProgress({
+      completedWords: 5,
+      totalWords: 10,
+      type: "digest-progress",
+    });
+
+    await renderer.stop();
+
+    expect(stream.visibleLines()).toStrictEqual([
+      "Serial  [######......] 5 / 10 words",
+      "Digest  [######......] 5 / 10 words",
+      "------------------------",
+      "#7 Line 1Line 2",
+      "       [######......] 5 / 10 words (1/2 fragments)",
+    ]);
+  });
 });
 
 class FakeTTYStream {

--- a/test/cli/progress.test.ts
+++ b/test/cli/progress.test.ts
@@ -37,11 +37,13 @@ describe("cli/progress", () => {
           {
             fragments: 3,
             id: 2,
+            title: "Chapter 2",
             words: 1820,
           },
           {
             fragments: 2,
             id: 1,
+            title: "Chapter 1",
             words: 882,
           },
         ],
@@ -87,7 +89,8 @@ describe("cli/progress", () => {
       "Serial  [###########.] 2,458 / 2,702 words",
       "Digest  [####........] 882 / 2,702 words",
       "------------------------",
-      "#2        [##########..] 1,576 / 1,820 words (2/3 fragments)",
+      "#2 Chapter 2",
+      "       [##########..] 1,576 / 1,820 words (2/3 fragments)",
     ]);
   });
 
@@ -113,11 +116,13 @@ describe("cli/progress", () => {
         {
           fragments: 2,
           id: 1,
+          title: "Chapter 1",
           words: 10,
         },
         {
           fragments: 2,
           id: 2,
+          title: "Chapter 2",
           words: 10,
         },
       ],
@@ -154,7 +159,74 @@ describe("cli/progress", () => {
       "Serial  [#########...] 15 / 20 words",
       "Digest  [............] 0 / 20 words",
       "------------------------",
-      "#2        [######......] 5 / 10 words (1/2 fragments)",
+      "#2 Chapter 2",
+      "       [######......] 5 / 10 words (1/2 fragments)",
+    ]);
+  });
+
+  it("does not show unstarted or completed serial rows", async () => {
+    const stream = new FakeTTYStream();
+    const renderer = createCLIProgressRenderer({
+      enabled: true,
+      stream: stream as unknown as NodeJS.WriteStream,
+    });
+
+    if (renderer.onProgress === undefined) {
+      throw new Error(
+        "Progress callback should exist when renderer is enabled",
+      );
+    }
+
+    await renderer.onProgress({
+      available: true,
+      serials: [
+        {
+          fragments: 1,
+          id: 1,
+          title: "Not started",
+          words: 10,
+        },
+        {
+          fragments: 2,
+          id: 2,
+          title: "In progress",
+          words: 20,
+        },
+        {
+          fragments: 3,
+          id: 3,
+          title: "Done",
+          words: 30,
+        },
+      ],
+      type: "serials-discovered",
+    });
+    await renderer.onProgress({
+      completedWords: 10,
+      totalWords: 60,
+      type: "digest-progress",
+    });
+    await renderer.onProgress({
+      completedFragments: 1,
+      completedWords: 10,
+      id: 2,
+      type: "serial-progress",
+    });
+    await renderer.onProgress({
+      completedFragments: 3,
+      completedWords: 30,
+      id: 3,
+      type: "serial-progress",
+    });
+
+    await renderer.stop();
+
+    expect(stream.visibleLines()).toStrictEqual([
+      "Serial  [########....] 40 / 60 words",
+      "Digest  [##..........] 10 / 60 words",
+      "------------------------",
+      "#2 In progress",
+      "       [######......] 10 / 20 words (1/2 fragments)",
     ]);
   });
 });

--- a/test/cli/status.test.ts
+++ b/test/cli/status.test.ts
@@ -1,0 +1,117 @@
+import { mkdir, writeFile } from "fs/promises";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const statusMockState = vi.hoisted(() => ({
+  stdoutTexts: [] as string[],
+}));
+
+vi.mock("../../src/cli/io.js", () => ({
+  writeTextToStdout: vi.fn(async (text: string) => {
+    statusMockState.stdoutTexts.push(text);
+  }),
+}));
+
+import { runStatusCommand } from "../../src/cli/status.js";
+import { withTempDir } from "../helpers/temp.js";
+
+describe("cli/status", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    statusMockState.stdoutTexts.length = 0;
+
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+        continue;
+      }
+
+      process.env[key] = value;
+    }
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+        continue;
+      }
+
+      process.env[key] = value;
+    }
+  });
+
+  it("prints {} when the config file does not exist", async () => {
+    await withTempDir("spinedigest-status-", async (path) => {
+      process.env.SPINEDIGEST_CONFIG = `${path}/missing.json`;
+      await runStatusCommand();
+
+      expect(statusMockState.stdoutTexts).toStrictEqual(["{}\n"]);
+    });
+  });
+
+  it("prints masked config json when the config file is valid", async () => {
+    await withTempDir("spinedigest-status-", async (path) => {
+      const configPath = `${path}/nested/config.json`;
+
+      await mkdir(`${path}/nested`, { recursive: true });
+      await writeFile(
+        configPath,
+        JSON.stringify(
+          {
+            llm: {
+              apiKey: "sk-test-secret-key",
+              model: "gpt-4.1",
+              provider: "openai",
+            },
+            paths: {
+              cacheDir: "./cache",
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      process.env.SPINEDIGEST_CONFIG = configPath;
+
+      await runStatusCommand();
+
+      expect(statusMockState.stdoutTexts).toStrictEqual([`{
+  "llm": {
+    "apiKey": "sk-t**********-key",
+    "model": "gpt-4.1",
+    "provider": "openai"
+  },
+  "paths": {
+    "cacheDir": "./cache"
+  }
+}\n`]);
+    });
+  });
+
+  it("throws when the config file is invalid", async () => {
+    await withTempDir("spinedigest-status-", async (path) => {
+      const configPath = `${path}/broken.json`;
+
+      await writeFile(configPath, "{not json", "utf8");
+      process.env.SPINEDIGEST_CONFIG = configPath;
+
+      await expect(runStatusCommand()).rejects.toThrow(
+        `Invalid CLI config JSON at ${configPath}:`,
+      );
+    });
+  });
+});

--- a/test/cli/status.test.ts
+++ b/test/cli/status.test.ts
@@ -7,7 +7,7 @@ const statusMockState = vi.hoisted(() => ({
 }));
 
 vi.mock("../../src/cli/io.js", () => ({
-  writeTextToStdout: vi.fn(async (text: string) => {
+  writeTextToStdout: vi.fn((text: string) => {
     statusMockState.stdoutTexts.push(text);
   }),
 }));
@@ -89,7 +89,8 @@ describe("cli/status", () => {
 
       await runStatusCommand();
 
-      expect(statusMockState.stdoutTexts).toStrictEqual([`{
+      expect(statusMockState.stdoutTexts).toStrictEqual([
+        `{
   "llm": {
     "apiKey": "sk-t**********-key",
     "model": "gpt-4.1",
@@ -98,7 +99,8 @@ describe("cli/status", () => {
   "paths": {
     "cacheDir": "./cache"
   }
-}\n`]);
+}\n`,
+      ]);
     });
   });
 

--- a/test/cli/status.test.ts
+++ b/test/cli/status.test.ts
@@ -104,6 +104,40 @@ describe("cli/status", () => {
     });
   });
 
+  it("masks short api keys without exposing the full secret", async () => {
+    await withTempDir("spinedigest-status-", async (path) => {
+      const configPath = `${path}/config.json`;
+
+      await writeFile(
+        configPath,
+        JSON.stringify(
+          {
+            llm: {
+              apiKey: "sk-x",
+              model: "gpt-4.1",
+              provider: "openai",
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      process.env.SPINEDIGEST_CONFIG = configPath;
+
+      await runStatusCommand();
+
+      expect(statusMockState.stdoutTexts).toStrictEqual([
+        `{
+  "llm": {
+    "apiKey": "sk-***",
+    "model": "gpt-4.1",
+    "provider": "openai"
+  }
+}\n`,
+      ]);
+    });
+  });
+
   it("throws when the config file is invalid", async () => {
     await withTempDir("spinedigest-status-", async (path) => {
       const configPath = `${path}/broken.json`;

--- a/test/common/progress.test.ts
+++ b/test/common/progress.test.ts
@@ -27,6 +27,7 @@ describe("progress/reporter", () => {
         {
           fragments: 4,
           id: 7,
+          title: "Chapter 7",
           words: 1600,
         },
       ],
@@ -40,6 +41,7 @@ describe("progress/reporter", () => {
         {
           fragments: 4,
           id: 7,
+          title: "Chapter 7",
           words: 1600,
         },
       ],

--- a/test/facade/import.test.ts
+++ b/test/facade/import.test.ts
@@ -299,11 +299,13 @@ describe("facade/import", () => {
             {
               fragments: 1,
               id: 1,
+              title: "Chapter 1",
               words: 2,
             },
             {
               fragments: 1,
               id: 2,
+              title: "Chapter 2",
               words: 3,
             },
           ],
@@ -371,10 +373,12 @@ describe("facade/import", () => {
           serials: [
             {
               id: 1,
+              title: "Chapter 1",
               words: 2,
             },
             {
               id: 2,
+              title: "Chapter 2",
               words: 3,
             },
           ],


### PR DESCRIPTION
## Summary
- refine serial progress rows to show only active serials and include section titles
- add \ to print the validated config JSON with a masked API key
- update help text and tests for the new CLI behavior

## Verification
- npm run lint:fix
- npm run typecheck
- npm run test:run -- test/cli/status.test.ts test/cli/args.test.ts test/cli/main.test.ts test/cli/progress.test.ts test/common/progress.test.ts test/facade/import.test.ts test/cli/config.test.ts