### PR TITLE
feat: add inline llm config flag

### DIFF
--- a/data/help/commands/root.jinja
+++ b/data/help/commands/root.jinja
@@ -8,9 +8,9 @@ Purpose:
   Digesting source input uses an LLM pipeline. Re-opening an existing .sdpub archive does not.
 
 Usage:
-  spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--prompt <text>] [--verbose|-v] [--help|-h]
-  spinedigest status [--help|-h]
-  spinedigest sdpub <subcommand> --input <path> [--serial <id>] [--help|-h]
+  spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--verbose|-v] [--help|-h]
+  spinedigest status [--llm <json>] [--help|-h]
+  spinedigest sdpub <subcommand> --input <path> [--serial <id>] [--llm <json>] [--help|-h]
   spinedigest help [topic] [--help|-h]
 
 Help contract:
@@ -24,7 +24,7 @@ Flag aliases:
 
 Common paths:
   Source input -> digest -> markdown | txt | epub | .sdpub
-  Config status -> validate config file -> print masked JSON
+  Config status -> validate merged config -> print masked JSON
   .sdpub input -> re-export or inspect without re-running the digest pipeline
 
 Help topics:

--- a/data/help/commands/sdpub/cat.jinja
+++ b/data/help/commands/sdpub/cat.jinja
@@ -7,7 +7,7 @@ Purpose:
   Print the summary text for one serial id.
 
 Usage:
-  spinedigest sdpub cat --input <path> --serial <id> [--help|-h]
+  spinedigest sdpub cat --input <path> --serial <id> [--llm <json>] [--help|-h]
 
 Required flags:
   --serial <id> must be a non-negative integer.

--- a/data/help/commands/sdpub/cover.jinja
+++ b/data/help/commands/sdpub/cover.jinja
@@ -7,7 +7,7 @@ Purpose:
   Write the raw cover bytes stored in the archive.
 
 Usage:
-  spinedigest sdpub cover --input <path> [--help|-h]
+  spinedigest sdpub cover --input <path> [--llm <json>] [--help|-h]
 
 Output shape:
   - Raw binary bytes on stdout

--- a/data/help/commands/sdpub/index.jinja
+++ b/data/help/commands/sdpub/index.jinja
@@ -7,17 +7,18 @@ Purpose:
   Inspect an existing .sdpub archive without exporting the whole document.
 
 Usage:
-  spinedigest sdpub info --input <path> [--help|-h]
-  spinedigest sdpub toc --input <path> [--help|-h]
-  spinedigest sdpub list --input <path> [--help|-h]
-  spinedigest sdpub cat --input <path> --serial <id> [--help|-h]
-  spinedigest sdpub cover --input <path> [--help|-h]
+  spinedigest sdpub info --input <path> [--llm <json>] [--help|-h]
+  spinedigest sdpub toc --input <path> [--llm <json>] [--help|-h]
+  spinedigest sdpub list --input <path> [--llm <json>] [--help|-h]
+  spinedigest sdpub cat --input <path> --serial <id> [--llm <json>] [--help|-h]
+  spinedigest sdpub cover --input <path> [--llm <json>] [--help|-h]
 
 Shared behavior:
   - All subcommands require `--input <path>` to an existing `.sdpub` archive.
   - Output is written to stdout.
   - stdin is not supported.
   - `--digest-dir`, `--output`, `--output-format`, `--prompt`, and `--verbose` are not supported.
+  - `--llm <json>` is accepted for wrapper consistency but is not used.
   - `-h` is available as the short form of `--help`.
   - These subcommands do not call an LLM provider.
 

--- a/data/help/commands/sdpub/info.jinja
+++ b/data/help/commands/sdpub/info.jinja
@@ -7,7 +7,7 @@ Purpose:
   Print archive metadata and high-level summary counts.
 
 Usage:
-  spinedigest sdpub info --input <path> [--help|-h]
+  spinedigest sdpub info --input <path> [--llm <json>] [--help|-h]
 
 Output shape:
   - Title

--- a/data/help/commands/sdpub/list.jinja
+++ b/data/help/commands/sdpub/list.jinja
@@ -7,7 +7,7 @@ Purpose:
   List the serial summaries referenced by the TOC.
 
 Usage:
-  spinedigest sdpub list --input <path> [--help|-h]
+  spinedigest sdpub list --input <path> [--llm <json>] [--help|-h]
 
 Output shape:
   [<serialId>] <TOC path> (fragments: <count>)

--- a/data/help/commands/sdpub/toc.jinja
+++ b/data/help/commands/sdpub/toc.jinja
@@ -7,7 +7,7 @@ Purpose:
   Print the archive TOC tree in reading order.
 
 Usage:
-  spinedigest sdpub toc --input <path> [--help|-h]
+  spinedigest sdpub toc --input <path> [--llm <json>] [--help|-h]
 
 Output shape:
   - Document title first, when available

--- a/data/help/commands/status.jinja
+++ b/data/help/commands/status.jinja
@@ -4,21 +4,22 @@ Command: spinedigest status
 SpineDigest Status
 
 Purpose:
-  Validate and print the currently selected CLI config file.
+  Validate and print the currently selected CLI config after supported overrides are applied.
 
 Usage:
-  spinedigest status [--help|-h]
+  spinedigest status [--llm <json>] [--help|-h]
 
 Behavior:
   - Resolves the active config path using `SPINEDIGEST_CONFIG` when set, otherwise `~/.spinedigest/config.json`.
-  - If the config file does not exist, prints `{}` to stdout and exits 0.
-  - If the config file exists and is valid, prints the config JSON to stdout.
+  - Merges environment variable overrides and optional `--llm <json>`.
+  - If no config values are available, prints `{}` to stdout and exits 0.
+  - If config values are valid, prints the merged JSON to stdout.
   - `llm.apiKey` is masked before printing.
-  - If the file cannot be read, parsed, or validated, prints the error to stderr and exits non-zero.
+  - If the file or inline JSON cannot be read, parsed, or validated, prints the error to stderr and exits non-zero.
 
 Notes:
   - This command does not support digest, I/O, or verbose flags.
-  - Environment variables other than `SPINEDIGEST_CONFIG` do not get merged into the printed JSON.
+  - `--llm` is useful for checking one-shot LLM client JSON without writing it to disk.
 
 Where to go next:
   - Need config precedence and override rules:

--- a/data/help/topics/command.jinja
+++ b/data/help/topics/command.jinja
@@ -4,11 +4,11 @@ Topic: command
 Command Reference
 
 Main convert command:
-  spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--prompt <text>] [--verbose|-v] [--help|-h]
+  spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--verbose|-v] [--help|-h]
 
 Status command:
-  spinedigest status [--help|-h]
-    Validate the active config file and print its masked JSON content.
+  spinedigest status [--llm <json>] [--help|-h]
+    Validate and print the masked merged config.
 
 Main flags:
   --input <path>          Read from a file. If omitted, stdin is used.
@@ -17,18 +17,25 @@ Main flags:
   --output-format <format>
                           Override output format inference.
   --digest-dir <path>     Keep the intermediate digest workspace for source digest runs.
+  --llm <json>            Inline LLM client JSON for this invocation.
   --prompt <text>         Override the extraction prompt for the current digest run.
   --verbose, -v           Write diagnostic logs to stderr.
   --help, -h              Print entry help.
 
 sdpub inspection family:
 {% for command in sdpubCommands %}
-  spinedigest sdpub {{ command.name }}{% if command.name == "cat" %} --serial <id>{% endif %} --input <path>
+  spinedigest sdpub {{ command.name }}{% if command.name == "cat" %} --serial <id>{% endif %} --input <path> [--llm <json>]
     {{ command.summary }}
 {% endfor %}
 
 sdpub-specific flags:
   --serial <id>          Required by `spinedigest sdpub cat`; must be a non-negative integer.
