### PR TITLE
fix: correct digest progress semantics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spinedigest",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "CLI-first tool for digesting long-form text and ebooks into compressed text, EPUB, or reusable .sdpub archives.",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/progress/tracker.ts
+++ b/src/progress/tracker.ts
@@ -56,14 +56,28 @@ export class DigestProgressTracker {
     });
   }
 
-  public async completeSerial(words: number): Promise<void> {
+  public async completeSerial(input: {
+    readonly id: number;
+    readonly words: number;
+  }): Promise<void> {
+    const previousCompletedWords =
+      this.#completedWordsBySerial.get(input.id) ?? 0;
+
+    if (input.words !== previousCompletedWords) {
+      this.#completedWordsBySerial.set(input.id, input.words);
+      this.#completedWords += input.words - previousCompletedWords;
+    }
+
     const nextTotalWords = Math.max(
       this.#totalWords,
       this.#completedWords,
-      words,
+      input.words,
     );
 
-    if (nextTotalWords === this.#totalWords) {
+    if (
+      nextTotalWords === this.#totalWords &&
+      input.words === previousCompletedWords
+    ) {
       return;
     }
 
@@ -76,28 +90,12 @@ export class DigestProgressTracker {
     readonly completedWords: number;
     readonly id: number;
   }): Promise<void> {
-    const previousCompletedWords =
-      this.#completedWordsBySerial.get(input.id) ?? 0;
-
-    if (input.completedWords !== previousCompletedWords) {
-      this.#completedWordsBySerial.set(input.id, input.completedWords);
-      this.#completedWords += input.completedWords - previousCompletedWords;
-
-      if (this.#completedWords > this.#totalWords) {
-        this.#totalWords = this.#completedWords;
-      }
-    }
-
     await this.#reporter.emit({
       completedFragments: input.completedFragments,
       completedWords: input.completedWords,
       id: input.id,
       type: "serial-progress",
     });
-
-    if (input.completedWords !== previousCompletedWords) {
-      await this.#emitDigestProgress();
-    }
   }
 
   async #emitDigestProgress(): Promise<void> {
@@ -152,7 +150,10 @@ export class SerialProgressTracker {
       completedWords: this.#completedWords,
       id: this.#id,
     });
-    await this.#digestTracker.completeSerial(this.#completedWords);
+    await this.#digestTracker.completeSerial({
+      id: this.#id,
+      words: this.#completedWords,
+    });
   }
 }
 

--- a/test/common/progress-tracker.test.ts
+++ b/test/common/progress-tracker.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { createDigestProgressTracker } from "../../src/progress/index.js";
 
 describe("progress/tracker", () => {
-  it("updates digest progress as fragment work advances", async () => {
+  it("updates digest progress only when a serial completes", async () => {
     const events: Array<{
       readonly completedFragments?: number;
       readonly completedWords?: number;
@@ -47,20 +47,20 @@ describe("progress/tracker", () => {
         type: "serial-progress",
       },
       {
-        completedWords: 3,
-        totalWords: 3,
-        type: "digest-progress",
-      },
-      {
         completedFragments: 1,
         completedWords: 3,
         id: 7,
         type: "serial-progress",
       },
+      {
+        completedWords: 3,
+        totalWords: 3,
+        type: "digest-progress",
+      },
     ]);
   });
 
-  it("keeps discovered digest totals while serial work is still in flight", async () => {
+  it("keeps digest progress at zero while serial work is still in flight", async () => {
     const events: Array<{
       readonly completedFragments?: number;
       readonly completedWords?: number;
@@ -118,11 +118,6 @@ describe("progress/tracker", () => {
         completedWords: 2,
         id: 3,
         type: "serial-progress",
-      },
-      {
-        completedWords: 2,
-        totalWords: 12,
-        type: "digest-progress",
       },
     ]);
   });


### PR DESCRIPTION
## Summary
- correct digest progress so it advances only when a serial finishes its second stage
- keep serial progress tied to first-stage fragment processing
- bump the package version to 0.1.7

## Testing
- pnpm run lint:fix
- pnpm test -- --runInBand test/common/progress-tracker.test.ts test/cli/progress.test.ts test/facade/digest.test.ts
