### PR TITLE
docs: add required LLM quickstart config

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,29 @@ spinedigest help ai
 ## Quick Start
 
 The first two examples below create a new digest from source input, so they require LLM configuration first.
-If you need config setup details, run:
+For full config details, run:
 
 ```bash
 spinedigest help config
+```
+
+Create the required LLM config before running a source digest:
+
+```bash
+mkdir -p ~/.spinedigest
+
+cat > ~/.spinedigest/config.json <<'JSON'
+{
+  "llm": {
+    "provider": "openai-compatible",
+    "model": "your-model",
+    "baseURL": "https://your-provider.example/v1",
+    "apiKey": "your-api-key"
+  }
+}
+JSON
+
+spinedigest status
 ```
 
 Digest an EPUB into Markdown:

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -48,10 +48,29 @@ spinedigest help ai
 ## 快速开始
 
 下面前两个例子都会从源输入创建新的 digest，因此需要先完成 LLM 配置。
-如果需要配置说明，先运行：
+完整配置说明：
 
 ```bash
 spinedigest help config
+```
+
+运行源文件 digest 之前，先创建必需的 LLM 配置：
+
+```bash
+mkdir -p ~/.spinedigest
+
+cat > ~/.spinedigest/config.json <<'JSON'
+{
+  "llm": {
+    "provider": "openai-compatible",
+    "model": "your-model",
+    "baseURL": "https://your-provider.example/v1",
+    "apiKey": "your-api-key"
+  }
+}
+JSON
+
+spinedigest status
 ```
 
 把一本 EPUB 摘要成 Markdown：

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -52,37 +52,24 @@ SpineDigest reads configuration from:
 
 - default path: `~/.spinedigest/config.json`
 - override path: `SPINEDIGEST_CONFIG`
-- one-shot inline LLM JSON: `--llm <json>`
 
-A minimal config file looks like this:
+Create the required LLM config, then verify it before running a source digest:
 
-```json
+```bash
+mkdir -p ~/.spinedigest
+
+cat > ~/.spinedigest/config.json <<'JSON'
 {
   "llm": {
-    "provider": "openai",
-    "model": "<your-model>"
+    "provider": "openai-compatible",
+    "model": "your-model",
+    "baseURL": "https://your-provider.example/v1",
+    "apiKey": "your-api-key"
   }
 }
-```
+JSON
 
-Set credentials with environment variables when possible:
-
-```bash
-export SPINEDIGEST_LLM_API_KEY="<your-api-key>"
-```
-
-For `openai-compatible`, you must also set a base URL:
-
-```bash
-export SPINEDIGEST_LLM_BASE_URL="https://your-provider.example/v1"
-```
-
-You can also place these fields in `config.json` if your environment requires it.
-
-For one-off automation, pass inline LLM client JSON instead of writing config:
-
-```bash
-spinedigest --llm "$LLM_JSON" --input ./book.md --output ./out/digest.md
+spinedigest status
 ```
 
 ## 5. Run Your First Digest

--- a/docs/zh-CN/quickstart.md
+++ b/docs/zh-CN/quickstart.md
@@ -52,37 +52,24 @@ SpineDigest 会从以下位置读取配置：
 
 - 默认路径：`~/.spinedigest/config.json`
 - 覆盖路径：`SPINEDIGEST_CONFIG`
-- 临时 inline LLM JSON：`--llm <json>`
 
-最小配置文件示例：
+先创建必需的 LLM 配置，再检查配置，然后才能运行源文件 digest：
 
-```json
+```bash
+mkdir -p ~/.spinedigest
+
+cat > ~/.spinedigest/config.json <<'JSON'
 {
   "llm": {
-    "provider": "openai",
-    "model": "<your-model>"
+    "provider": "openai-compatible",
+    "model": "your-model",
+    "baseURL": "https://your-provider.example/v1",
+    "apiKey": "your-api-key"
   }
 }
-```
+JSON
 
-凭据建议优先通过环境变量提供：
-
-```bash
-export SPINEDIGEST_LLM_API_KEY="<your-api-key>"
-```
-
-如果使用 `openai-compatible`，还必须提供 base URL：
-
-```bash
-export SPINEDIGEST_LLM_BASE_URL="https://your-provider.example/v1"
-```
-
-如果你的环境更适合写进 `config.json`，也可以把这些字段写入配置文件。
-
-如果只是自动化里临时运行一次，也可以直接传 inline LLM client JSON：
-
-```bash
-spinedigest --llm "$LLM_JSON" --input ./book.md --output ./out/digest.md
+spinedigest status
 ```
 
 ## 5. 跑第一条命令


### PR DESCRIPTION
## Summary
- Add a required LLM config setup block before README source digest examples
- Update English and Chinese Quick Start docs to start from a complete `config.json` with provider, model, baseURL, and apiKey
- Remove the env-var-first and inline-LLM detours from Quick Start so the first-run path is copyable

Refs #50

## Tests
- `pnpm install`
- `pnpm run lint:fix`
- `git diff --check`