+
+LLM flag:
+  `--llm <json>` accepts a one-shot LLM client object.
+  Supported fields include `provider`, `model`, `apiKey`, `baseURL`, `baseUrl`, `chatCompletionsUrl`, and `name`.
+  It overrides LLM fields from environment variables and `config.json`.
+  It does not make `.sdpub` re-export or inspection call an LLM.
 
 Help routing:
   spinedigest --help

--- a/data/help/topics/config-file.jinja
+++ b/data/help/topics/config-file.jinja
@@ -11,6 +11,7 @@ Location:
 
 Scope:
   This file defines persistent machine defaults.
+  `--llm` overrides LLM-related file values for one run.
   Environment variables override file values.
   `--prompt` overrides prompt-related defaults for one run.
 
@@ -121,6 +122,11 @@ Applicability:
   - `llm.*`, `prompt`, `paths.cacheDir`, and `request.*` matter for source digest runs.
   - `.sdpub` re-export through the main convert command does not require LLM settings.
   - `paths.debugLogDir` can still matter outside source digest runs when the app emits debug logs.
+
+Inline LLM note:
+  `--llm <json>` is intentionally broader than this file schema.
+  It accepts direct LLM objects and common OpenAI-compatible aliases such as `baseUrl`.
+  The config file remains the narrower persistent schema shown on this page.
 
 Common failures:
   - Invalid JSON fails before execution starts.

--- a/data/help/topics/config.jinja
+++ b/data/help/topics/config.jinja
@@ -9,13 +9,14 @@ Purpose:
 
 Precedence:
   - `--prompt` overrides both environment and config-file prompt settings for one run.
+  - `--llm` overrides LLM environment variables and config-file LLM settings for one run.
   - Environment variables override the config file.
   - The config file provides persistent machine defaults.
   - Explicit format flags are separate from config and override file-extension inference.
 
 Configuration layers:
   1. CLI flags:
-     Per-invocation decisions such as `--prompt`, `--input-format`, and `--output-format`.
+     Per-invocation decisions such as `--llm`, `--prompt`, `--input-format`, and `--output-format`.
   2. Environment variables:
      Best for one shell session, CI, wrappers, or temporary overrides.
   3. Config file:
@@ -26,10 +27,17 @@ Minimum digest configuration:
   - llm.model
   These are required only for source digest runs.
 
+Inline LLM JSON:
+  `--llm <json>` accepts an inline LLM client object for the current invocation.
+  It may use the same `llm` object shape as the config file, or the object directly.
+  It also accepts common OpenAI-compatible aliases such as `baseUrl` and `chatCompletionsUrl`.
+  A base URL implies `openai-compatible` when `provider` is omitted.
+  Prefer this for wrapper tools or one-shot automation that already has client JSON.
+
 Execution paths:
   - Source digest runs use prompt, LLM, cache, and request settings.
   - `.sdpub` re-export through the main convert command does not require LLM settings.
-  - `sdpub` inspection subcommands do not use these LLM settings.
+  - `sdpub` inspection subcommands accept but do not use these LLM settings.
   - `paths.debugLogDir` may still matter when the app emits debug logs.
 
 When to prefer each layer:

--- a/data/help/topics/env.jinja
+++ b/data/help/topics/env.jinja
@@ -5,6 +5,7 @@ Environment Variable Reference
 
 Scope:
   These variables let shell invocations override machine defaults without editing `~/.spinedigest/config.json`.
+  `--llm` overrides LLM environment variables for one run.
   Environment variables override the config file.
   `--prompt` still overrides both for one run.
 

--- a/data/help/topics/troubleshoot.jinja
+++ b/data/help/topics/troubleshoot.jinja
@@ -7,7 +7,7 @@ Missing LLM configuration:
   Symptom:
     Source digest runs fail before processing starts.
   Check:
-    `llm.provider` and `llm.model` in config or the matching env vars.
+    `--llm`, `llm.provider` and `llm.model` in config, or the matching env vars.
 
 Unexpected format errors:
   Symptom:

--- a/docs/en/ai-agents.md
+++ b/docs/en/ai-agents.md
@@ -103,6 +103,8 @@ For example:
 
 Environment variable overrides are supported and are often better for secrets.
 
+Agents that already have a runtime LLM client descriptor can pass it with `--llm <json>` for one invocation. This inline object may use `baseURL`, `baseUrl`, or `chatCompletionsUrl` for OpenAI-compatible clients.
+
 ## Safe Defaults For Agents
 
 - prefer output to a file over `stdout`

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -9,15 +9,17 @@ SpineDigest is designed to be used from the command line first.
 Installed CLI:
 
 ```bash
-spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--prompt <text>] [--verbose]
-spinedigest sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>]
+spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--verbose]
+spinedigest status [--llm <json>]
+spinedigest sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>] [--llm <json>]
 ```
 
 From a source checkout:
 
 ```bash
-pnpm dev -- [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--prompt <text>] [--verbose]
-pnpm dev -- sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>]
+pnpm dev -- [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--verbose]
+pnpm dev -- status [--llm <json>]
+pnpm dev -- sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>] [--llm <json>]
 ```
 
 ## Flags
@@ -27,6 +29,7 @@ pnpm dev -- sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>]
 - `--input-format <format>`: input format override
 - `--output-format <format>`: output format override
 - `--digest-dir <path>`: keep the digest workspace; the directory is cleared before each run
+- `--llm <json>`: inline LLM client JSON for this invocation
 - `--prompt <text>`: one-off extraction prompt override for the current digest run
 - `--verbose`: write diagnostic logs to `stderr`
 - `-h`, `--help`: print help text
@@ -38,6 +41,8 @@ The `sdpub` inspection interface uses positional subcommands: `spinedigest sdpub
 The `sdpub` inspection subcommands only accept `--input`, and `cat` also requires `--serial`.
 
 `--prompt` only affects digest generation from source inputs. It does not apply when reopening `.sdpub` archives or using `spinedigest sdpub ...`.
+
+`--llm` overrides LLM settings from environment variables and `config.json`. It is accepted by command paths that do not call an LLM so wrapper scripts can pass one consistent option set.
 
 ## Formats
 
@@ -128,6 +133,12 @@ Use a one-off extraction prompt:
 spinedigest --input ./book.md --output ./digest.md --prompt "Preserve named entities and decisive transitions."
 ```
 
+Use one-shot LLM client JSON:
+
+```bash
+spinedigest --llm "$LLM_JSON" --input ./book.md --output ./digest.md
+```
+
 ## Configuration
 
 Default config path:
@@ -171,7 +182,19 @@ Config fields:
 
 `request.timeout` is in milliseconds.
 
+Inline LLM JSON can be either a direct LLM object or an object with an `llm` field. It supports `provider`, `model`, `apiKey`, `baseURL`, `baseUrl`, `chatCompletionsUrl`, and `name`. A base URL implies `openai-compatible` when `provider` is omitted.
+
+```json
+{
+  "model": "<your-model>",
+  "apiKey": "<optional>",
+  "baseUrl": "https://your-provider.example/v1"
+}
+```
+
 For the main digest command, `--prompt` has the highest priority for the current run. Otherwise, `SPINEDIGEST_PROMPT` overrides `config.json`, and missing values fall back to the built-in default prompt.
+
+For LLM settings, `--llm` overrides `SPINEDIGEST_LLM_*` variables, which override `config.json`.
 
 ## Environment Variables
 
@@ -193,7 +216,7 @@ SpineDigest can override config values with environment variables:
 - `SPINEDIGEST_REQUEST_TEMPERATURE`
 - `SPINEDIGEST_REQUEST_TOP_P`
 
