### PR TITLE
fix: harden guaranteed JSON retries for chunk extraction

### DIFF
--- a/data/guaranteed/response_intent_classifier.jinja
+++ b/data/guaranteed/response_intent_classifier.jinja
@@ -1,0 +1,8 @@
+Classify the raw assistant reply into exactly one label.
+
+Labels:
+- malformed_json: the reply is trying to provide JSON, but it is broken or truncated
+- natural_language: the reply is plain conversational language, apology, refusal, or explanation instead of JSON
+- ambiguous: unclear or mixed
+
+Reply with the label only.

--- a/src/editor/review.ts
+++ b/src/editor/review.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 
-import { requestGuaranteedJson } from "../guaranteed/index.js";
+import {
+  requestGuaranteedJson,
+  RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE,
+} from "../guaranteed/index.js";
 import type { Language } from "../common/language.js";
 import type { LLMessage, LLM } from "../llm/index.js";
 import type { ReadonlySerialFragments } from "../document/index.js";
@@ -135,6 +138,9 @@ export class CompressionReviewer<S extends string> {
               weight: clueReviewer.weight,
             },
           }),
+          responseIntentClassifierPrompt: this.#llm.loadSystemPrompt(
+            RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE,
+          ),
           request: async (retryMessages, retryIndex, retryMax) =>
             await this.#llm.request(retryMessages, {
               retryIndex,

