### PR TITLE
fix: parallelize serial imports

### DIFF
--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from "async_hooks";
-import { mkdir, readFile, unlink, writeFile } from "fs/promises";
+import { mkdir, readFile, rm, unlink, writeFile } from "fs/promises";
 import { join, resolve } from "path";
 import { z } from "zod";
 
@@ -58,6 +58,13 @@ export interface ReadonlyDocument {
   release(): Promise<void>;
 }
 
+export interface DocumentContext {
+  complete(): void;
+  dispose(): Promise<void>;
+  ownSerial(serialId: number): void;
+  run<T>(operation: () => Promise<T> | T): Promise<T>;
+}
+
 export interface Document extends ReadonlyDocument {
   readonly chunks: ChunkStore;
   readonly fragmentGroups: FragmentGroupStore;
@@ -67,6 +74,7 @@ export interface Document extends ReadonlyDocument {
   readonly snakeEdges: SnakeEdgeStore;
   readonly snakes: SnakeStore;
 
+  createContext(): DocumentContext;
   getSerialFragments(serialId: number): SerialFragments;
   createSerial(): Promise<number>;
   flush(): Promise<void>;
@@ -76,10 +84,6 @@ export interface Document extends ReadonlyDocument {
   writeCover(cover: SourceAsset): Promise<void>;
   writeSummary(serialId: number, summary: string): Promise<void>;
   writeToc(toc: TocFile): Promise<void>;
-}
-
-interface DocumentSessionState {
-  readonly createdFilePaths: string[];
 }
 
 export class DirectoryDocument implements Document {
@@ -94,7 +98,7 @@ export class DirectoryDocument implements Document {
 
   readonly #database: Database;
   readonly #fragments: Fragments;
-  readonly #sessionScope = new AsyncLocalStorage<DocumentSessionState>();
+  readonly #contextScope = new AsyncLocalStorage<DirectoryDocumentContext>();
 
   public constructor(database: Database, fragments: Fragments, path: string) {
     this.#database = database;
@@ -153,8 +157,15 @@ export class DirectoryDocument implements Document {
     return this.#fragments.getSerial(serialId);
   }
 
+  public createContext(): DocumentContext {
+    return new DirectoryDocumentContext(this);
+  }
+
   public async createSerial(): Promise<number> {
-    return await this.serials.create();
+    const serialId = await this.serials.create();
+
+    this.#contextScope.getStore()?.ownSerial(serialId);
+    return serialId;
   }
 
   public async getSentence(sentenceId: SentenceId): Promise<string> {
@@ -164,27 +175,23 @@ export class DirectoryDocument implements Document {
   public async openSession<T>(
     operation: (document: Document) => Promise<T> | T,
   ): Promise<T> {
-    const activeSession = this.#sessionScope.getStore();
+    const activeContext = this.#contextScope.getStore();
 
-    if (activeSession !== undefined) {
+    if (activeContext !== undefined) {
       return await operation(this);
     }
 
-    const session = {
-      createdFilePaths: [],
-    } satisfies DocumentSessionState;
+    const context = new DirectoryDocumentContext(this);
 
     try {
-      return await this.#database.transaction(
-        async () =>
-          await this.#sessionScope.run(
-            session,
-            async () => await operation(this),
-          ),
+      const result = await this.#database.transaction(
+        async () => await context.run(async () => await operation(this)),
       );
-    } catch (error) {
-      await this.#rollbackCreatedFiles(session);
-      throw error;
+
+      context.complete();
+      return result;
+    } finally {
+      await context.dispose();
     }
   }
 
@@ -274,10 +281,122 @@ export class DirectoryDocument implements Document {
     await this.release();
   }
 
-  async #rollbackCreatedFiles(session: DocumentSessionState): Promise<void> {
-    for (const path of [...session.createdFilePaths].reverse()) {
+  async #rollbackContext(context: DirectoryDocumentContext): Promise<void> {
+    await this.#rollbackOwnedSerials(context.listOwnedSerialIds());
+    await this.#rollbackCreatedFiles(context.listCreatedFilePaths());
+  }
+
+  async #rollbackCreatedFiles(
+    createdFilePaths: readonly string[],
+  ): Promise<void> {
+    for (const path of [...createdFilePaths].reverse()) {
       try {
         await unlink(path);
+      } catch (error) {
+        if (isNodeError(error) && error.code === "ENOENT") {
+          continue;
+        }
+
+        throw error;
+      }
+    }
+  }
+
+  async #rollbackOwnedSerials(serialIds: readonly number[]): Promise<void> {
+    for (const serialId of [...serialIds].sort(compareNumberDescending)) {
+      await this.#database.transaction(async () => {
+        await this.#database.run(
+          `
+            DELETE FROM snake_edges
+            WHERE from_snake_id IN (
+              SELECT id
+              FROM snakes
+              WHERE serial_id = ?
+            ) OR to_snake_id IN (
+              SELECT id
+              FROM snakes
+              WHERE serial_id = ?
+            )
+          `,
+          [serialId, serialId],
+        );
+        await this.#database.run(
+          `
+            DELETE FROM snake_chunks
+            WHERE snake_id IN (
+              SELECT id
+              FROM snakes
+              WHERE serial_id = ?
+            )
+          `,
+          [serialId],
+        );
+        await this.#database.run(
+          `
+            DELETE FROM snakes
+            WHERE serial_id = ?
+          `,
+          [serialId],
+        );
+        await this.#database.run(
+          `
+            DELETE FROM fragment_groups
+            WHERE serial_id = ?
+          `,
+          [serialId],
+        );
+        await this.#database.run(
+          `
+            DELETE FROM knowledge_edges
+            WHERE from_id IN (
+              SELECT id
+              FROM chunks
+              WHERE serial_id = ?
+            ) OR to_id IN (
+              SELECT id
+              FROM chunks
+              WHERE serial_id = ?
+            )
+          `,
+          [serialId, serialId],
+        );
+        await this.#database.run(
+          `
+            DELETE FROM chunk_sentences
+            WHERE serial_id = ?
+          `,
+          [serialId],
+        );
+        await this.#database.run(
+          `
+            DELETE FROM chunks
+            WHERE serial_id = ?
+          `,
+          [serialId],
+        );
+        await this.#database.run(
+          `
+            DELETE FROM serial_states
+            WHERE serial_id = ?
+          `,
+          [serialId],
+        );
+        await this.#database.run(
+          `
+            DELETE FROM serials
+            WHERE id = ?
+          `,
+          [serialId],
+        );
+      });
+
+      await rm(this.#fragments.getSerial(serialId).path, {
+        force: true,
+        recursive: true,
+      });
+
+      try {
+        await unlink(this.#getSummaryPath(serialId));
       } catch (error) {
         if (isNodeError(error) && error.code === "ENOENT") {
           continue;
@@ -352,7 +471,7 @@ export class DirectoryDocument implements Document {
       throw error;
     }
 
-    this.#sessionScope.getStore()?.createdFilePaths.push(path);
+    this.#contextScope.getStore()?.registerCreatedFile(path);
   }
 
   #getSummariesPath(): string {
@@ -382,4 +501,80 @@ export class DirectoryDocument implements Document {
   #getTocPath(): string {
     return join(this.path, "toc.json");
   }
+
+  public async runWithContext<T>(
+    context: DirectoryDocumentContext,
+    operation: () => Promise<T> | T,
+  ): Promise<T> {
+    return await this.#contextScope.run(context, operation);
+  }
+
+  public async rollbackContext(
+    context: DirectoryDocumentContext,
+  ): Promise<void> {
+    await this.#rollbackContext(context);
+  }
+}
+
+class DirectoryDocumentContext implements DocumentContext {
+  readonly #createdFilePaths: string[] = [];
+  readonly #document: DirectoryDocument;
+  readonly #ownedSerialIds = new Set<number>();
+  #completed = false;
+  #disposed = false;
+
+  public constructor(document: DirectoryDocument) {
+    this.#document = document;
+  }
+
+  public complete(): void {
+    this.#assertActive();
+    this.#completed = true;
+  }
+
+  public async dispose(): Promise<void> {
+    if (this.#disposed) {
+      return;
+    }
+
+    this.#disposed = true;
+
+    if (this.#completed) {
+      return;
+    }
+
+    await this.#document.rollbackContext(this);
+  }
+
+  public ownSerial(serialId: number): void {
+    this.#assertActive();
+    this.#ownedSerialIds.add(serialId);
+  }
+
+  public async run<T>(operation: () => Promise<T> | T): Promise<T> {
+    this.#assertActive();
+    return await this.#document.runWithContext(this, operation);
+  }
+
+  public listCreatedFilePaths(): readonly string[] {
+    return [...this.#createdFilePaths];
+  }
+
+  public listOwnedSerialIds(): readonly number[] {
+    return [...this.#ownedSerialIds];
+  }
+
+  public registerCreatedFile(path: string): void {
+    this.#createdFilePaths.push(path);
+  }
+
+  #assertActive(): void {
+    if (this.#disposed) {
+      throw new Error("DocumentContext is already disposed");
+    }
+  }
+}
+
+function compareNumberDescending(left: number, right: number): number {
+  return right - left;
 }

--- a/src/document/index.ts
+++ b/src/document/index.ts
@@ -5,7 +5,11 @@ export type {
   ReadonlySerialFragments,
 } from "./fragments.js";
 export { DirectoryDocument } from "./document.js";
-export type { Document, ReadonlyDocument } from "./document.js";
+export type {
+  Document,
+  DocumentContext,
+  ReadonlyDocument,
+} from "./document.js";
 export { SCHEMA_SQL } from "./schema.js";
 export {
   ChunkStore,

--- a/src/facade/import.ts
+++ b/src/facade/import.ts
@@ -1,5 +1,6 @@
 import type { Document } from "../document/index.js";
 import type { DigestProgressTracker } from "../progress/index.js";
+import { AsyncSemaphore } from "../utils/async-semaphore.js";
 import {
   SerialGeneration,
   discoverSerial,
@@ -87,7 +88,6 @@ export async function importSourceDocument(
       ? {}
       : { segmenter: options.segmenter }),
   });
-  const serials: Serial[] = [];
 
   if (options.digestProgressTracker !== undefined) {
     const discoveries = await discoverPlannedSections(plannedSections, {
@@ -99,28 +99,14 @@ export async function importSourceDocument(
     await options.digestProgressTracker.discoverSerials(discoveries);
   }
 
-  for (const plannedSection of plannedSections) {
-    const serialProgressTracker =
-      options.digestProgressTracker?.createSerialTracker({
-        id: plannedSection.serialId,
-      });
-
-    const serial = await options.document.openSession(async () => {
-      return await generation.generateInto(
-        plannedSection.serialId,
-        await plannedSection.section.open(),
-        {
-          extractionPrompt: options.extractionPrompt,
-          ...(options.userLanguage === undefined
-            ? {}
-            : { userLanguage: options.userLanguage }),
-        },
-        serialProgressTracker,
-      );
-    });
-
-    serials.push(serial);
-  }
+  const serials = await generatePlannedSerials(plannedSections, {
+    digestProgressTracker: options.digestProgressTracker,
+    document: options.document,
+    extractionPrompt: options.extractionPrompt,
+    generation,
+    serialConcurrency: resolveSerialGenerationConcurrency(options.llm),
+    userLanguage: options.userLanguage,
+  });
 
   await options.document.openSession(async (document) => {
     await document.writeBookMeta(meta);
@@ -137,6 +123,56 @@ export async function importSourceDocument(
     serials,
     toc,
   };
+}
+
+async function generatePlannedSerials(
+  plannedSections: readonly PlannedSection[],
+  options: {
+    readonly digestProgressTracker?: DigestProgressTracker;
+    readonly document: Document;
+    readonly extractionPrompt: string;
+    readonly generation: SerialGeneration;
+    readonly serialConcurrency: number;
+    readonly userLanguage?: GenerateSerialOptions["userLanguage"];
+  },
+): Promise<Serial[]> {
+  const limiter = new AsyncSemaphore(options.serialConcurrency);
+  const serials = await Promise.all(
+    plannedSections.map(async (plannedSection) => {
+      return await limiter.use(async () => {
+        const context = options.document.createContext();
+
+        context.ownSerial(plannedSection.serialId);
+
+        try {
+          const serialProgressTracker =
+            options.digestProgressTracker?.createSerialTracker({
+              id: plannedSection.serialId,
+            });
+          const serial = await context.run(async () => {
+            return await options.generation.generateInto(
+              plannedSection.serialId,
+              await plannedSection.section.open(),
+              {
+                extractionPrompt: options.extractionPrompt,
+                ...(options.userLanguage === undefined
+                  ? {}
+                  : { userLanguage: options.userLanguage }),
+              },
+              serialProgressTracker,
+            );
+          });
+
+          context.complete();
+          return serial;
+        } finally {
+          await context.dispose();
+        }
+      });
+    }),
+  );
+
+  return [...serials].sort((left, right) => left.id - right.id);
 }
 
 function planTocItems(input: {
@@ -269,4 +305,24 @@ async function discoverPlannedSections(
   }
 
   return discoveries;
+}
+
+function resolveSerialGenerationConcurrency(
+  llm: Pick<ImportSourceOptions, "llm">["llm"],
+): number {
+  if (
+    typeof llm !== "object" ||
+    llm === null ||
+    !("config" in llm) ||
+    typeof llm.config !== "object" ||
+    llm.config === null ||
+    !("concurrent" in llm.config) ||
+    typeof llm.config.concurrent !== "number" ||
+    !Number.isInteger(llm.config.concurrent) ||
+    llm.config.concurrent < 1
+  ) {
+    return 1;
+  }
+
+  return llm.config.concurrent;
 }

--- a/src/facade/import.ts
+++ b/src/facade/import.ts
@@ -100,12 +100,16 @@ export async function importSourceDocument(
   }
 
   const serials = await generatePlannedSerials(plannedSections, {
-    digestProgressTracker: options.digestProgressTracker,
     document: options.document,
     extractionPrompt: options.extractionPrompt,
     generation,
     serialConcurrency: resolveSerialGenerationConcurrency(options.llm),
-    userLanguage: options.userLanguage,
+    ...(options.digestProgressTracker === undefined
+      ? {}
+      : { digestProgressTracker: options.digestProgressTracker }),
+    ...(options.userLanguage === undefined
+      ? {}
+      : { userLanguage: options.userLanguage }),
   });
 
   await options.document.openSession(async (document) => {

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -96,6 +96,7 @@ export class LLM<S extends string> {
   readonly #topP: TemperatureSetting;
 
   public readonly config: Readonly<{
+    concurrent: number;
     provider?: string;
     modelId: string;
     sampling?: SamplingScopeConfig<S>;
@@ -115,6 +116,7 @@ export class LLM<S extends string> {
     const modelInfo = resolveModelInfo(options.model);
 
     this.config = Object.freeze({
+      concurrent,
       modelId: modelInfo.modelId,
       temperature,
       stream,

--- a/test/document/directory-document.test.ts
+++ b/test/document/directory-document.test.ts
@@ -131,4 +131,30 @@ describe("document/directory-document", () => {
       }
     });
   });
+
+  it("rolls back owned serial resources when a document context is disposed without completion", async () => {
+    await withTempDir("spinedigest-document-", async (path) => {
+      const document = await DirectoryDocument.open(path);
+      const context = document.createContext();
+
+      context.ownSerial(1);
+
+      try {
+        await context.run(async () => {
+          await document.serials.createWithId(1);
+          await document.serials.setTopologyReady(1);
+          await document.writeSummary(1, "Transient summary");
+        });
+      } finally {
+        await context.dispose();
+      }
+
+      try {
+        await expect(document.serials.listIds()).resolves.toStrictEqual([]);
+        await expect(document.readSummary(1)).resolves.toBeUndefined();
+      } finally {
+        await document.release();
+      }
+    });
+  });
 });

--- a/test/facade/import.test.ts
+++ b/test/facade/import.test.ts
@@ -21,6 +21,8 @@ const serialMockState = vi.hoisted(() => ({
     readonly streamText: string;
   }>,
   releaseSerials: new Map<number, () => void>(),
+  startedResolvers: new Map<number, () => void>(),
+  startedSignals: new Map<number, Promise<void>>(),
   startedSerialIds: [] as number[],
 }));
 
@@ -56,6 +58,7 @@ vi.mock("../../src/serial.js", () => ({
       options: unknown,
     ): Promise<{ readonly id: number }> {
       serialMockState.startedSerialIds.push(serialId);
+      serialMockState.startedResolvers.get(serialId)?.();
 
       if (serialMockState.blockedSerialIds.has(serialId)) {
         await new Promise<void>((resolve) => {
@@ -90,6 +93,8 @@ describe("facade/import", () => {
     serialMockState.constructorOptions.length = 0;
     serialMockState.generateIntoCalls.length = 0;
     serialMockState.releaseSerials.clear();
+    serialMockState.startedResolvers.clear();
+    serialMockState.startedSignals.clear();
     serialMockState.startedSerialIds.length = 0;
   });
 
@@ -410,6 +415,16 @@ describe("facade/import", () => {
   it("runs planned serial generation up to the llm concurrent limit", async () => {
     await withTempDir("spinedigest-import-", async (path) => {
       const document = await DirectoryDocument.open(`${path}/document`);
+      const startedPromises = new Map<number, Promise<void>>();
+
+      for (const serialId of [1, 2, 3]) {
+        startedPromises.set(
+          serialId,
+          new Promise<void>((resolve) => {
+            serialMockState.startedResolvers.set(serialId, resolve);
+          }),
+        );
+      }
 
       serialMockState.blockedSerialIds.add(1);
       serialMockState.blockedSerialIds.add(2);
@@ -449,17 +464,16 @@ describe("facade/import", () => {
           },
         );
 
-        await vi.waitFor(() => {
-          expect(serialMockState.startedSerialIds).toStrictEqual([1, 2]);
-        });
-        await new Promise((resolve) => setTimeout(resolve, 20));
+        await Promise.all([
+          startedPromises.get(1),
+          startedPromises.get(2),
+        ]);
         expect(serialMockState.startedSerialIds).toStrictEqual([1, 2]);
 
         serialMockState.releaseSerials.get(1)?.();
 
-        await vi.waitFor(() => {
-          expect(serialMockState.startedSerialIds).toStrictEqual([1, 2, 3]);
-        });
+        await startedPromises.get(3);
+        expect(serialMockState.startedSerialIds).toStrictEqual([1, 2, 3]);
 
         serialMockState.releaseSerials.get(2)?.();
 

--- a/test/facade/import.test.ts
+++ b/test/facade/import.test.ts
@@ -13,12 +13,15 @@ import { importSource, importSourceDocument } from "../../src/facade/import.js";
 import { withTempDir } from "../helpers/temp.js";
 
 const serialMockState = vi.hoisted(() => ({
+  blockedSerialIds: new Set<number>(),
   constructorOptions: [] as unknown[],
   generateIntoCalls: [] as Array<{
     readonly options: unknown;
     readonly serialId: number;
     readonly streamText: string;
   }>,
+  releaseSerials: new Map<number, () => void>(),
+  startedSerialIds: [] as number[],
 }));
 
 vi.mock("../../src/serial.js", () => ({
@@ -52,6 +55,14 @@ vi.mock("../../src/serial.js", () => ({
       stream: AsyncIterable<string> | Iterable<string>,
       options: unknown,
     ): Promise<{ readonly id: number }> {
+      serialMockState.startedSerialIds.push(serialId);
+
+      if (serialMockState.blockedSerialIds.has(serialId)) {
+        await new Promise<void>((resolve) => {
+          serialMockState.releaseSerials.set(serialId, resolve);
+        });
+      }
+
       let streamText = "";
 
       for await (const chunk of stream) {
@@ -75,8 +86,11 @@ vi.mock("../../src/serial.js", () => ({
 
 describe("facade/import", () => {
   beforeEach(() => {
+    serialMockState.blockedSerialIds.clear();
     serialMockState.constructorOptions.length = 0;
     serialMockState.generateIntoCalls.length = 0;
+    serialMockState.releaseSerials.clear();
+    serialMockState.startedSerialIds.length = 0;
   });
 
   it("imports source sections into an empty document with planned toc titles", async () => {
@@ -388,6 +402,75 @@ describe("facade/import", () => {
         expect(openCounts.get("Spacer")).toBeUndefined();
         expect(openCounts.get("Chapter 2")).toBe(1);
       } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("runs planned serial generation up to the llm concurrent limit", async () => {
+    await withTempDir("spinedigest-import-", async (path) => {
+      const document = await DirectoryDocument.open(`${path}/document`);
+
+      serialMockState.blockedSerialIds.add(1);
+      serialMockState.blockedSerialIds.add(2);
+
+      try {
+        const importPromise = importSourceDocument(
+          createSourceDocument({
+            meta: createBookMeta({
+              title: "Concurrent Fixture",
+            }),
+            sections: [
+              createSourceSection({
+                hasContent: true,
+                streamText: "Chapter one",
+                title: "Chapter 1",
+              }),
+              createSourceSection({
+                hasContent: true,
+                streamText: "Chapter two",
+                title: "Chapter 2",
+              }),
+              createSourceSection({
+                hasContent: true,
+                streamText: "Chapter three",
+                title: "Chapter 3",
+              }),
+            ],
+          }),
+          {
+            document,
+            extractionPrompt: "Keep key beats",
+            llm: {
+              config: {
+                concurrent: 2,
+              },
+            } as never,
+          },
+        );
+
+        await vi.waitFor(() => {
+          expect(serialMockState.startedSerialIds).toStrictEqual([1, 2]);
+        });
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        expect(serialMockState.startedSerialIds).toStrictEqual([1, 2]);
+
+        serialMockState.releaseSerials.get(1)?.();
+
+        await vi.waitFor(() => {
+          expect(serialMockState.startedSerialIds).toStrictEqual([1, 2, 3]);
+        });
+
+        serialMockState.releaseSerials.get(2)?.();
+
+        const imported = await importPromise;
+
+        expect(imported.serials.map((serial) => serial.id)).toStrictEqual([
+          1, 2, 3,
+        ]);
+      } finally {
+        serialMockState.releaseSerials.get(1)?.();
+        serialMockState.releaseSerials.get(2)?.();
         await document.release();
       }
     });

--- a/test/facade/import.test.ts
+++ b/test/facade/import.test.ts
@@ -464,10 +464,7 @@ describe("facade/import", () => {
           },
         );
 
-        await Promise.all([
-          startedPromises.get(1),
-          startedPromises.get(2),
-        ]);
+        await Promise.all([startedPromises.get(1), startedPromises.get(2)]);
         expect(serialMockState.startedSerialIds).toStrictEqual([1, 2]);
 
         serialMockState.releaseSerials.get(1)?.();

--- a/test/llm/client.test.ts
+++ b/test/llm/client.test.ts
@@ -80,6 +80,7 @@ vi.mock("ai", () => ({
 
 import { SpineDigestScope } from "../../src/common/llm-scope.js";
 import { LLM } from "../../src/llm/client.js";
+import { withTempDir } from "../helpers/temp.js";
 
 const RETRYABLE_TRANSPORT_CODES = [
   "UND_ERR_SOCKET",
@@ -176,31 +177,33 @@ describe("llm/client", () => {
   });
 
   it("keeps cache keys based on the original messages", async () => {
-    const llm = new LLM({
-      cacheDirPath: process.cwd(),
-      dataDirPath: process.cwd(),
-      model: {
-        modelId: "test-model",
-        provider: "test-provider",
-      } as never,
+    await withTempDir("spinedigest-llm-cache-", async (cacheDirPath) => {
+      const llm = new LLM({
+        cacheDirPath,
+        dataDirPath: process.cwd(),
+        model: {
+          modelId: "test-model",
+          provider: "test-provider",
+        } as never,
+      });
+      const messages = [
+        {
+          content: "follow the style guide",
+          role: "system",
+        },
+        {
+          content: "hello",
+          role: "user",
+        },
+      ] as const;
+
+      await expect(llm.request(messages)).resolves.toBe("generated response");
+      aiMockState.generateTextResponse = "cached response should not be used";
+
+      await expect(llm.request(messages)).resolves.toBe("generated response");
+
+      expect(aiMockState.generateTextCalls).toHaveLength(1);
     });
-    const messages = [
-      {
-        content: "follow the style guide",
-        role: "system",
-      },
-      {
-        content: "hello",
-        role: "user",
-      },
-    ] as const;
-
-    await expect(llm.request(messages)).resolves.toBe("generated response");
-    aiMockState.generateTextResponse = "cached response should not be used";
-
-    await expect(llm.request(messages)).resolves.toBe("generated response");
-
-    expect(aiMockState.generateTextCalls).toHaveLength(1);
   });
 
   it("preserves non-leading system messages in the messages array", async () => {


### PR DESCRIPTION
## Summary
- parallelize serial generation during import up to the configured concurrent limit
- add explicit document context ownership and rollback for serial-scoped resources
- keep imported serial ordering stable by returning results sorted by serial id

## Testing
- npm run lint:fix
- pnpm test -- --runInBand test/document/directory-document.test.ts test/facade/import.test.ts