-`openai-compatible` requires a base URL from config or `SPINEDIGEST_LLM_BASE_URL`.
+`openai-compatible` requires a base URL from `--llm`, config, or `SPINEDIGEST_LLM_BASE_URL`.
 
 ## `.sdpub` Behavior
 

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -52,6 +52,7 @@ SpineDigest reads configuration from:
 
 - default path: `~/.spinedigest/config.json`
 - override path: `SPINEDIGEST_CONFIG`
+- one-shot inline LLM JSON: `--llm <json>`
 
 A minimal config file looks like this:
 
@@ -77,6 +78,12 @@ export SPINEDIGEST_LLM_BASE_URL="https://your-provider.example/v1"
 ```
 
 You can also place these fields in `config.json` if your environment requires it.
+
+For one-off automation, pass inline LLM client JSON instead of writing config:
+
+```bash
+spinedigest --llm "$LLM_JSON" --input ./book.md --output ./out/digest.md
+```
 
 ## 5. Run Your First Digest
 
@@ -177,6 +184,7 @@ This prompt is applied when digesting source files or text streams. It is not us
 If you see a missing LLM configuration error:
 
 - make sure `llm.provider` and `llm.model` are set
+- or pass an inline LLM object with `--llm`
 - make sure the corresponding API key is available
 
 If format inference fails:

--- a/docs/zh-CN/ai-agents.md
+++ b/docs/zh-CN/ai-agents.md
@@ -103,6 +103,8 @@ SpineDigest 至少需要：
 
 如果涉及密钥，通常更推荐通过环境变量覆盖。
 
+如果 Agent 已经持有运行时 LLM client descriptor，可以通过 `--llm <json>` 只为当前调用传入。这个 inline 对象对 OpenAI-compatible client 支持 `baseURL`、`baseUrl` 或 `chatCompletionsUrl`。
+
 ## 面向 Agent 的安全默认值
 
 - 相比 `stdout`，优先输出到文件

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -9,15 +9,17 @@ SpineDigest 的设计重心是命令行使用。
 已安装 CLI 时：
 
 ```bash
-spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--prompt <text>] [--verbose]
-spinedigest sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>]
+spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--verbose]
+spinedigest status [--llm <json>]
+spinedigest sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>] [--llm <json>]
 ```
 
 在源码仓库中运行时：
 
 ```bash
-pnpm dev -- [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--prompt <text>] [--verbose]
-pnpm dev -- sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>]
+pnpm dev -- [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--verbose]
+pnpm dev -- status [--llm <json>]
+pnpm dev -- sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>] [--llm <json>]
 ```
 
 ## 参数
@@ -27,6 +29,7 @@ pnpm dev -- sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>]
 - `--input-format <format>`：显式指定输入格式
 - `--output-format <format>`：显式指定输出格式
 - `--digest-dir <path>`：保留 digest 中间工作目录；每次运行前会先清空该目录
+- `--llm <json>`：为当前这次调用传入 inline LLM client JSON
 - `--prompt <text>`：为当前这次 digest 临时覆盖 extraction prompt
 - `--verbose`：把诊断日志输出到 `stderr`
 - `-h`, `--help`：打印帮助文本
@@ -38,6 +41,8 @@ pnpm dev -- sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>]
 `sdpub` 检查子命令只接受 `--input`，其中 `cat` 还要求提供 `--serial`。
 
 `--prompt` 只影响从源输入生成 digest 的过程，不适用于重新打开 `.sdpub` 或使用 `spinedigest sdpub ...`。
+
+`--llm` 会覆盖环境变量和 `config.json` 中的 LLM 设置。不调用 LLM 的命令路径也接受这个参数，方便 wrapper 脚本统一传参。
 
 ## 支持的格式
 
@@ -128,6 +133,12 @@ cat ./chapter.txt | spinedigest --input-format txt --output-format markdown
 spinedigest --input ./book.md --output ./digest.md --prompt "Preserve named entities and decisive transitions."
 ```
 
+临时传入 LLM client JSON：
+
+```bash
+spinedigest --llm "$LLM_JSON" --input ./book.md --output ./digest.md
+```
+
 ## 配置
 
 默认配置路径：
@@ -171,7 +182,19 @@ SPINEDIGEST_CONFIG
 
 `request.timeout` 的单位是毫秒。
 
+Inline LLM JSON 可以直接是 LLM 对象，也可以包含一个 `llm` 字段。它支持 `provider`、`model`、`apiKey`、`baseURL`、`baseUrl`、`chatCompletionsUrl` 和 `name`。如果省略 `provider` 但提供了 base URL，则按 `openai-compatible` 处理。
+
+```json
+{
+  "model": "<your-model>",
+  "apiKey": "<optional>",
+  "baseUrl": "https://your-provider.example/v1"
+}
+```
+
 对于主 digest 命令，`--prompt` 的优先级最高，只影响当前这次运行。否则，`SPINEDIGEST_PROMPT` 会覆盖 `config.json`，再没有时使用内置默认 prompt。
+
+对于 LLM 设置，`--llm` 会覆盖 `SPINEDIGEST_LLM_*` 环境变量，后者再覆盖 `config.json`。
 
 ## 环境变量
 
@@ -193,7 +216,7 @@ SpineDigest 支持通过环境变量覆盖配置值：
 - `SPINEDIGEST_REQUEST_TEMPERATURE`
 - `SPINEDIGEST_REQUEST_TOP_P`
 
-`openai-compatible` 必须通过配置或 `SPINEDIGEST_LLM_BASE_URL` 提供 base URL。
+`openai-compatible` 必须通过 `--llm`、配置或 `SPINEDIGEST_LLM_BASE_URL` 提供 base URL。
 
 ## `.sdpub` 行为
 

--- a/docs/zh-CN/quickstart.md
+++ b/docs/zh-CN/quickstart.md
@@ -52,6 +52,7 @@ SpineDigest 会从以下位置读取配置：
 
 - 默认路径：`~/.spinedigest/config.json`
 - 覆盖路径：`SPINEDIGEST_CONFIG`
+- 临时 inline LLM JSON：`--llm <json>`
 
 最小配置文件示例：
 