--- a/src/guaranteed/classifier.ts
+++ b/src/guaranteed/classifier.ts
@@ -1,0 +1,142 @@
+import type { LLMessage } from "../llm/index.js";
+
+export type GuaranteedResponseIntent =
+  | "ambiguous"
+  | "malformed_json"
+  | "natural_language";
+
+const NATURAL_LANGUAGE_PATTERNS = [
+  /\b(?:sorry|apologies)\b/i,
+  /\b(?:i\s+can(?:not|'t)|unable\s+to|do\s+not\s+understand)\b/i,
+  /\b(?:cannot\s+answer|can't\s+answer|can't\s+help)\b/i,
+  /\bno\s+relevant\s+result/i,
+  /抱歉/,
+  /无法回答/,
+  /无法识别/,
+  /无法给到/,
+  /没有找到相关的结果/,
+];
+
+export function buildResponseIntentClassificationMessages(
+  response: string,
+): readonly LLMessage[] {
+  return [
+    {
+      role: "system",
+      content: [
+        "Classify the raw assistant reply into exactly one label.",
+        "",
+        "Labels:",
+        "- malformed_json: the reply is trying to provide JSON, but it is broken or truncated",
+        "- natural_language: the reply is plain conversational language, apology, refusal, or explanation instead of JSON",
+        "- ambiguous: unclear or mixed",
+        "",
+        "Reply with the label only.",
+      ].join("\n"),
+    },
+    {
+      role: "user",
+      content: response,
+    },
+  ];
+}
+
+export function classifyResponseIntentLocally(
+  response: string,
+): GuaranteedResponseIntent {
+  const trimmed = response.trim();
+
+  if (trimmed === "") {
+    return "ambiguous";
+  }
+
+  if (hasStrongMalformedJsonSignal(trimmed)) {
+    return "malformed_json";
+  }
+
+  if (looksLikeNaturalLanguage(trimmed)) {
+    return "natural_language";
+  }
+
+  if (hasWeakMalformedJsonSignal(trimmed)) {
+    return "ambiguous";
+  }
+
+  if (looksLikePlainSentence(trimmed)) {
+    return "natural_language";
+  }
+
+  return "ambiguous";
+}
+
+export function parseResponseIntentClassification(
+  response: string,
+): GuaranteedResponseIntent {
+  const normalized = response.trim().toLowerCase();
+
+  if (normalized.includes("malformed_json")) {
+    return "malformed_json";
+  }
+
+  if (normalized.includes("natural_language")) {
+    return "natural_language";
+  }
+
+  if (normalized.includes("ambiguous")) {
+    return "ambiguous";
+  }
+
+  return "ambiguous";
+}
+
+function hasStrongMalformedJsonSignal(text: string): boolean {
+  return (
+    /^(?:```json\b|```|\{|\[)/i.test(text) ||
+    /"[^"\r\n]+"\s*:/.test(text) ||
+    (hasWeakMalformedJsonSignal(text) && endsWithLikelyTruncationToken(text))
+  );
+}
+
+function hasWeakMalformedJsonSignal(text: string): boolean {
+  const punctuationCount =
+    (text.match(/[\{\}\[\]:,]/g) ?? []).length +
+    (text.match(/"/g) ?? []).length;
+
+  return (
+    /:\s/.test(text) ||
+    punctuationCount >= 3 ||
+    hasUnbalancedBrackets(text) ||
+    /[:,]\s*$/.test(text)
+  );
+}
+
+function hasUnbalancedBrackets(text: string): boolean {
+  return count(text, "{") !== count(text, "}") ||
+    count(text, "[") !== count(text, "]")
+    ? true
+    : false;
+}
+
+function endsWithLikelyTruncationToken(text: string): boolean {
+  return /[:,"{\[]\s*$/.test(text);
+}
+
+function looksLikeNaturalLanguage(text: string): boolean {
+  if (NATURAL_LANGUAGE_PATTERNS.some((pattern) => pattern.test(text))) {
+    return true;
+  }
+
+  return !hasWeakMalformedJsonSignal(text) && looksLikePlainSentence(text);
+}
+
+function looksLikePlainSentence(text: string): boolean {
+  return (
+    /[\p{Script=Han}A-Za-z]/u.test(text) &&
+    !/^[\[{]/.test(text) &&
+    !/"[^"\r\n]+"\s*:/.test(text)
+  );
+}
+
+function count(text: string, character: string): number {
+  return text.split(character).length - 1;
+}

--- a/src/guaranteed/classifier.ts
+++ b/src/guaranteed/classifier.ts
@@ -1,5 +1,8 @@
 import type { LLMessage } from "../llm/index.js";
 
+export const RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE =
+  "guaranteed/response_intent_classifier";
+
 export type GuaranteedResponseIntent =
   | "ambiguous"
   | "malformed_json"
@@ -18,21 +21,13 @@ const NATURAL_LANGUAGE_PATTERNS = [
 ];
 
 export function buildResponseIntentClassificationMessages(
+  systemPrompt: string,
   response: string,
 ): readonly LLMessage[] {
   return [
     {
       role: "system",
-      content: [
-        "Classify the raw assistant reply into exactly one label.",
-        "",
-        "Labels:",
-        "- malformed_json: the reply is trying to provide JSON, but it is broken or truncated",
-        "- natural_language: the reply is plain conversational language, apology, refusal, or explanation instead of JSON",
-        "- ambiguous: unclear or mixed",
-        "",
-        "Reply with the label only.",
-      ].join("\n"),
+      content: systemPrompt,
     },
     {
       role: "user",

--- a/src/guaranteed/classifier.ts
+++ b/src/guaranteed/classifier.ts
@@ -86,7 +86,7 @@ export function parseResponseIntentClassification(
 
 function hasStrongMalformedJsonSignal(text: string): boolean {
   return (
-    /^(?:```json\b|```|\{|\[)/i.test(text) ||
+    /^(?:```json\b|```|{|\[)/i.test(text) ||
     /"[^"\r\n]+"\s*:/.test(text) ||
     (hasWeakMalformedJsonSignal(text) && endsWithLikelyTruncationToken(text))
   );
@@ -94,8 +94,7 @@ function hasStrongMalformedJsonSignal(text: string): boolean {
 
 function hasWeakMalformedJsonSignal(text: string): boolean {
   const punctuationCount =
-    (text.match(/[\{\}\[\]:,]/g) ?? []).length +
-    (text.match(/"/g) ?? []).length;
+    (text.match(/[{}[\]:,]/g) ?? []).length + (text.match(/"/g) ?? []).length;
 
   return (
     /:\s/.test(text) ||
@@ -113,7 +112,7 @@ function hasUnbalancedBrackets(text: string): boolean {
 }
 
 function endsWithLikelyTruncationToken(text: string): boolean {
-  return /[:,"{\[]\s*$/.test(text);
+  return /[:, "{[]\s*$/.test(text);
 }
 
 function looksLikeNaturalLanguage(text: string): boolean {
@@ -127,7 +126,7 @@ function looksLikeNaturalLanguage(text: string): boolean {
 function looksLikePlainSentence(text: string): boolean {
   return (
     /[\p{Script=Han}A-Za-z]/u.test(text) &&
-    !/^[\[{]/.test(text) &&
+    !/^[{[]/.test(text) &&
     !/"[^"\r\n]+"\s*:/.test(text)
   );
 }

--- a/src/guaranteed/errors.ts
+++ b/src/guaranteed/errors.ts
@@ -8,21 +8,30 @@ export class ParsedJsonError extends Error {
   }
 }
 
-export class GuaranteedEmptyResponseError extends Error {
+export abstract class GuaranteedRequestFailureError extends Error {
   public readonly attempts: number;
   public readonly maxRetries: number;
 
-  public constructor(attempts: number, maxRetries: number) {
-    super("LLM returned empty response after all retries");
-    this.name = "GuaranteedEmptyResponseError";
+  protected constructor(message: string, attempts: number, maxRetries: number) {
+    super(message);
+    this.name = "GuaranteedRequestFailureError";
     this.attempts = attempts;
     this.maxRetries = maxRetries;
   }
 }
 
-export class SuspectedModelRefusalError extends Error {
-  public readonly attempts: number;
-  public readonly maxRetries: number;
+export class GuaranteedEmptyResponseError extends GuaranteedRequestFailureError {
+  public constructor(attempts: number, maxRetries: number) {
+    super(
+      "LLM returned empty response after all retries",
+      attempts,
+      maxRetries,
+    );
+    this.name = "GuaranteedEmptyResponseError";
+  }
+}
+
+export class SuspectedModelRefusalError extends GuaranteedRequestFailureError {
   public readonly response: string;
   public readonly reason: string;
 
@@ -36,19 +45,17 @@ export class SuspectedModelRefusalError extends Error {
   ) {
     super(
       `Suspected model refusal after ${attempts} JSON syntax error attempt(s): ${input.reason}. Last response: ${JSON.stringify(input.response)}`,
+      attempts,
+      maxRetries,
     );
     this.name = "SuspectedModelRefusalError";
-    this.attempts = attempts;
-    this.maxRetries = maxRetries;
     this.response = input.response;
     this.reason = input.reason;
   }
 }
 
-export class GuaranteedSchemaValidationError extends Error {
-  public readonly attempts: number;
+export class GuaranteedSchemaValidationError extends GuaranteedRequestFailureError {
   public readonly issues: readonly string[];
-  public readonly maxRetries: number;
   public readonly response: string;
 
   public constructor(
@@ -60,19 +67,16 @@ export class GuaranteedSchemaValidationError extends Error {
     },
     cause: unknown,
   ) {
-    super("Schema validation failed after all retries", { cause });
+    super("Schema validation failed after all retries", attempts, maxRetries);
     this.name = "GuaranteedSchemaValidationError";
-    this.attempts = attempts;
     this.issues = [...input.issues];
-    this.maxRetries = maxRetries;
     this.response = input.response;
+    this.cause = cause;
   }
 }
 
-export class GuaranteedParseValidationError extends Error {
-  public readonly attempts: number;
+export class GuaranteedParseValidationError extends GuaranteedRequestFailureError {
   public readonly issues: readonly string[];
-  public readonly maxRetries: number;
   public readonly response: string;
 
   public constructor(
@@ -84,11 +88,10 @@ export class GuaranteedParseValidationError extends Error {
     },
     cause: unknown,
   ) {
-    super("Parse validation failed after all retries", { cause });
+    super("Parse validation failed after all retries", attempts, maxRetries);
     this.name = "GuaranteedParseValidationError";
-    this.attempts = attempts;
     this.issues = [...input.issues];
-    this.maxRetries = maxRetries;
     this.response = input.response;
+    this.cause = cause;
   }
 }

--- a/src/guaranteed/index.ts
+++ b/src/guaranteed/index.ts
@@ -1,5 +1,6 @@
 export {
   GuaranteedEmptyResponseError,
+  GuaranteedRequestFailureError,
   GuaranteedParseValidationError,
   GuaranteedSchemaValidationError,
   ParsedJsonError,

--- a/src/guaranteed/index.ts
+++ b/src/guaranteed/index.ts
@@ -5,6 +5,7 @@ export {
   ParsedJsonError,
   SuspectedModelRefusalError,
 } from "./errors.js";
+export { RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE } from "./classifier.js";
 export { requestGuaranteedJson } from "./request.js";
 export type {
   GuaranteedParser,

--- a/src/guaranteed/request.ts
+++ b/src/guaranteed/request.ts
@@ -1,5 +1,11 @@
 import type { LLMessage } from "../llm/index.js";
 import {
+  buildResponseIntentClassificationMessages,
+  classifyResponseIntentLocally,
+  parseResponseIntentClassification,
+  type GuaranteedResponseIntent,
+} from "./classifier.js";
+import {
   GuaranteedEmptyResponseError,
   GuaranteedParseValidationError,
   GuaranteedSchemaValidationError,
@@ -7,6 +13,8 @@ import {
   SuspectedModelRefusalError,
 } from "./errors.js";
 import {
+  buildMalformedJsonMessage,
+  buildNaturalLanguageMessage,
   buildBusinessErrorMessage,
   buildSchemaErrorMessage,
   buildSyntaxErrorMessage,
@@ -23,7 +31,7 @@ export async function requestGuaranteedJson<TData, TResult>(
 ): Promise<TResult> {
   const initialMessages = [...options.messages];
   let currentMessages = [...options.messages];
-  let consecutiveJsonSyntaxErrors = 0;
+  let consecutiveProtocolDerailments = 0;
   const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
 
   for (let index = 0; index <= maxRetries; index += 1) {
@@ -42,30 +50,75 @@ export async function requestGuaranteedJson<TData, TResult>(
 
       parsedData = JSON.parse(repairedJsonText);
     } catch (error) {
-      consecutiveJsonSyntaxErrors += 1;
+      const intent = await classifyResponseIntent(options, response, index);
 
-      if (consecutiveJsonSyntaxErrors >= 2 || index >= maxRetries) {
-        const reason =
-          index >= maxRetries
-            ? "last retry still returned non-JSON content"
-            : "two consecutive retries returned non-JSON content";
-        throw new SuspectedModelRefusalError(index + 1, maxRetries, {
+      if (intent === "natural_language") {
+        consecutiveProtocolDerailments += 1;
+
+        if (consecutiveProtocolDerailments >= 2 || index >= maxRetries) {
+          const reason =
+            index >= maxRetries
+              ? "last retry still returned natural-language content"
+              : "two consecutive retries returned natural-language content";
+          throw new SuspectedModelRefusalError(index + 1, maxRetries, {
+            response,
+            reason,
+          });
+        }
+
+        currentMessages = buildRetryMessages(
+          initialMessages,
           response,
-          reason,
-        });
+          buildNaturalLanguageMessage(),
+          false,
+        );
+        continue;
       }
+
+      consecutiveProtocolDerailments = 0;
       currentMessages = buildRetryMessages(
         initialMessages,
         response,
-        buildSyntaxErrorMessage(asSyntaxError(error)),
+        intent === "malformed_json"
+          ? buildMalformedJsonMessage(asSyntaxError(error))
+          : buildSyntaxErrorMessage(asSyntaxError(error)),
+        true,
       );
       continue;
     }
-    consecutiveJsonSyntaxErrors = 0;
+    consecutiveProtocolDerailments = 0;
 
     const validation = await options.schema.safeParseAsync(parsedData);
 
     if (!validation.success) {
+      if (shouldTreatSchemaFailureAsNaturalLanguage(validation.error, parsedData)) {
+        const intent = await classifyResponseIntent(options, response, index);
+
+        if (intent === "natural_language") {
+          consecutiveProtocolDerailments += 1;
+
+          if (consecutiveProtocolDerailments >= 2 || index >= maxRetries) {
+            const reason =
+              index >= maxRetries
+                ? "last retry still returned natural-language content"
+                : "two consecutive retries returned natural-language content";
+            throw new SuspectedModelRefusalError(index + 1, maxRetries, {
+              response,
+              reason,
+            });
+          }
+
+          currentMessages = buildRetryMessages(
+            initialMessages,
+            response,
+            buildNaturalLanguageMessage(),
+            false,
+          );
+          continue;
+        }
+      }
+
+      consecutiveProtocolDerailments = 0;
       const feedback = buildSchemaErrorMessage(validation.error);
 
       if (index >= maxRetries) {
@@ -79,7 +132,12 @@ export async function requestGuaranteedJson<TData, TResult>(
           validation.error,
         );
       }
-      currentMessages = buildRetryMessages(initialMessages, response, feedback);
+      currentMessages = buildRetryMessages(
+        initialMessages,
+        response,
+        feedback,
+        true,
+      );
       continue;
     }
 
@@ -102,7 +160,12 @@ export async function requestGuaranteedJson<TData, TResult>(
           error,
         );
       }
-      currentMessages = buildRetryMessages(initialMessages, response, feedback);
+      currentMessages = buildRetryMessages(
+        initialMessages,
+        response,
+        feedback,
+        true,
+      );
     }
   }
   throw new Error("requestGuaranteedJson failed unexpectedly");
@@ -112,13 +175,18 @@ function buildRetryMessages(
   initialMessages: readonly LLMessage[],
   response: string,
   feedback: string,
+  includeAssistantResponse: boolean,
 ): LLMessage[] {
   return [
     ...initialMessages,
-    {
-      role: "assistant",
-      content: response,
-    },
+    ...(includeAssistantResponse
+      ? [
+          {
+            role: "assistant" as const,
+            content: response,
+          },
+        ]
+      : []),
     {
       role: "user",
       content: feedback,
@@ -132,4 +200,57 @@ function asSyntaxError(error: unknown): SyntaxError {
   }
 
   return new SyntaxError(String(error));
+}
+
+async function classifyResponseIntent<TData, TResult>(
+  options: GuaranteedRequestOptions<TData, TResult>,
+  response: string,
+  index: number,
+): Promise<GuaranteedResponseIntent> {
+  const localIntent = classifyResponseIntentLocally(response);
+
+  if (localIntent !== "ambiguous") {
+    return localIntent;
+  }
+
+  try {
+    const classifierResponse = await options.request(
+      buildResponseIntentClassificationMessages(response),
+      index,
+      options.maxRetries ?? DEFAULT_MAX_RETRIES,
+    );
+
+    if (classifierResponse === undefined || classifierResponse.trim() === "") {
+      return "natural_language";
+    }
+
+    const classifierIntent =
+      parseResponseIntentClassification(classifierResponse);
+
+    return classifierIntent === "ambiguous"
+      ? "natural_language"
+      : classifierIntent;
+  } catch {
+    return "natural_language";
+  }
+}
+
+function shouldTreatSchemaFailureAsNaturalLanguage(
+  error: { issues: readonly { code?: string; path: readonly PropertyKey[]; expected?: unknown }[] },
+  parsedData: unknown,
+): boolean {
+  if (!isPrimitiveJsonValue(parsedData)) {
+    return false;
+  }
+
+  return error.issues.some(
+    (issue) =>
+      issue.code === "invalid_type" &&
+      issue.path.length === 0 &&
+      (issue.expected === "object" || issue.expected === "array"),
+  );
+}
+
+function isPrimitiveJsonValue(value: unknown): boolean {
+  return value === null || (typeof value !== "object" && typeof value !== "function");
 }

--- a/src/guaranteed/request.ts
+++ b/src/guaranteed/request.ts
@@ -215,7 +215,10 @@ async function classifyResponseIntent<TData, TResult>(
 
   try {
     const classifierResponse = await options.request(
-      buildResponseIntentClassificationMessages(response),
+      buildResponseIntentClassificationMessages(
+        options.responseIntentClassifierPrompt,
+        response,
+      ),
       index,
       options.maxRetries ?? DEFAULT_MAX_RETRIES,
     );

--- a/src/guaranteed/request.ts
+++ b/src/guaranteed/request.ts
@@ -91,7 +91,9 @@ export async function requestGuaranteedJson<TData, TResult>(
     const validation = await options.schema.safeParseAsync(parsedData);
 
     if (!validation.success) {
-      if (shouldTreatSchemaFailureAsNaturalLanguage(validation.error, parsedData)) {
+      if (
+        shouldTreatSchemaFailureAsNaturalLanguage(validation.error, parsedData)
+      ) {
         const intent = await classifyResponseIntent(options, response, index);
 
         if (intent === "natural_language") {
@@ -239,7 +241,13 @@ async function classifyResponseIntent<TData, TResult>(
 }
 
 function shouldTreatSchemaFailureAsNaturalLanguage(
-  error: { issues: readonly { code?: string; path: readonly PropertyKey[]; expected?: unknown }[] },
+  error: {
+    issues: readonly {
+      code?: string;
+      path: readonly PropertyKey[];
+      expected?: unknown;
+    }[];
+  },
   parsedData: unknown,
 ): boolean {
   if (!isPrimitiveJsonValue(parsedData)) {
@@ -255,5 +263,7 @@ function shouldTreatSchemaFailureAsNaturalLanguage(
 }
 
 function isPrimitiveJsonValue(value: unknown): boolean {
-  return value === null || (typeof value !== "object" && typeof value !== "function");
+  return (
+    value === null || (typeof value !== "object" && typeof value !== "function")
+  );
 }

--- a/src/guaranteed/response.ts
+++ b/src/guaranteed/response.ts
@@ -50,6 +50,31 @@ export function buildSyntaxErrorMessage(error: SyntaxError): string {
   return lines.join("\n");
 }
 
+export function buildMalformedJsonMessage(error: SyntaxError): string {
+  const lines = [
+    "Your previous reply looked like malformed JSON.",
+    `Error: ${error.message}`,
+    "",
+    "Return complete and valid JSON directly.",
+    "Do not answer conversationally.",
+    "Do not add explanations or markdown fences.",
+  ];
+
+  return lines.join("\n");
+}
+
+export function buildNaturalLanguageMessage(): string {
+  const lines = [
+    "Your previous reply was plain natural language, not a JSON object or array.",
+    "",
+    "Do not apologize or explain.",
+    "Do not answer conversationally.",
+    "Return complete and valid JSON directly.",
+  ];
+
+  return lines.join("\n");
+}
+
 export function buildSchemaErrorMessage(error: ZodError): string {
   const issues = error.issues.map(formatZodIssue);
   const lines = [

--- a/src/guaranteed/types.ts
+++ b/src/guaranteed/types.ts
@@ -14,6 +14,7 @@ export type GuaranteedParser<TData, TResult> = (
 ) => TResult | Promise<TResult>;
 
 export interface GuaranteedRequestOptions<TData, TResult> {
+  readonly responseIntentClassifierPrompt: string;
   readonly schema: ZodType<TData>;
   readonly request: GuaranteedRequest;
   readonly messages: readonly LLMessage[];

--- a/src/reader/chunk-batch/extractor.ts
+++ b/src/reader/chunk-batch/extractor.ts
@@ -2,6 +2,7 @@ import { z, type ZodType } from "zod";
 
 import {
   GuaranteedParseValidationError,
+  GuaranteedRequestFailureError,
   ParsedJsonError,
   RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE,
   requestGuaranteedJson,
@@ -238,7 +239,7 @@ export class ChunkExtractor<S extends string> {
             result,
           };
         } catch (error) {
-          if (isParsedJsonValidationFailure(error)) {
+          if (isRecoverableChunkExtractionFailure(error)) {
             return {
               parser,
               result: {
@@ -368,6 +369,13 @@ function isParsedJsonValidationFailure(error: unknown): boolean {
   return (
     error instanceof GuaranteedParseValidationError &&
     error.cause instanceof ParsedJsonError
+  );
+}
+
+function isRecoverableChunkExtractionFailure(error: unknown): boolean {
+  return (
+    isParsedJsonValidationFailure(error) ||
+    error instanceof GuaranteedRequestFailureError
   );
 }
 

--- a/src/reader/chunk-batch/extractor.ts
+++ b/src/reader/chunk-batch/extractor.ts
@@ -3,6 +3,7 @@ import { z, type ZodType } from "zod";
 import {
   GuaranteedParseValidationError,
   ParsedJsonError,
+  RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE,
   requestGuaranteedJson,
 } from "../../guaranteed/index.js";
 import type { Language } from "../../common/language.js";
@@ -184,6 +185,9 @@ export class ChunkExtractor<S extends string> {
         const parser = new ChunkBatchParser<TData>({
           metadataField: input.metadataField,
           projection: input.projection,
+          responseIntentClassifierPrompt: this.#llm.loadSystemPrompt(
+            RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE,
+          ),
           sentenceTextSource: this.#sentenceTextSource,
           sentences: input.sentences,
           visibleChunkIds: input.visibleChunkIds,
@@ -218,6 +222,9 @@ export class ChunkExtractor<S extends string> {
               await parser.parse(data, {
                 isLastGenerationAttempt: index >= maxRetries,
               }),
+            responseIntentClassifierPrompt: this.#llm.loadSystemPrompt(
+              RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE,
+            ),
             request: async (messages, index, maxRetries) =>
               await context.request(messages, {
                 retryIndex: index,
@@ -344,6 +351,9 @@ export class ChunkExtractor<S extends string> {
         validateTranslatedChunks(chunks, data);
         return data;
       },
+      responseIntentClassifierPrompt: this.#llm.loadSystemPrompt(
+        RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE,
+      ),
       request: async (messages, index, maxRetries) =>
         await this.#llm.request(messages, {
           retryIndex: index,

--- a/src/reader/chunk-batch/parser.ts
+++ b/src/reader/chunk-batch/parser.ts
@@ -151,6 +151,7 @@ export class ChunkBatchParser<
     Record<string, readonly SentenceId[]>
   >;
   readonly #projection: FragmentProjection;
+  readonly #responseIntentClassifierPrompt: string;
   readonly #requestChoice: GuaranteedChoiceRequest;
   readonly #sentenceTextByKey: Readonly<Record<string, string>>;
   readonly #sentenceTextSource: SentenceTextSource;
@@ -163,6 +164,7 @@ export class ChunkBatchParser<
     choiceSystemPrompt: string;
     metadataField: ChunkMetadataField;
     projection: FragmentProjection;
+    responseIntentClassifierPrompt: string;
     requestChoice: GuaranteedChoiceRequest;
     sentenceTextSource: SentenceTextSource;
     sentences: readonly ChunkExtractionSentence[];
@@ -172,6 +174,7 @@ export class ChunkBatchParser<
     this.#choiceSystemPrompt = input.choiceSystemPrompt;
     this.#metadataField = input.metadataField;
     this.#projection = input.projection;
+    this.#responseIntentClassifierPrompt = input.responseIntentClassifierPrompt;
     this.#requestChoice = input.requestChoice;
     this.#sentenceTextSource = input.sentenceTextSource;
     this.#sentences = input.sentences;
@@ -577,6 +580,7 @@ export class ChunkBatchParser<
 
           return candidate;
         },
+        responseIntentClassifierPrompt: this.#responseIntentClassifierPrompt,
         request: this.#requestChoice,
         schema: choiceResponseSchema,
       });

--- a/test/editor/editor.test.ts
+++ b/test/editor/editor.test.ts
@@ -32,6 +32,7 @@ import {
   REVISION_FEEDBACK_PROMPT_TEMPLATE,
   TEXT_COMPRESSOR_PROMPT_TEMPLATE,
 } from "../../src/editor/prompt-templates.js";
+import { RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE } from "../../src/guaranteed/index.js";
 import { ScriptedLLM } from "../helpers/scripted-llm.js";
 
 describe("editor/editor", () => {
@@ -143,9 +144,11 @@ describe("editor/editor", () => {
       CLUE_REVIEWER_GENERATOR_PROMPT_TEMPLATE,
       TEXT_COMPRESSOR_PROMPT_TEMPLATE,
       CLUE_REVIEWER_PROMPT_TEMPLATE,
+      RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE,
       REVISION_FEEDBACK_PROMPT_TEMPLATE,
       TEXT_COMPRESSOR_PROMPT_TEMPLATE,
       CLUE_REVIEWER_PROMPT_TEMPLATE,
+      RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE,
     ]);
     expect(llm.calls).toHaveLength(5);
     expect(llm.calls[0]?.options.scope).toBe(

--- a/test/guaranteed/request.test.ts
+++ b/test/guaranteed/request.test.ts
@@ -15,7 +15,7 @@ const schema = z.object({
 });
 
 describe("guaranteed/request", () => {
-  it("retries after syntax failures and eventually succeeds", async () => {
+  it("retries natural-language replies without keeping broken assistant history", async () => {
     const request = vi
       .fn<
         (
@@ -44,12 +44,11 @@ describe("guaranteed/request", () => {
 
     const secondCallMessages = request.mock.calls[1]?.[0];
 
-    expect(secondCallMessages).toHaveLength(3);
+    expect(secondCallMessages).toHaveLength(2);
     expect(secondCallMessages?.[1]).toMatchObject({
-      role: "assistant",
-      content: "not json",
+      role: "user",
     });
-    expect(secondCallMessages?.[2]?.content).toContain("structural issues");
+    expect(secondCallMessages?.[1]?.content).toContain("plain natural language");
   });
 
   it("treats consecutive non-JSON responses as a refusal", async () => {
@@ -57,7 +56,7 @@ describe("guaranteed/request", () => {
       requestGuaranteedJson({
         messages: [],
         parse: (data) => data.value,
-        request: () => Promise.resolve("}"),
+        request: () => Promise.resolve("I cannot answer that."),
         schema,
       }),
     ).rejects.toBeInstanceOf(SuspectedModelRefusalError);
@@ -99,5 +98,71 @@ describe("guaranteed/request", () => {
         schema,
       }),
     ).rejects.toBeInstanceOf(GuaranteedParseValidationError);
+  });
+
+  it("keeps malformed JSON in history so the model can repair it", async () => {
+    const request = vi
+      .fn<
+        (
+          messages: readonly LLMessage[],
+          retryIndex: number,
+          retryMax: number,
+        ) => Promise<string>
+      >()
+      .mockResolvedValueOnce('{"value": "\\uZZZZ"}')
+      .mockResolvedValueOnce('{"value": 5}');
+
+    const result = await requestGuaranteedJson({
+      messages: [],
+      parse: (data) => data.value,
+      request,
+      schema,
+    });
+
+    expect(result).toBe(5);
+
+    const secondCallMessages = request.mock.calls[1]?.[0];
+
+    expect(secondCallMessages).toHaveLength(2);
+    expect(secondCallMessages?.[0]).toMatchObject({
+      role: "assistant",
+      content: '{"value": "\\uZZZZ"}',
+    });
+    expect(secondCallMessages?.[1]?.content).toContain("malformed JSON");
+  });
+
+  it("uses classifier fallback for ambiguous replies before deciding to keep history", async () => {
+    const request = vi
+      .fn<
+        (
+          messages: readonly LLMessage[],
+          retryIndex: number,
+          retryMax: number,
+        ) => Promise<string>
+      >()
+      .mockResolvedValueOnce("value: 1")
+      .mockResolvedValueOnce("malformed_json")
+      .mockResolvedValueOnce('{"value": 7}');
+
+    const result = await requestGuaranteedJson({
+      messages: [],
+      parse: (data) => data.value,
+      request,
+      schema,
+    });
+
+    expect(result).toBe(7);
+    expect(request).toHaveBeenCalledTimes(3);
+
+    const classifierMessages = request.mock.calls[1]?.[0];
+    const retryMessages = request.mock.calls[2]?.[0];
+
+    expect(classifierMessages?.[0]?.content).toContain(
+      "Classify the raw assistant reply",
+    );
+    expect(retryMessages?.[0]).toMatchObject({
+      role: "assistant",
+      content: "value: 1",
+    });
   });
 });

--- a/test/guaranteed/request.test.ts
+++ b/test/guaranteed/request.test.ts
@@ -49,7 +49,9 @@ describe("guaranteed/request", () => {
     expect(secondCallMessages?.[1]).toMatchObject({
       role: "user",
     });
-    expect(secondCallMessages?.[1]?.content).toContain("plain natural language");
+    expect(secondCallMessages?.[1]?.content).toContain(
+      "plain natural language",
+    );
   });
 
   it("treats consecutive non-JSON responses as a refusal", async () => {

--- a/test/guaranteed/request.test.ts
+++ b/test/guaranteed/request.test.ts
@@ -35,6 +35,7 @@ describe("guaranteed/request", () => {
         },
       ],
       parse: (data) => data.value,
+      responseIntentClassifierPrompt: "classifier prompt",
       request,
       schema,
     });
@@ -56,6 +57,7 @@ describe("guaranteed/request", () => {
       requestGuaranteedJson({
         messages: [],
         parse: (data) => data.value,
+        responseIntentClassifierPrompt: "classifier prompt",
         request: () => Promise.resolve("I cannot answer that."),
         schema,
       }),
@@ -79,6 +81,7 @@ describe("guaranteed/request", () => {
         maxRetries: 1,
         messages: [],
         parse: (data) => data.value,
+        responseIntentClassifierPrompt: "classifier prompt",
         request,
         schema,
       }),
@@ -94,6 +97,7 @@ describe("guaranteed/request", () => {
         parse: () => {
           throw new ParsedJsonError(["value is not acceptable"]);
         },
+        responseIntentClassifierPrompt: "classifier prompt",
         request: () => Promise.resolve('{"value": 1}'),
         schema,
       }),
@@ -115,6 +119,7 @@ describe("guaranteed/request", () => {
     const result = await requestGuaranteedJson({
       messages: [],
       parse: (data) => data.value,
+      responseIntentClassifierPrompt: "classifier prompt",
       request,
       schema,
     });
@@ -147,6 +152,7 @@ describe("guaranteed/request", () => {
     const result = await requestGuaranteedJson({
       messages: [],
       parse: (data) => data.value,
+      responseIntentClassifierPrompt: "classifier prompt",
       request,
       schema,
     });
@@ -157,9 +163,7 @@ describe("guaranteed/request", () => {
     const classifierMessages = request.mock.calls[1]?.[0];
     const retryMessages = request.mock.calls[2]?.[0];
 
-    expect(classifierMessages?.[0]?.content).toContain(
-      "Classify the raw assistant reply",
-    );
+    expect(classifierMessages?.[0]?.content).toBe("classifier prompt");
     expect(retryMessages?.[0]).toMatchObject({
       role: "assistant",
       content: "value: 1",

--- a/test/reader/chunk-batch/extractor.test.ts
+++ b/test/reader/chunk-batch/extractor.test.ts
@@ -242,6 +242,44 @@ describe("reader/chunk-batch/extractor", () => {
     expect(llm.calls.every((call) => call.viaContext)).toBe(true);
   });
 
+  it("returns an empty chunk batch when guaranteed retries are exhausted", async () => {
+    const llm = new ScriptedLLM<SpineDigestScope>(
+      Array.from({ length: 16 }, () => "I cannot answer that."),
+    );
+    const extractor = new ChunkExtractor<SpineDigestScope>({
+      extractionGuidance: "Focus on plot",
+      llm: llm as never,
+      scopes: SPINE_DIGEST_READER_SCOPES,
+      sentenceTextSource: {
+        getSentence: (sentenceId) => Promise.resolve(sentenceId.join(":")),
+      },
+    });
+
+    const result = await extractor.extractUserFocused({
+      sentences: [
+        {
+          sentenceId: [1, 0, 0],
+          text: "Alpha begins.",
+          wordsCount: 2,
+        },
+      ],
+      text: "Alpha begins.",
+      visibleChunkIds: [],
+      workingMemoryPrompt: "memory",
+    });
+
+    expect(result).toStrictEqual({
+      chunkBatch: {
+        chunks: [],
+        links: [],
+        orderCorrect: true,
+        tempIds: [],
+      },
+      fragmentSummary: "",
+    });
+    expect(llm.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
   it("translates extracted chunks when the requested language differs", async () => {
     const llm = new ScriptedLLM<SpineDigestScope>([
       JSON.stringify({

--- a/test/reader/chunk-batch/parser.test.ts
+++ b/test/reader/chunk-batch/parser.test.ts
@@ -18,6 +18,7 @@ describe("reader/chunk-batch/parser", () => {
       choiceSystemPrompt: "choice prompt",
       metadataField: ChunkMetadataField.Retention,
       projection: new FragmentProjection(createSentences()),
+      responseIntentClassifierPrompt: "classifier prompt",
       requestChoice: () => Promise.resolve('{"choice":"S1"}'),
       sentenceTextSource: {
         getSentence: (sentenceId) => Promise.resolve(sentenceId.join(":")),
@@ -89,6 +90,7 @@ describe("reader/chunk-batch/parser", () => {
       choiceSystemPrompt: "choice prompt",
       metadataField: ChunkMetadataField.Retention,
       projection: new FragmentProjection(sentences),
+      responseIntentClassifierPrompt: "classifier prompt",
       requestChoice,
       sentenceTextSource: {
         getSentence: (sentenceId) => Promise.resolve(sentenceId.join(":")),
@@ -131,6 +133,7 @@ describe("reader/chunk-batch/parser", () => {
       choiceSystemPrompt: "choice prompt",
       metadataField: ChunkMetadataField.Importance,
       projection: new FragmentProjection(createSentences()),
+      responseIntentClassifierPrompt: "classifier prompt",
       requestChoice: () => Promise.resolve('{"choice":"S1"}'),
       sentenceTextSource: {
         getSentence: (sentenceId) => Promise.resolve(sentenceId.join(":")),
@@ -177,6 +180,7 @@ describe("reader/chunk-batch/parser", () => {
       choiceSystemPrompt: "choice prompt",
       metadataField: ChunkMetadataField.Retention,
       projection: new FragmentProjection(createSentences()),
+      responseIntentClassifierPrompt: "classifier prompt",
       requestChoice: () => Promise.resolve('{"choice":"S1"}'),
       sentenceTextSource: {
         getSentence: (sentenceId) => Promise.resolve(sentenceId.join(":")),
@@ -239,6 +243,7 @@ describe("reader/chunk-batch/parser", () => {
       choiceSystemPrompt: "choice prompt",
       metadataField: ChunkMetadataField.Retention,
       projection: new FragmentProjection(sentences),
+      responseIntentClassifierPrompt: "classifier prompt",
       requestChoice: () => Promise.resolve('{"choice":"S1"}'),
       sentenceTextSource: {
         getSentence: (sentenceId) => Promise.resolve(sentenceId.join(":")),


### PR DESCRIPTION
## Summary
- stop replaying natural-language assistant replies into guaranteed JSON retries
- move the response-intent classifier prompt into managed Jinja templates
- fall back to empty chunk batches when fragment extraction exhausts guaranteed retries

## Testing
- pnpm lint:fix
- pnpm vitest run test/reader/chunk-batch/extractor.test.ts test/guaranteed/request.test.ts
- pnpm typecheck