@@ -77,6 +78,12 @@ export SPINEDIGEST_LLM_BASE_URL="https://your-provider.example/v1"
 ```
 
 如果你的环境更适合写进 `config.json`，也可以把这些字段写入配置文件。
+
+如果只是自动化里临时运行一次，也可以直接传 inline LLM client JSON：
+
+```bash
+spinedigest --llm "$LLM_JSON" --input ./book.md --output ./out/digest.md
+```
 
 ## 5. 跑第一条命令
 
@@ -177,6 +184,7 @@ spinedigest --input ./book.md --output ./digest.md --prompt "Preserve key argume
 如果看到缺少 LLM 配置的错误：
 
 - 确认已经设置 `llm.provider` 和 `llm.model`
+- 或者通过 `--llm` 传入 inline LLM 对象
 - 确认对应 provider 的 API key 已经可用
 
 如果格式推断失败：

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -22,6 +22,7 @@ export interface CLIArguments {
   readonly help: boolean;
   readonly inputPath?: string;
   readonly inputFormat?: CLIFormat;
+  readonly llmJSON?: string;
   readonly outputPath?: string;
   readonly outputFormat?: CLIFormat;
   readonly prompt?: string;
@@ -30,8 +31,13 @@ export interface CLIArguments {
 
 export interface CLISdpubArguments {
   readonly inputPath: string;
+  readonly llmJSON?: string;
   readonly serialId?: number;
   readonly subcommand: SDPubSubcommand;
+}
+
+export interface CLIStatusArguments {
+  readonly llmJSON?: string;
 }
 
 export type ParsedCLIArguments =
@@ -63,10 +69,12 @@ export type ParsedCLIArguments =
       readonly kind: "help";
     }
   | {
+      readonly args: CLIStatusArguments;
       readonly help: false;
       readonly kind: "status";
     }
   | {
+      readonly args: CLIStatusArguments;
       readonly help: true;
       readonly helpText: string;
       readonly kind: "status";
@@ -90,6 +98,9 @@ export function parseCLIArguments(
         type: "string",
       },
       "input-format": {
+        type: "string",
+      },
+      llm: {
         type: "string",
       },
       output: {
@@ -144,6 +155,7 @@ export function parseCLIArguments(
       : {
           inputFormat: parseCLIFormat(values["input-format"], "--input-format"),
         }),
+    ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
     ...(values.output === undefined ? {} : { outputPath: values.output }),
     ...(values["output-format"] === undefined
       ? {}
@@ -180,6 +192,7 @@ function parseSdpubArguments(
     readonly help?: boolean;
     readonly input?: string;
     readonly "input-format"?: string;
+    readonly llm?: string;
     readonly output?: string;
     readonly "output-format"?: string;
     readonly prompt?: string;
@@ -334,6 +347,7 @@ function parseSdpubArguments(
   return {
     args: {
       inputPath: inputPath!,
+      ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
       ...(serialId === undefined ? {} : { serialId }),
       subcommand: parsedSubcommand,
     },
@@ -349,6 +363,7 @@ function parseHelpArguments(
     readonly help?: boolean;
     readonly input?: string;
     readonly "input-format"?: string;
+    readonly llm?: string;
     readonly output?: string;
     readonly "output-format"?: string;
     readonly prompt?: string;
@@ -359,6 +374,7 @@ function parseHelpArguments(
   rejectHelpFlag("digest-dir", values["digest-dir"]);
   rejectHelpFlag("input", values.input);
   rejectHelpFlag("input-format", values["input-format"]);
+  rejectHelpFlag("llm", values.llm);
   rejectHelpFlag("output", values.output);
   rejectHelpFlag("output-format", values["output-format"]);
   rejectHelpFlag("prompt", values.prompt);
@@ -404,6 +420,7 @@ function parseStatusArguments(
     readonly help?: boolean;
     readonly input?: string;
     readonly "input-format"?: string;
+    readonly llm?: string;
     readonly output?: string;
     readonly "output-format"?: string;
     readonly prompt?: string;
@@ -437,8 +454,13 @@ function parseStatusArguments(
     );
   }
 
+  const args = {
+    ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
+  } satisfies CLIStatusArguments;
+
   if (values.help ?? false) {
     return {
+      args,
       help: true,
       helpText: renderStatusHelpText(),
       kind: "status",
@@ -446,6 +468,7 @@ function parseStatusArguments(
   }
 
   return {
+    args,
     help: false,
     kind: "status",
   };

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -16,6 +16,26 @@ const CLI_PROVIDER_VALUES = [
 
 const cliProviderSchema = z.enum(CLI_PROVIDER_VALUES);
 const samplingSettingSchema = z.union([z.number(), z.array(z.number())]);
+const inlineLLMConfigSchema = z.object({
+  apiKey: z.string().min(1).optional(),
+  baseURL: z.string().min(1).optional(),
+  baseUrl: z.string().min(1).optional(),
+  chatCompletionsUrl: z.string().min(1).optional(),
+  llm: z
+    .object({
+      apiKey: z.string().min(1).optional(),
+      baseURL: z.string().min(1).optional(),
+      baseUrl: z.string().min(1).optional(),
+      chatCompletionsUrl: z.string().min(1).optional(),
+      model: z.string().min(1).optional(),
+      name: z.string().min(1).optional(),
+      provider: cliProviderSchema.optional(),
+    })
+    .optional(),
+  model: z.string().min(1).optional(),
+  name: z.string().min(1).optional(),
+  provider: cliProviderSchema.optional(),
+});
 const cliConfigSchema = z.object({
   llm: z
     .object({
@@ -75,10 +95,18 @@ export interface CLIConfig {
 
 type CLIConfigFile = z.infer<typeof cliConfigSchema>;
 
-export async function loadCLIConfig(): Promise<CLIConfig> {
+type InlineLLMConfig = NonNullable<CLIConfig["llm"]>;
+
+export async function loadCLIConfig(options?: {
+  readonly llmJSON?: string;
+}): Promise<CLIConfig> {
   const configFilePath = resolveCLIConfigFilePath();
   const fileConfig = await readCLIConfigFile(configFilePath);
   const configDirectoryPath = dirname(configFilePath);
+  const inlineLLMConfig =
+    options?.llmJSON === undefined
+      ? undefined
+      : parseInlineLLMConfig(options.llmJSON);
 
   const prompt = firstDefined(
     normalizeString(process.env.SPINEDIGEST_PROMPT),
@@ -86,24 +114,39 @@ export async function loadCLIConfig(): Promise<CLIConfig> {
   );
   const llm = createLLMConfig({
     apiKey: firstDefined(
-      normalizeString(process.env.SPINEDIGEST_LLM_API_KEY),
-      fileConfig.llm?.apiKey,
+      inlineLLMConfig?.apiKey,
+      firstDefined(
+        normalizeString(process.env.SPINEDIGEST_LLM_API_KEY),
+        fileConfig.llm?.apiKey,
+      ),
     ),
     baseURL: firstDefined(
-      normalizeString(process.env.SPINEDIGEST_LLM_BASE_URL),
-      fileConfig.llm?.baseURL,
+      inlineLLMConfig?.baseURL,
+      firstDefined(
+        normalizeString(process.env.SPINEDIGEST_LLM_BASE_URL),
+        fileConfig.llm?.baseURL,
+      ),
     ),
     model: firstDefined(
-      normalizeString(process.env.SPINEDIGEST_LLM_MODEL),
-      fileConfig.llm?.model,
+      inlineLLMConfig?.model,
+      firstDefined(
+        normalizeString(process.env.SPINEDIGEST_LLM_MODEL),
+        fileConfig.llm?.model,
+      ),
     ),
     name: firstDefined(
-      normalizeString(process.env.SPINEDIGEST_LLM_NAME),
-      fileConfig.llm?.name,
+      inlineLLMConfig?.name,
+      firstDefined(
+        normalizeString(process.env.SPINEDIGEST_LLM_NAME),
+        fileConfig.llm?.name,
+      ),
     ),
     provider: firstDefined(
-      parseOptionalProvider(process.env.SPINEDIGEST_LLM_PROVIDER),
-      fileConfig.llm?.provider,
+      inlineLLMConfig?.provider,
+      firstDefined(
+        parseOptionalProvider(process.env.SPINEDIGEST_LLM_PROVIDER),
+        fileConfig.llm?.provider,
+      ),
     ),
   });
   const paths = createPathsConfig({
@@ -216,6 +259,123 @@ export async function readCLIConfigFile(path: string): Promise<CLIConfigFile> {
   }
 
   return parsed.data;
+}
+
+function parseInlineLLMConfig(value: string): InlineLLMConfig | undefined {
+  const normalized = normalizeString(value);
+
+  if (normalized === undefined) {
+    throw new Error(
+      withHelpRoute(
+        "--llm must be a non-empty JSON object.",
+        CLI_HELP_ROUTES.config,
+      ),
+    );
+  }
+
+  let parsedJson: unknown;
+
+  try {
+    parsedJson = JSON.parse(normalized);
+  } catch (error) {
+    throw new Error(
+      withHelpRoute(
+        `Invalid --llm JSON: ${formatError(error)}`,
+        CLI_HELP_ROUTES.config,
+      ),
+    );
+  }
+
+  const parsed = inlineLLMConfigSchema.safeParse(parsedJson);
+
+  if (!parsed.success) {
+    throw new Error(
+      withHelpRoute(
+        `Invalid --llm config: ${parsed.error.issues
+          .map(
+            (issue) => `${issue.path.join(".") || "<root>"}: ${issue.message}`,
+          )
+          .join("; ")}`,
+        CLI_HELP_ROUTES.config,
+      ),
+    );
+  }
+
+  const input = parsed.data.llm ?? parsed.data;
+  const provider = input.provider ?? inferInlineProvider(input);
+  const baseURL = resolveInlineBaseURL(input);
+  const config = createLLMConfig({
+    apiKey: input.apiKey,
+    baseURL,
+    model: input.model,
+    name: input.name,
+    provider,
+  });
+
+  if (config === undefined) {
+    throw new Error(
+      withHelpRoute(
+        "--llm must contain at least one supported LLM field.",
+        CLI_HELP_ROUTES.config,
+      ),
+    );
+  }
+
+  return config;
+}
+
+function inferInlineProvider(input: {
+  readonly baseURL?: string | undefined;
+  readonly baseUrl?: string | undefined;
+  readonly chatCompletionsUrl?: string | undefined;
+  readonly provider?: CLIProvider | undefined;
+}): CLIProvider | undefined {
+  if (
+    input.provider === undefined &&
+    (input.baseURL !== undefined ||
+      input.baseUrl !== undefined ||
+      input.chatCompletionsUrl !== undefined)
+  ) {
+    return "openai-compatible";
+  }
+
+  return input.provider;
+}
+
+function inferBaseURLFromChatCompletionsURL(input: {
+  readonly chatCompletionsUrl?: string | undefined;
+}): string | undefined {
+  if (input.chatCompletionsUrl === undefined) {
+    return undefined;
+  }
+
+  const suffix = "/chat/completions";
+
+  if (!input.chatCompletionsUrl.endsWith(suffix)) {
+    throw new Error(
+      withHelpRoute(
+        "--llm chatCompletionsUrl must end with /chat/completions when baseURL is not provided.",
+        CLI_HELP_ROUTES.config,
+      ),
+    );
+  }
+
+  return input.chatCompletionsUrl.slice(0, -suffix.length);
+}
+
+function resolveInlineBaseURL(input: {
+  readonly baseURL?: string | undefined;
+  readonly baseUrl?: string | undefined;
+  readonly chatCompletionsUrl?: string | undefined;
+}): string | undefined {
+  if (input.baseURL !== undefined) {
+    return input.baseURL;
+  }
+  if (input.baseUrl !== undefined) {
+    return input.baseUrl;
+  }
+
+  return inferBaseURLFromChatCompletionsURL(input);
 }
 
 function resolveConfigFilePath(path: string | undefined): string {

--- a/src/cli/convert.ts
+++ b/src/cli/convert.ts
@@ -63,7 +63,7 @@ export async function runConvertCommand(args: CLIArguments): Promise<void> {
   const inputFormat = input.format;
   const requiresDigest = inputFormat !== "sdpub";
   const digestDirPath = await prepareDigestDirPath(args, requiresDigest);
-  const config = await loadRequiredConfig(requiresDigest);
+  const config = await loadRequiredConfig(args, requiresDigest);
   const app = new SpineDigestApp(
     createAppOptions(args, config, requiresDigest),
   );
@@ -197,8 +197,13 @@ async function prepareDigestDirPath(
   return resolvedPath;
 }
 
-async function loadRequiredConfig(requiresDigest: boolean): Promise<CLIConfig> {
-  const config = await loadCLIConfig();
+async function loadRequiredConfig(
+  args: CLIArguments,
+  requiresDigest: boolean,
+): Promise<CLIConfig> {
+  const config = await loadCLIConfig({
+    ...(args.llmJSON === undefined ? {} : { llmJSON: args.llmJSON }),
+  });
 
   if (!requiresDigest) {
     return config;
@@ -207,7 +212,7 @@ async function loadRequiredConfig(requiresDigest: boolean): Promise<CLIConfig> {
   if (config.llm?.provider === undefined || config.llm.model === undefined) {
     throw new Error(
       withHelpRoute(
-        "Missing LLM configuration. Set `llm.provider` and `llm.model` in ~/.spinedigest/config.json or the matching SPINEDIGEST_LLM_* environment variables.",
+        "Missing LLM configuration. Set --llm, `llm.provider` and `llm.model` in ~/.spinedigest/config.json, or the matching SPINEDIGEST_LLM_* environment variables.",
         CLI_HELP_ROUTES.config,
       ),
     );

--- a/src/cli/llm.ts
+++ b/src/cli/llm.ts
@@ -86,7 +86,7 @@ function createLanguageModel(
       if (options.baseURL !== undefined) {
         throw new Error(
           withHelpRoute(
-            "openai does not accept llm.baseURL, --llm baseURL, or SPINEDIGEST_LLM_BASE_URL. Use openai-compatible for third-party OpenAI-style APIs.",
+            "openai does not accept llm.baseURL, baseURL in --llm JSON, or SPINEDIGEST_LLM_BASE_URL. Use openai-compatible for third-party OpenAI-style APIs.",
             CLI_HELP_ROUTES.config,
           ),
         );
@@ -103,7 +103,7 @@ function createLanguageModel(
       if (options.baseURL === undefined) {
         throw new Error(
           withHelpRoute(
-            "openai-compatible requires llm.baseURL, --llm baseURL, or SPINEDIGEST_LLM_BASE_URL.",
+            "openai-compatible requires llm.baseURL, baseURL in --llm JSON, or SPINEDIGEST_LLM_BASE_URL.",
             CLI_HELP_ROUTES.config,
           ),
         );

--- a/src/cli/llm.ts
+++ b/src/cli/llm.ts
@@ -14,7 +14,7 @@ export function buildLLMOptions(config: CLIConfig): SpineDigestLLMOptions {
   if (llm?.provider === undefined || llm.model === undefined) {
     throw new Error(
       withHelpRoute(
-        "Missing LLM configuration. Set `llm.provider` and `llm.model` in ~/.spinedigest/config.json or the matching SPINEDIGEST_LLM_* environment variables.",
+        "Missing LLM configuration. Set --llm, `llm.provider` and `llm.model` in ~/.spinedigest/config.json, or the matching SPINEDIGEST_LLM_* environment variables.",
         CLI_HELP_ROUTES.config,
       ),
     );
@@ -86,7 +86,7 @@ function createLanguageModel(
       if (options.baseURL !== undefined) {
         throw new Error(
           withHelpRoute(
-            "openai does not accept llm.baseURL or SPINEDIGEST_LLM_BASE_URL. Use openai-compatible for third-party OpenAI-style APIs.",
+            "openai does not accept llm.baseURL, --llm baseURL, or SPINEDIGEST_LLM_BASE_URL. Use openai-compatible for third-party OpenAI-style APIs.",
             CLI_HELP_ROUTES.config,
           ),
         );
@@ -103,7 +103,7 @@ function createLanguageModel(
       if (options.baseURL === undefined) {
         throw new Error(
           withHelpRoute(
-            "openai-compatible requires llm.baseURL or SPINEDIGEST_LLM_BASE_URL.",
+            "openai-compatible requires llm.baseURL, --llm baseURL, or SPINEDIGEST_LLM_BASE_URL.",
             CLI_HELP_ROUTES.config,
           ),
         );

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -26,7 +26,7 @@ export async function main(): Promise<void> {
         await runSdpubCommand(parsed.args);
         return;
       case "status":
-        await runStatusCommand();
+        await runStatusCommand(parsed.args);
         return;
     }
   } catch (error) {

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -1,9 +1,15 @@
-import { readCLIConfigFile, resolveCLIConfigFilePath } from "./config.js";
+import type { CLIStatusArguments } from "./args.js";
+import { loadCLIConfig } from "./config.js";
 import { writeTextToStdout } from "./io.js";
 
-export async function runStatusCommand(): Promise<void> {
-  const configFilePath = resolveCLIConfigFilePath();
-  const masked = maskConfigSecrets(await readCLIConfigFile(configFilePath));
+export async function runStatusCommand(
+  args: CLIStatusArguments,
+): Promise<void> {
+  const masked = maskConfigSecrets(
+    await loadCLIConfig({
+      ...(args.llmJSON === undefined ? {} : { llmJSON: args.llmJSON }),
+    }),
+  );
 
   await writeTextToStdout(`${JSON.stringify(masked, null, 2)}\n`);
 }

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -24,6 +24,8 @@ describe("cli/args", () => {
         "out.txt",
         "--output-format",
         "markdown",
+        "--llm",
+        '{"model":"cli-model"}',
         "--prompt",
         "Keep named entities",
       ]),
@@ -33,6 +35,7 @@ describe("cli/args", () => {
         help: true,
         inputFormat: "epub",
         inputPath: "book.epub",
+        llmJSON: '{"model":"cli-model"}',
         outputFormat: "markdown",
         outputPath: "out.txt",
         prompt: "Keep named entities",
@@ -96,6 +99,30 @@ describe("cli/args", () => {
     );
   });
 
+  it("parses --llm for runtime-configurable commands", () => {
+    expect(parseCLIArguments(["--llm", '{"model":"cli-model"}'])).toStrictEqual(
+      {
+        args: {
+          help: false,
+          llmJSON: '{"model":"cli-model"}',
+          verbose: false,
+        },
+        help: false,
+        kind: "convert",
+      },
+    );
+
+    expect(
+      parseCLIArguments(["status", "--llm", '{"model":"cli-model"}']),
+    ).toStrictEqual({
+      args: {
+        llmJSON: '{"model":"cli-model"}',
+      },
+      help: false,
+      kind: "status",
+    });
+  });
+
   it("parses sdpub subcommands", () => {
     expect(
       parseCLIArguments([
@@ -105,10 +132,13 @@ describe("cli/args", () => {
         "book.sdpub",
         "--serial",
         "12",
+        "--llm",
+        '{"model":"cli-model"}',
       ]),
     ).toStrictEqual({
       args: {
         inputPath: "book.sdpub",
+        llmJSON: '{"model":"cli-model"}',
         serialId: 12,
         subcommand: "cat",
       },
@@ -127,11 +157,13 @@ describe("cli/args", () => {
 
   it("parses status and prints status help text", () => {
     expect(parseCLIArguments(["status"])).toStrictEqual({
+      args: {},
       help: false,
       kind: "status",
     });
 
     expect(parseCLIArguments(["status", "--help"])).toStrictEqual({
+      args: {},
       help: true,
       helpText: renderStatusHelpText(),
       kind: "status",
@@ -259,7 +291,7 @@ describe("cli/args", () => {
     const commandHelpText = renderHelpTopicText("command");
 
     expect(rootHelpText).toContain("spinedigest help [topic]");
-    expect(rootHelpText).toContain("spinedigest status [--help|-h]");
+    expect(rootHelpText).toContain("spinedigest status [--llm <json>]");
     expect(rootHelpText).toContain("spinedigest help overview");
     expect(rootHelpText).toContain("spinedigest help env");
     expect(rootHelpText).toContain("spinedigest help config-file");
@@ -294,12 +326,15 @@ describe("cli/args", () => {
       "--input-format <format>",
       "--output-format <format>",
       "--digest-dir <path>",
+      "--llm <json>",
       "--prompt <text>",
       "--serial <id>",
     ]) {
       expect(commandHelpText).toContain(flag);
     }
     expect(renderHelpTopicText("config")).toContain("spinedigest help env");
+    expect(renderHelpTopicText("config")).toContain("Inline LLM JSON");
+    expect(renderHelpTopicText("config")).toContain("baseUrl");
     expect(renderHelpTopicText("env")).toContain("SPINEDIGEST_LLM_MODEL");
     expect(renderHelpTopicText("env")).toContain("SPINEDIGEST_REQUEST_STREAM");
     expect(renderHelpTopicText("env")).toContain(

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -271,6 +271,11 @@ describe("cli/args", () => {
     ).toThrow(
       "The `help` command does not support --input.\nSee: spinedigest --help",
     );
+    expect(() =>
+      parseCLIArguments(["help", "overview", "--llm", '{"model":"cli-model"}']),
+    ).toThrow(
+      "The `help` command does not support --llm.\nSee: spinedigest --help",
+    );
   });
 
   it("rejects invalid status usage", () => {

--- a/test/cli/config.test.ts
+++ b/test/cli/config.test.ts
@@ -145,6 +145,73 @@ describe("cli/config", () => {
     });
   });
 
+  it("lets inline llm json override env and file llm values", async () => {
+    await withTempDir("spinedigest-config-", async (path) => {
+      const configPath = `${path}/config.json`;
+
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          llm: {
+            apiKey: "file-key",
+            baseURL: "https://file.example/v1",
+            model: "file-model",
+            provider: "openai",
+          },
+        }),
+      );
+
+      process.env.SPINEDIGEST_CONFIG = configPath;
+      process.env.SPINEDIGEST_LLM_API_KEY = "env-key";
+      process.env.SPINEDIGEST_LLM_BASE_URL = "https://env.example/v1";
+      process.env.SPINEDIGEST_LLM_MODEL = "env-model";
+      process.env.SPINEDIGEST_LLM_PROVIDER = "openai-compatible";
+
+      await expect(
+        loadCLIConfig({
+          llmJSON: JSON.stringify({
+            apiKey: "inline-key",
+            baseUrl: "https://inline.example/v1",
+            model: "inline-model",
+          }),
+        }),
+      ).resolves.toStrictEqual({
+        configFilePath: configPath,
+        llm: {
+          apiKey: "inline-key",
+          baseURL: "https://inline.example/v1",
+          model: "inline-model",
+          provider: "openai-compatible",
+        },
+      });
+    });
+  });
+
+  it("accepts nested inline llm json and chat completions urls", async () => {
+    await withTempDir("spinedigest-config-", async (path) => {
+      process.env.SPINEDIGEST_CONFIG = `${path}/missing.json`;
+
+      await expect(
+        loadCLIConfig({
+          llmJSON: JSON.stringify({
+            llm: {
+              apiKey: "inline-key",
+              chatCompletionsUrl: "https://inline.example/v1/chat/completions",
+              model: "inline-model",
+            },
+          }),
+        }),
+      ).resolves.toStrictEqual({
+        llm: {
+          apiKey: "inline-key",
+          baseURL: "https://inline.example/v1",
+          model: "inline-model",
+          provider: "openai-compatible",
+        },
+      });
+    });
+  });
+
   it("returns an empty config when no config file exists", async () => {
     await withTempDir("spinedigest-config-", async (path) => {
       process.env.SPINEDIGEST_CONFIG = `${path}/missing.json`;
@@ -193,6 +260,26 @@ describe("cli/config", () => {
 
     await expect(loadCLIConfig()).rejects.toThrow(
       "SPINEDIGEST_REQUEST_STREAM must be true/false or 1/0.\nSee: spinedigest help env",
+    );
+
+    delete process.env.SPINEDIGEST_REQUEST_STREAM;
+
+    await expect(loadCLIConfig({ llmJSON: "{not json" })).rejects.toThrow(
+      "Invalid --llm JSON:",
+    );
+
+    await expect(loadCLIConfig({ llmJSON: "{}" })).rejects.toThrow(
+      "--llm must contain at least one supported LLM field.\nSee: spinedigest help config",
+    );
+
+    await expect(
+      loadCLIConfig({
+        llmJSON: JSON.stringify({
+          chatCompletionsUrl: "https://example.test/responses",
+        }),
+      }),
+    ).rejects.toThrow(
+      "--llm chatCompletionsUrl must end with /chat/completions when baseURL is not provided.\nSee: spinedigest help config",
     );
   });
 });

--- a/test/cli/config.test.ts
+++ b/test/cli/config.test.ts
@@ -281,5 +281,17 @@ describe("cli/config", () => {
     ).rejects.toThrow(
       "--llm chatCompletionsUrl must end with /chat/completions when baseURL is not provided.\nSee: spinedigest help config",
     );
+
+    await expect(
+      loadCLIConfig({
+        llmJSON: JSON.stringify({
+          llm: {
+            chatCompletionsUrl: "https://example.test/responses",
+          },
+        }),
+      }),
+    ).rejects.toThrow(
+      "--llm chatCompletionsUrl must end with /chat/completions when baseURL is not provided.\nSee: spinedigest help config",
+    );
   });
 });

--- a/test/cli/convert.test.ts
+++ b/test/cli/convert.test.ts
@@ -26,6 +26,7 @@ const cliMockState = vi.hoisted(() => ({
     readonly method: "exportEpub" | "exportText" | "saveAs";
     readonly path: string;
   }>,
+  loadCLIConfigOptions: [] as unknown[],
   openCalls: [] as string[],
   resetDigestDirCalls: [] as string[],
   removeTemporaryDirectoryCalls: [] as string[],
@@ -99,7 +100,10 @@ vi.mock("../../src/index.js", () => ({
 }));
 
 vi.mock("../../src/cli/config.js", () => ({
-  loadCLIConfig: vi.fn(() => Promise.resolve(cliMockState.config)),
+  loadCLIConfig: vi.fn((options?: unknown) => {
+    cliMockState.loadCLIConfigOptions.push(options);
+    return Promise.resolve(cliMockState.config);
+  }),
 }));
 
 vi.mock("../../src/cli/llm.js", () => ({
@@ -156,6 +160,7 @@ describe("cli/convert", () => {
     cliMockState.digestCalls.textStream.length = 0;
     cliMockState.digestCalls.txt.length = 0;
     cliMockState.exportCalls.length = 0;
+    cliMockState.loadCLIConfigOptions.length = 0;
     cliMockState.openCalls.length = 0;
     cliMockState.resetDigestDirCalls.length = 0;
     cliMockState.removeTemporaryDirectoryCalls.length = 0;
@@ -285,6 +290,50 @@ describe("cli/convert", () => {
     ]);
   });
 
+  it("passes inline llm json into config loading", async () => {
+    cliMockState.config = {
+      llm: {
+        model: "gpt-test",
+        provider: "openai",
+      },
+    };
+
+    await runConvertCommand({
+      help: false,
+      inputPath: "/tmp/book.txt",
+      llmJSON: '{"model":"inline-model"}',
+      outputPath: "/tmp/output.txt",
+      verbose: false,
+    });
+
+    expect(cliMockState.loadCLIConfigOptions).toStrictEqual([
+      {
+        llmJSON: '{"model":"inline-model"}',
+      },
+    ]);
+    expect(cliMockState.buildLLMOptionsConfig).toStrictEqual([
+      cliMockState.config,
+    ]);
+  });
+
+  it("accepts inline llm json while reopening sdpub without building llm options", async () => {
+    await runConvertCommand({
+      help: false,
+      inputPath: "/tmp/book.sdpub",
+      llmJSON: '{"model":"inline-model"}',
+      outputPath: "/tmp/output.txt",
+      verbose: false,
+    });
+
+    expect(cliMockState.loadCLIConfigOptions).toStrictEqual([
+      {
+        llmJSON: '{"model":"inline-model"}',
+      },
+    ]);
+    expect(cliMockState.buildLLMOptionsConfig).toHaveLength(0);
+    expect(cliMockState.openCalls).toStrictEqual(["/tmp/book.sdpub"]);
+  });
+
   it("refuses to read interactive stdin when input is omitted", async () => {
     cliMockState.config = {
       llm: {
@@ -357,7 +406,7 @@ describe("cli/convert", () => {
         verbose: false,
       }),
     ).rejects.toThrow(
-      "Missing LLM configuration. Set `llm.provider` and `llm.model` in ~/.spinedigest/config.json or the matching SPINEDIGEST_LLM_* environment variables.\nSee: spinedigest help config",
+      "Missing LLM configuration. Set --llm, `llm.provider` and `llm.model` in ~/.spinedigest/config.json, or the matching SPINEDIGEST_LLM_* environment variables.\nSee: spinedigest help config",
     );
 
     expect(cliMockState.appConstructorOptions).toHaveLength(0);

--- a/test/cli/llm.test.ts
+++ b/test/cli/llm.test.ts
@@ -214,7 +214,7 @@ describe("cli/llm", () => {
 
   it("rejects missing provider/model inputs and missing openai-compatible base urls", () => {
     expect(() => buildLLMOptions({})).toThrow(
-      "Missing LLM configuration. Set `llm.provider` and `llm.model` in ~/.spinedigest/config.json or the matching SPINEDIGEST_LLM_* environment variables.\nSee: spinedigest help config",
+      "Missing LLM configuration. Set --llm, `llm.provider` and `llm.model` in ~/.spinedigest/config.json, or the matching SPINEDIGEST_LLM_* environment variables.\nSee: spinedigest help config",
     );
     expect(() =>
       buildLLMOptions({
@@ -224,7 +224,7 @@ describe("cli/llm", () => {
         },
       }),
     ).toThrow(
-      "openai-compatible requires llm.baseURL or SPINEDIGEST_LLM_BASE_URL.\nSee: spinedigest help config",
+      "openai-compatible requires llm.baseURL, --llm baseURL, or SPINEDIGEST_LLM_BASE_URL.\nSee: spinedigest help config",
     );
   });
 
@@ -239,7 +239,7 @@ describe("cli/llm", () => {
         },
       }),
     ).toThrow(
-      "openai does not accept llm.baseURL or SPINEDIGEST_LLM_BASE_URL. Use openai-compatible for third-party OpenAI-style APIs.\nSee: spinedigest help config",
+      "openai does not accept llm.baseURL, --llm baseURL, or SPINEDIGEST_LLM_BASE_URL. Use openai-compatible for third-party OpenAI-style APIs.\nSee: spinedigest help config",
     );
   });
 });

--- a/test/cli/llm.test.ts
+++ b/test/cli/llm.test.ts
@@ -224,7 +224,7 @@ describe("cli/llm", () => {
         },
       }),
     ).toThrow(
-      "openai-compatible requires llm.baseURL, --llm baseURL, or SPINEDIGEST_LLM_BASE_URL.\nSee: spinedigest help config",
+      "openai-compatible requires llm.baseURL, baseURL in --llm JSON, or SPINEDIGEST_LLM_BASE_URL.\nSee: spinedigest help config",
     );
   });
 
@@ -239,7 +239,7 @@ describe("cli/llm", () => {
         },
       }),
     ).toThrow(
-      "openai does not accept llm.baseURL, --llm baseURL, or SPINEDIGEST_LLM_BASE_URL. Use openai-compatible for third-party OpenAI-style APIs.\nSee: spinedigest help config",
+      "openai does not accept llm.baseURL, baseURL in --llm JSON, or SPINEDIGEST_LLM_BASE_URL. Use openai-compatible for third-party OpenAI-style APIs.\nSee: spinedigest help config",
     );
   });
 });

--- a/test/cli/main.test.ts
+++ b/test/cli/main.test.ts
@@ -13,6 +13,7 @@ const mainMockState = vi.hoisted(() => ({
   parseError: undefined as Error | undefined,
   runCalls: [] as unknown[],
   statusRunCalls: 0,
+  statusRunArgs: [] as unknown[],
   sdpubRunCalls: [] as unknown[],
   runError: undefined as Error | undefined,
   statusRunError: undefined as Error | undefined,
@@ -42,8 +43,9 @@ vi.mock("../../src/cli/convert.js", () => ({
 }));
 
 vi.mock("../../src/cli/status.js", () => ({
-  runStatusCommand: vi.fn(() => {
+  runStatusCommand: vi.fn((args: unknown) => {
     mainMockState.statusRunCalls += 1;
+    mainMockState.statusRunArgs.push(args);
 
     if (mainMockState.statusRunError !== undefined) {
       return Promise.reject(mainMockState.statusRunError);
@@ -87,6 +89,7 @@ describe("cli/main", () => {
     mainMockState.parseError = undefined;
     mainMockState.runCalls.length = 0;
     mainMockState.statusRunCalls = 0;
+    mainMockState.statusRunArgs.length = 0;
     mainMockState.sdpubRunCalls.length = 0;
     mainMockState.runError = undefined;
     mainMockState.statusRunError = undefined;
@@ -162,6 +165,7 @@ describe("cli/main", () => {
 
   it("runs the status command for status execution", async () => {
     mainMockState.argsResult = {
+      args: {},
       help: false,
       kind: "status",
     };
@@ -170,6 +174,7 @@ describe("cli/main", () => {
 
     expect(mainMockState.runCalls).toHaveLength(0);
     expect(mainMockState.statusRunCalls).toBe(1);
+    expect(mainMockState.statusRunArgs).toStrictEqual([{}]);
     expect(mainMockState.sdpubRunCalls).toHaveLength(0);
     expect(process.exitCode).toBe(0);
   });
@@ -232,6 +237,7 @@ describe("cli/main", () => {
 
   it("writes status command failures to stderr and sets a non-zero exit code", async () => {
     mainMockState.argsResult = {
+      args: {},
       help: false,
       kind: "status",
     };
@@ -241,6 +247,7 @@ describe("cli/main", () => {
 
     expect(stderrChunks).toStrictEqual(["status failed\n"]);
     expect(mainMockState.statusRunCalls).toBe(1);
+    expect(mainMockState.statusRunArgs).toStrictEqual([{}]);
     expect(process.exitCode).toBe(1);
   });
 

--- a/test/cli/main.test.ts
+++ b/test/cli/main.test.ts
@@ -165,7 +165,9 @@ describe("cli/main", () => {
 
   it("runs the status command for status execution", async () => {
     mainMockState.argsResult = {
-      args: {},
+      args: {
+        llmJSON: '{"model":"inline-model"}',
+      },
       help: false,
       kind: "status",
     };
@@ -174,7 +176,11 @@ describe("cli/main", () => {
 
     expect(mainMockState.runCalls).toHaveLength(0);
     expect(mainMockState.statusRunCalls).toBe(1);
-    expect(mainMockState.statusRunArgs).toStrictEqual([{}]);
+    expect(mainMockState.statusRunArgs).toStrictEqual([
+      {
+        llmJSON: '{"model":"inline-model"}',
+      },
+    ]);
     expect(mainMockState.sdpubRunCalls).toHaveLength(0);
     expect(process.exitCode).toBe(0);
   });
@@ -237,7 +243,9 @@ describe("cli/main", () => {
 
   it("writes status command failures to stderr and sets a non-zero exit code", async () => {
     mainMockState.argsResult = {
-      args: {},
+      args: {
+        llmJSON: '{"model":"inline-model"}',
+      },
       help: false,
       kind: "status",
     };
@@ -247,7 +255,11 @@ describe("cli/main", () => {
 
     expect(stderrChunks).toStrictEqual(["status failed\n"]);
     expect(mainMockState.statusRunCalls).toBe(1);
-    expect(mainMockState.statusRunArgs).toStrictEqual([{}]);
+    expect(mainMockState.statusRunArgs).toStrictEqual([
+      {
+        llmJSON: '{"model":"inline-model"}',
+      },
+    ]);
     expect(process.exitCode).toBe(1);
   });
 

--- a/test/cli/status.test.ts
+++ b/test/cli/status.test.ts
@@ -57,7 +57,7 @@ describe("cli/status", () => {
   it("prints {} when the config file does not exist", async () => {
     await withTempDir("spinedigest-status-", async (path) => {
       process.env.SPINEDIGEST_CONFIG = `${path}/missing.json`;
-      await runStatusCommand();
+      await runStatusCommand({});
 
       expect(statusMockState.stdoutTexts).toStrictEqual(["{}\n"]);
     });
@@ -87,17 +87,18 @@ describe("cli/status", () => {
       );
       process.env.SPINEDIGEST_CONFIG = configPath;
 
-      await runStatusCommand();
+      await runStatusCommand({});
 
       expect(statusMockState.stdoutTexts).toStrictEqual([
         `{
+  "configFilePath": "${configPath}",
   "llm": {
     "apiKey": "sk-t**********-key",
     "model": "gpt-4.1",
     "provider": "openai"
   },
   "paths": {
-    "cacheDir": "./cache"
+    "cacheDir": "${path}/nested/cache"
   }
 }\n`,
       ]);
@@ -124,10 +125,11 @@ describe("cli/status", () => {
       );
       process.env.SPINEDIGEST_CONFIG = configPath;
 
-      await runStatusCommand();
+      await runStatusCommand({});
 
       expect(statusMockState.stdoutTexts).toStrictEqual([
         `{
+  "configFilePath": "${configPath}",
   "llm": {
     "apiKey": "sk-***",
     "model": "gpt-4.1",
@@ -145,9 +147,34 @@ describe("cli/status", () => {
       await writeFile(configPath, "{not json", "utf8");
       process.env.SPINEDIGEST_CONFIG = configPath;
 
-      await expect(runStatusCommand()).rejects.toThrow(
+      await expect(runStatusCommand({})).rejects.toThrow(
         `Invalid CLI config JSON at ${configPath}:`,
       );
+    });
+  });
+
+  it("prints masked merged config when inline llm json is provided", async () => {
+    await withTempDir("spinedigest-status-", async (path) => {
+      process.env.SPINEDIGEST_CONFIG = `${path}/missing.json`;
+
+      await runStatusCommand({
+        llmJSON: JSON.stringify({
+          apiKey: "sk-inline-secret-key",
+          baseUrl: "https://inline.example/v1",
+          model: "inline-model",
+        }),
+      });
+
+      expect(statusMockState.stdoutTexts).toStrictEqual([
+        `{
+  "llm": {
+    "apiKey": "sk-i************-key",
+    "baseURL": "https://inline.example/v1",
+    "model": "inline-model",
+    "provider": "openai-compatible"
+  }
+}\n`,
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Summary
- add a broad `--llm <json>` option for one-shot LLM client configuration
- support direct and nested inline LLM JSON, including OpenAI-compatible aliases like `baseUrl` and `chatCompletionsUrl`
- update status/help/docs/tests for the new config precedence and command surface

## Validation
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `./node_modules/.bin/eslint .`
- `./node_modules/.bin/prettier . --check`
- `./node_modules/.bin/vitest run --passWithNoTests`

Note: local `pnpm` shim currently fails with `This: command not found`, so validation used project-local binaries.