### PR TITLE
feat: add staged SDPUB editing workflows

### DIFF
--- a/data/help/commands/root.jinja
+++ b/data/help/commands/root.jinja
@@ -10,7 +10,7 @@ Purpose:
 Usage:
   spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose|-v] [--help|-h]
   spinedigest status [--llm <json>] [--help|-h]
-  spinedigest sdpub <subcommand> --input <path> [--serial <id>] [--llm <json>] [--help|-h]
+  spinedigest sdpub <info|toc|list|cat|cover|meta> --input <path> [options] [--help|-h]
   spinedigest sdpub chapter <action> <path> [options] [--help|-h]
   spinedigest sdpub stage <action> <path> [options] [--help|-h]
   spinedigest help [topic] [--help|-h]

--- a/data/help/commands/root.jinja
+++ b/data/help/commands/root.jinja
@@ -8,10 +8,11 @@ Purpose:
   Digesting source input uses an LLM pipeline. Re-opening an existing .sdpub archive does not.
 
 Usage:
-  spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--verbose|-v] [--help|-h]
+  spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose|-v] [--help|-h]
   spinedigest status [--llm <json>] [--help|-h]
   spinedigest sdpub <subcommand> --input <path> [--serial <id>] [--llm <json>] [--help|-h]
   spinedigest sdpub chapter <action> <path> [options] [--help|-h]
+  spinedigest sdpub stage <action> <path> [options] [--help|-h]
   spinedigest help [topic] [--help|-h]
 
 Help contract:

--- a/data/help/commands/root.jinja
+++ b/data/help/commands/root.jinja
@@ -11,6 +11,7 @@ Usage:
   spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--verbose|-v] [--help|-h]
   spinedigest status [--llm <json>] [--help|-h]
   spinedigest sdpub <subcommand> --input <path> [--serial <id>] [--llm <json>] [--help|-h]
+  spinedigest sdpub chapter <action> <path> [options] [--help|-h]
   spinedigest help [topic] [--help|-h]
 
 Help contract:

--- a/data/help/commands/sdpub/chapter.jinja
+++ b/data/help/commands/sdpub/chapter.jinja
@@ -9,8 +9,6 @@ Usage:
   spinedigest sdpub chapter remove <path> --chapter <id> [--recursive] [--llm <json>] [--help|-h]
   spinedigest sdpub chapter reset <path> --chapter <id> --to <stage> [--llm <json>] [--help|-h]
   spinedigest sdpub chapter set-source <path> --chapter <id> [--input <path>] --input-format <format> [--llm <json>] [--help|-h]
-  spinedigest sdpub chapter generate-graph <path> --chapter <id> [--prompt <text>] [--llm <json>] [--help|-h]
-  spinedigest sdpub chapter generate-summary <path> --chapter <id> [--llm <json>] [--help|-h]
   spinedigest sdpub chapter set-summary <path> --chapter <id> [--input <path>] [--llm <json>] [--help|-h]
 
 Chapter stages:
@@ -26,7 +24,9 @@ Input rules:
   - `set-source` and `set-summary` read `--input <path>` when provided, otherwise stdin.
   - `set-source` accepts only `txt` or `markdown` for `--input-format`.
   - `reset --to` accepts `planned`, `sourced`, or `graphed`.
+  - To generate graph or summary for a chapter, use `spinedigest sdpub stage advance <path> --chapter <id> --to <stage>`.
 
 See also:
   - spinedigest sdpub chapter list <path>
+  - spinedigest sdpub stage --help
   - spinedigest help sdpub

--- a/data/help/commands/sdpub/chapter.jinja
+++ b/data/help/commands/sdpub/chapter.jinja
@@ -24,6 +24,7 @@ Input rules:
   - `set-source` and `set-summary` read `--input <path>` when provided, otherwise stdin.
   - `set-source` accepts only `txt` or `markdown` for `--input-format`.
   - `reset --to` accepts `planned`, `sourced`, or `graphed`.
+  - Structure edits, `set-source`, `set-summary`, and `reset` do not call an LLM provider.
   - To generate graph or summary for a chapter, use `spinedigest sdpub stage advance <path> --chapter <id> --to <stage>`.
 
 See also:

--- a/data/help/commands/sdpub/chapter.jinja
+++ b/data/help/commands/sdpub/chapter.jinja
@@ -1,0 +1,31 @@
+Command: spinedigest sdpub chapter
+
+Edit chapters inside an existing `.sdpub` archive.
+
+Usage:
+  spinedigest sdpub chapter list <path> [--llm <json>] [--help|-h]
+  spinedigest sdpub chapter status <path> --chapter <id> [--llm <json>] [--help|-h]
+  spinedigest sdpub chapter add <path> --title <title> [--parent <id>] [--llm <json>] [--help|-h]
+  spinedigest sdpub chapter remove <path> --chapter <id> [--recursive] [--llm <json>] [--help|-h]
+  spinedigest sdpub chapter reset <path> --chapter <id> --to <stage> [--llm <json>] [--help|-h]
+  spinedigest sdpub chapter set-source <path> --chapter <id> [--input <path>] --input-format <format> [--llm <json>] [--help|-h]
+  spinedigest sdpub chapter generate-graph <path> --chapter <id> [--prompt <text>] [--llm <json>] [--help|-h]
+  spinedigest sdpub chapter generate-summary <path> --chapter <id> [--llm <json>] [--help|-h]
+  spinedigest sdpub chapter set-summary <path> --chapter <id> [--input <path>] [--llm <json>] [--help|-h]
+
+Chapter stages:
+  planned     TOC chapter exists, but no source is stored.
+  sourced     Normalized source fragments are stored.
+  graphed     Source plus generated graph are stored.
+  summarized  Source, graph, and final summary are stored.
+
+Input rules:
+  - `<path>` is the `.sdpub` archive edited in place.
+  - `--chapter` is the numeric chapter id printed by `list` or `add`.
+  - `set-source` and `set-summary` read `--input <path>` when provided, otherwise stdin.
+  - `set-source` accepts only `txt` or `markdown` for `--input-format`.
+  - `reset --to` accepts `planned`, `sourced`, or `graphed`.
+
+See also:
+  - spinedigest sdpub chapter list <path>
+  - spinedigest help sdpub

--- a/data/help/commands/sdpub/chapter.jinja
+++ b/data/help/commands/sdpub/chapter.jinja
@@ -5,7 +5,7 @@ Edit chapters inside an existing `.sdpub` archive.
 Usage:
   spinedigest sdpub chapter list <path> [--llm <json>] [--help|-h]
   spinedigest sdpub chapter status <path> --chapter <id> [--llm <json>] [--help|-h]
-  spinedigest sdpub chapter add <path> --title <title> [--parent <id>] [--llm <json>] [--help|-h]
+  spinedigest sdpub chapter add <path> [--title <title>] [--parent <id>] [--llm <json>] [--help|-h]
   spinedigest sdpub chapter remove <path> --chapter <id> [--recursive] [--llm <json>] [--help|-h]
   spinedigest sdpub chapter reset <path> --chapter <id> --to <stage> [--llm <json>] [--help|-h]
   spinedigest sdpub chapter set-source <path> --chapter <id> [--input <path>] --input-format <format> [--llm <json>] [--help|-h]
@@ -22,6 +22,7 @@ Chapter stages:
 Input rules:
   - `<path>` is the `.sdpub` archive edited in place.
   - `--chapter` is the numeric chapter id printed by `list` or `add`.
+  - `add` creates an untitled planned chapter when `--title` is omitted.
   - `set-source` and `set-summary` read `--input <path>` when provided, otherwise stdin.
   - `set-source` accepts only `txt` or `markdown` for `--input-format`.
   - `reset --to` accepts `planned`, `sourced`, or `graphed`.

--- a/data/help/commands/sdpub/index.jinja
+++ b/data/help/commands/sdpub/index.jinja
@@ -4,7 +4,7 @@ Command: spinedigest sdpub
 sdpub Command Family
 
 Purpose:
-  Inspect an existing .sdpub archive without exporting the whole document.
+  Inspect or edit an existing .sdpub archive without exporting the whole document.
 
 Usage:
   spinedigest sdpub info --input <path> [--llm <json>] [--help|-h]
@@ -17,15 +17,16 @@ Usage:
   spinedigest sdpub chapter <action> <path> [options] [--help|-h]
 
 Shared behavior:
-  - Inspection subcommands require `--input <path>` to an existing `.sdpub` archive.
+  - Inspection subcommands use `--input <path>` for an existing `.sdpub` archive.
+  - `stage` and `chapter` actions use the archive path as a positional argument.
   - `sdpub meta` edits metadata in place when metadata options are present.
   - Output is written to stdout, except `sdpub cover` writes binary bytes.
-  - stdin is not supported by this command family.
+  - `chapter set-source` and `chapter set-summary` can read content from stdin when `--input` is omitted.
   - `--digest-dir`, `--output`, `--output-format`, and `--verbose` are not supported.
   - `--prompt` is only supported by `sdpub stage advance`.
-  - `--llm <json>` is accepted for wrapper consistency but is not used.
+  - `sdpub stage advance` calls an LLM provider when graph or summary generation is needed.
+  - Inspection commands and metadata/tree edits do not call an LLM provider.
   - `-h` is available as the short form of `--help`.
-  - These subcommands do not call an LLM provider.
 
 Subcommands:
 {% for command in sdpubCommands %}
@@ -43,5 +44,5 @@ Where to go next:
     spinedigest help format
   - Need runtime rules for stdout or binary cover output:
     spinedigest help runtime
-  - Need failure handling for archive inspection:
+  - Need failure handling for archive commands:
     spinedigest help troubleshoot

--- a/data/help/commands/sdpub/index.jinja
+++ b/data/help/commands/sdpub/index.jinja
@@ -13,6 +13,7 @@ Usage:
   spinedigest sdpub cat --input <path> --serial <id> [--llm <json>] [--help|-h]
   spinedigest sdpub cover --input <path> [--llm <json>] [--help|-h]
   spinedigest sdpub meta --input <path> [metadata options] [--llm <json>] [--help|-h]
+  spinedigest sdpub stage <action> <path> [options] [--help|-h]
   spinedigest sdpub chapter <action> <path> [options] [--help|-h]
 
 Shared behavior:
@@ -20,7 +21,8 @@ Shared behavior:
   - `sdpub meta` edits metadata in place when metadata options are present.
   - Output is written to stdout, except `sdpub cover` writes binary bytes.
   - stdin is not supported by this command family.
-  - `--digest-dir`, `--output`, `--output-format`, `--prompt`, and `--verbose` are not supported.
+  - `--digest-dir`, `--output`, `--output-format`, and `--verbose` are not supported.
+  - `--prompt` is only supported by `sdpub stage advance`.
   - `--llm <json>` is accepted for wrapper consistency but is not used.
   - `-h` is available as the short form of `--help`.
   - These subcommands do not call an LLM provider.

--- a/data/help/commands/sdpub/index.jinja
+++ b/data/help/commands/sdpub/index.jinja
@@ -12,6 +12,7 @@ Usage:
   spinedigest sdpub list --input <path> [--llm <json>] [--help|-h]
   spinedigest sdpub cat --input <path> --serial <id> [--llm <json>] [--help|-h]
   spinedigest sdpub cover --input <path> [--llm <json>] [--help|-h]
+  spinedigest sdpub chapter <action> <path> [options] [--help|-h]
 
 Shared behavior:
   - All subcommands require `--input <path>` to an existing `.sdpub` archive.

--- a/data/help/commands/sdpub/index.jinja
+++ b/data/help/commands/sdpub/index.jinja
@@ -12,12 +12,14 @@ Usage:
   spinedigest sdpub list --input <path> [--llm <json>] [--help|-h]
   spinedigest sdpub cat --input <path> --serial <id> [--llm <json>] [--help|-h]
   spinedigest sdpub cover --input <path> [--llm <json>] [--help|-h]
+  spinedigest sdpub meta --input <path> [metadata options] [--llm <json>] [--help|-h]
   spinedigest sdpub chapter <action> <path> [options] [--help|-h]
 
 Shared behavior:
-  - All subcommands require `--input <path>` to an existing `.sdpub` archive.
-  - Output is written to stdout.
-  - stdin is not supported.
+  - Inspection subcommands require `--input <path>` to an existing `.sdpub` archive.
+  - `sdpub meta` edits metadata in place when metadata options are present.
+  - Output is written to stdout, except `sdpub cover` writes binary bytes.
+  - stdin is not supported by this command family.
   - `--digest-dir`, `--output`, `--output-format`, `--prompt`, and `--verbose` are not supported.
   - `--llm <json>` is accepted for wrapper consistency but is not used.
   - `-h` is available as the short form of `--help`.

--- a/data/help/commands/sdpub/info.jinja
+++ b/data/help/commands/sdpub/info.jinja
@@ -10,6 +10,7 @@ Usage:
   spinedigest sdpub info --input <path> [--llm <json>] [--help|-h]
 
 Output shape:
+  - Archive Format Version
   - Title
   - Authors
   - Language
@@ -24,5 +25,6 @@ Output shape:
   - Total fragment count
 
 Notes:
+  - Archives without `manifest.json` are reported as archive format version 1.
   - Missing metadata fields are omitted.
   - If no document metadata exists, the command prints a fallback message.

--- a/data/help/commands/sdpub/meta.jinja
+++ b/data/help/commands/sdpub/meta.jinja
@@ -1,0 +1,49 @@
+Help Type: command
+Command: spinedigest sdpub meta
+
+sdpub meta
+
+Purpose:
+  Read or edit book metadata stored in an existing `.sdpub` archive.
+
+Usage:
+  spinedigest sdpub meta --input <path> [--llm <json>] [--help|-h]
+  spinedigest sdpub meta --input <path> [metadata options] [--llm <json>] [--help|-h]
+
+Metadata options:
+  --title <text>             Set the book title.
+  --author <text>            Replace the author list. May be repeated.
+  --language <text>          Set the language metadata.
+  --identifier <text>        Set the identifier metadata.
+  --publisher <text>         Set the publisher metadata.
+  --published-at <text>      Set the publication date metadata.
+  --description <text>       Set the description metadata.
+  --clear-title              Clear the book title.
+  --clear-authors            Clear all authors.
+  --clear-language           Clear the language metadata.
+  --clear-identifier         Clear the identifier metadata.
+  --clear-publisher          Clear the publisher metadata.
+  --clear-published-at       Clear the publication date metadata.
+  --clear-description        Clear the description metadata.
+
+Behavior:
+  - Without metadata options, this command prints the current metadata.
+  - With metadata options, this command edits the archive in place and then prints the updated metadata.
+  - `--author` replaces the entire author list; pass it once per author.
+  - `version` and `sourceFormat` are preserved and cannot be edited by this command.
+  - Empty string metadata values are rejected. Use the matching `--clear-*` flag instead.
+  - This command does not call an LLM provider.
+
+Examples:
+  spinedigest sdpub meta --input ./book.sdpub
+  spinedigest sdpub meta --input ./book.sdpub --title "New Title"
+  spinedigest sdpub meta --input ./book.sdpub --author "Author One" --author "Author Two"
+  spinedigest sdpub meta --input ./book.sdpub --clear-title --clear-description
+
+Where to go next:
+  - Need the whole `.sdpub` command family:
+    spinedigest sdpub --help
+  - Need chapter tree editing:
+    spinedigest sdpub chapter --help
+  - Need archive-vs-source mental model:
+    spinedigest help sdpub

--- a/data/help/commands/sdpub/stage.jinja
+++ b/data/help/commands/sdpub/stage.jinja
@@ -1,0 +1,40 @@
+Help Type: command
+Command: spinedigest sdpub stage
+
+sdpub stage
+
+Purpose:
+  Inspect unfinished chapters or safely advance chapter stages in an existing `.sdpub` archive.
+
+Usage:
+  spinedigest sdpub stage pending <path> [--llm <json>] [--help|-h]
+  spinedigest sdpub stage advance <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>] [--help|-h]
+
+Stages:
+  planned     Chapter exists, but no source is stored.
+  sourced     Normalized source fragments are stored.
+  graphed     Source plus generated graph are stored.
+  summarized  Source, graph, and final summary are stored.
+
+Behavior:
+  - `pending` prints every chapter that is not `summarized`.
+  - `advance` moves chapters forward until `--to <stage>` is reached.
+  - `advance` is idempotent and never resets or deletes later-stage data.
+  - If `--to` is omitted, `advance` targets `summarized`.
+  - `--to planned` is accepted and makes no changes.
+  - `--chapter <id>` limits `advance` to that chapter and its descendants.
+  - `planned` chapters are skipped by graph and summary generation because they have no source.
+  - `--prompt <text>` is used when graph generation is needed.
+
+Examples:
+  spinedigest sdpub stage pending ./book.sdpub
+  spinedigest sdpub stage advance ./book.sdpub --to graphed --prompt "Focus on arguments and named entities."
+  spinedigest sdpub stage advance ./book.sdpub --chapter 3 --to summarized
+
+Where to go next:
+  - Need chapter structure editing:
+    spinedigest sdpub chapter --help
+  - Need archive metadata editing:
+    spinedigest sdpub meta --help
+  - Need the whole `.sdpub` command family:
+    spinedigest sdpub --help

--- a/data/help/commands/sdpub/stage.jinja
+++ b/data/help/commands/sdpub/stage.jinja
@@ -25,6 +25,7 @@ Behavior:
   - `--chapter <id>` limits `advance` to that chapter and its descendants.
   - `planned` chapters are skipped by graph and summary generation because they have no source.
   - `--prompt <text>` is used when graph generation is needed.
+  - `--llm <json>` can provide the LLM configuration needed by graph or summary generation.
 
 Examples:
   spinedigest sdpub stage pending ./book.sdpub

--- a/data/help/topics/ai.jinja
+++ b/data/help/topics/ai.jinja
@@ -9,6 +9,7 @@ Primary contract:
   - Check exit status and read stderr for failures.
   - Assume source digest runs require LLM configuration.
   - Assume `.sdpub` re-export and `sdpub` inspection do not call an LLM.
+  - Assume `sdpub stage advance` may call an LLM when graph or summary generation is needed.
 
 Suggested first pass:
   - Begin at `spinedigest --help`, which acts as the root page of the layered help system.
@@ -27,7 +28,7 @@ Navigation:
   - Need config file schema details: `spinedigest help config-file`
   - Need runtime guarantees: `spinedigest help runtime`
   - Need examples: `spinedigest help recipe`
-  - Need archive inspection details: `spinedigest help sdpub`
+  - Need archive command details: `spinedigest help sdpub`
   - Need error-focused recovery: `spinedigest help troubleshoot`
 
 Stable terms:
@@ -37,9 +38,9 @@ Stable terms:
   - TOC path: the section path that points to a serial
 
 Safety reminders:
-  - Do not use stdin for `.sdpub` inspection.
+  - Do not use stdin for `.sdpub` inspection; only `sdpub chapter set-source` and `set-summary` accept content from stdin.
   - Do not combine `--verbose` with stdout digest output.
   - Do not send `sdpub cover` binary output to an interactive terminal.
 
 Discovery rule:
-  - If a user question sounds like task selection, format support, config setup, runtime behavior, failure diagnosis, or `.sdpub` inspection, read the matching help topic before guessing.
+  - If a user question sounds like task selection, format support, config setup, runtime behavior, failure diagnosis, or `.sdpub` commands, read the matching help topic before guessing.

--- a/data/help/topics/command.jinja
+++ b/data/help/topics/command.jinja
@@ -23,22 +23,39 @@ Main flags:
   --verbose, -v           Write diagnostic logs to stderr.
   --help, -h              Print entry help.
 
-sdpub inspection family:
-{% for command in sdpubCommands %}
-  spinedigest sdpub {{ command.name }}{% if command.name == "cat" %} --serial <id>{% endif %} --input <path> [--llm <json>]
-    {{ command.summary }}
-{% endfor %}
+sdpub inspection and metadata commands:
+  spinedigest sdpub info --input <path> [--llm <json>]
+  spinedigest sdpub toc --input <path> [--llm <json>]
+  spinedigest sdpub list --input <path> [--llm <json>]
+  spinedigest sdpub cat --input <path> --serial <id> [--llm <json>]
+  spinedigest sdpub cover --input <path> [--llm <json>]
+  spinedigest sdpub meta --input <path> [metadata options] [--llm <json>]
+
+sdpub stage commands:
+  spinedigest sdpub stage pending <path> [--llm <json>]
+  spinedigest sdpub stage advance <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>]
+
+sdpub chapter commands:
+  spinedigest sdpub chapter list <path> [--llm <json>]
+  spinedigest sdpub chapter status <path> --chapter <id> [--llm <json>]
+  spinedigest sdpub chapter add <path> [--title <title>] [--parent <id>] [--llm <json>]
+  spinedigest sdpub chapter remove <path> --chapter <id> [--recursive] [--llm <json>]
+  spinedigest sdpub chapter reset <path> --chapter <id> --to <stage> [--llm <json>]
+  spinedigest sdpub chapter set-source <path> --chapter <id> [--input <path>] --input-format <format> [--llm <json>]
+  spinedigest sdpub chapter set-summary <path> --chapter <id> [--input <path>] [--llm <json>]
 
 sdpub-specific flags:
   --serial <id>          Required by `spinedigest sdpub cat`; must be a non-negative integer.
-  --chapter <id>         Used by `spinedigest sdpub stage advance` to limit work to one chapter subtree.
-  --to <stage>           Used by `spinedigest sdpub stage advance`; defaults to summarized.
+  --chapter <id>         Numeric chapter id printed by `sdpub chapter list` or `add`.
+  --parent <id>          Parent chapter id for `sdpub chapter add`.
+  --to <stage>           Target stage for `sdpub stage advance` or `sdpub chapter reset`.
 
 LLM flag:
   `--llm <json>` accepts a one-shot LLM client object.
   Supported fields include `provider`, `model`, `apiKey`, `baseURL`, `baseUrl`, `chatCompletionsUrl`, and `name`.
   It overrides LLM fields from environment variables and `config.json`.
-  It does not make `.sdpub` re-export or inspection call an LLM.
+  It does not make `.sdpub` re-export, inspection, metadata edits, or chapter tree edits call an LLM.
+  `sdpub stage advance` uses it when graph or summary generation is needed.
 
 Help routing:
   spinedigest --help
@@ -63,7 +80,7 @@ Where to go next:
     spinedigest help runtime
   - Need task-oriented examples instead of raw flags:
     spinedigest help task
-  - Need archive inspection command details:
+  - Need archive command details:
     spinedigest help sdpub
   - Need error-oriented guidance:
     spinedigest help troubleshoot

--- a/data/help/topics/command.jinja
+++ b/data/help/topics/command.jinja
@@ -4,7 +4,7 @@ Topic: command
 Command Reference
 
 Main convert command:
-  spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--verbose|-v] [--help|-h]
+  spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose|-v] [--help|-h]
 
 Status command:
   spinedigest status [--llm <json>] [--help|-h]
@@ -19,6 +19,7 @@ Main flags:
   --digest-dir <path>     Keep the intermediate digest workspace for source digest runs.
   --llm <json>            Inline LLM client JSON for this invocation.
   --prompt <text>         Override the extraction prompt for the current digest run.
+  --stage <stage>         For .sdpub output, stop at planned, sourced, graphed, or summarized.
   --verbose, -v           Write diagnostic logs to stderr.
   --help, -h              Print entry help.
 
@@ -30,6 +31,8 @@ sdpub inspection family:
 
 sdpub-specific flags:
   --serial <id>          Required by `spinedigest sdpub cat`; must be a non-negative integer.
+  --chapter <id>         Used by `spinedigest sdpub stage advance` to limit work to one chapter subtree.
+  --to <stage>           Used by `spinedigest sdpub stage advance`; defaults to summarized.
 
 LLM flag:
   `--llm <json>` accepts a one-shot LLM client object.

--- a/data/help/topics/config-file.jinja
+++ b/data/help/topics/config-file.jinja
@@ -47,7 +47,7 @@ Top-level structure:
 
 Fields:
   `prompt`
-    Default extraction prompt for source digest runs.
+    Default extraction prompt for graph generation.
     Type: non-empty string.
 
   `llm.provider`
@@ -75,7 +75,7 @@ Fields:
     Type: non-empty string.
 
   `paths.cacheDir`
-    LLM cache directory for source digest runs.
+    LLM cache directory for LLM-backed operations.
     Type: path string.
 
   `paths.debugLogDir`
@@ -110,7 +110,7 @@ Fields:
     Streaming toggle.
     Type: JSON boolean, either `true` or `false`.
 
-Minimum source digest config:
+Minimum LLM-backed operation config:
   {
     "llm": {
       "provider": "openai",
@@ -119,8 +119,9 @@ Minimum source digest config:
   }
 
 Applicability:
-  - `llm.*`, `prompt`, `paths.cacheDir`, and `request.*` matter for source digest runs.
+  - `llm.*`, `prompt`, `paths.cacheDir`, and `request.*` matter for source digest runs and `sdpub stage advance` when generation is needed.
   - `.sdpub` re-export through the main convert command does not require LLM settings.
+  - `sdpub` inspection, metadata, and chapter tree edit commands do not require LLM settings.
   - `paths.debugLogDir` can still matter outside source digest runs when the app emits debug logs.
 
 Inline LLM note:
@@ -131,7 +132,7 @@ Inline LLM note:
 Common failures:
   - Invalid JSON fails before execution starts.
   - Schema mismatches are reported with field paths.
-  - Missing `llm.provider` or `llm.model` breaks source digest runs but not `.sdpub` re-export.
+  - Missing `llm.provider` or `llm.model` breaks LLM-backed operations but not `.sdpub` re-export.
 
 Where to go next:
   - Need the overview and precedence model:

--- a/data/help/topics/config.jinja
+++ b/data/help/topics/config.jinja
@@ -22,10 +22,10 @@ Configuration layers:
   3. Config file:
      Best for stable machine defaults in `~/.spinedigest/config.json`.
 
-Minimum digest configuration:
+Minimum LLM-backed operation configuration:
   - llm.provider
   - llm.model
-  These are required only for source digest runs.
+  These are required for source digest runs, and for `sdpub stage advance` when generation is needed.
 
 Inline LLM JSON:
   `--llm <json>` accepts an inline LLM client object for the current invocation.
@@ -37,7 +37,8 @@ Inline LLM JSON:
 Execution paths:
   - Source digest runs use prompt, LLM, cache, and request settings.
   - `.sdpub` re-export through the main convert command does not require LLM settings.
-  - `sdpub` inspection subcommands accept but do not use these LLM settings.
+  - `sdpub` inspection, metadata, and chapter tree edit commands accept but do not use these LLM settings.
+  - `sdpub stage advance` uses LLM settings when graph or summary generation is needed.
   - `paths.debugLogDir` may still matter when the app emits debug logs.
 
 When to prefer each layer:

--- a/data/help/topics/env.jinja
+++ b/data/help/topics/env.jinja
@@ -14,8 +14,8 @@ Path resolution:
   - `~` is expanded to the current user's home directory.
   - Relative paths are resolved from the current working directory.
 
-Source digest only:
-  The following settings matter only when digesting source input such as EPUB, Markdown, txt, or stdin:
+LLM-backed operations:
+  The following settings matter when digesting source input, or when `sdpub stage advance` needs graph or summary generation:
   - `SPINEDIGEST_PROMPT`
   - `SPINEDIGEST_LLM_PROVIDER`
   - `SPINEDIGEST_LLM_MODEL`
@@ -37,7 +37,7 @@ Variables:
     Type: path string.
 
   `SPINEDIGEST_PROMPT`
-    Override the default extraction prompt for source digest runs.
+    Override the default extraction prompt for graph generation.
     Type: non-empty string.
 
   `SPINEDIGEST_LLM_PROVIDER`
@@ -64,7 +64,7 @@ Variables:
     Type: non-empty string.
 
   `SPINEDIGEST_CACHE_DIR`
-    Store cached LLM responses for source digest runs.
+    Store cached LLM responses for LLM-backed operations.
     Type: path string.
 
   `SPINEDIGEST_DEBUG_LOG_DIR`

--- a/data/help/topics/format.jinja
+++ b/data/help/topics/format.jinja
@@ -14,6 +14,7 @@ Input rules:
 
 Output rules:
   - File output supports `markdown`, `txt`, `epub`, and `.sdpub`.
+  - `.sdpub` output supports `--stage planned|sourced|graphed|summarized`.
   - `stdout` supports only `markdown` or `txt`.
   - `sdpub info`, `toc`, `list`, `cat`, and `meta` print text to stdout.
   - `sdpub cover` writes raw binary bytes to stdout.
@@ -25,7 +26,9 @@ Inference:
   - Stream input and output cannot be inferred reliably, so explicit format flags are recommended there.
 
 LLM usage:
-  - Source digest runs require LLM configuration.
+  - Source digest runs require LLM configuration when they generate graph or summary data.
+  - `.sdpub` output with `--stage planned` or `--stage sourced` does not call an LLM provider.
+  - `sdpub stage advance` calls an LLM provider when it needs graph or summary generation.
   - `.sdpub` re-export and `sdpub` inspection do not call an LLM provider.
 
 Where to go next:

--- a/data/help/topics/format.jinja
+++ b/data/help/topics/format.jinja
@@ -8,9 +8,10 @@ Supported formats:
 
 Input rules:
   - `epub`, `markdown`, and `txt` are source formats for new digest runs.
-  - `.sdpub` is a processed archive format for re-export and inspection.
+  - `.sdpub` is a processed archive format for re-export, inspection, and staged editing.
   - `stdin` is supported only for txt or markdown input.
-  - `sdpub` subcommands require a real archive file path. stdin is not supported.
+  - `sdpub` archive commands require a real archive file path.
+  - `sdpub chapter set-source` and `set-summary` can read content from stdin when their `--input` flag is omitted.
 
 Output rules:
   - File output supports `markdown`, `txt`, `epub`, and `.sdpub`.
@@ -19,6 +20,7 @@ Output rules:
   - `sdpub info`, `toc`, `list`, `cat`, and `meta` print text to stdout.
   - `sdpub cover` writes raw binary bytes to stdout.
   - `sdpub meta` edits book metadata in place when metadata edit flags are present.
+  - `sdpub stage` and `sdpub chapter` edit existing archives in place when their action changes data.
 
 Inference:
   - If `--input-format` is omitted, input format is inferred from the file extension.
@@ -29,7 +31,7 @@ LLM usage:
   - Source digest runs require LLM configuration when they generate graph or summary data.
   - `.sdpub` output with `--stage planned` or `--stage sourced` does not call an LLM provider.
   - `sdpub stage advance` calls an LLM provider when it needs graph or summary generation.
-  - `.sdpub` re-export and `sdpub` inspection do not call an LLM provider.
+  - `.sdpub` re-export, inspection, metadata edits, and chapter tree edits do not call an LLM provider.
 
 Where to go next:
   - Need the product-level mental model behind source vs archive paths:
@@ -38,7 +40,7 @@ Where to go next:
     spinedigest help command
   - Need real task examples:
     spinedigest help task
-  - Need archive inspection and `.sdpub` semantics:
+  - Need archive commands and `.sdpub` semantics:
     spinedigest help sdpub
   - Need stdin, stdout, or binary-output runtime rules:
     spinedigest help runtime

--- a/data/help/topics/format.jinja
+++ b/data/help/topics/format.jinja
@@ -15,8 +15,9 @@ Input rules:
 Output rules:
   - File output supports `markdown`, `txt`, `epub`, and `.sdpub`.
   - `stdout` supports only `markdown` or `txt`.
-  - `sdpub info`, `toc`, `list`, and `cat` print text to stdout.
+  - `sdpub info`, `toc`, `list`, `cat`, and `meta` print text to stdout.
   - `sdpub cover` writes raw binary bytes to stdout.
+  - `sdpub meta` edits book metadata in place when metadata edit flags are present.
 
 Inference:
   - If `--input-format` is omitted, input format is inferred from the file extension.

--- a/data/help/topics/overview.jinja
+++ b/data/help/topics/overview.jinja
@@ -16,13 +16,13 @@ Mental model:
      .sdpub preserves reusable structured output for later export.
   3. Re-export path:
      Opening .sdpub can export markdown, txt, or EPUB without calling an LLM again.
-  4. Inspection path:
-     `spinedigest sdpub ...` reads archive internals and prints them to stdout.
+  4. Archive command path:
+     `spinedigest sdpub ...` inspects or edits existing archives.
 
 Think in terms of intent:
   - Use source input when you want a new digest.
   - Use .sdpub input when you want deterministic reuse of a previous digest.
-  - Use `sdpub` subcommands when you want to inspect the archive, not export it.
+  - Use `sdpub` subcommands when you want to inspect or edit an archive, not export it.
 
 Where to go next:
   - Need a task-shaped entry point:
@@ -33,7 +33,7 @@ Where to go next:
     spinedigest help command
   - Need LLM or environment setup:
     spinedigest help config
-  - Need archive inspection details:
+  - Need archive command details:
     spinedigest help sdpub
   - Need failure-handling guidance:
     spinedigest help troubleshoot

--- a/data/help/topics/recipe.jinja
+++ b/data/help/topics/recipe.jinja
@@ -9,6 +9,9 @@ Digest an EPUB into markdown:
 Digest an EPUB into a reusable archive:
   spinedigest --input ./book.epub --output ./book.sdpub
 
+Prepare an EPUB archive without LLM generation:
+  spinedigest --input ./book.epub --output ./book.sdpub --stage sourced
+
 Re-export an archive to EPUB:
   spinedigest --input ./book.sdpub --output ./book.epub
 
@@ -20,6 +23,15 @@ Digest piped text:
 
 Inspect archive metadata:
   spinedigest sdpub info --input ./book.sdpub
+
+List unfinished archive chapters:
+  spinedigest sdpub stage pending ./book.sdpub
+
+Advance a staged archive to summaries:
+  spinedigest sdpub stage advance ./book.sdpub --to summarized
+
+Add an empty planned chapter:
+  spinedigest sdpub chapter add ./book.sdpub --title "Appendix"
 
 List archive serial ids:
   spinedigest sdpub list --input ./book.sdpub
@@ -39,7 +51,7 @@ Where to go next:
     spinedigest help format
   - Need LLM setup before running source digests:
     spinedigest help config
-  - Need `.sdpub` inspection commands after generating an archive:
+  - Need `.sdpub` commands after generating an archive:
     spinedigest help sdpub
   - Need help because a copied recipe failed:
     spinedigest help troubleshoot

--- a/data/help/topics/runtime.jinja
+++ b/data/help/topics/runtime.jinja
@@ -7,6 +7,7 @@ Streams:
   - If `--input` is omitted, the CLI reads stdin.
   - If `--output` is omitted, the CLI writes stdout.
   - Interactive stdin is rejected for source digest runs.
+  - `sdpub chapter set-source` and `set-summary` read stdin when their `--input` flag is omitted.
   - `--verbose` cannot be used when digest output goes to stdout.
 
 Exit behavior:
@@ -38,7 +39,7 @@ Where to go next:
     spinedigest help command
   - Need task examples that avoid stdout and stdin mistakes:
     spinedigest help recipe
-  - Need archive inspection specifics:
+  - Need archive command specifics:
     spinedigest help sdpub
   - Need error-driven guidance:
     spinedigest help troubleshoot

--- a/data/help/topics/sdpub.jinja
+++ b/data/help/topics/sdpub.jinja
@@ -14,6 +14,7 @@ Command help entry points:
   - spinedigest sdpub cat --help
   - spinedigest sdpub cover --help
   - spinedigest sdpub meta --help
+  - spinedigest sdpub stage --help
   - spinedigest sdpub chapter --help
 
 Use this topic when:

--- a/data/help/topics/sdpub.jinja
+++ b/data/help/topics/sdpub.jinja
@@ -4,7 +4,7 @@ Topic: sdpub
 sdpub Help Topic
 
 Purpose:
-  This topic points to the command-help pages for `.sdpub` inspection and chapter editing.
+  This topic points to the command-help pages for `.sdpub` inspection, metadata editing, stage advancement, and chapter editing.
 
 Command help entry points:
   - spinedigest sdpub --help
@@ -18,7 +18,7 @@ Command help entry points:
   - spinedigest sdpub chapter --help
 
 Use this topic when:
-  - You know `.sdpub` is relevant, but you have not yet chosen the exact inspection or editing command.
+  - You know `.sdpub` is relevant, but you have not yet chosen the exact archive command.
   - You want to jump from topic help into command help.
 
 Where to go next:

--- a/data/help/topics/sdpub.jinja
+++ b/data/help/topics/sdpub.jinja
@@ -13,6 +13,7 @@ Command help entry points:
   - spinedigest sdpub list --help
   - spinedigest sdpub cat --help
   - spinedigest sdpub cover --help
+  - spinedigest sdpub meta --help
   - spinedigest sdpub chapter --help
 
 Use this topic when:

--- a/data/help/topics/sdpub.jinja
+++ b/data/help/topics/sdpub.jinja
@@ -4,7 +4,7 @@ Topic: sdpub
 sdpub Help Topic
 
 Purpose:
-  This topic points to the command-help pages for the `.sdpub` inspection command family.
+  This topic points to the command-help pages for `.sdpub` inspection and chapter editing.
 
 Command help entry points:
   - spinedigest sdpub --help
@@ -13,9 +13,10 @@ Command help entry points:
   - spinedigest sdpub list --help
   - spinedigest sdpub cat --help
   - spinedigest sdpub cover --help
+  - spinedigest sdpub chapter --help
 
 Use this topic when:
-  - You know `.sdpub` is relevant, but you have not yet chosen the exact inspection command.
+  - You know `.sdpub` is relevant, but you have not yet chosen the exact inspection or editing command.
   - You want to jump from topic help into command help.
 
 Where to go next:

--- a/data/help/topics/task.jinja
+++ b/data/help/topics/task.jinja
@@ -12,6 +12,8 @@ Digest source material into .sdpub:
   Use when you want a reusable archive for future export or inspection.
   Command shape:
     spinedigest --input <source> --output <digest.sdpub>
+  To stop before graph or summary generation:
+    spinedigest --input <source> --output <digest.sdpub> --stage sourced
 
 Re-export an existing .sdpub:
   Use when the digest already exists and you only need markdown, txt, or EPUB output.
@@ -22,6 +24,11 @@ Inspect archive structure:
   Use when you need metadata, TOC, serial ids, one serial summary, or raw cover bytes.
   Command shape:
     spinedigest sdpub <info|toc|list|cat|cover|meta> --input <digest.sdpub>
+
+Advance staged .sdpub chapters:
+  Use when an archive has planned, sourced, or graphed chapters and you want to continue safely.
+  Command shape:
+    spinedigest sdpub stage advance <digest.sdpub> --to summarized
 
 Pipe text through stdin/stdout:
   Use only for txt or markdown streams in non-interactive contexts.

--- a/data/help/topics/task.jinja
+++ b/data/help/topics/task.jinja
@@ -12,8 +12,8 @@ Digest source material into .sdpub:
   Use when you want a reusable archive for future export or inspection.
   Command shape:
     spinedigest --input <source> --output <digest.sdpub>
-  To stop before graph or summary generation:
-    spinedigest --input <source> --output <digest.sdpub> --stage sourced
+  To choose how far the archive is prepared:
+    spinedigest --input <source> --output <digest.sdpub> --stage <planned|sourced|graphed|summarized>
 
 Re-export an existing .sdpub:
   Use when the digest already exists and you only need markdown, txt, or EPUB output.
@@ -21,9 +21,14 @@ Re-export an existing .sdpub:
     spinedigest --input <digest.sdpub> --output <target>
 
 Inspect archive structure:
-  Use when you need metadata, TOC, serial ids, one serial summary, or raw cover bytes.
+  Use when you need format version, metadata, TOC, serial ids, one serial summary, or raw cover bytes.
   Command shape:
     spinedigest sdpub <info|toc|list|cat|cover|meta> --input <digest.sdpub>
+
+Edit archive chapters:
+  Use when you need to add, remove, reset, or fill individual chapters.
+  Command shape:
+    spinedigest sdpub chapter <action> <digest.sdpub> [options]
 
 Advance staged .sdpub chapters:
   Use when an archive has planned, sourced, or graphed chapters and you want to continue safely.
@@ -42,9 +47,9 @@ Where to go next:
     spinedigest help command
   - Need format compatibility or stream limits:
     spinedigest help format
-  - Need to prepare LLM configuration for source digest runs:
+  - Need to prepare LLM configuration for digest or stage advancement:
     spinedigest help config
   - Need runtime rules like stdout, stderr, or digest-dir behavior:
     spinedigest help runtime
-  - Need archive inspection commands after producing `.sdpub`:
+  - Need archive commands after producing `.sdpub`:
     spinedigest help sdpub

--- a/data/help/topics/task.jinja
+++ b/data/help/topics/task.jinja
@@ -21,7 +21,7 @@ Re-export an existing .sdpub:
 Inspect archive structure:
   Use when you need metadata, TOC, serial ids, one serial summary, or raw cover bytes.
   Command shape:
-    spinedigest sdpub <info|toc|list|cat|cover> --input <digest.sdpub>
+    spinedigest sdpub <info|toc|list|cat|cover|meta> --input <digest.sdpub>
 
 Pipe text through stdin/stdout:
   Use only for txt or markdown streams in non-interactive contexts.

--- a/data/help/topics/troubleshoot.jinja
+++ b/data/help/topics/troubleshoot.jinja
@@ -25,8 +25,10 @@ sdpub command failure:
   Symptom:
     `sdpub` subcommands reject flags or input.
   Check:
-    `sdpub` requires `--input <path>` to an existing archive file.
-    `cat` also requires `--serial <id>`.
+    Inspection commands such as `info`, `toc`, `list`, `cat`, `cover`, and `meta` require `--input <path>`.
+    `stage` and `chapter` actions require the `.sdpub` path as a positional argument.
+    `cat` requires `--serial <id>`.
+    Chapter-specific actions usually require `--chapter <id>`.
 
 Binary cover output blocked:
   Symptom:
@@ -49,5 +51,5 @@ Where to go next:
     spinedigest help command
   - Need task-level alternatives:
     spinedigest help task
-  - Need archive inspection-specific guidance:
+  - Need archive command-specific guidance:
     spinedigest help sdpub

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -9,17 +9,19 @@ SpineDigest is designed to be used from the command line first.
 Installed CLI:
 
 ```bash
-spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--verbose]
+spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose]
 spinedigest status [--llm <json>]
 spinedigest sdpub <info|toc|list|cat|cover|meta> --input <path> [--serial <id>] [--llm <json>]
+spinedigest sdpub stage <pending|advance> <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>]
 ```
 
 From a source checkout:
 
 ```bash
-pnpm dev -- [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--verbose]
+pnpm dev -- [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose]
 pnpm dev -- status [--llm <json>]
 pnpm dev -- sdpub <info|toc|list|cat|cover|meta> --input <path> [--serial <id>] [--llm <json>]
+pnpm dev -- sdpub stage <pending|advance> <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>]
 ```
 
 ## Flags
@@ -31,6 +33,7 @@ pnpm dev -- sdpub <info|toc|list|cat|cover|meta> --input <path> [--serial <id>] 
 - `--digest-dir <path>`: keep the digest workspace; the directory is cleared before each run
 - `--llm <json>`: inline LLM client JSON for this invocation
 - `--prompt <text>`: one-off extraction prompt override for the current digest run
+- `--stage <stage>`: create `.sdpub` output up to `planned`, `sourced`, `graphed`, or `summarized`
 - `--verbose`: write diagnostic logs to `stderr`
 - `-h`, `--help`: print help text
 
@@ -40,7 +43,7 @@ The `sdpub` inspection interface uses positional subcommands: `spinedigest sdpub
 
 The `sdpub` inspection subcommands only accept `--input`, except `cat` also requires `--serial` and `meta` accepts metadata edit flags.
 
-`--prompt` only affects digest generation from source inputs. It does not apply when reopening `.sdpub` archives or using `spinedigest sdpub ...`.
+`--prompt` affects digest generation from source inputs and graph generation through `spinedigest sdpub stage advance`.
 
 `--llm` overrides LLM settings from environment variables and `config.json`. It is accepted by command paths that do not call an LLM so wrapper scripts can pass one consistent option set.
 
@@ -105,6 +108,12 @@ Create an `.sdpub` archive:
 spinedigest --input ./book.md --output ./book.sdpub
 ```
 
+Create a staged `.sdpub` archive without LLM generation:
+
+```bash
+spinedigest --input ./book.epub --output ./book.sdpub --stage sourced
+```
+
 Reuse an existing `.sdpub` archive:
 
 ```bash
@@ -120,6 +129,8 @@ spinedigest sdpub list --input ./book.sdpub
 spinedigest sdpub cat --input ./book.sdpub --serial 12
 spinedigest sdpub cover --input ./book.sdpub > ./cover.png
 spinedigest sdpub meta --input ./book.sdpub
+spinedigest sdpub stage pending ./book.sdpub
+spinedigest sdpub stage advance ./book.sdpub --to summarized
 ```
 
 Use pipes:

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -11,7 +11,7 @@ Installed CLI:
 ```bash
 spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--verbose]
 spinedigest status [--llm <json>]
-spinedigest sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>] [--llm <json>]
+spinedigest sdpub <info|toc|list|cat|cover|meta> --input <path> [--serial <id>] [--llm <json>]
 ```
 
 From a source checkout:
@@ -19,7 +19,7 @@ From a source checkout:
 ```bash
 pnpm dev -- [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--verbose]
 pnpm dev -- status [--llm <json>]
-pnpm dev -- sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>] [--llm <json>]
+pnpm dev -- sdpub <info|toc|list|cat|cover|meta> --input <path> [--serial <id>] [--llm <json>]
 ```
 
 ## Flags
@@ -38,7 +38,7 @@ The main conversion command does not support positional arguments.
 
 The `sdpub` inspection interface uses positional subcommands: `spinedigest sdpub <subcommand>`.
 
-The `sdpub` inspection subcommands only accept `--input`, and `cat` also requires `--serial`.
+The `sdpub` inspection subcommands only accept `--input`, except `cat` also requires `--serial` and `meta` accepts metadata edit flags.
 
 `--prompt` only affects digest generation from source inputs. It does not apply when reopening `.sdpub` archives or using `spinedigest sdpub ...`.
 
@@ -119,6 +119,7 @@ spinedigest sdpub toc --input ./book.sdpub
 spinedigest sdpub list --input ./book.sdpub
 spinedigest sdpub cat --input ./book.sdpub --serial 12
 spinedigest sdpub cover --input ./book.sdpub > ./cover.png
+spinedigest sdpub meta --input ./book.sdpub
 ```
 
 Use pipes:

--- a/docs/sdpub.md
+++ b/docs/sdpub.md
@@ -28,8 +28,8 @@ that layout.
 
 In this document, a _serial_ means one persisted digest unit referenced
 from `toc.json` by `serialId`. A serial usually corresponds to one
-exportable section, carries one serial summary text file, and may also
-have fragment files.
+exportable section. Depending on the archive stage, it may carry source
+fragments, graph data, and a serial summary text file.
 
 ## Container Model
 
@@ -71,14 +71,14 @@ requirements are treated separately.
 
 For archives written by SpineDigest today:
 
-| Path family                                              | SpineDigest writer behavior                             | Notes                                         |
-| -------------------------------------------------------- | ------------------------------------------------------- | --------------------------------------------- |
-| `database.db`                                            | always written                                          | Created for every document directory          |
-| `book-meta.json`                                         | always written                                          | Written for TXT, Markdown, and EPUB imports   |
-| `toc.json`                                               | always written                                          | Written for TXT, Markdown, and EPUB imports   |
-| `cover/info.json` + `cover/data.bin`                     | written together only when a source cover exists        | Treat as a pair                               |
-| `summaries/serial-<serialId>.txt`                        | written for every `serialId` that appears in `toc.json` | Grouping-only TOC nodes have no summary file  |
-| `fragments/serial-<serialId>/fragment_<fragmentId>.json` | written only for non-empty fragments                    | Do not assume every serial has fragment files |
+| Path family                                              | SpineDigest writer behavior                      | Notes                                         |
+| -------------------------------------------------------- | ------------------------------------------------ | --------------------------------------------- |
+| `database.db`                                            | always written                                   | Created for every document directory          |
+| `book-meta.json`                                         | always written                                   | Written for TXT, Markdown, and EPUB imports   |
+| `toc.json`                                               | always written                                   | Written for TXT, Markdown, and EPUB imports   |
+| `cover/info.json` + `cover/data.bin`                     | written together only when a source cover exists | Treat as a pair                               |
+| `summaries/serial-<serialId>.txt`                        | written for summarized serials                   | Staged archives may omit summary files        |
+| `fragments/serial-<serialId>/fragment_<fragmentId>.json` | written only for non-empty fragments             | Do not assume every serial has fragment files |
 
 Source-specific notes:
 
@@ -89,11 +89,18 @@ Source-specific notes:
   supplied.
 - EPUB input may or may not produce a cover.
 - EPUB input may produce grouping TOC nodes that omit `serialId`.
+- When the CLI is run with `--stage planned`, serials are allocated but
+  source fragments, graph data, and summaries are omitted.
+- When the CLI is run with `--stage sourced`, source fragments are
+  written but graph data and summaries are omitted.
+- When the CLI is run with `--stage graphed`, graph data is written but
+  summaries are omitted.
 
 For readers and validators:
 
 - `toc.json` plus `summaries/` is the minimum useful set for ordered text
-  rendering.
+  rendering of completed archives. Staged archives may require
+  `spinedigest sdpub stage advance` before text rendering is complete.
 - `book-meta.json` is optional for plain rendering, but required if
   metadata is part of the target feature set.
 - `cover/info.json` and `cover/data.bin` are optional as a pair.
@@ -236,7 +243,7 @@ again.
 
 ### `summaries/serial-<serialId>.txt`
 
-Each serial summary is stored as a standalone UTF-8 text file.
+Each completed serial summary is stored as a standalone UTF-8 text file.
 
 The text is the serial-level digest content used by plain-text and EPUB
 export. The file may be empty. Readers should not depend on a trailing
@@ -310,7 +317,7 @@ This database is useful when an implementation needs full structural
 fidelity with SpineDigest's internal model.
 
 A minimal reader does not need to understand the entire database. For
-simple rendering, `toc.json` plus `summaries/` is enough. For
+simple rendering of completed archives, `toc.json` plus `summaries/` is enough. For
 sentence-level inspection, `fragments/` is enough for sentence payloads,
 but `toc.json` is still needed if reading order or section titles
 matter. The SQLite layer matters when the implementation needs chunk
@@ -324,7 +331,7 @@ For a lightweight reader:
 
 1. read `book-meta.json` if metadata is needed
 2. read `toc.json`
-3. follow each `serialId` into `summaries/serial-<serialId>.txt`
+3. follow each summarized `serialId` into `summaries/serial-<serialId>.txt`
 4. read `cover/info.json` and `cover/data.bin` only if a cover is needed
 
 For a sentence-aware reader:
@@ -356,7 +363,7 @@ Readers that accept untrusted `.sdpub` input should validate at least the follow
 
 - the ZIP entry path normalizes to a safe relative path
 - JSON payloads match the expected schema
-- every `serialId` referenced by `toc.json` has a matching summary file
+- every summarized `serialId` referenced by `toc.json` has a matching summary file
 - cover metadata and cover bytes either both exist or are both absent
 - fragment files, if present, use non-negative integer ids and valid
   sentence records

--- a/docs/sdpub.md
+++ b/docs/sdpub.md
@@ -22,9 +22,9 @@ At a high level, the archive contains three layers of data:
 - digest text outputs at serial and fragment granularity
 - internal relational state used by SpineDigest itself
 
-No archive-level manifest currently exists. Compatibility is expressed
-through the archive path layout and the versioned JSON payloads inside
-that layout.
+Archive-level compatibility is expressed by `manifest.json`. Archives
+that omit `manifest.json` are interpreted as format version `1` for
+compatibility with earlier SpineDigest output.
 
 In this document, a _serial_ means one persisted digest unit referenced
 from `toc.json` by `serialId`. A serial usually corresponds to one
@@ -39,6 +39,7 @@ Conforming archives produced by SpineDigest use POSIX-style archive
 paths and contain entries from this path set:
 
 - `database.db`
+- `manifest.json`
 - `book-meta.json`
 - `toc.json`
 - `cover/info.json`
@@ -74,6 +75,7 @@ For archives written by SpineDigest today:
 | Path family                                              | SpineDigest writer behavior                      | Notes                                         |
 | -------------------------------------------------------- | ------------------------------------------------ | --------------------------------------------- |
 | `database.db`                                            | always written                                   | Created for every document directory          |
+| `manifest.json`                                          | always written                                   | Declares the archive-level format version     |
 | `book-meta.json`                                         | always written                                   | Written for TXT, Markdown, and EPUB imports   |
 | `toc.json`                                               | always written                                   | Written for TXT, Markdown, and EPUB imports   |
 | `cover/info.json` + `cover/data.bin`                     | written together only when a source cover exists | Treat as a pair                               |
@@ -114,6 +116,7 @@ For readers and validators:
 
 - `database.db`: SQLite database with internal indexed state for
   serials, chunks, topology, and graph relationships
+- `manifest.json`: UTF-8 JSON with the archive-level format version
 - `book-meta.json`: UTF-8 JSON with source-level metadata for the
   processed document
 - `toc.json`: UTF-8 JSON with the navigation tree used for export and
@@ -133,6 +136,25 @@ Fragment ids are integers scoped to a serial. SpineDigest currently
 allocates them from `0` upward within each serial directory.
 
 ## File Formats
+
+### `manifest.json`
+
+`manifest.json` declares the archive-level `.sdpub` format version.
+
+Current schema:
+
+```json
+{
+  "formatVersion": 1
+}
+```
+
+Field contract:
+
+- `formatVersion`: currently `1`
+
+Archives that omit `manifest.json` are interpreted as
+`formatVersion: 1`.
 
 ### `book-meta.json`
 
@@ -348,8 +370,9 @@ For a full-fidelity implementation:
 
 ## Compatibility Notes
 
-- There is no top-level archive version number.
-- Compatibility is currently versioned per JSON payload, not per archive.
+- `manifest.json` carries the archive-level format version.
+- Archives without `manifest.json` are treated as archive format version
+  `1`.
 - `book-meta.json` currently uses `version: 1`.
 - `toc.json` currently uses `version: 1`.
 - Fragment files have no explicit version field.

--- a/docs/sdpub.md
+++ b/docs/sdpub.md
@@ -83,9 +83,10 @@ For archives written by SpineDigest today:
 Source-specific notes:
 
 - TXT input currently produces one top-level serial and never produces a
-  cover.
+  cover. The TOC item may omit `title` when no title is supplied.
 - Markdown input currently produces one top-level serial and never
-  produces a cover.
+  produces a cover. The TOC item may omit `title` when no title is
+  supplied.
 - EPUB input may or may not produce a cover.
 - EPUB input may produce grouping TOC nodes that omit `serialId`.
 
@@ -162,6 +163,10 @@ Field contract:
 metadata. It is not a promise that the current public CLI necessarily
 accepts that source type as direct input.
 
+The public CLI can inspect and edit these fields with
+`spinedigest sdpub meta --input <path>`. The command preserves `version`
+and `sourceFormat`.
+
 ### `toc.json`
 
 `toc.json` defines the exported reading order and section tree.
@@ -188,7 +193,7 @@ Current schema:
 
 Each item contains:
 
-- `title`: non-empty string
+- `title`: optional non-empty string or `null`
 - `serialId`: optional non-negative integer
 - `children`: array of child items
 
@@ -198,6 +203,11 @@ A node may omit `serialId` and act as a pure grouping node. When
 `serialId` is present, it points to
 `summaries/serial-<serialId>.txt` and may also have a matching
 fragment directory.
+
+A node may omit `title` or set it to `null`. Text renderers may omit the
+heading for such nodes. EPUB renderers should use a display fallback such
+as `Section <serialId>` because EPUB navigation and section documents
+need visible labels.
 
 ### `cover/info.json` and `cover/data.bin`
 

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -9,17 +9,19 @@ SpineDigest 的设计重心是命令行使用。
 已安装 CLI 时：
 
 ```bash
-spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--verbose]
+spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose]
 spinedigest status [--llm <json>]
 spinedigest sdpub <info|toc|list|cat|cover|meta> --input <path> [--serial <id>] [--llm <json>]
+spinedigest sdpub stage <pending|advance> <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>]
 ```
 
 在源码仓库中运行时：
 
 ```bash
-pnpm dev -- [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--verbose]
+pnpm dev -- [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose]
 pnpm dev -- status [--llm <json>]
 pnpm dev -- sdpub <info|toc|list|cat|cover|meta> --input <path> [--serial <id>] [--llm <json>]
+pnpm dev -- sdpub stage <pending|advance> <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>]
 ```
 
 ## 参数
@@ -31,6 +33,7 @@ pnpm dev -- sdpub <info|toc|list|cat|cover|meta> --input <path> [--serial <id>] 
 - `--digest-dir <path>`：保留 digest 中间工作目录；每次运行前会先清空该目录
 - `--llm <json>`：为当前这次调用传入 inline LLM client JSON
 - `--prompt <text>`：为当前这次 digest 临时覆盖 extraction prompt
+- `--stage <stage>`：把 `.sdpub` 输出生成到 `planned`、`sourced`、`graphed` 或 `summarized`
 - `--verbose`：把诊断日志输出到 `stderr`
 - `-h`, `--help`：打印帮助文本
 
@@ -40,7 +43,7 @@ pnpm dev -- sdpub <info|toc|list|cat|cover|meta> --input <path> [--serial <id>] 
 
 `sdpub` 检查子命令只接受 `--input`，其中 `cat` 还要求提供 `--serial`，`meta` 额外接受 metadata 编辑参数。
 
-`--prompt` 只影响从源输入生成 digest 的过程，不适用于重新打开 `.sdpub` 或使用 `spinedigest sdpub ...`。
+`--prompt` 影响从源输入生成 digest 的过程，也会影响 `spinedigest sdpub stage advance` 中的 graph 生成。
 
 `--llm` 会覆盖环境变量和 `config.json` 中的 LLM 设置。不调用 LLM 的命令路径也接受这个参数，方便 wrapper 脚本统一传参。
 
@@ -105,6 +108,12 @@ spinedigest --input ./book.txt --output ./digest.epub
 spinedigest --input ./book.md --output ./book.sdpub
 ```
 
+生成不触发 LLM 的 staged `.sdpub` 归档：
+
+```bash
+spinedigest --input ./book.epub --output ./book.sdpub --stage sourced
+```
+
 复用已有 `.sdpub`：
 
 ```bash
@@ -120,6 +129,8 @@ spinedigest sdpub list --input ./book.sdpub
 spinedigest sdpub cat --input ./book.sdpub --serial 12
 spinedigest sdpub cover --input ./book.sdpub > ./cover.png
 spinedigest sdpub meta --input ./book.sdpub
+spinedigest sdpub stage pending ./book.sdpub
+spinedigest sdpub stage advance ./book.sdpub --to summarized
 ```
 
 通过管道处理：

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -11,7 +11,7 @@ SpineDigest 的设计重心是命令行使用。
 ```bash
 spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--verbose]
 spinedigest status [--llm <json>]
-spinedigest sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>] [--llm <json>]
+spinedigest sdpub <info|toc|list|cat|cover|meta> --input <path> [--serial <id>] [--llm <json>]
 ```
 
 在源码仓库中运行时：
@@ -19,7 +19,7 @@ spinedigest sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>] [--ll
 ```bash
 pnpm dev -- [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--verbose]
 pnpm dev -- status [--llm <json>]
-pnpm dev -- sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>] [--llm <json>]
+pnpm dev -- sdpub <info|toc|list|cat|cover|meta> --input <path> [--serial <id>] [--llm <json>]
 ```
 
 ## 参数
@@ -38,7 +38,7 @@ pnpm dev -- sdpub <info|toc|list|cat|cover> --input <path> [--serial <id>] [--ll
 
 `sdpub` 检查接口本身使用 positional subcommands：`spinedigest sdpub <subcommand>`。
 
-`sdpub` 检查子命令只接受 `--input`，其中 `cat` 还要求提供 `--serial`。
+`sdpub` 检查子命令只接受 `--input`，其中 `cat` 还要求提供 `--serial`，`meta` 额外接受 metadata 编辑参数。
 
 `--prompt` 只影响从源输入生成 digest 的过程，不适用于重新打开 `.sdpub` 或使用 `spinedigest sdpub ...`。
 
@@ -119,6 +119,7 @@ spinedigest sdpub toc --input ./book.sdpub
 spinedigest sdpub list --input ./book.sdpub
 spinedigest sdpub cat --input ./book.sdpub --serial 12
 spinedigest sdpub cover --input ./book.sdpub > ./cover.png
+spinedigest sdpub meta --input ./book.sdpub
 ```
 
 通过管道处理：

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -27,6 +27,7 @@ export interface CLIArguments {
   readonly outputPath?: string;
   readonly outputFormat?: CLIFormat;
   readonly prompt?: string;
+  readonly targetStage?: ChapterStage;
   readonly verbose: boolean;
 }
 
@@ -84,6 +85,17 @@ export interface CLIStatusArguments {
   readonly llmJSON?: string;
 }
 
+export type CLISdpubStageAction = "advance" | "pending";
+
+export interface CLISdpubStageArguments {
+  readonly action: CLISdpubStageAction;
+  readonly chapterId?: number;
+  readonly llmJSON?: string;
+  readonly path: string;
+  readonly prompt?: string;
+  readonly targetStage?: ChapterStage;
+}
+
 interface SdpubMetaFlagValues {
   readonly author?: readonly string[];
   readonly "clear-authors"?: boolean;
@@ -133,6 +145,16 @@ export type ParsedCLIArguments =
       readonly help: true;
       readonly helpText: string;
       readonly kind: "sdpub-chapter";
+    }
+  | {
+      readonly args: CLISdpubStageArguments;
+      readonly help: false;
+      readonly kind: "sdpub-stage";
+    }
+  | {
+      readonly help: true;
+      readonly helpText: string;
+      readonly kind: "sdpub-stage";
     }
   | {
       readonly help: true;
@@ -220,6 +242,9 @@ export function parseCLIArguments(
       serial: {
         type: "string",
       },
+      stage: {
+        type: "string",
+      },
       chapter: {
         type: "string",
       },
@@ -294,6 +319,15 @@ export function parseCLIArguments(
           ),
         }),
     ...(values.prompt === undefined ? {} : { prompt: values.prompt }),
+    ...(values.stage === undefined
+      ? {}
+      : {
+          targetStage: parseChapterStage(
+            values.stage,
+            "--stage",
+            CLI_HELP_ROUTES.command,
+          ),
+        }),
     verbose: values.verbose ?? false,
   } satisfies CLIArguments;
 
@@ -341,6 +375,7 @@ function parseSdpubArguments(
     readonly prompt?: string;
     readonly recursive?: boolean;
     readonly serial?: string;
+    readonly stage?: string;
     readonly title?: string;
     readonly to?: string;
     readonly verbose?: boolean;
@@ -354,6 +389,9 @@ function parseSdpubArguments(
 
   if (subcommand === "chapter") {
     return parseSdpubChapterArguments(positionals.slice(1), values);
+  }
+  if (subcommand === "stage") {
+    return parseSdpubStageArguments(positionals.slice(1), values);
   }
 
   if (positionals.length > 1) {
@@ -431,6 +469,14 @@ function parseSdpubArguments(
     throw new Error(
       withHelpRoute(
         "The `sdpub` subcommands do not support --prompt. It only applies to digest generation from source inputs.",
+        CLI_HELP_ROUTES.sdpub,
+      ),
+    );
+  }
+  if (values.stage !== undefined) {
+    throw new Error(
+      withHelpRoute(
+        "The `sdpub` subcommands do not support --stage. Use the main command when creating .sdpub output.",
         CLI_HELP_ROUTES.sdpub,
       ),
     );
@@ -536,6 +582,7 @@ function parseSdpubChapterArguments(
     readonly prompt?: string;
     readonly recursive?: boolean;
     readonly serial?: string;
+    readonly stage?: string;
     readonly title?: string;
     readonly to?: string;
     readonly verbose?: boolean;
@@ -550,6 +597,7 @@ function parseSdpubChapterArguments(
   rejectSdpubChapterFlag("output", values.output);
   rejectSdpubChapterFlag("output-format", values["output-format"]);
   rejectSdpubChapterFlag("serial", values.serial);
+  rejectSdpubChapterFlag("stage", values.stage);
   rejectSdpubChapterMetaFlags(values);
   if (values.verbose) {
     throw new Error(
@@ -600,6 +648,139 @@ function parseSdpubChapterArguments(
     help: false,
     kind: "sdpub-chapter",
   };
+}
+
+function parseSdpubStageArguments(
+  positionals: readonly string[],
+  values: {
+    readonly author?: readonly string[];
+    readonly chapter?: string;
+    readonly "clear-authors"?: boolean;
+    readonly "clear-description"?: boolean;
+    readonly "clear-identifier"?: boolean;
+    readonly "clear-language"?: boolean;
+    readonly "clear-published-at"?: boolean;
+    readonly "clear-publisher"?: boolean;
+    readonly "clear-title"?: boolean;
+    readonly description?: string;
+    readonly "digest-dir"?: string;
+    readonly help?: boolean;
+    readonly identifier?: string;
+    readonly input?: string;
+    readonly "input-format"?: string;
+    readonly language?: string;
+    readonly llm?: string;
+    readonly output?: string;
+    readonly "output-format"?: string;
+    readonly parent?: string;
+    readonly "published-at"?: string;
+    readonly publisher?: string;
+    readonly prompt?: string;
+    readonly recursive?: boolean;
+    readonly serial?: string;
+    readonly stage?: string;
+    readonly title?: string;
+    readonly to?: string;
+    readonly verbose?: boolean;
+  },
+): ParsedCLIArguments {
+  const help = values.help ?? false;
+  const action = positionals[0];
+  const path = positionals[1];
+  const helpRoute = "spinedigest sdpub stage --help";
+
+  rejectSdpubStageFlag("digest-dir", values["digest-dir"]);
+  rejectSdpubStageFlag("input", values.input);
+  rejectSdpubStageFlag("input-format", values["input-format"]);
+  rejectSdpubStageFlag("output", values.output);
+  rejectSdpubStageFlag("output-format", values["output-format"]);
+  rejectSdpubStageFlag("parent", values.parent);
+  rejectSdpubStageFlag("recursive", values.recursive);
+  rejectSdpubStageFlag("serial", values.serial);
+  rejectSdpubStageFlag("stage", values.stage);
+  rejectSdpubStageFlag("title", values.title);
+  rejectSdpubStageMetaFlags(values);
+  if (values.verbose) {
+    throw new Error(
+      withHelpRoute(
+        "The `sdpub stage` command does not support --verbose.",
+        helpRoute,
+      ),
+    );
+  }
+
+  if (help) {
+    return {
+      help: true,
+      helpText: renderSdpubSubcommandHelpText("stage"),
+      kind: "sdpub-stage",
+    };
+  }
+
+  if (!isSdpubStageAction(action)) {
+    throw new Error(
+      withHelpRoute(
+        action === undefined
+          ? "Missing sdpub stage action."
+          : `Invalid sdpub stage action: ${action}.`,
+        helpRoute,
+      ),
+    );
+  }
+  if (path === undefined || path === "-") {
+    throw new Error(
+      withHelpRoute(
+        "`spinedigest sdpub stage` requires a .sdpub path positional argument.",
+        helpRoute,
+      ),
+    );
+  }
+  if (positionals.length > 2) {
+    throw new Error(
+      withHelpRoute(
+        `Unexpected positional arguments: ${positionals.slice(2).join(" ")}.`,
+        helpRoute,
+      ),
+    );
+  }
+
+  const chapterId =
+    values.chapter === undefined
+      ? undefined
+      : parseSerialId(values.chapter, "--chapter", helpRoute);
+  const targetStage =
+    values.to === undefined
+      ? undefined
+      : parseChapterStage(values.to, "--to", helpRoute);
+
+  switch (action) {
+    case "advance":
+      return {
+        args: {
+          action,
+          ...(chapterId === undefined ? {} : { chapterId }),
+          ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
+          path,
+          ...(values.prompt === undefined ? {} : { prompt: values.prompt }),
+          ...(targetStage === undefined ? {} : { targetStage }),
+        },
+        help: false,
+        kind: "sdpub-stage",
+      };
+    case "pending":
+      rejectSdpubStageActionFlag(values.chapter, "--chapter", action);
+      rejectSdpubStageActionFlag(values.prompt, "--prompt", action);
+      rejectSdpubStageActionFlag(values.to, "--to", action);
+      return {
+        args: {
+          action,
+          ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
+          path,
+        },
+        help: false,
+        kind: "sdpub-stage",
+      };
+  }
 }
 
 function normalizeSdpubChapterArguments(
@@ -893,6 +1074,7 @@ function parseHelpArguments(
     readonly publisher?: string;
     readonly prompt?: string;
     readonly serial?: string;
+    readonly stage?: string;
     readonly verbose?: boolean;
   },
 ): ParsedCLIArguments {
@@ -904,6 +1086,7 @@ function parseHelpArguments(
   rejectHelpFlag("output-format", values["output-format"]);
   rejectHelpFlag("prompt", values.prompt);
   rejectHelpFlag("serial", values.serial);
+  rejectHelpFlag("stage", values.stage);
   rejectHelpMetaFlags(values);
 
   if (values.verbose) {
@@ -964,6 +1147,7 @@ function parseStatusArguments(
     readonly publisher?: string;
     readonly prompt?: string;
     readonly serial?: string;
+    readonly stage?: string;
     readonly verbose?: boolean;
   },
 ): ParsedCLIArguments {
@@ -974,6 +1158,7 @@ function parseStatusArguments(
   rejectStatusFlag("output-format", values["output-format"]);
   rejectStatusFlag("prompt", values.prompt);
   rejectStatusFlag("serial", values.serial);
+  rejectStatusFlag("stage", values.stage);
   rejectStatusMetaFlags(values);
 
   if (values.verbose) {
@@ -1042,6 +1227,31 @@ function isSdpubChapterAction(
     value === "set-source" ||
     value === "set-summary" ||
     value === "status"
+  );
+}
+
+function isSdpubStageAction(
+  value: string | undefined,
+): value is CLISdpubStageAction {
+  return value === "advance" || value === "pending";
+}
+
+function parseChapterStage(
+  value: string,
+  flag: string,
+  helpRoute: string,
+): ChapterStage {
+  const normalized = value.trim().toLowerCase();
+
+  if (CHAPTER_STAGES.includes(normalized as ChapterStage)) {
+    return normalized as ChapterStage;
+  }
+
+  throw new Error(
+    withHelpRoute(
+      `Invalid ${flag}: ${value}. Expected planned, sourced, graphed, or summarized.`,
+      helpRoute,
+    ),
   );
 }
 
@@ -1227,7 +1437,7 @@ function normalizeNonEmptyFlagValue(
 function rejectActionFlag(
   value: string | undefined,
   flag: string,
-  action: CLISdpubChapterAction,
+  action: string,
   helpRoute: string,
 ): void {
   if (value !== undefined) {
@@ -1243,7 +1453,7 @@ function rejectActionFlag(
 function rejectActionBooleanFlag(
   value: boolean | undefined,
   flag: string,
-  action: CLISdpubChapterAction,
+  action: string,
   helpRoute: string,
 ): void {
   if (value !== undefined) {
@@ -1256,12 +1466,41 @@ function rejectActionBooleanFlag(
   }
 }
 
+function rejectSdpubStageActionFlag(
+  value: string | undefined,
+  flag: string,
+  action: CLISdpubStageAction,
+): void {
+  if (value !== undefined) {
+    throw new Error(
+      withHelpRoute(
+        `The \`sdpub stage ${action}\` action does not support ${flag}.`,
+        "spinedigest sdpub stage --help",
+      ),
+    );
+  }
+}
+
 function rejectSdpubChapterFlag(name: string, value: string | undefined): void {
   if (value !== undefined) {
     throw new Error(
       withHelpRoute(
         `The \`sdpub chapter\` command does not support --${name}.`,
         "spinedigest sdpub chapter --help",
+      ),
+    );
+  }
+}
+
+function rejectSdpubStageFlag(
+  name: string,
+  value: boolean | string | undefined,
+): void {
+  if (value !== undefined) {
+    throw new Error(
+      withHelpRoute(
+        `The \`sdpub stage\` command does not support --${name}.`,
+        "spinedigest sdpub stage --help",
       ),
     );
   }
@@ -1284,6 +1523,17 @@ function rejectSdpubChapterMetaFlags(values: SdpubMetaFlagValues): void {
       withHelpRoute(
         `The \`sdpub chapter\` command does not support ${flag}.`,
         "spinedigest sdpub chapter --help",
+      ),
+    );
+  }
+}
+
+function rejectSdpubStageMetaFlags(values: SdpubMetaFlagValues): void {
+  for (const flag of listPresentMetaFlags(values)) {
+    throw new Error(
+      withHelpRoute(
+        `The \`sdpub stage\` command does not support ${flag}.`,
+        "spinedigest sdpub stage --help",
       ),
     );
   }

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -6,6 +6,7 @@ import {
   sdpubSubcommandHelpRoute,
   withHelpRoute,
 } from "./errors.js";
+import { CHAPTER_STAGES, type ChapterStage } from "../facade/index.js";
 import {
   parseHelpTopic,
   renderHelpTopicText,
@@ -33,7 +34,32 @@ export interface CLISdpubArguments {
   readonly inputPath: string;
   readonly llmJSON?: string;
   readonly serialId?: number;
-  readonly subcommand: SDPubSubcommand;
+  readonly subcommand: Exclude<SDPubSubcommand, "chapter">;
+}
+
+export type CLISdpubChapterAction =
+  | "add"
+  | "generate-graph"
+  | "generate-summary"
+  | "list"
+  | "remove"
+  | "reset"
+  | "set-source"
+  | "set-summary"
+  | "status";
+
+export interface CLISdpubChapterArguments {
+  readonly action: CLISdpubChapterAction;
+  readonly chapterId?: number;
+  readonly inputFormat?: Extract<CLIFormat, "markdown" | "txt">;
+  readonly inputPath?: string;
+  readonly llmJSON?: string;
+  readonly parentChapterId?: number;
+  readonly path: string;
+  readonly prompt?: string;
+  readonly recursive?: boolean;
+  readonly resetStage?: Exclude<ChapterStage, "summarized">;
+  readonly title?: string;
 }
 
 export interface CLIStatusArguments {
@@ -62,6 +88,16 @@ export type ParsedCLIArguments =
       readonly help: true;
       readonly helpText: string;
       readonly kind: "sdpub";
+    }
+  | {
+      readonly args: CLISdpubChapterArguments;
+      readonly help: false;
+      readonly kind: "sdpub-chapter";
+    }
+  | {
+      readonly help: true;
+      readonly helpText: string;
+      readonly kind: "sdpub-chapter";
     }
   | {
       readonly help: true;
@@ -113,6 +149,21 @@ export function parseCLIArguments(
         type: "string",
       },
       serial: {
+        type: "string",
+      },
+      chapter: {
+        type: "string",
+      },
+      parent: {
+        type: "string",
+      },
+      recursive: {
+        type: "boolean",
+      },
+      title: {
+        type: "string",
+      },
+      to: {
         type: "string",
       },
       verbose: {
@@ -188,6 +239,7 @@ export function parseCLIArguments(
 function parseSdpubArguments(
   positionals: readonly string[],
   values: {
+    readonly chapter?: string;
     readonly "digest-dir"?: string;
     readonly help?: boolean;
     readonly input?: string;
@@ -195,8 +247,12 @@ function parseSdpubArguments(
     readonly llm?: string;
     readonly output?: string;
     readonly "output-format"?: string;
+    readonly parent?: string;
     readonly prompt?: string;
+    readonly recursive?: boolean;
     readonly serial?: string;
+    readonly title?: string;
+    readonly to?: string;
     readonly verbose?: boolean;
   },
 ): ParsedCLIArguments {
@@ -205,6 +261,10 @@ function parseSdpubArguments(
   const isKnownSubcommand =
     subcommand !== undefined &&
     SDPUB_SUBCOMMANDS.includes(subcommand as SDPubSubcommand);
+
+  if (subcommand === "chapter") {
+    return parseSdpubChapterArguments(positionals.slice(1), values);
+  }
 
   if (positionals.length > 1) {
     throw new Error(
@@ -243,7 +303,7 @@ function parseSdpubArguments(
     );
   }
 
-  const parsedSubcommand = subcommand as SDPubSubcommand;
+  const parsedSubcommand = subcommand as Exclude<SDPubSubcommand, "chapter">;
 
   if (values["digest-dir"] !== undefined) {
     throw new Error(
@@ -354,6 +414,353 @@ function parseSdpubArguments(
     help: false,
     kind: "sdpub",
   };
+}
+
+function parseSdpubChapterArguments(
+  positionals: readonly string[],
+  values: {
+    readonly chapter?: string;
+    readonly "digest-dir"?: string;
+    readonly help?: boolean;
+    readonly input?: string;
+    readonly "input-format"?: string;
+    readonly llm?: string;
+    readonly output?: string;
+    readonly "output-format"?: string;
+    readonly parent?: string;
+    readonly prompt?: string;
+    readonly recursive?: boolean;
+    readonly serial?: string;
+    readonly title?: string;
+    readonly to?: string;
+    readonly verbose?: boolean;
+  },
+): ParsedCLIArguments {
+  const help = values.help ?? false;
+  const action = positionals[0];
+  const path = positionals[1];
+  const helpRoute = "spinedigest sdpub chapter --help";
+
+  rejectSdpubChapterFlag("digest-dir", values["digest-dir"]);
+  rejectSdpubChapterFlag("output", values.output);
+  rejectSdpubChapterFlag("output-format", values["output-format"]);
+  rejectSdpubChapterFlag("serial", values.serial);
+  if (values.verbose) {
+    throw new Error(
+      withHelpRoute(
+        "The `sdpub chapter` command does not support --verbose.",
+        helpRoute,
+      ),
+    );
+  }
+
+  if (help) {
+    return {
+      help: true,
+      helpText: renderSdpubSubcommandHelpText("chapter"),
+      kind: "sdpub-chapter",
+    };
+  }
+
+  if (!isSdpubChapterAction(action)) {
+    throw new Error(
+      withHelpRoute(
+        action === undefined
+          ? "Missing sdpub chapter action."
+          : `Invalid sdpub chapter action: ${action}.`,
+        helpRoute,
+      ),
+    );
+  }
+  if (path === undefined || path === "-") {
+    throw new Error(
+      withHelpRoute(
+        "`spinedigest sdpub chapter` requires a .sdpub path positional argument.",
+        helpRoute,
+      ),
+    );
+  }
+  if (positionals.length > 2) {
+    throw new Error(
+      withHelpRoute(
+        `Unexpected positional arguments: ${positionals.slice(2).join(" ")}.`,
+        helpRoute,
+      ),
+    );
+  }
+
+  return {
+    args: normalizeSdpubChapterArguments(action, path, values, helpRoute),
+    help: false,
+    kind: "sdpub-chapter",
+  };
+}
+
+function normalizeSdpubChapterArguments(
+  action: CLISdpubChapterAction,
+  path: string,
+  values: {
+    readonly chapter?: string;
+    readonly input?: string;
+    readonly "input-format"?: string;
+    readonly llm?: string;
+    readonly parent?: string;
+    readonly prompt?: string;
+    readonly recursive?: boolean;
+    readonly title?: string;
+    readonly to?: string;
+  },
+  helpRoute: string,
+): CLISdpubChapterArguments {
+  const chapterId =
+    values.chapter === undefined
+      ? undefined
+      : parseSerialId(values.chapter, "--chapter", helpRoute);
+  const parentChapterId =
+    values.parent === undefined
+      ? undefined
+      : parseSerialId(values.parent, "--parent", helpRoute);
+  const inputFormat =
+    values["input-format"] === undefined
+      ? undefined
+      : parseChapterInputFormat(values["input-format"], helpRoute);
+  const resetStage =
+    values.to === undefined ? undefined : parseResetStage(values.to, helpRoute);
+
+  switch (action) {
+    case "add":
+      requireFlag(values.title, "--title", action, helpRoute);
+      rejectActionFlag(values.chapter, "--chapter", action, helpRoute);
+      rejectActionFlag(values.input, "--input", action, helpRoute);
+      rejectActionFlag(
+        values["input-format"],
+        "--input-format",
+        action,
+        helpRoute,
+      );
+      rejectActionFlag(values.prompt, "--prompt", action, helpRoute);
+      rejectActionFlag(values.to, "--to", action, helpRoute);
+      rejectActionBooleanFlag(
+        values.recursive,
+        "--recursive",
+        action,
+        helpRoute,
+      );
+      return {
+        action,
+        path,
+        ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
+        ...(parentChapterId === undefined ? {} : { parentChapterId }),
+        title: values.title,
+      };
+    case "generate-graph":
+      requireChapterId(chapterId, action, helpRoute);
+      rejectActionFlag(values.input, "--input", action, helpRoute);
+      rejectActionFlag(
+        values["input-format"],
+        "--input-format",
+        action,
+        helpRoute,
+      );
+      rejectActionFlag(values.parent, "--parent", action, helpRoute);
+      rejectActionFlag(values.title, "--title", action, helpRoute);
+      rejectActionFlag(values.to, "--to", action, helpRoute);
+      rejectActionBooleanFlag(
+        values.recursive,
+        "--recursive",
+        action,
+        helpRoute,
+      );
+      return {
+        action,
+        chapterId,
+        path,
+        ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
+        ...(values.prompt === undefined ? {} : { prompt: values.prompt }),
+      };
+    case "generate-summary":
+      requireChapterId(chapterId, action, helpRoute);
+      rejectActionFlag(values.input, "--input", action, helpRoute);
+      rejectActionFlag(
+        values["input-format"],
+        "--input-format",
+        action,
+        helpRoute,
+      );
+      rejectActionFlag(values.parent, "--parent", action, helpRoute);
+      rejectActionFlag(values.prompt, "--prompt", action, helpRoute);
+      rejectActionFlag(values.title, "--title", action, helpRoute);
+      rejectActionFlag(values.to, "--to", action, helpRoute);
+      rejectActionBooleanFlag(
+        values.recursive,
+        "--recursive",
+        action,
+        helpRoute,
+      );
+      return {
+        action,
+        chapterId,
+        path,
+        ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
+      };
+    case "list":
+      rejectActionFlag(values.chapter, "--chapter", action, helpRoute);
+      rejectActionFlag(values.input, "--input", action, helpRoute);
+      rejectActionFlag(
+        values["input-format"],
+        "--input-format",
+        action,
+        helpRoute,
+      );
+      rejectActionFlag(values.parent, "--parent", action, helpRoute);
+      rejectActionFlag(values.prompt, "--prompt", action, helpRoute);
+      rejectActionFlag(values.title, "--title", action, helpRoute);
+      rejectActionFlag(values.to, "--to", action, helpRoute);
+      rejectActionBooleanFlag(
+        values.recursive,
+        "--recursive",
+        action,
+        helpRoute,
+      );
+      return {
+        action,
+        path,
+        ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
+      };
+    case "remove":
+      requireChapterId(chapterId, action, helpRoute);
+      rejectActionFlag(values.input, "--input", action, helpRoute);
+      rejectActionFlag(
+        values["input-format"],
+        "--input-format",
+        action,
+        helpRoute,
+      );
+      rejectActionFlag(values.parent, "--parent", action, helpRoute);
+      rejectActionFlag(values.prompt, "--prompt", action, helpRoute);
+      rejectActionFlag(values.title, "--title", action, helpRoute);
+      rejectActionFlag(values.to, "--to", action, helpRoute);
+      return {
+        action,
+        chapterId,
+        path,
+        ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
+        ...(values.recursive === undefined
+          ? {}
+          : { recursive: values.recursive }),
+      };
+    case "reset":
+      requireChapterId(chapterId, action, helpRoute);
+      if (resetStage === undefined) {
+        throw new Error(
+          withHelpRoute(
+            "Missing --to. `sdpub chapter reset` requires planned, sourced, or graphed.",
+            helpRoute,
+          ),
+        );
+      }
+      rejectActionFlag(values.input, "--input", action, helpRoute);
+      rejectActionFlag(
+        values["input-format"],
+        "--input-format",
+        action,
+        helpRoute,
+      );
+      rejectActionFlag(values.parent, "--parent", action, helpRoute);
+      rejectActionFlag(values.prompt, "--prompt", action, helpRoute);
+      rejectActionFlag(values.title, "--title", action, helpRoute);
+      rejectActionBooleanFlag(
+        values.recursive,
+        "--recursive",
+        action,
+        helpRoute,
+      );
+      return {
+        action,
+        chapterId,
+        path,
+        resetStage,
+        ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
+      };
+    case "set-source":
+      requireChapterId(chapterId, action, helpRoute);
+      if (inputFormat === undefined) {
+        throw new Error(
+          withHelpRoute(
+            "Missing --input-format. `sdpub chapter set-source` requires txt or markdown.",
+            helpRoute,
+          ),
+        );
+      }
+      rejectActionFlag(values.parent, "--parent", action, helpRoute);
+      rejectActionFlag(values.prompt, "--prompt", action, helpRoute);
+      rejectActionFlag(values.title, "--title", action, helpRoute);
+      rejectActionFlag(values.to, "--to", action, helpRoute);
+      rejectActionBooleanFlag(
+        values.recursive,
+        "--recursive",
+        action,
+        helpRoute,
+      );
+      return {
+        action,
+        chapterId,
+        inputFormat,
+        path,
+        ...(values.input === undefined ? {} : { inputPath: values.input }),
+        ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
+      };
+    case "set-summary":
+      requireChapterId(chapterId, action, helpRoute);
+      rejectActionFlag(
+        values["input-format"],
+        "--input-format",
+        action,
+        helpRoute,
+      );
+      rejectActionFlag(values.parent, "--parent", action, helpRoute);
+      rejectActionFlag(values.prompt, "--prompt", action, helpRoute);
+      rejectActionFlag(values.title, "--title", action, helpRoute);
+      rejectActionFlag(values.to, "--to", action, helpRoute);
+      rejectActionBooleanFlag(
+        values.recursive,
+        "--recursive",
+        action,
+        helpRoute,
+      );
+      return {
+        action,
+        chapterId,
+        path,
+        ...(values.input === undefined ? {} : { inputPath: values.input }),
+        ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
+      };
+    case "status":
+      requireChapterId(chapterId, action, helpRoute);
+      rejectActionFlag(values.input, "--input", action, helpRoute);
+      rejectActionFlag(
+        values["input-format"],
+        "--input-format",
+        action,
+        helpRoute,
+      );
+      rejectActionFlag(values.parent, "--parent", action, helpRoute);
+      rejectActionFlag(values.prompt, "--prompt", action, helpRoute);
+      rejectActionFlag(values.title, "--title", action, helpRoute);
+      rejectActionFlag(values.to, "--to", action, helpRoute);
+      rejectActionBooleanFlag(
+        values.recursive,
+        "--recursive",
+        action,
+        helpRoute,
+      );
+      return {
+        action,
+        chapterId,
+        path,
+        ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
+      };
+  }
 }
 
 function parseHelpArguments(
@@ -487,6 +894,144 @@ function parseSerialId(value: string, flag: string, helpRoute: string): number {
   }
 
   return Number(normalized);
+}
+
+function isSdpubChapterAction(
+  value: string | undefined,
+): value is CLISdpubChapterAction {
+  return (
+    value === "add" ||
+    value === "generate-graph" ||
+    value === "generate-summary" ||
+    value === "list" ||
+    value === "remove" ||
+    value === "reset" ||
+    value === "set-source" ||
+    value === "set-summary" ||
+    value === "status"
+  );
+}
+
+function parseChapterInputFormat(
+  value: string,
+  helpRoute: string,
+): Extract<CLIFormat, "markdown" | "txt"> {
+  const format = parseCLIFormat(value, "--input-format");
+
+  if (format === "markdown" || format === "txt") {
+    return format;
+  }
+
+  throw new Error(
+    withHelpRoute(
+      `Invalid --input-format for sdpub chapter source: ${value}. Expected txt or markdown.`,
+      helpRoute,
+    ),
+  );
+}
+
+function parseResetStage(
+  value: string,
+  helpRoute: string,
+): Exclude<ChapterStage, "summarized"> {
+  const normalized = value.trim().toLowerCase();
+
+  if (
+    normalized === "planned" ||
+    normalized === "sourced" ||
+    normalized === "graphed"
+  ) {
+    return normalized;
+  }
+  if (CHAPTER_STAGES.includes(normalized as ChapterStage)) {
+    throw new Error(
+      withHelpRoute(
+        "`sdpub chapter reset` does not support --to summarized.",
+        helpRoute,
+      ),
+    );
+  }
+
+  throw new Error(
+    withHelpRoute(
+      `Invalid --to: ${value}. Expected planned, sourced, or graphed.`,
+      helpRoute,
+    ),
+  );
+}
+
+function rejectActionFlag(
+  value: string | undefined,
+  flag: string,
+  action: CLISdpubChapterAction,
+  helpRoute: string,
+): void {
+  if (value !== undefined) {
+    throw new Error(
+      withHelpRoute(
+        `The \`sdpub chapter ${action}\` action does not support ${flag}.`,
+        helpRoute,
+      ),
+    );
+  }
+}
+
+function rejectActionBooleanFlag(
+  value: boolean | undefined,
+  flag: string,
+  action: CLISdpubChapterAction,
+  helpRoute: string,
+): void {
+  if (value !== undefined) {
+    throw new Error(
+      withHelpRoute(
+        `The \`sdpub chapter ${action}\` action does not support ${flag}.`,
+        helpRoute,
+      ),
+    );
+  }
+}
+
+function rejectSdpubChapterFlag(name: string, value: string | undefined): void {
+  if (value !== undefined) {
+    throw new Error(
+      withHelpRoute(
+        `The \`sdpub chapter\` command does not support --${name}.`,
+        "spinedigest sdpub chapter --help",
+      ),
+    );
+  }
+}
+
+function requireChapterId(
+  chapterId: number | undefined,
+  action: CLISdpubChapterAction,
+  helpRoute: string,
+): asserts chapterId is number {
+  if (chapterId === undefined) {
+    throw new Error(
+      withHelpRoute(
+        `Missing --chapter. \`sdpub chapter ${action}\` requires a chapter id.`,
+        helpRoute,
+      ),
+    );
+  }
+}
+
+function requireFlag(
+  value: string | undefined,
+  flag: string,
+  action: CLISdpubChapterAction,
+  helpRoute: string,
+): asserts value is string {
+  if (value === undefined) {
+    throw new Error(
+      withHelpRoute(
+        `Missing ${flag}. \`sdpub chapter ${action}\` requires it.`,
+        helpRoute,
+      ),
+    );
+  }
 }
 
 function rejectHelpFlag(name: string, value: string | undefined): void {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -33,8 +33,26 @@ export interface CLIArguments {
 export interface CLISdpubArguments {
   readonly inputPath: string;
   readonly llmJSON?: string;
+  readonly metaPatch?: SdpubMetaPatch;
   readonly serialId?: number;
   readonly subcommand: Exclude<SDPubSubcommand, "chapter">;
+}
+
+export interface SdpubMetaPatch {
+  readonly authors?: readonly string[];
+  readonly clearAuthors?: boolean;
+  readonly clearDescription?: boolean;
+  readonly clearIdentifier?: boolean;
+  readonly clearLanguage?: boolean;
+  readonly clearPublishedAt?: boolean;
+  readonly clearPublisher?: boolean;
+  readonly clearTitle?: boolean;
+  readonly description?: string;
+  readonly identifier?: string;
+  readonly language?: string;
+  readonly publishedAt?: string;
+  readonly publisher?: string;
+  readonly title?: string;
 }
 
 export type CLISdpubChapterAction =
@@ -64,6 +82,23 @@ export interface CLISdpubChapterArguments {
 
 export interface CLIStatusArguments {
   readonly llmJSON?: string;
+}
+
+interface SdpubMetaFlagValues {
+  readonly author?: readonly string[];
+  readonly "clear-authors"?: boolean;
+  readonly "clear-description"?: boolean;
+  readonly "clear-identifier"?: boolean;
+  readonly "clear-language"?: boolean;
+  readonly "clear-published-at"?: boolean;
+  readonly "clear-publisher"?: boolean;
+  readonly "clear-title"?: boolean;
+  readonly description?: string;
+  readonly identifier?: string;
+  readonly language?: string;
+  readonly "published-at"?: string;
+  readonly publisher?: string;
+  readonly title?: string;
 }
 
 export type ParsedCLIArguments =
@@ -123,6 +158,34 @@ export function parseCLIArguments(
     allowPositionals: true,
     args: argv,
     options: {
+      author: {
+        multiple: true,
+        type: "string",
+      },
+      "clear-authors": {
+        type: "boolean",
+      },
+      "clear-description": {
+        type: "boolean",
+      },
+      "clear-identifier": {
+        type: "boolean",
+      },
+      "clear-language": {
+        type: "boolean",
+      },
+      "clear-published-at": {
+        type: "boolean",
+      },
+      "clear-publisher": {
+        type: "boolean",
+      },
+      "clear-title": {
+        type: "boolean",
+      },
+      description: {
+        type: "string",
+      },
       help: {
         short: "h",
         type: "boolean",
@@ -130,10 +193,16 @@ export function parseCLIArguments(
       "digest-dir": {
         type: "string",
       },
+      identifier: {
+        type: "string",
+      },
       input: {
         type: "string",
       },
       "input-format": {
+        type: "string",
+      },
+      language: {
         type: "string",
       },
       llm: {
@@ -155,6 +224,12 @@ export function parseCLIArguments(
         type: "string",
       },
       parent: {
+        type: "string",
+      },
+      "published-at": {
+        type: "string",
+      },
+      publisher: {
         type: "string",
       },
       recursive: {
@@ -194,6 +269,8 @@ export function parseCLIArguments(
       ),
     );
   }
+
+  rejectConvertMetaFlags(values);
 
   const args = {
     ...(values["digest-dir"] === undefined
@@ -239,15 +316,28 @@ export function parseCLIArguments(
 function parseSdpubArguments(
   positionals: readonly string[],
   values: {
+    readonly author?: readonly string[];
     readonly chapter?: string;
+    readonly "clear-authors"?: boolean;
+    readonly "clear-description"?: boolean;
+    readonly "clear-identifier"?: boolean;
+    readonly "clear-language"?: boolean;
+    readonly "clear-published-at"?: boolean;
+    readonly "clear-publisher"?: boolean;
+    readonly "clear-title"?: boolean;
+    readonly description?: string;
     readonly "digest-dir"?: string;
     readonly help?: boolean;
+    readonly identifier?: string;
     readonly input?: string;
     readonly "input-format"?: string;
+    readonly language?: string;
     readonly llm?: string;
     readonly output?: string;
     readonly "output-format"?: string;
     readonly parent?: string;
+    readonly "published-at"?: string;
+    readonly publisher?: string;
     readonly prompt?: string;
     readonly recursive?: boolean;
     readonly serial?: string;
@@ -345,6 +435,7 @@ function parseSdpubArguments(
       ),
     );
   }
+  const metaPatch = parseSdpubMetaPatch(values, parsedSubcommand);
   if (values.verbose) {
     throw new Error(
       withHelpRoute(
@@ -408,6 +499,7 @@ function parseSdpubArguments(
     args: {
       inputPath: inputPath!,
       ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
+      ...(metaPatch === undefined ? {} : { metaPatch }),
       ...(serialId === undefined ? {} : { serialId }),
       subcommand: parsedSubcommand,
     },
@@ -419,15 +511,28 @@ function parseSdpubArguments(
 function parseSdpubChapterArguments(
   positionals: readonly string[],
   values: {
+    readonly author?: readonly string[];
     readonly chapter?: string;
+    readonly "clear-authors"?: boolean;
+    readonly "clear-description"?: boolean;
+    readonly "clear-identifier"?: boolean;
+    readonly "clear-language"?: boolean;
+    readonly "clear-published-at"?: boolean;
+    readonly "clear-publisher"?: boolean;
+    readonly "clear-title"?: boolean;
+    readonly description?: string;
     readonly "digest-dir"?: string;
     readonly help?: boolean;
+    readonly identifier?: string;
     readonly input?: string;
     readonly "input-format"?: string;
+    readonly language?: string;
     readonly llm?: string;
     readonly output?: string;
     readonly "output-format"?: string;
     readonly parent?: string;
+    readonly "published-at"?: string;
+    readonly publisher?: string;
     readonly prompt?: string;
     readonly recursive?: boolean;
     readonly serial?: string;
@@ -445,6 +550,7 @@ function parseSdpubChapterArguments(
   rejectSdpubChapterFlag("output", values.output);
   rejectSdpubChapterFlag("output-format", values["output-format"]);
   rejectSdpubChapterFlag("serial", values.serial);
+  rejectSdpubChapterMetaFlags(values);
   if (values.verbose) {
     throw new Error(
       withHelpRoute(
@@ -529,7 +635,6 @@ function normalizeSdpubChapterArguments(
 
   switch (action) {
     case "add":
-      requireFlag(values.title, "--title", action, helpRoute);
       rejectActionFlag(values.chapter, "--chapter", action, helpRoute);
       rejectActionFlag(values.input, "--input", action, helpRoute);
       rejectActionFlag(
@@ -551,7 +656,7 @@ function normalizeSdpubChapterArguments(
         path,
         ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
         ...(parentChapterId === undefined ? {} : { parentChapterId }),
-        title: values.title,
+        ...(values.title === undefined ? {} : { title: values.title }),
       };
     case "generate-graph":
       requireChapterId(chapterId, action, helpRoute);
@@ -766,13 +871,26 @@ function normalizeSdpubChapterArguments(
 function parseHelpArguments(
   positionals: readonly string[],
   values: {
+    readonly author?: readonly string[];
+    readonly "clear-authors"?: boolean;
+    readonly "clear-description"?: boolean;
+    readonly "clear-identifier"?: boolean;
+    readonly "clear-language"?: boolean;
+    readonly "clear-published-at"?: boolean;
+    readonly "clear-publisher"?: boolean;
+    readonly "clear-title"?: boolean;
+    readonly description?: string;
     readonly "digest-dir"?: string;
     readonly help?: boolean;
+    readonly identifier?: string;
     readonly input?: string;
     readonly "input-format"?: string;
+    readonly language?: string;
     readonly llm?: string;
     readonly output?: string;
     readonly "output-format"?: string;
+    readonly "published-at"?: string;
+    readonly publisher?: string;
     readonly prompt?: string;
     readonly serial?: string;
     readonly verbose?: boolean;
@@ -786,6 +904,7 @@ function parseHelpArguments(
   rejectHelpFlag("output-format", values["output-format"]);
   rejectHelpFlag("prompt", values.prompt);
   rejectHelpFlag("serial", values.serial);
+  rejectHelpMetaFlags(values);
 
   if (values.verbose) {
     throw new Error(
@@ -823,13 +942,26 @@ function parseHelpArguments(
 function parseStatusArguments(
   positionals: readonly string[],
   values: {
+    readonly author?: readonly string[];
+    readonly "clear-authors"?: boolean;
+    readonly "clear-description"?: boolean;
+    readonly "clear-identifier"?: boolean;
+    readonly "clear-language"?: boolean;
+    readonly "clear-published-at"?: boolean;
+    readonly "clear-publisher"?: boolean;
+    readonly "clear-title"?: boolean;
+    readonly description?: string;
     readonly "digest-dir"?: string;
     readonly help?: boolean;
+    readonly identifier?: string;
     readonly input?: string;
     readonly "input-format"?: string;
+    readonly language?: string;
     readonly llm?: string;
     readonly output?: string;
     readonly "output-format"?: string;
+    readonly "published-at"?: string;
+    readonly publisher?: string;
     readonly prompt?: string;
     readonly serial?: string;
     readonly verbose?: boolean;
@@ -842,6 +974,7 @@ function parseStatusArguments(
   rejectStatusFlag("output-format", values["output-format"]);
   rejectStatusFlag("prompt", values.prompt);
   rejectStatusFlag("serial", values.serial);
+  rejectStatusMetaFlags(values);
 
   if (values.verbose) {
     throw new Error(
@@ -960,6 +1093,137 @@ function parseResetStage(
   );
 }
 
+function parseSdpubMetaPatch(
+  values: SdpubMetaFlagValues,
+  subcommand: Exclude<SDPubSubcommand, "chapter">,
+): SdpubMetaPatch | undefined {
+  const helpRoute = sdpubSubcommandHelpRoute(subcommand);
+  const patch = {
+    ...parseSdpubStringMetaPatch(values, "title", "title", helpRoute),
+    ...parseSdpubStringMetaPatch(values, "language", "language", helpRoute),
+    ...parseSdpubStringMetaPatch(values, "identifier", "identifier", helpRoute),
+    ...parseSdpubStringMetaPatch(values, "publisher", "publisher", helpRoute),
+    ...parseSdpubStringMetaPatch(
+      values,
+      "publishedAt",
+      "published-at",
+      helpRoute,
+    ),
+    ...parseSdpubStringMetaPatch(
+      values,
+      "description",
+      "description",
+      helpRoute,
+    ),
+    ...parseSdpubAuthorsMetaPatch(values, helpRoute),
+  } satisfies SdpubMetaPatch;
+
+  if (Object.keys(patch).length === 0) {
+    return undefined;
+  }
+  if (subcommand !== "meta") {
+    throw new Error(
+      withHelpRoute(
+        `The \`sdpub ${subcommand}\` subcommand does not support metadata edit flags.`,
+        sdpubSubcommandHelpRoute(subcommand),
+      ),
+    );
+  }
+
+  return patch;
+}
+
+function parseSdpubStringMetaPatch(
+  values: SdpubMetaFlagValues,
+  key:
+    | "description"
+    | "identifier"
+    | "language"
+    | "publishedAt"
+    | "publisher"
+    | "title",
+  flag:
+    | "description"
+    | "identifier"
+    | "language"
+    | "published-at"
+    | "publisher"
+    | "title",
+  helpRoute: string,
+): Partial<SdpubMetaPatch> {
+  const value = values[flag];
+  const clearFlag = `clear-${flag}` as keyof SdpubMetaFlagValues;
+  const clearValue = values[clearFlag];
+
+  if (value !== undefined && clearValue === true) {
+    throw new Error(
+      withHelpRoute(
+        `Cannot combine --${flag} with --clear-${flag}.`,
+        helpRoute,
+      ),
+    );
+  }
+  if (value !== undefined) {
+    const normalized = normalizeNonEmptyFlagValue(
+      value,
+      `--${flag}`,
+      helpRoute,
+    );
+
+    return {
+      [key]: normalized,
+    };
+  }
+  if (clearValue === true) {
+    const clearKey = `clear${key[0]!.toUpperCase()}${key.slice(1)}`;
+
+    return {
+      [clearKey]: true,
+    } as Partial<SdpubMetaPatch>;
+  }
+
+  return {};
+}
+
+function parseSdpubAuthorsMetaPatch(
+  values: SdpubMetaFlagValues,
+  helpRoute: string,
+): Partial<SdpubMetaPatch> {
+  if (values.author !== undefined && values["clear-authors"] === true) {
+    throw new Error(
+      withHelpRoute("Cannot combine --author with --clear-authors.", helpRoute),
+    );
+  }
+  if (values.author !== undefined) {
+    return {
+      authors: values.author.map((value) =>
+        normalizeNonEmptyFlagValue(value, "--author", helpRoute),
+      ),
+    };
+  }
+  if (values["clear-authors"] === true) {
+    return {
+      clearAuthors: true,
+    };
+  }
+
+  return {};
+}
+
+function normalizeNonEmptyFlagValue(
+  value: string,
+  flag: string,
+  helpRoute: string,
+): string {
+  const normalized = value.trim();
+
+  if (normalized === "") {
+    throw new Error(withHelpRoute(`${flag} cannot be empty.`, helpRoute));
+  }
+
+  return normalized;
+}
+
 function rejectActionFlag(
   value: string | undefined,
   flag: string,
@@ -1003,6 +1267,83 @@ function rejectSdpubChapterFlag(name: string, value: string | undefined): void {
   }
 }
 
+function rejectConvertMetaFlags(values: SdpubMetaFlagValues): void {
+  for (const flag of listPresentMetaFlags(values)) {
+    throw new Error(
+      withHelpRoute(
+        `The main convert command does not support ${flag}.`,
+        CLI_HELP_ROUTES.command,
+      ),
+    );
+  }
+}
+
+function rejectSdpubChapterMetaFlags(values: SdpubMetaFlagValues): void {
+  for (const flag of listPresentMetaFlags(values, { includeTitle: false })) {
+    throw new Error(
+      withHelpRoute(
+        `The \`sdpub chapter\` command does not support ${flag}.`,
+        "spinedigest sdpub chapter --help",
+      ),
+    );
+  }
+}
+
+function rejectHelpMetaFlags(values: SdpubMetaFlagValues): void {
+  for (const flag of listPresentMetaFlags(values)) {
+    throw new Error(
+      withHelpRoute(
+        `The \`help\` command does not support ${flag}.`,
+        CLI_HELP_ROUTES.root,
+      ),
+    );
+  }
+}
+
+function rejectStatusMetaFlags(values: SdpubMetaFlagValues): void {
+  for (const flag of listPresentMetaFlags(values)) {
+    throw new Error(
+      withHelpRoute(
+        `The \`status\` command does not support ${flag}.`,
+        "spinedigest status --help",
+      ),
+    );
+  }
+}
+
+function listPresentMetaFlags(
+  values: SdpubMetaFlagValues,
+  options: { readonly includeTitle?: boolean } = {},
+): readonly string[] {
+  const includeTitle = options.includeTitle ?? true;
+  const flags: string[] = [];
+
+  if (values.author !== undefined) flags.push("--author");
+  if (values["clear-authors"] !== undefined) flags.push("--clear-authors");
+  if (values["clear-description"] !== undefined) {
+    flags.push("--clear-description");
+  }
+  if (values["clear-identifier"] !== undefined) {
+    flags.push("--clear-identifier");
+  }
+  if (values["clear-language"] !== undefined) flags.push("--clear-language");
+  if (values["clear-published-at"] !== undefined) {
+    flags.push("--clear-published-at");
+  }
+  if (values["clear-publisher"] !== undefined) flags.push("--clear-publisher");
+  if (includeTitle && values["clear-title"] !== undefined) {
+    flags.push("--clear-title");
+  }
+  if (values.description !== undefined) flags.push("--description");
+  if (values.identifier !== undefined) flags.push("--identifier");
+  if (values.language !== undefined) flags.push("--language");
+  if (values["published-at"] !== undefined) flags.push("--published-at");
+  if (values.publisher !== undefined) flags.push("--publisher");
+  if (includeTitle && values.title !== undefined) flags.push("--title");
+
+  return flags;
+}
+
 function requireChapterId(
   chapterId: number | undefined,
   action: CLISdpubChapterAction,
@@ -1012,22 +1353,6 @@ function requireChapterId(
     throw new Error(
       withHelpRoute(
         `Missing --chapter. \`sdpub chapter ${action}\` requires a chapter id.`,
-        helpRoute,
-      ),
-    );
-  }
-}
-
-function requireFlag(
-  value: string | undefined,
-  flag: string,
-  action: CLISdpubChapterAction,
-  helpRoute: string,
-): asserts value is string {
-  if (value === undefined) {
-    throw new Error(
-      withHelpRoute(
-        `Missing ${flag}. \`sdpub chapter ${action}\` requires it.`,
         helpRoute,
       ),
     );

--- a/src/cli/convert.ts
+++ b/src/cli/convert.ts
@@ -50,6 +50,7 @@ type ResolvedOutputEndpoint =
 export async function runConvertCommand(args: CLIArguments): Promise<void> {
   const input = resolveInputEndpoint(args);
   const output = resolveOutputEndpoint(args);
+  const targetStage = args.targetStage ?? "summarized";
 
   if (args.verbose && output.standardStream === "stdout") {
     throw new Error(
@@ -59,14 +60,30 @@ export async function runConvertCommand(args: CLIArguments): Promise<void> {
       ),
     );
   }
+  if (args.targetStage !== undefined && output.format !== "sdpub") {
+    throw new Error(
+      withHelpRoute(
+        "--stage is only supported when output format is sdpub.",
+        CLI_HELP_ROUTES.command,
+      ),
+    );
+  }
 
   const inputFormat = input.format;
+  if (args.targetStage !== undefined && inputFormat === "sdpub") {
+    throw new Error(
+      withHelpRoute(
+        "--stage is only supported when creating .sdpub from source input.",
+        CLI_HELP_ROUTES.command,
+      ),
+    );
+  }
   const requiresDigest = inputFormat !== "sdpub";
+  const requiresLLM =
+    requiresDigest && targetStage !== "planned" && targetStage !== "sourced";
   const digestDirPath = await prepareDigestDirPath(args, requiresDigest);
-  const config = await loadRequiredConfig(args, requiresDigest);
-  const app = new SpineDigestApp(
-    createAppOptions(args, config, requiresDigest),
-  );
+  const config = await loadRequiredConfig(args, requiresLLM);
+  const app = new SpineDigestApp(createAppOptions(args, config, requiresLLM));
   const progressRenderer = createCLIProgressRenderer({
     enabled:
       requiresDigest &&
@@ -114,6 +131,7 @@ export async function runConvertCommand(args: CLIArguments): Promise<void> {
           sourceFormat: input.format,
           stream: readTextStreamFromStdin(),
           ...(extractionPrompt === undefined ? {} : { extractionPrompt }),
+          targetStage,
         },
         async (digest) => {
           await writeDigestOutput(digest, output);
@@ -134,6 +152,7 @@ export async function runConvertCommand(args: CLIArguments): Promise<void> {
               : { onProgress: progressRenderer.onProgress }),
             path: input.path,
             ...(extractionPrompt === undefined ? {} : { extractionPrompt }),
+            targetStage,
           },
           async (digest) => {
             await writeDigestOutput(digest, output);
@@ -151,6 +170,7 @@ export async function runConvertCommand(args: CLIArguments): Promise<void> {
               : { onProgress: progressRenderer.onProgress }),
             path: input.path,
             ...(extractionPrompt === undefined ? {} : { extractionPrompt }),
+            targetStage,
           },
           async (digest) => {
             await writeDigestOutput(digest, output);
@@ -168,6 +188,7 @@ export async function runConvertCommand(args: CLIArguments): Promise<void> {
               : { onProgress: progressRenderer.onProgress }),
             path: input.path,
             ...(extractionPrompt === undefined ? {} : { extractionPrompt }),
+            targetStage,
           },
           async (digest) => {
             await writeDigestOutput(digest, output);

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -28,6 +28,7 @@ export const SDPUB_SUBCOMMANDS = [
   "cat",
   "cover",
   "meta",
+  "stage",
   "chapter",
 ] as const;
 
@@ -114,6 +115,10 @@ const SDPUB_SUBCOMMAND_METADATA: readonly {
   {
     name: "meta",
     summary: "Read or edit book metadata stored in the archive.",
+  },
+  {
+    name: "stage",
+    summary: "List pending chapters or advance chapter stages.",
   },
   {
     name: "chapter",

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -27,6 +27,7 @@ export const SDPUB_SUBCOMMANDS = [
   "list",
   "cat",
   "cover",
+  "meta",
   "chapter",
 ] as const;
 
@@ -109,6 +110,10 @@ const SDPUB_SUBCOMMAND_METADATA: readonly {
   {
     name: "cover",
     summary: "Write raw cover bytes to stdout for redirection or piping.",
+  },
+  {
+    name: "meta",
+    summary: "Read or edit book metadata stored in the archive.",
   },
   {
     name: "chapter",

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -27,6 +27,7 @@ export const SDPUB_SUBCOMMANDS = [
   "list",
   "cat",
   "cover",
+  "chapter",
 ] as const;
 
 export type SDPubSubcommand = (typeof SDPUB_SUBCOMMANDS)[number];
@@ -81,7 +82,7 @@ const HELP_TOPIC_METADATA: readonly {
   },
   {
     name: "sdpub",
-    summary: "The .sdpub inspection command family and its subcommands.",
+    summary: "The .sdpub inspection and chapter editing command family.",
   },
 ] as const;
 
@@ -108,6 +109,10 @@ const SDPUB_SUBCOMMAND_METADATA: readonly {
   {
     name: "cover",
     summary: "Write raw cover bytes to stdout for redirection or piping.",
+  },
+  {
+    name: "chapter",
+    summary: "Edit the chapter tree and per-chapter digest stages.",
   },
 ] as const;
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -3,6 +3,7 @@ import { runConvertCommand } from "./convert.js";
 import { runStatusCommand } from "./status.js";
 import { runSdpubCommand } from "./sdpub.js";
 import { runSdpubChapterCommand } from "./sdpub-chapter.js";
+import { runSdpubStageCommand } from "./sdpub-stage.js";
 import { LLMPaymentRequiredError } from "../llm/index.js";
 import { formatError } from "../utils/node-error.js";
 
@@ -28,6 +29,9 @@ export async function main(): Promise<void> {
         return;
       case "sdpub-chapter":
         await runSdpubChapterCommand(parsed.args);
+        return;
+      case "sdpub-stage":
+        await runSdpubStageCommand(parsed.args);
         return;
       case "status":
         await runStatusCommand(parsed.args);

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -2,6 +2,7 @@ import { parseCLIArguments } from "./args.js";
 import { runConvertCommand } from "./convert.js";
 import { runStatusCommand } from "./status.js";
 import { runSdpubCommand } from "./sdpub.js";
+import { runSdpubChapterCommand } from "./sdpub-chapter.js";
 import { LLMPaymentRequiredError } from "../llm/index.js";
 import { formatError } from "../utils/node-error.js";
 
@@ -24,6 +25,9 @@ export async function main(): Promise<void> {
         }
 
         await runSdpubCommand(parsed.args);
+        return;
+      case "sdpub-chapter":
+        await runSdpubChapterCommand(parsed.args);
         return;
       case "status":
         await runStatusCommand(parsed.args);

--- a/src/cli/sdpub-chapter.ts
+++ b/src/cli/sdpub-chapter.ts
@@ -1,8 +1,6 @@
 import { createReadStream } from "fs";
 import { readFile } from "fs/promises";
 
-import { resolveDataDirPath } from "../common/data-dir.js";
-import type { SpineDigestScope } from "../common/llm-scope.js";
 import type { DirectoryDocument } from "../document/index.js";
 import {
   addChapter,
@@ -17,18 +15,15 @@ import {
   type ChapterDetails,
   type ChapterEntry,
 } from "../facade/index.js";
-import { createDefaultSpineDigestSampling } from "../facade/llm-sampling.js";
 import { SpineDigestFile } from "../facade/spine-digest-file.js";
-import { LLM } from "../llm/index.js";
 
 import type { CLISdpubChapterArguments } from "./args.js";
-import { loadCLIConfig, type CLIConfig } from "./config.js";
-import { CLI_HELP_ROUTES, withHelpRoute } from "./errors.js";
-import { buildLLMOptions } from "./llm.js";
 import { readTextStreamFromStdin, writeTextToStdout } from "./io.js";
-
-const DEFAULT_EXTRACTION_PROMPT =
-  "Focus on the main storyline and key character developments. Preserve important dialogues and critical plot points. Background descriptions and minor details can be compressed significantly.";
+import {
+  createStageLLM,
+  loadRequiredStageConfig,
+  resolveExtractionPrompt,
+} from "./stage-runtime.js";
 
 export async function runSdpubChapterCommand(
   args: CLISdpubChapterArguments,
@@ -48,12 +43,12 @@ export async function runSdpubChapterCommand(
       return;
     case "generate-graph":
       await runEditableCommand(args.path, async (document) => {
-        const config = await loadRequiredChapterConfig(args);
+        const config = await loadRequiredStageConfig(args);
         const details = await generateChapterGraph(document, args.chapterId!, {
           extractionPrompt: resolveExtractionPrompt(
             args.prompt ?? config.prompt,
           ),
-          llm: createChapterLLM(config),
+          llm: createStageLLM(config),
         });
 
         await writeChapterDetails(details);
@@ -61,12 +56,12 @@ export async function runSdpubChapterCommand(
       return;
     case "generate-summary":
       await runEditableCommand(args.path, async (document) => {
-        const config = await loadRequiredChapterConfig(args);
+        const config = await loadRequiredStageConfig(args);
         const details = await generateChapterSummary(
           document,
           args.chapterId!,
           {
-            llm: createChapterLLM(config),
+            llm: createStageLLM(config),
           },
         );
 
@@ -131,48 +126,6 @@ export async function runSdpubChapterCommand(
       );
       return;
   }
-}
-
-function resolveExtractionPrompt(prompt: string | undefined): string {
-  const normalizedPrompt = prompt?.trim();
-
-  return normalizedPrompt === undefined || normalizedPrompt === ""
-    ? DEFAULT_EXTRACTION_PROMPT
-    : normalizedPrompt;
-}
-
-function createChapterLLM(config: CLIConfig): LLM<SpineDigestScope> {
-  const llmOptions = buildLLMOptions(config);
-
-  return new LLM<SpineDigestScope>({
-    dataDirPath: resolveDataDirPath(),
-    sampling: createDefaultSpineDigestSampling({
-      ...(llmOptions.temperature === undefined
-        ? {}
-        : { temperature: llmOptions.temperature }),
-      ...(llmOptions.topP === undefined ? {} : { topP: llmOptions.topP }),
-    }),
-    ...llmOptions,
-  });
-}
-
-async function loadRequiredChapterConfig(
-  args: CLISdpubChapterArguments,
-): Promise<CLIConfig> {
-  const config = await loadCLIConfig({
-    ...(args.llmJSON === undefined ? {} : { llmJSON: args.llmJSON }),
-  });
-
-  if (config.llm?.provider === undefined || config.llm.model === undefined) {
-    throw new Error(
-      withHelpRoute(
-        "Missing LLM configuration. Set --llm, `llm.provider` and `llm.model` in ~/.spinedigest/config.json, or the matching SPINEDIGEST_LLM_* environment variables.",
-        CLI_HELP_ROUTES.config,
-      ),
-    );
-  }
-
-  return config;
 }
 
 async function runEditableCommand(

--- a/src/cli/sdpub-chapter.ts
+++ b/src/cli/sdpub-chapter.ts
@@ -40,7 +40,7 @@ export async function runSdpubChapterCommand(
           ...(args.parentChapterId === undefined
             ? {}
             : { parentChapterId: args.parentChapterId }),
-          title: args.title!,
+          ...(args.title === undefined ? {} : { title: args.title }),
         });
 
         await writeChapterDetails(details);
@@ -215,7 +215,7 @@ async function readContentText(
 async function writeChapterDetails(details: ChapterDetails): Promise<void> {
   const lines = [
     `Chapter: ${details.chapterId}`,
-    `Title: ${details.title}`,
+    `Title: ${details.title ?? "[untitled]"}`,
     `Stage: ${details.stage}`,
     `Fragments: ${details.fragmentCount}`,
     `Children: ${details.childCount}`,
@@ -238,7 +238,7 @@ async function writeChapterList(
     `${entries
       .map(
         (entry) =>
-          `${"  ".repeat(entry.depth)}[${entry.chapterId}] ${entry.stage.padEnd(10)} ${entry.title}`,
+          `${"  ".repeat(entry.depth)}[${entry.chapterId}] ${entry.stage.padEnd(10)} ${entry.title ?? "[untitled]"}`,
       )
       .join("\n")}\n`,
   );

--- a/src/cli/sdpub-chapter.ts
+++ b/src/cli/sdpub-chapter.ts
@@ -1,0 +1,245 @@
+import { createReadStream } from "fs";
+import { readFile } from "fs/promises";
+
+import { resolveDataDirPath } from "../common/data-dir.js";
+import type { SpineDigestScope } from "../common/llm-scope.js";
+import type { DirectoryDocument } from "../document/index.js";
+import {
+  addChapter,
+  generateChapterGraph,
+  generateChapterSummary,
+  getChapterDetails,
+  listChapters,
+  removeChapter,
+  resetChapter,
+  setChapterSource,
+  setChapterSummary,
+  type ChapterDetails,
+  type ChapterEntry,
+} from "../facade/index.js";
+import { createDefaultSpineDigestSampling } from "../facade/llm-sampling.js";
+import { SpineDigestFile } from "../facade/spine-digest-file.js";
+import { LLM } from "../llm/index.js";
+
+import type { CLISdpubChapterArguments } from "./args.js";
+import { loadCLIConfig, type CLIConfig } from "./config.js";
+import { CLI_HELP_ROUTES, withHelpRoute } from "./errors.js";
+import { buildLLMOptions } from "./llm.js";
+import { readTextStreamFromStdin, writeTextToStdout } from "./io.js";
+
+const DEFAULT_EXTRACTION_PROMPT =
+  "Focus on the main storyline and key character developments. Preserve important dialogues and critical plot points. Background descriptions and minor details can be compressed significantly.";
+
+export async function runSdpubChapterCommand(
+  args: CLISdpubChapterArguments,
+): Promise<void> {
+  switch (args.action) {
+    case "add":
+      await runEditableCommand(args.path, async (document) => {
+        const details = await addChapter(document, {
+          ...(args.parentChapterId === undefined
+            ? {}
+            : { parentChapterId: args.parentChapterId }),
+          title: args.title!,
+        });
+
+        await writeChapterDetails(details);
+      });
+      return;
+    case "generate-graph":
+      await runEditableCommand(args.path, async (document) => {
+        const config = await loadRequiredChapterConfig(args);
+        const details = await generateChapterGraph(document, args.chapterId!, {
+          extractionPrompt: resolveExtractionPrompt(
+            args.prompt ?? config.prompt,
+          ),
+          llm: createChapterLLM(config),
+        });
+
+        await writeChapterDetails(details);
+      });
+      return;
+    case "generate-summary":
+      await runEditableCommand(args.path, async (document) => {
+        const config = await loadRequiredChapterConfig(args);
+        const details = await generateChapterSummary(
+          document,
+          args.chapterId!,
+          {
+            llm: createChapterLLM(config),
+          },
+        );
+
+        await writeChapterDetails(details);
+      });
+      return;
+    case "list":
+      await new SpineDigestFile(args.path).openEditableSession(
+        async (document) => {
+          await writeChapterList(await listChapters(document));
+        },
+      );
+      return;
+    case "remove":
+      await runEditableCommand(args.path, async (document) => {
+        await removeChapter(document, args.chapterId!, {
+          recursive: args.recursive ?? false,
+        });
+        await writeTextToStdout(`Removed chapter ${args.chapterId!}.\n`);
+      });
+      return;
+    case "reset":
+      await runEditableCommand(args.path, async (document) => {
+        const details = await resetChapter(
+          document,
+          args.chapterId!,
+          args.resetStage!,
+        );
+
+        await writeChapterDetails(details);
+      });
+      return;
+    case "set-source":
+      await runEditableCommand(args.path, async (document) => {
+        const details = await setChapterSource(
+          document,
+          args.chapterId!,
+          createContentStream(args),
+        );
+
+        await writeChapterDetails(details);
+      });
+      return;
+    case "set-summary":
+      await runEditableCommand(args.path, async (document) => {
+        const details = await setChapterSummary(
+          document,
+          args.chapterId!,
+          await readContentText(args),
+        );
+
+        await writeChapterDetails(details);
+      });
+      return;
+    case "status":
+      await new SpineDigestFile(args.path).openEditableSession(
+        async (document) => {
+          await writeChapterDetails(
+            await getChapterDetails(document, args.chapterId!),
+          );
+        },
+      );
+      return;
+  }
+}
+
+function resolveExtractionPrompt(prompt: string | undefined): string {
+  const normalizedPrompt = prompt?.trim();
+
+  return normalizedPrompt === undefined || normalizedPrompt === ""
+    ? DEFAULT_EXTRACTION_PROMPT
+    : normalizedPrompt;
+}
+
+function createChapterLLM(config: CLIConfig): LLM<SpineDigestScope> {
+  const llmOptions = buildLLMOptions(config);
+
+  return new LLM<SpineDigestScope>({
+    dataDirPath: resolveDataDirPath(),
+    sampling: createDefaultSpineDigestSampling({
+      ...(llmOptions.temperature === undefined
+        ? {}
+        : { temperature: llmOptions.temperature }),
+      ...(llmOptions.topP === undefined ? {} : { topP: llmOptions.topP }),
+    }),
+    ...llmOptions,
+  });
+}
+
+async function loadRequiredChapterConfig(
+  args: CLISdpubChapterArguments,
+): Promise<CLIConfig> {
+  const config = await loadCLIConfig({
+    ...(args.llmJSON === undefined ? {} : { llmJSON: args.llmJSON }),
+  });
+
+  if (config.llm?.provider === undefined || config.llm.model === undefined) {
+    throw new Error(
+      withHelpRoute(
+        "Missing LLM configuration. Set --llm, `llm.provider` and `llm.model` in ~/.spinedigest/config.json, or the matching SPINEDIGEST_LLM_* environment variables.",
+        CLI_HELP_ROUTES.config,
+      ),
+    );
+  }
+
+  return config;
+}
+
+async function runEditableCommand(
+  path: string,
+  operation: (document: DirectoryDocument) => Promise<void> | void,
+): Promise<void> {
+  await new SpineDigestFile(path).openEditableSession(operation);
+}
+
+function createContentStream(
+  args: Pick<CLISdpubChapterArguments, "inputPath">,
+): AsyncIterable<string> {
+  if (args.inputPath !== undefined) {
+    return createReadStream(args.inputPath, { encoding: "utf8" });
+  }
+  if (process.stdin.isTTY) {
+    throw new Error(
+      "Missing --input. Pipe text into stdin or pass --input <path>.",
+    );
+  }
+
+  return readTextStreamFromStdin();
+}
+
+async function readContentText(
+  args: Pick<CLISdpubChapterArguments, "inputPath">,
+): Promise<string> {
+  if (args.inputPath !== undefined) {
+    return await readFile(args.inputPath, "utf8");
+  }
+  let content = "";
+
+  for await (const chunk of createContentStream(args)) {
+    content += chunk;
+  }
+
+  return content;
+}
+
+async function writeChapterDetails(details: ChapterDetails): Promise<void> {
+  const lines = [
+    `Chapter: ${details.chapterId}`,
+    `Title: ${details.title}`,
+    `Stage: ${details.stage}`,
+    `Fragments: ${details.fragmentCount}`,
+    `Children: ${details.childCount}`,
+    `Graph: ${details.graphReady ? "yes" : "no"}`,
+    `Summary: ${details.hasSummary ? "yes" : "no"}`,
+  ];
+
+  await writeTextToStdout(`${lines.join("\n")}\n`);
+}
+
+async function writeChapterList(
+  entries: readonly ChapterEntry[],
+): Promise<void> {
+  if (entries.length === 0) {
+    await writeTextToStdout("No chapters.\n");
+    return;
+  }
+
+  await writeTextToStdout(
+    `${entries
+      .map(
+        (entry) =>
+          `${"  ".repeat(entry.depth)}[${entry.chapterId}] ${entry.stage.padEnd(10)} ${entry.title}`,
+      )
+      .join("\n")}\n`,
+  );
+}

--- a/src/cli/sdpub-stage.ts
+++ b/src/cli/sdpub-stage.ts
@@ -1,0 +1,101 @@
+import {
+  advanceChapterStages,
+  listChapters,
+  type AdvanceChapterStagesResult,
+  type ChapterEntry,
+} from "../facade/index.js";
+import { SpineDigestFile } from "../facade/spine-digest-file.js";
+
+import type { CLISdpubStageArguments } from "./args.js";
+import { writeTextToStdout } from "./io.js";
+import {
+  createStageLLM,
+  loadRequiredStageConfig,
+  resolveExtractionPrompt,
+} from "./stage-runtime.js";
+
+export async function runSdpubStageCommand(
+  args: CLISdpubStageArguments,
+): Promise<void> {
+  switch (args.action) {
+    case "pending":
+      await new SpineDigestFile(args.path).openEditableSession(
+        async (document) => {
+          await writePendingChapters(await listChapters(document));
+        },
+      );
+      return;
+    case "advance":
+      await new SpineDigestFile(args.path).openEditableSession(
+        async (document) => {
+          const targetStage = args.targetStage ?? "summarized";
+
+          if (targetStage === "planned") {
+            await writeAdvanceResult({
+              advanced: [],
+              pending: [],
+              skipped: [],
+            });
+            return;
+          }
+
+          const config = await loadRequiredStageConfig(args);
+          const result = await advanceChapterStages(document, {
+            ...(args.chapterId === undefined
+              ? {}
+              : { chapterId: args.chapterId }),
+            extractionPrompt: resolveExtractionPrompt(
+              args.prompt ?? config.prompt,
+            ),
+            llm: createStageLLM(config),
+            targetStage,
+          });
+
+          await writeAdvanceResult(result);
+        },
+      );
+      return;
+  }
+}
+
+async function writePendingChapters(
+  entries: readonly ChapterEntry[],
+): Promise<void> {
+  const pending = entries.filter((entry) => entry.stage !== "summarized");
+
+  if (pending.length === 0) {
+    await writeTextToStdout("No pending chapters.\n");
+    return;
+  }
+
+  await writeTextToStdout(`${pending.map(formatChapterEntry).join("\n")}\n`);
+}
+
+async function writeAdvanceResult(
+  result: AdvanceChapterStagesResult,
+): Promise<void> {
+  const lines = [
+    `Advanced: ${result.advanced.length}`,
+    `Pending: ${result.pending.length}`,
+    `Skipped: ${result.skipped.length}`,
+  ];
+
+  if (result.pending.length > 0) {
+    lines.push("", "Pending chapters:");
+    lines.push(...result.pending.map(formatChapterEntry));
+  }
+
+  await writeTextToStdout(`${lines.join("\n")}\n`);
+}
+
+function formatChapterEntry(entry: ChapterEntry): string {
+  return `[${entry.chapterId}] ${entry.stage.padEnd(10)} ${formatTocPath(entry)}`;
+}
+
+function formatTocPath(entry: ChapterEntry): string {
+  if (entry.tocPath.length === 0) {
+    return entry.title ?? "[untitled]";
+  }
+
+  return entry.tocPath.join(" / ");
+}

--- a/src/cli/sdpub.ts
+++ b/src/cli/sdpub.ts
@@ -38,7 +38,8 @@ export async function runSdpubCommand(args: CLISdpubArguments): Promise<void> {
 }
 
 async function writeSdpubInfo(digest: SpineDigest): Promise<void> {
-  const [meta, cover, toc, serials] = await Promise.all([
+  const [formatVersion, meta, cover, toc, serials] = await Promise.all([
+    digest.readArchiveFormatVersion(),
     digest.readMeta(),
     digest.readCover(),
     digest.readToc(),
@@ -55,6 +56,7 @@ async function writeSdpubInfo(digest: SpineDigest): Promise<void> {
   ]);
   const lines: string[] = [];
 
+  lines.push(`Archive Format Version: ${formatVersion}`);
   appendOptionalLine(lines, "Title", meta?.title);
   if (meta?.authors.length !== undefined && meta.authors.length > 0) {
     lines.push(`Authors: ${meta.authors.join(", ")}`);

--- a/src/cli/sdpub.ts
+++ b/src/cli/sdpub.ts
@@ -1,13 +1,18 @@
 import { SpineDigestApp } from "../index.js";
+import { SpineDigestFile } from "../facade/spine-digest-file.js";
 import type { SpineDigest } from "../facade/index.js";
-import type { TocFile, TocItem } from "../source/index.js";
+import type { BookMeta, TocFile, TocItem } from "../source/index.js";
 
-import type { CLISdpubArguments } from "./args.js";
+import type { CLISdpubArguments, SdpubMetaPatch } from "./args.js";
 import { writeBinaryToStdout, writeTextToStdout } from "./io.js";
 
 export async function runSdpubCommand(args: CLISdpubArguments): Promise<void> {
-  const app = new SpineDigestApp({});
+  if (args.subcommand === "meta" && args.metaPatch !== undefined) {
+    await updateSdpubMeta(args.inputPath, args.metaPatch);
+    return;
+  }
 
+  const app = new SpineDigestApp({});
   await app.openSession(args.inputPath, async (digest) => {
     switch (args.subcommand) {
       case "info":
@@ -24,6 +29,9 @@ export async function runSdpubCommand(args: CLISdpubArguments): Promise<void> {
         return;
       case "cover":
         await writeSdpubCover(digest);
+        return;
+      case "meta":
+        await writeSdpubMeta(await digest.readMeta());
         return;
     }
   });
@@ -140,6 +148,77 @@ async function writeSdpubCover(digest: SpineDigest): Promise<void> {
   await writeBinaryToStdout(cover.data);
 }
 
+async function updateSdpubMeta(
+  path: string,
+  patch: SdpubMetaPatch,
+): Promise<void> {
+  await new SpineDigestFile(path).openEditableSession(async (document) => {
+    const meta = await document.readBookMeta();
+
+    if (meta === undefined) {
+      throw new Error("Document book meta is missing.");
+    }
+
+    const updatedMeta = applySdpubMetaPatch(meta, patch);
+
+    await document.replaceBookMeta(updatedMeta);
+    await writeSdpubMeta(updatedMeta);
+  });
+}
+
+async function writeSdpubMeta(meta: BookMeta | undefined): Promise<void> {
+  if (meta === undefined) {
+    await writeTextToStdout("No document metadata is available.\n");
+    return;
+  }
+
+  const lines = [
+    `Source Format: ${meta.sourceFormat}`,
+    `Title: ${meta.title ?? "[none]"}`,
+    `Authors: ${
+      meta.authors.length === 0 ? "[none]" : meta.authors.join(", ")
+    }`,
+    `Language: ${meta.language ?? "[none]"}`,
+    `Identifier: ${meta.identifier ?? "[none]"}`,
+    `Publisher: ${meta.publisher ?? "[none]"}`,
+    `Published At: ${meta.publishedAt ?? "[none]"}`,
+    `Description: ${meta.description ?? "[none]"}`,
+  ];
+
+  await writeTextToStdout(`${lines.join("\n")}\n`);
+}
+
+function applySdpubMetaPatch(meta: BookMeta, patch: SdpubMetaPatch): BookMeta {
+  return {
+    ...meta,
+    title: patch.clearTitle === true ? null : (patch.title ?? meta.title),
+    authors:
+      patch.clearAuthors === true
+        ? []
+        : patch.authors === undefined
+          ? meta.authors
+          : [...patch.authors],
+    language:
+      patch.clearLanguage === true ? null : (patch.language ?? meta.language),
+    identifier:
+      patch.clearIdentifier === true
+        ? null
+        : (patch.identifier ?? meta.identifier),
+    publisher:
+      patch.clearPublisher === true
+        ? null
+        : (patch.publisher ?? meta.publisher),
+    publishedAt:
+      patch.clearPublishedAt === true
+        ? null
+        : (patch.publishedAt ?? meta.publishedAt),
+    description:
+      patch.clearDescription === true
+        ? null
+        : (patch.description ?? meta.description),
+  };
+}
+
 function appendOptionalLine(
   lines: string[],
   label: string,
@@ -178,7 +257,7 @@ function renderTocLines(
 
   for (const item of items) {
     lines.push(
-      `${"  ".repeat(depth)}${item.title}${
+      `${"  ".repeat(depth)}${item.title?.trim() || "[untitled]"}${
         item.serialId === undefined ? "" : ` [serial ${item.serialId}]`
       }`,
     );

--- a/src/cli/stage-runtime.ts
+++ b/src/cli/stage-runtime.ts
@@ -1,0 +1,53 @@
+import { resolveDataDirPath } from "../common/data-dir.js";
+import type { SpineDigestScope } from "../common/llm-scope.js";
+import { createDefaultSpineDigestSampling } from "../facade/llm-sampling.js";
+import { LLM } from "../llm/index.js";
+
+import { loadCLIConfig, type CLIConfig } from "./config.js";
+import { CLI_HELP_ROUTES, withHelpRoute } from "./errors.js";
+import { buildLLMOptions } from "./llm.js";
+
+export const DEFAULT_EXTRACTION_PROMPT =
+  "Focus on the main storyline and key character developments. Preserve important dialogues and critical plot points. Background descriptions and minor details can be compressed significantly.";
+
+export function createStageLLM(config: CLIConfig): LLM<SpineDigestScope> {
+  const llmOptions = buildLLMOptions(config);
+
+  return new LLM<SpineDigestScope>({
+    dataDirPath: resolveDataDirPath(),
+    sampling: createDefaultSpineDigestSampling({
+      ...(llmOptions.temperature === undefined
+        ? {}
+        : { temperature: llmOptions.temperature }),
+      ...(llmOptions.topP === undefined ? {} : { topP: llmOptions.topP }),
+    }),
+    ...llmOptions,
+  });
+}
+
+export async function loadRequiredStageConfig(options: {
+  readonly llmJSON?: string;
+}): Promise<CLIConfig> {
+  const config = await loadCLIConfig({
+    ...(options.llmJSON === undefined ? {} : { llmJSON: options.llmJSON }),
+  });
+
+  if (config.llm?.provider === undefined || config.llm.model === undefined) {
+    throw new Error(
+      withHelpRoute(
+        "Missing LLM configuration. Set --llm, `llm.provider` and `llm.model` in ~/.spinedigest/config.json, or the matching SPINEDIGEST_LLM_* environment variables.",
+        CLI_HELP_ROUTES.config,
+      ),
+    );
+  }
+
+  return config;
+}
+
+export function resolveExtractionPrompt(prompt: string | undefined): string {
+  const normalizedPrompt = prompt?.trim();
+
+  return normalizedPrompt === undefined || normalizedPrompt === ""
+    ? DEFAULT_EXTRACTION_PROMPT
+    : normalizedPrompt;
+}

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,0 +1,11 @@
+export {
+  createSpineDigestTaskId,
+  SpineDigestTask,
+  SpineDigestTaskContext,
+  SPINE_DIGEST_CONTEXT_VERSION,
+} from "./task-context.js";
+export type {
+  SpineDigestTaskContextOptions,
+  SpineDigestTaskIdentity,
+  SpineDigestTaskType,
+} from "./task-context.js";

--- a/src/context/task-context.ts
+++ b/src/context/task-context.ts
@@ -1,0 +1,163 @@
+import { mkdir, readFile, rm, writeFile } from "fs/promises";
+import { join, resolve } from "path";
+import { z } from "zod";
+
+import { createHash } from "../utils/hash.js";
+import { isNodeError } from "../utils/node-error.js";
+
+export const SPINE_DIGEST_CONTEXT_VERSION = 1;
+
+const TASK_STATUS_VERSION = 1;
+
+const taskStatusSchema = z.object({
+  completedAt: z.string().optional(),
+  startedAt: z.string(),
+  status: z.enum(["running", "succeeded"]),
+  version: z.literal(TASK_STATUS_VERSION),
+});
+
+export type SpineDigestTaskType = "source-to-graph" | "source-graph-to-summary";
+
+export interface SpineDigestTaskIdentity {
+  readonly normalizedSource: string;
+  readonly parameters: unknown;
+  readonly taskType: SpineDigestTaskType;
+  readonly version?: number;
+}
+
+export interface SpineDigestTaskContextOptions {
+  readonly rootDirPath: string;
+}
+
+export interface SpineDigestTaskRun<T> {
+  readonly task: SpineDigestTask;
+  run(operation: (task: SpineDigestTask) => Promise<T> | T): Promise<T>;
+}
+
+interface TaskStatus {
+  readonly completedAt?: string | undefined;
+  readonly startedAt: string;
+  readonly status: "running" | "succeeded";
+  readonly version: typeof TASK_STATUS_VERSION;
+}
+
+export class SpineDigestTaskContext {
+  readonly #rootDirPath: string;
+
+  public constructor(options: SpineDigestTaskContextOptions) {
+    this.#rootDirPath = resolve(options.rootDirPath);
+  }
+
+  public createTask(identity: SpineDigestTaskIdentity): SpineDigestTask {
+    const taskId = createSpineDigestTaskId(identity);
+
+    return new SpineDigestTask(taskId, join(this.#rootDirPath, taskId));
+  }
+
+  public async runTask<T>(
+    identity: SpineDigestTaskIdentity,
+    operation: (task: SpineDigestTask) => Promise<T> | T,
+  ): Promise<T> {
+    const task = this.createTask(identity);
+
+    return await task.run(operation);
+  }
+}
+
+export class SpineDigestTask {
+  readonly #id: string;
+  readonly #path: string;
+
+  public constructor(id: string, path: string) {
+    this.#id = id;
+    this.#path = resolve(path);
+  }
+
+  public get artifactDirPath(): string {
+    return join(this.#path, "artifacts");
+  }
+
+  public get id(): string {
+    return this.#id;
+  }
+
+  public get path(): string {
+    return this.#path;
+  }
+
+  public async readStatus(): Promise<TaskStatus | undefined> {
+    try {
+      const status = JSON.parse(
+        await readFile(this.#getStatusPath(), "utf8"),
+      ) as unknown;
+
+      return taskStatusSchema.parse(status);
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return undefined;
+      }
+
+      throw error;
+    }
+  }
+
+  public async run<T>(
+    operation: (task: SpineDigestTask) => Promise<T> | T,
+  ): Promise<T> {
+    await this.#begin();
+
+    const result = await operation(this);
+
+    await this.#complete();
+    await this.remove();
+    return result;
+  }
+
+  public async remove(): Promise<void> {
+    await rm(this.#path, { force: true, recursive: true });
+  }
+
+  async #begin(): Promise<void> {
+    await mkdir(this.artifactDirPath, { recursive: true });
+    await this.#writeStatus({
+      startedAt: new Date().toISOString(),
+      status: "running",
+      version: TASK_STATUS_VERSION,
+    });
+  }
+
+  async #complete(): Promise<void> {
+    const existingStatus = await this.readStatus();
+
+    await this.#writeStatus({
+      completedAt: new Date().toISOString(),
+      startedAt: existingStatus?.startedAt ?? new Date().toISOString(),
+      status: "succeeded",
+      version: TASK_STATUS_VERSION,
+    });
+  }
+
+  async #writeStatus(status: TaskStatus): Promise<void> {
+    await mkdir(this.#path, { recursive: true });
+    await writeFile(
+      this.#getStatusPath(),
+      `${JSON.stringify(status, null, 2)}\n`,
+      "utf8",
+    );
+  }
+
+  #getStatusPath(): string {
+    return join(this.#path, "status.json");
+  }
+}
+
+export function createSpineDigestTaskId(
+  identity: SpineDigestTaskIdentity,
+): string {
+  return createHash({
+    normalizedSource: identity.normalizedSource,
+    parameters: identity.parameters,
+    taskType: identity.taskType,
+    version: identity.version ?? SPINE_DIGEST_CONTEXT_VERSION,
+  });
+}

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -84,6 +84,7 @@ export interface Document extends ReadonlyDocument {
   flush(): Promise<void>;
   openSession<T>(operation: (document: Document) => Promise<T> | T): Promise<T>;
   peekNextSerialId(): Promise<number>;
+  replaceBookMeta(meta: BookMeta): Promise<void>;
   replaceToc(toc: TocFile): Promise<void>;
   writeBookMeta(meta: BookMeta): Promise<void>;
   writeCover(cover: SourceAsset): Promise<void>;
@@ -283,6 +284,12 @@ export class DirectoryDocument implements Document {
 
   public async writeBookMeta(meta: BookMeta): Promise<void> {
     await this.#writeJsonFile(this.#getBookMetaPath(), meta);
+  }
+
+  public async replaceBookMeta(meta: BookMeta): Promise<void> {
+    await this.#writeJsonFile(this.#getBookMetaPath(), meta, {
+      overwrite: true,
+    });
   }
 
   public async writeCover(cover: SourceAsset): Promise<void> {

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -77,9 +77,14 @@ export interface Document extends ReadonlyDocument {
   createContext(): DocumentContext;
   getSerialFragments(serialId: number): SerialFragments;
   createSerial(): Promise<number>;
+  clearSerialGraph(serialId: number): Promise<void>;
+  clearSerialSource(serialId: number): Promise<void>;
+  deleteSerial(serialId: number): Promise<void>;
+  deleteSummary(serialId: number): Promise<void>;
   flush(): Promise<void>;
   openSession<T>(operation: (document: Document) => Promise<T> | T): Promise<T>;
   peekNextSerialId(): Promise<number>;
+  replaceToc(toc: TocFile): Promise<void>;
   writeBookMeta(meta: BookMeta): Promise<void>;
   writeCover(cover: SourceAsset): Promise<void>;
   writeSummary(serialId: number, summary: string): Promise<void>;
@@ -166,6 +171,36 @@ export class DirectoryDocument implements Document {
 
     this.#contextScope.getStore()?.ownSerial(serialId);
     return serialId;
+  }
+
+  public async clearSerialGraph(serialId: number): Promise<void> {
+    await this.deleteSummary(serialId);
+    await this.#deleteSerialGraphRecords(serialId);
+    await this.serials.setTopologyReady(serialId, false);
+  }
+
+  public async clearSerialSource(serialId: number): Promise<void> {
+    await this.clearSerialGraph(serialId);
+    await rm(this.#fragments.getSerial(serialId).path, {
+      force: true,
+      recursive: true,
+    });
+  }
+
+  public async deleteSerial(serialId: number): Promise<void> {
+    await this.#deleteSerialResources(serialId);
+  }
+
+  public async deleteSummary(serialId: number): Promise<void> {
+    try {
+      await unlink(this.#getSummaryPath(serialId));
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return;
+      }
+
+      throw error;
+    }
   }
 
   public async getSentence(sentenceId: SentenceId): Promise<string> {
@@ -268,6 +303,10 @@ export class DirectoryDocument implements Document {
     await this.#writeJsonFile(this.#getTocPath(), toc);
   }
 
+  public async replaceToc(toc: TocFile): Promise<void> {
+    await this.#writeJsonFile(this.#getTocPath(), toc, { overwrite: true });
+  }
+
   public async flush(): Promise<void> {
     await this.#database.flush();
   }
@@ -304,107 +343,108 @@ export class DirectoryDocument implements Document {
 
   async #rollbackOwnedSerials(serialIds: readonly number[]): Promise<void> {
     for (const serialId of [...serialIds].sort(compareNumberDescending)) {
-      await this.#database.transaction(async () => {
-        await this.#database.run(
-          `
-            DELETE FROM snake_edges
-            WHERE from_snake_id IN (
-              SELECT id
-              FROM snakes
-              WHERE serial_id = ?
-            ) OR to_snake_id IN (
-              SELECT id
-              FROM snakes
-              WHERE serial_id = ?
-            )
-          `,
-          [serialId, serialId],
-        );
-        await this.#database.run(
-          `
-            DELETE FROM snake_chunks
-            WHERE snake_id IN (
-              SELECT id
-              FROM snakes
-              WHERE serial_id = ?
-            )
-          `,
-          [serialId],
-        );
-        await this.#database.run(
-          `
-            DELETE FROM snakes
-            WHERE serial_id = ?
-          `,
-          [serialId],
-        );
-        await this.#database.run(
-          `
-            DELETE FROM fragment_groups
-            WHERE serial_id = ?
-          `,
-          [serialId],
-        );
-        await this.#database.run(
-          `
-            DELETE FROM knowledge_edges
-            WHERE from_id IN (
-              SELECT id
-              FROM chunks
-              WHERE serial_id = ?
-            ) OR to_id IN (
-              SELECT id
-              FROM chunks
-              WHERE serial_id = ?
-            )
-          `,
-          [serialId, serialId],
-        );
-        await this.#database.run(
-          `
-            DELETE FROM chunk_sentences
-            WHERE serial_id = ?
-          `,
-          [serialId],
-        );
-        await this.#database.run(
-          `
-            DELETE FROM chunks
-            WHERE serial_id = ?
-          `,
-          [serialId],
-        );
-        await this.#database.run(
-          `
-            DELETE FROM serial_states
-            WHERE serial_id = ?
-          `,
-          [serialId],
-        );
-        await this.#database.run(
-          `
-            DELETE FROM serials
-            WHERE id = ?
-          `,
-          [serialId],
-        );
-      });
-
-      await rm(this.#fragments.getSerial(serialId).path, {
-        force: true,
-        recursive: true,
-      });
-
-      try {
-        await unlink(this.#getSummaryPath(serialId));
-      } catch (error) {
-        if (isNodeError(error) && error.code === "ENOENT") {
-          continue;
-        }
-
-        throw error;
-      }
+      await this.#deleteSerialResources(serialId);
     }
+  }
+
+  async #deleteSerialResources(serialId: number): Promise<void> {
+    await this.#deleteSerialGraphRecords(serialId);
+    await this.#database.transaction(async () => {
+      await this.#database.run(
+        `
+          DELETE FROM serial_states
+          WHERE serial_id = ?
+        `,
+        [serialId],
+      );
+      await this.#database.run(
+        `
+          DELETE FROM serials
+          WHERE id = ?
+        `,
+        [serialId],
+      );
+    });
+
+    await rm(this.#fragments.getSerial(serialId).path, {
+      force: true,
+      recursive: true,
+    });
+    await this.deleteSummary(serialId);
+  }
+
+  async #deleteSerialGraphRecords(serialId: number): Promise<void> {
+    await this.#database.transaction(async () => {
+      await this.#database.run(
+        `
+          DELETE FROM snake_edges
+          WHERE from_snake_id IN (
+            SELECT id
+            FROM snakes
+            WHERE serial_id = ?
+          ) OR to_snake_id IN (
+            SELECT id
+            FROM snakes
+            WHERE serial_id = ?
+          )
+        `,
+        [serialId, serialId],
+      );
+      await this.#database.run(
+        `
+          DELETE FROM snake_chunks
+          WHERE snake_id IN (
+            SELECT id
+            FROM snakes
+            WHERE serial_id = ?
+          )
+        `,
+        [serialId],
+      );
+      await this.#database.run(
+        `
+          DELETE FROM snakes
+          WHERE serial_id = ?
+        `,
+        [serialId],
+      );
+      await this.#database.run(
+        `
+          DELETE FROM fragment_groups
+          WHERE serial_id = ?
+        `,
+        [serialId],
+      );
+      await this.#database.run(
+        `
+          DELETE FROM knowledge_edges
+          WHERE from_id IN (
+            SELECT id
+            FROM chunks
+            WHERE serial_id = ?
+          ) OR to_id IN (
+            SELECT id
+            FROM chunks
+            WHERE serial_id = ?
+          )
+        `,
+        [serialId, serialId],
+      );
+      await this.#database.run(
+        `
+          DELETE FROM chunk_sentences
+          WHERE serial_id = ?
+        `,
+        [serialId],
+      );
+      await this.#database.run(
+        `
+          DELETE FROM chunks
+          WHERE serial_id = ?
+        `,
+        [serialId],
+      );
+    });
   }
 
   async #readJsonFile<T>(
@@ -444,23 +484,35 @@ export class DirectoryDocument implements Document {
     }
   }
 
-  async #writeJsonFile(path: string, value: unknown): Promise<void> {
-    await this.#writeNewFile(path, `${JSON.stringify(value, null, 2)}\n`);
+  async #writeJsonFile(
+    path: string,
+    value: unknown,
+    options: { readonly overwrite?: boolean } = {},
+  ): Promise<void> {
+    await this.#writeFile(path, `${JSON.stringify(value, null, 2)}\n`, options);
   }
 
   async #writeNewFile(
     path: string,
     content: string | Uint8Array,
   ): Promise<void> {
+    await this.#writeFile(path, content, { overwrite: false });
+  }
+
+  async #writeFile(
+    path: string,
+    content: string | Uint8Array,
+    options: { readonly overwrite?: boolean },
+  ): Promise<void> {
     try {
       if (typeof content === "string") {
         await writeFile(path, content, {
           encoding: "utf8",
-          flag: "wx",
+          flag: options.overwrite === true ? "w" : "wx",
         });
       } else {
         await writeFile(path, content, {
-          flag: "wx",
+          flag: options.overwrite === true ? "w" : "wx",
         });
       }
     } catch (error) {
@@ -471,7 +523,9 @@ export class DirectoryDocument implements Document {
       throw error;
     }
 
-    this.#contextScope.getStore()?.registerCreatedFile(path);
+    if (options.overwrite !== true) {
+      this.#contextScope.getStore()?.registerCreatedFile(path);
+    }
   }
 
   #getSummariesPath(): string {

--- a/src/document/stores.ts
+++ b/src/document/stores.ts
@@ -174,15 +174,15 @@ export class SerialStore implements ReadonlySerialStore {
     return maxId ?? 0;
   }
 
-  public async setTopologyReady(serialId: number): Promise<void> {
+  public async setTopologyReady(serialId: number, ready = true): Promise<void> {
     await this.ensure(serialId);
     await this.#database.run(
       `
         UPDATE serial_states
-        SET topology_ready = 1
+        SET topology_ready = ?
         WHERE serial_id = ?
       `,
-      [serialId],
+      [ready ? 1 : 0, serialId],
     );
   }
 

--- a/src/facade/app.ts
+++ b/src/facade/app.ts
@@ -28,6 +28,7 @@ import {
 import { createDefaultSpineDigestSampling } from "./llm-sampling.js";
 import { SpineDigestFile } from "./spine-digest-file.js";
 import type { SpineDigest } from "./spine-digest.js";
+import type { ChapterStage } from "./chapter.js";
 
 const DATA_DIR_PATH = resolveDataDirPath();
 
@@ -59,6 +60,7 @@ export interface SpineDigestSourceSessionOptions extends DigestDocumentSessionOp
   readonly extractionPrompt?: string;
   readonly onProgress?: SpineDigestProgressCallback;
   readonly path: string;
+  readonly targetStage?: ChapterStage;
   readonly userLanguage?: Language;
 }
 
@@ -68,6 +70,7 @@ export interface SpineDigestTextStreamSessionOptions extends DigestDocumentSessi
   readonly onProgress?: SpineDigestProgressCallback;
   readonly sourceFormat?: "markdown" | "txt";
   readonly stream: AsyncIterable<string> | Iterable<string>;
+  readonly targetStage?: ChapterStage;
   readonly title?: string | null;
   readonly userLanguage?: Language;
 }
@@ -133,7 +136,7 @@ export class SpineDigestApp {
         await digestTextStreamSession(
           {
             extractionPrompt: resolveExtractionPrompt(options.extractionPrompt),
-            llm: this.#requireLLM(),
+            ...optionalLLM(this.#resolveStageLLM(options.targetStage)),
             ...(options.onProgress === undefined
               ? {}
               : { onProgress: options.onProgress }),
@@ -150,6 +153,9 @@ export class SpineDigestApp {
             ...(options.sourceFormat === undefined
               ? {}
               : { sourceFormat: options.sourceFormat }),
+            ...(options.targetStage === undefined
+              ? {}
+              : { targetStage: options.targetStage }),
             ...(options.title === undefined ? {} : { title: options.title }),
             ...(options.userLanguage === undefined
               ? {}
@@ -192,7 +198,7 @@ export class SpineDigestApp {
   ): DigestSourceSessionOptions {
     return {
       extractionPrompt: resolveExtractionPrompt(options.extractionPrompt),
-      llm: this.#requireLLM(),
+      ...optionalLLM(this.#resolveStageLLM(options.targetStage)),
       ...(options.onProgress === undefined
         ? {}
         : { onProgress: options.onProgress }),
@@ -203,6 +209,9 @@ export class SpineDigestApp {
       ...(options.documentDirPath === undefined
         ? {}
         : { documentDirPath: options.documentDirPath }),
+      ...(options.targetStage === undefined
+        ? {}
+        : { targetStage: options.targetStage }),
       ...(options.userLanguage === undefined
         ? {}
         : { userLanguage: options.userLanguage }),
@@ -217,6 +226,16 @@ export class SpineDigestApp {
     }
 
     return this.#llm;
+  }
+
+  #resolveStageLLM(
+    targetStage: ChapterStage | undefined,
+  ): LLM<SpineDigestScope> | undefined {
+    if (targetStage === "planned" || targetStage === "sourced") {
+      return undefined;
+    }
+
+    return this.#requireLLM();
   }
 
   async #withLogging<T>(operation: string, task: () => Promise<T>): Promise<T> {
@@ -243,6 +262,12 @@ export type {
   SpineDigestProgressEventType,
   SpineDigestOperation,
 };
+
+function optionalLLM(
+  llm: LLM<SpineDigestScope> | undefined,
+): { readonly llm: LLM<SpineDigestScope> } | Record<string, never> {
+  return llm === undefined ? {} : { llm };
+}
 
 function normalizeLLMOptions(
   llm: NonNullable<SpineDigestAppOptions["llm"]>,

--- a/src/facade/archive.ts
+++ b/src/facade/archive.ts
@@ -1,5 +1,5 @@
 import { createWriteStream } from "fs";
-import { mkdir, readdir } from "fs/promises";
+import { mkdir, readFile, readdir } from "fs/promises";
 import { dirname, join, posix, relative, resolve, sep } from "path";
 import { finished, pipeline } from "stream/promises";
 
@@ -11,7 +11,7 @@ import {
 } from "yauzl";
 import { ZipFile as YazlZipFile } from "yazl";
 
-const SDPUB_FORMAT_VERSION = 1;
+export const SDPUB_FORMAT_VERSION = 1;
 const SDPUB_MANIFEST_PATH = "manifest.json";
 const SDPUB_MANIFEST_CONTENT = `${JSON.stringify({
   formatVersion: SDPUB_FORMAT_VERSION,
@@ -96,6 +96,22 @@ export async function writeSdpubArchive(
   await Promise.all([outputDone, zipDone]);
 }
 
+export async function readSdpubArchiveFormatVersion(
+  documentDirectoryPath: string,
+): Promise<number> {
+  try {
+    return parseSdpubManifest(
+      await readFile(join(documentDirectoryPath, SDPUB_MANIFEST_PATH), "utf8"),
+    ).formatVersion;
+  } catch (error) {
+    if (isFileMissingError(error)) {
+      return SDPUB_FORMAT_VERSION;
+    }
+
+    throw error;
+  }
+}
+
 async function listDocumentFiles(
   rootDirectoryPath: string,
   currentDirectoryPath = rootDirectoryPath,
@@ -175,8 +191,20 @@ async function validateArchiveManifest(
     return;
   }
 
-  const content = await readArchiveEntryText(zipFile, entry);
-  const parsed: unknown = JSON.parse(content);
+  parseSdpubManifest(await readArchiveEntryText(zipFile, entry));
+}
+
+function parseSdpubManifest(
+  content: string,
+): z.infer<typeof sdpubManifestSchema> {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    throw new Error(`Invalid SDPUB manifest: ${SDPUB_MANIFEST_PATH}.`);
+  }
+
   const result = sdpubManifestSchema.safeParse(parsed);
 
   if (!result.success) {
@@ -184,6 +212,8 @@ async function validateArchiveManifest(
       `Unsupported SDPUB format version in ${SDPUB_MANIFEST_PATH}.`,
     );
   }
+
+  return result.data;
 }
 
 function assertWithinDirectory(
@@ -261,4 +291,10 @@ async function readArchiveEntryText(
   }
 
   return Buffer.concat(chunks).toString("utf8");
+}
+
+function isFileMissingError(error: unknown): boolean {
+  return (
+    error instanceof Error && (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
 }

--- a/src/facade/archive.ts
+++ b/src/facade/archive.ts
@@ -3,6 +3,7 @@ import { mkdir, readdir } from "fs/promises";
 import { dirname, join, posix, relative, resolve, sep } from "path";
 import { finished, pipeline } from "stream/promises";
 
+import { z } from "zod";
 import {
   open as openZip,
   type Entry,
@@ -10,7 +11,14 @@ import {
 } from "yauzl";
 import { ZipFile as YazlZipFile } from "yazl";
 
+const SDPUB_FORMAT_VERSION = 1;
+const SDPUB_MANIFEST_PATH = "manifest.json";
+const SDPUB_MANIFEST_CONTENT = `${JSON.stringify({
+  formatVersion: SDPUB_FORMAT_VERSION,
+})}\n`;
+
 const SDPUB_ARCHIVE_PATTERNS = [
+  /^manifest\.json$/u,
   /^database\.db$/u,
   /^book-meta\.json$/u,
   /^toc\.json$/u,
@@ -18,6 +26,10 @@ const SDPUB_ARCHIVE_PATTERNS = [
   /^summaries\/serial-\d+\.txt$/u,
   /^fragments\/serial-\d+\/fragment_\d+\.json$/u,
 ] as const;
+
+const sdpubManifestSchema = z.object({
+  formatVersion: z.literal(SDPUB_FORMAT_VERSION),
+});
 
 export async function extractSdpubArchive(
   inputPath: string,
@@ -27,6 +39,8 @@ export async function extractSdpubArchive(
   const entries = await indexArchiveEntries(zipFile);
 
   try {
+    await validateArchiveManifest(zipFile, entries);
+
     for (const entry of entries) {
       const archivePath = normalizeArchivePath(entry.fileName);
 
@@ -56,9 +70,20 @@ export async function writeSdpubArchive(
 
   const zipFile = new YazlZipFile();
   const files = await listDocumentFiles(documentDirectoryPath);
+  const entries = [
+    ...files.filter((file) => file.archivePath !== SDPUB_MANIFEST_PATH),
+    {
+      archivePath: SDPUB_MANIFEST_PATH,
+      content: Buffer.from(SDPUB_MANIFEST_CONTENT, "utf8"),
+    },
+  ].sort((left, right) => left.archivePath.localeCompare(right.archivePath));
 
-  for (const file of files) {
-    zipFile.addFile(file.absolutePath, file.archivePath);
+  for (const entry of entries) {
+    if ("content" in entry) {
+      zipFile.addBuffer(entry.content, entry.archivePath);
+    } else {
+      zipFile.addFile(entry.absolutePath, entry.archivePath);
+    }
   }
 
   zipFile.end();
@@ -137,6 +162,30 @@ function isSdpubArchivePath(archivePath: string): boolean {
   return SDPUB_ARCHIVE_PATTERNS.some((pattern) => pattern.test(archivePath));
 }
 
+async function validateArchiveManifest(
+  zipFile: YauzlZipFile,
+  entries: readonly Entry[],
+): Promise<void> {
+  const entry = entries.find(
+    (candidate) =>
+      normalizeArchivePath(candidate.fileName) === SDPUB_MANIFEST_PATH,
+  );
+
+  if (entry === undefined) {
+    return;
+  }
+
+  const content = await readArchiveEntryText(zipFile, entry);
+  const parsed: unknown = JSON.parse(content);
+  const result = sdpubManifestSchema.safeParse(parsed);
+
+  if (!result.success) {
+    throw new Error(
+      `Unsupported SDPUB format version in ${SDPUB_MANIFEST_PATH}.`,
+    );
+  }
+}
+
 function assertWithinDirectory(
   rootDirectoryPath: string,
   targetPath: string,
@@ -198,4 +247,18 @@ async function openArchiveEntryStream(
       resolve(stream);
     });
   });
+}
+
+async function readArchiveEntryText(
+  zipFile: YauzlZipFile,
+  entry: Entry,
+): Promise<string> {
+  const chunks: Buffer[] = [];
+  const stream = await openArchiveEntryStream(zipFile, entry);
+
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  return Buffer.concat(chunks).toString("utf8");
 }

--- a/src/facade/chapter.ts
+++ b/src/facade/chapter.ts
@@ -34,6 +34,21 @@ export interface ChapterDetails extends ChapterEntry {
   readonly hasSummary: boolean;
 }
 
+export interface AdvanceChapterStagesOptions {
+  readonly chapterId?: number;
+  readonly extractionPrompt: string;
+  readonly llm: LLM<SpineDigestScope>;
+  readonly logDirPath?: string;
+  readonly targetStage: ChapterStage;
+  readonly userLanguage?: Language;
+}
+
+export interface AdvanceChapterStagesResult {
+  readonly advanced: readonly ChapterEntry[];
+  readonly pending: readonly ChapterEntry[];
+  readonly skipped: readonly ChapterEntry[];
+}
+
 export interface AddChapterOptions {
   readonly parentChapterId?: number;
   readonly title?: string | null | undefined;
@@ -50,6 +65,48 @@ export interface GenerateChapterSummaryOptions {
   readonly llm: LLM<SpineDigestScope>;
   readonly logDirPath?: string;
   readonly userLanguage?: Language;
+}
+
+export async function advanceChapterStages(
+  document: Document,
+  options: AdvanceChapterStagesOptions,
+): Promise<AdvanceChapterStagesResult> {
+  if (options.targetStage === "planned") {
+    return {
+      advanced: [],
+      pending: await selectChapterEntries(document, options.chapterId),
+      skipped: [],
+    };
+  }
+
+  const advancedIds = new Set<number>();
+  const entries = await selectChapterEntries(document, options.chapterId);
+
+  if (isStageBefore("sourced", options.targetStage)) {
+    await advanceEntriesToGraphed(document, entries, options, {
+      advancedIds,
+    });
+  }
+  if (isStageBefore("graphed", options.targetStage)) {
+    const graphedEntries = await selectChapterEntries(
+      document,
+      options.chapterId,
+    );
+
+    await advanceEntriesToSummarized(document, graphedEntries, options, {
+      advancedIds,
+    });
+  }
+
+  const nextEntries = await selectChapterEntries(document, options.chapterId);
+
+  return {
+    advanced: nextEntries.filter((entry) => advancedIds.has(entry.chapterId)),
+    pending: nextEntries.filter((entry) =>
+      isStageBefore(entry.stage, options.targetStage),
+    ),
+    skipped: nextEntries.filter((entry) => entry.stage === "planned"),
+  };
 }
 
 export async function addChapter(
@@ -335,6 +392,120 @@ async function collectChapterEntries(
   return entries;
 }
 
+async function advanceEntriesToGraphed(
+  document: Document,
+  entries: readonly ChapterEntry[],
+  options: AdvanceChapterStagesOptions,
+  state: { readonly advancedIds: Set<number> },
+): Promise<readonly ChapterEntry[]> {
+  for (const entry of entries) {
+    if (entry.stage !== "sourced") {
+      continue;
+    }
+
+    await generateChapterGraph(document, entry.chapterId, {
+      extractionPrompt: options.extractionPrompt,
+      llm: options.llm,
+      ...(options.logDirPath === undefined
+        ? {}
+        : { logDirPath: options.logDirPath }),
+      ...(options.userLanguage === undefined
+        ? {}
+        : { userLanguage: options.userLanguage }),
+    });
+    state.advancedIds.add(entry.chapterId);
+  }
+
+  return await selectChapterEntries(document, options.chapterId);
+}
+
+async function advanceEntriesToSummarized(
+  document: Document,
+  entries: readonly ChapterEntry[],
+  options: AdvanceChapterStagesOptions,
+  state: { readonly advancedIds: Set<number> },
+): Promise<readonly ChapterEntry[]> {
+  for (const entry of entries) {
+    if (entry.stage !== "graphed") {
+      continue;
+    }
+
+    await generateChapterSummary(document, entry.chapterId, {
+      llm: options.llm,
+      ...(options.logDirPath === undefined
+        ? {}
+        : { logDirPath: options.logDirPath }),
+      ...(options.userLanguage === undefined
+        ? {}
+        : { userLanguage: options.userLanguage }),
+    });
+    state.advancedIds.add(entry.chapterId);
+  }
+
+  return await selectChapterEntries(document, options.chapterId);
+}
+
+async function selectChapterEntries(
+  document: Document,
+  chapterId: number | undefined,
+): Promise<readonly ChapterEntry[]> {
+  const entries = await listChapters(document);
+
+  if (chapterId === undefined) {
+    return entries;
+  }
+
+  const selectedIds = await collectChapterSubtreeIds(document, chapterId);
+
+  if (selectedIds.size === 0) {
+    throw new Error(`Chapter ${chapterId} does not exist.`);
+  }
+
+  return entries.filter((entry) => selectedIds.has(entry.chapterId));
+}
+
+async function collectChapterSubtreeIds(
+  document: Document,
+  chapterId: number,
+): Promise<ReadonlySet<number>> {
+  const toc = await normalizeChapterToc(document);
+  const selectedIds = new Set<number>();
+
+  for (const item of toc.items) {
+    if (collectChapterSubtreeIdsFromItem(item, chapterId, selectedIds)) {
+      break;
+    }
+  }
+
+  return selectedIds;
+}
+
+function collectChapterSubtreeIdsFromItem(
+  item: TocItem,
+  chapterId: number,
+  selectedIds: Set<number>,
+): boolean {
+  if (item.serialId === chapterId) {
+    collectChapterIds(item, selectedIds);
+    return true;
+  }
+
+  for (const child of item.children) {
+    if (collectChapterSubtreeIdsFromItem(child, chapterId, selectedIds)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isStageBefore(
+  stage: ChapterStage,
+  targetStage: ChapterStage,
+): boolean {
+  return CHAPTER_STAGES.indexOf(stage) < CHAPTER_STAGES.indexOf(targetStage);
+}
+
 async function resolveChapterStage(
   document: Document,
   chapterId: number,
@@ -468,9 +639,16 @@ function removeChapterFromItems(
   };
 }
 
-function collectChapterIds(item: TocItem, chapterIds: number[]): void {
+function collectChapterIds(
+  item: TocItem,
+  chapterIds: number[] | Set<number>,
+): void {
   if (item.serialId !== undefined) {
-    chapterIds.push(item.serialId);
+    if (Array.isArray(chapterIds)) {
+      chapterIds.push(item.serialId);
+    } else {
+      chapterIds.add(item.serialId);
+    }
   }
 
   for (const child of item.children) {

--- a/src/facade/chapter.ts
+++ b/src/facade/chapter.ts
@@ -1,0 +1,493 @@
+import type { Document } from "../document/index.js";
+import type { Language } from "../common/language.js";
+import type { SpineDigestScope } from "../common/llm-scope.js";
+import type { LLM } from "../llm/index.js";
+import type { ReaderTextStream } from "../reader/index.js";
+import {
+  SerialGeneration,
+  writeSerialSource,
+  type BuildSerialTopologyOptions,
+} from "../serial.js";
+import { TOC_FILE_VERSION, type TocItem } from "../source/index.js";
+
+export const CHAPTER_STAGES = [
+  "planned",
+  "sourced",
+  "graphed",
+  "summarized",
+] as const;
+
+export type ChapterStage = (typeof CHAPTER_STAGES)[number];
+
+export interface ChapterEntry {
+  readonly chapterId: number;
+  readonly childCount: number;
+  readonly depth: number;
+  readonly fragmentCount: number;
+  readonly stage: ChapterStage;
+  readonly title: string;
+  readonly tocPath: readonly string[];
+}
+
+export interface ChapterDetails extends ChapterEntry {
+  readonly graphReady: boolean;
+  readonly hasSummary: boolean;
+}
+
+export interface AddChapterOptions {
+  readonly parentChapterId?: number;
+  readonly title: string;
+}
+
+export interface GenerateChapterGraphOptions {
+  readonly extractionPrompt: string;
+  readonly llm: LLM<SpineDigestScope>;
+  readonly logDirPath?: string;
+  readonly userLanguage?: Language;
+}
+
+export interface GenerateChapterSummaryOptions {
+  readonly llm: LLM<SpineDigestScope>;
+  readonly logDirPath?: string;
+  readonly userLanguage?: Language;
+}
+
+export async function addChapter(
+  document: Document,
+  options: AddChapterOptions,
+): Promise<ChapterDetails> {
+  return await document.openSession(async (openedDocument) => {
+    const toc = await normalizeChapterToc(openedDocument);
+    const normalizedTitle = normalizeTitle(options.title);
+
+    if (normalizedTitle === undefined) {
+      throw new Error("Chapter title is required.");
+    }
+
+    const chapterId = await openedDocument.createSerial();
+    const chapterItem = {
+      children: [],
+      serialId: chapterId,
+      title: normalizedTitle,
+    } satisfies TocItem;
+
+    if (options.parentChapterId === undefined) {
+      toc.items = [...toc.items, chapterItem];
+    } else if (
+      !appendChildToChapter(toc.items, options.parentChapterId, chapterItem)
+    ) {
+      throw new Error(`Chapter ${options.parentChapterId} does not exist.`);
+    }
+
+    await openedDocument.replaceToc(toc);
+    return await getChapterDetails(openedDocument, chapterId);
+  });
+}
+
+export async function generateChapterGraph(
+  document: Document,
+  chapterId: number,
+  options: GenerateChapterGraphOptions,
+): Promise<ChapterDetails> {
+  return await document.openSession(async (openedDocument) => {
+    const details = await requireChapterDetails(openedDocument, chapterId);
+
+    if (details.stage !== "sourced") {
+      throw new Error(
+        `Chapter ${chapterId} is ${details.stage}. Generate a graph only for sourced chapters.`,
+      );
+    }
+
+    const generation = new SerialGeneration({
+      document: openedDocument,
+      llm: options.llm,
+      ...(options.logDirPath === undefined
+        ? {}
+        : { logDirPath: options.logDirPath }),
+    });
+
+    await generation.buildTopologyInto(
+      chapterId,
+      readChapterSource(openedDocument, chapterId),
+      createTopologyOptions(options),
+    );
+    return await getChapterDetails(openedDocument, chapterId);
+  });
+}
+
+export async function generateChapterSummary(
+  document: Document,
+  chapterId: number,
+  options: GenerateChapterSummaryOptions,
+): Promise<ChapterDetails> {
+  return await document.openSession(async (openedDocument) => {
+    const details = await requireChapterDetails(openedDocument, chapterId);
+
+    if (details.stage !== "graphed") {
+      throw new Error(
+        `Chapter ${chapterId} is ${details.stage}. Generate a summary only for graphed chapters.`,
+      );
+    }
+
+    const generation = new SerialGeneration({
+      document: openedDocument,
+      llm: options.llm,
+      ...(options.logDirPath === undefined
+        ? {}
+        : { logDirPath: options.logDirPath }),
+    });
+
+    await generation.buildSummary(chapterId, {
+      ...(options.userLanguage === undefined
+        ? {}
+        : { userLanguage: options.userLanguage }),
+    });
+    return await getChapterDetails(openedDocument, chapterId);
+  });
+}
+
+export async function getChapterDetails(
+  document: Document,
+  chapterId: number,
+): Promise<ChapterDetails> {
+  const entries = await listChapters(document);
+  const entry = entries.find((item) => item.chapterId === chapterId);
+
+  if (entry === undefined) {
+    throw new Error(`Chapter ${chapterId} does not exist.`);
+  }
+
+  const serial = await document.serials.getById(chapterId);
+  const summary = await document.readSummary(chapterId);
+
+  return {
+    ...entry,
+    graphReady: serial?.topologyReady === true,
+    hasSummary: summary !== undefined,
+  };
+}
+
+export async function listChapters(
+  document: Document,
+): Promise<readonly ChapterEntry[]> {
+  const toc = await normalizeChapterToc(document);
+
+  return await collectChapterEntries(document, toc.items);
+}
+
+export async function removeChapter(
+  document: Document,
+  chapterId: number,
+  options: { readonly recursive?: boolean } = {},
+): Promise<void> {
+  await document.openSession(async (openedDocument) => {
+    const toc = await normalizeChapterToc(openedDocument);
+    const removedChapterIds: number[] = [];
+    const result = removeChapterFromItems(toc.items, chapterId, {
+      recursive: options.recursive ?? false,
+      removedChapterIds,
+    });
+
+    if (!result.removed) {
+      throw new Error(`Chapter ${chapterId} does not exist.`);
+    }
+
+    toc.items = result.items;
+    await openedDocument.replaceToc(toc);
+
+    for (const removedChapterId of removedChapterIds) {
+      await openedDocument.deleteSerial(removedChapterId);
+    }
+  });
+}
+
+export async function resetChapter(
+  document: Document,
+  chapterId: number,
+  stage: Exclude<ChapterStage, "summarized">,
+): Promise<ChapterDetails> {
+  return await document.openSession(async (openedDocument) => {
+    await requireChapterDetails(openedDocument, chapterId);
+
+    switch (stage) {
+      case "planned":
+        await openedDocument.clearSerialSource(chapterId);
+        break;
+      case "sourced":
+        await openedDocument.clearSerialGraph(chapterId);
+        break;
+      case "graphed":
+        await openedDocument.deleteSummary(chapterId);
+        break;
+    }
+
+    return await getChapterDetails(openedDocument, chapterId);
+  });
+}
+
+export async function setChapterSource(
+  document: Document,
+  chapterId: number,
+  stream: ReaderTextStream,
+): Promise<ChapterDetails> {
+  return await document.openSession(async (openedDocument) => {
+    const details = await requireChapterDetails(openedDocument, chapterId);
+
+    if (details.stage !== "planned") {
+      throw new Error(
+        `Chapter ${chapterId} is ${details.stage}. Reset it to planned before setting source.`,
+      );
+    }
+
+    await writeSerialSource(openedDocument, chapterId, stream);
+    return await getChapterDetails(openedDocument, chapterId);
+  });
+}
+
+export async function setChapterSummary(
+  document: Document,
+  chapterId: number,
+  summary: string,
+): Promise<ChapterDetails> {
+  return await document.openSession(async (openedDocument) => {
+    const details = await requireChapterDetails(openedDocument, chapterId);
+
+    if (details.stage !== "graphed") {
+      throw new Error(
+        `Chapter ${chapterId} is ${details.stage}. Set a summary only for graphed chapters.`,
+      );
+    }
+
+    await openedDocument.writeSummary(chapterId, summary);
+    return await getChapterDetails(openedDocument, chapterId);
+  });
+}
+
+async function normalizeChapterToc(
+  document: Document,
+): Promise<MutableTocFile> {
+  const existingToc = await document.readToc();
+  const toc: MutableTocFile =
+    existingToc === undefined
+      ? { items: [], version: TOC_FILE_VERSION }
+      : {
+          items: existingToc.items.map(cloneTocItem),
+          version: existingToc.version,
+        };
+  let changed = false;
+
+  const normalizeItems = async (items: MutableTocItem[]): Promise<void> => {
+    for (const item of items) {
+      if (item.serialId === undefined) {
+        item.serialId = await document.createSerial();
+        changed = true;
+      } else {
+        await document.serials.ensure(item.serialId);
+      }
+
+      await normalizeItems(item.children);
+    }
+  };
+
+  await normalizeItems(toc.items);
+
+  if (existingToc === undefined || changed) {
+    await document.replaceToc(toc);
+  }
+
+  return toc;
+}
+
+async function collectChapterEntries(
+  document: Document,
+  items: readonly TocItem[],
+  ancestorTitles: readonly string[] = [],
+  depth = 0,
+): Promise<ChapterEntry[]> {
+  const entries: ChapterEntry[] = [];
+
+  for (const item of items) {
+    if (item.serialId === undefined) {
+      continue;
+    }
+
+    const tocPath = [...ancestorTitles, item.title];
+    const fragmentCount = (
+      await document.getSerialFragments(item.serialId).listFragmentIds()
+    ).length;
+
+    entries.push({
+      chapterId: item.serialId,
+      childCount: item.children.length,
+      depth,
+      fragmentCount,
+      stage: await resolveChapterStage(document, item.serialId, fragmentCount),
+      title: item.title,
+      tocPath,
+    });
+    entries.push(
+      ...(await collectChapterEntries(
+        document,
+        item.children,
+        tocPath,
+        depth + 1,
+      )),
+    );
+  }
+
+  return entries;
+}
+
+async function resolveChapterStage(
+  document: Document,
+  chapterId: number,
+  fragmentCount: number,
+): Promise<ChapterStage> {
+  const summary = await document.readSummary(chapterId);
+
+  if (summary !== undefined) {
+    return "summarized";
+  }
+
+  const serial = await document.serials.getById(chapterId);
+
+  if (serial?.topologyReady === true) {
+    return "graphed";
+  }
+
+  if (fragmentCount > 0) {
+    return "sourced";
+  }
+
+  return "planned";
+}
+
+async function requireChapterDetails(
+  document: Document,
+  chapterId: number,
+): Promise<ChapterDetails> {
+  return await getChapterDetails(document, chapterId);
+}
+
+function appendChildToChapter(
+  items: MutableTocItem[],
+  parentChapterId: number,
+  child: MutableTocItem,
+): boolean {
+  for (const item of items) {
+    if (item.serialId === parentChapterId) {
+      item.children = [...item.children, child];
+      return true;
+    }
+
+    if (appendChildToChapter(item.children, parentChapterId, child)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function cloneTocItem(item: TocItem): MutableTocItem {
+  return {
+    children: item.children.map(cloneTocItem),
+    ...(item.serialId === undefined ? {} : { serialId: item.serialId }),
+    title: item.title,
+  };
+}
+
+function createTopologyOptions(
+  options: GenerateChapterGraphOptions,
+): BuildSerialTopologyOptions {
+  return {
+    extractionPrompt: options.extractionPrompt,
+    ...(options.userLanguage === undefined
+      ? {}
+      : { userLanguage: options.userLanguage }),
+  };
+}
+
+async function* readChapterSource(
+  document: Document,
+  chapterId: number,
+): ReaderTextStream {
+  const fragments = document.getSerialFragments(chapterId);
+
+  for (const fragmentId of await fragments.listFragmentIds()) {
+    const fragment = await fragments.getFragment(fragmentId);
+
+    for (const sentence of fragment.sentences) {
+      yield sentence.text;
+    }
+  }
+}
+
+function normalizeTitle(title: string): string | undefined {
+  const normalized = title.trim();
+
+  return normalized === "" ? undefined : normalized;
+}
+
+function removeChapterFromItems(
+  items: readonly MutableTocItem[],
+  chapterId: number,
+  options: {
+    readonly recursive: boolean;
+    readonly removedChapterIds: number[];
+  },
+): { readonly items: MutableTocItem[]; readonly removed: boolean } {
+  const nextItems: MutableTocItem[] = [];
+  let removed = false;
+
+  for (const item of items) {
+    if (item.serialId === chapterId) {
+      if (!options.recursive && item.children.length > 0) {
+        throw new Error(
+          `Chapter ${chapterId} has child chapters. Use --recursive to remove it and its descendants.`,
+        );
+      }
+
+      collectChapterIds(item, options.removedChapterIds);
+      removed = true;
+      continue;
+    }
+
+    const childResult = removeChapterFromItems(
+      item.children,
+      chapterId,
+      options,
+    );
+
+    nextItems.push({
+      ...item,
+      children: childResult.items,
+    });
+    removed ||= childResult.removed;
+  }
+
+  return {
+    items: nextItems,
+    removed,
+  };
+}
+
+function collectChapterIds(item: TocItem, chapterIds: number[]): void {
+  if (item.serialId !== undefined) {
+    chapterIds.push(item.serialId);
+  }
+
+  for (const child of item.children) {
+    collectChapterIds(child, chapterIds);
+  }
+}
+
+interface MutableTocFile {
+  items: MutableTocItem[];
+  version: typeof TOC_FILE_VERSION;
+}
+
+interface MutableTocItem {
+  children: MutableTocItem[];
+  serialId?: number | undefined;
+  title: string;
+}

--- a/src/facade/chapter.ts
+++ b/src/facade/chapter.ts
@@ -25,7 +25,7 @@ export interface ChapterEntry {
   readonly depth: number;
   readonly fragmentCount: number;
   readonly stage: ChapterStage;
-  readonly title: string;
+  readonly title: string | null;
   readonly tocPath: readonly string[];
 }
 
@@ -36,7 +36,7 @@ export interface ChapterDetails extends ChapterEntry {
 
 export interface AddChapterOptions {
   readonly parentChapterId?: number;
-  readonly title: string;
+  readonly title?: string | null | undefined;
 }
 
 export interface GenerateChapterGraphOptions {
@@ -60,15 +60,11 @@ export async function addChapter(
     const toc = await normalizeChapterToc(openedDocument);
     const normalizedTitle = normalizeTitle(options.title);
 
-    if (normalizedTitle === undefined) {
-      throw new Error("Chapter title is required.");
-    }
-
     const chapterId = await openedDocument.createSerial();
     const chapterItem = {
       children: [],
       serialId: chapterId,
-      title: normalizedTitle,
+      ...(normalizedTitle === undefined ? {} : { title: normalizedTitle }),
     } satisfies TocItem;
 
     if (options.parentChapterId === undefined) {
@@ -311,7 +307,8 @@ async function collectChapterEntries(
       continue;
     }
 
-    const tocPath = [...ancestorTitles, item.title];
+    const title = normalizeTitle(item.title) ?? null;
+    const tocPath = [...ancestorTitles, title ?? `Chapter ${item.serialId}`];
     const fragmentCount = (
       await document.getSerialFragments(item.serialId).listFragmentIds()
     ).length;
@@ -322,7 +319,7 @@ async function collectChapterEntries(
       depth,
       fragmentCount,
       stage: await resolveChapterStage(document, item.serialId, fragmentCount),
-      title: item.title,
+      title,
       tocPath,
     });
     entries.push(
@@ -422,10 +419,10 @@ async function* readChapterSource(
   }
 }
 
-function normalizeTitle(title: string): string | undefined {
-  const normalized = title.trim();
+function normalizeTitle(title: string | null | undefined): string | undefined {
+  const normalized = title?.trim();
 
-  return normalized === "" ? undefined : normalized;
+  return normalized === undefined || normalized === "" ? undefined : normalized;
 }
 
 function removeChapterFromItems(
@@ -489,5 +486,5 @@ interface MutableTocFile {
 interface MutableTocItem {
   children: MutableTocItem[];
   serialId?: number | undefined;
-  title: string;
+  title?: string | null | undefined;
 }

--- a/src/facade/digest.ts
+++ b/src/facade/digest.ts
@@ -19,18 +19,20 @@ import {
 } from "../progress/index.js";
 import type { ReaderSegmenter, ReaderTextStream } from "../reader/index.js";
 import type { LLM } from "../llm/index.js";
-import { SerialGeneration } from "../serial.js";
+import { SerialGeneration, writeSerialSource } from "../serial.js";
 
 import { importSource } from "./import.js";
 import { SpineDigest } from "./spine-digest.js";
+import type { ChapterStage } from "./chapter.js";
 
 interface DigestSessionOptions {
   readonly documentDirPath?: string;
   readonly extractionPrompt: string;
-  readonly llm: LLM<SpineDigestScope>;
+  readonly llm?: LLM<SpineDigestScope>;
   readonly logDirPath?: string;
   readonly onProgress?: SpineDigestProgressCallback;
   readonly segmenter?: ReaderSegmenter;
+  readonly targetStage?: ChapterStage;
   readonly userLanguage?: Language;
 }
 
@@ -88,32 +90,60 @@ export async function digestTextStreamSession<T>(
     await document.openSession(async (openedDocument) => {
       const serialId = await openedDocument.peekNextSerialId();
       const normalizedTitle = normalizeTitle(options.title);
-      const serialProgressTracker = progressTracker.createSerialTracker({
-        id: serialId,
-      });
+      const targetStage = options.targetStage ?? "summarized";
       await progressTracker.markDiscoveryUnavailable();
 
-      const generation = new SerialGeneration({
-        document: openedDocument,
-        llm: options.llm,
-        ...(options.logDirPath === undefined
-          ? {}
-          : { logDirPath: options.logDirPath }),
-        ...(options.segmenter === undefined
-          ? {}
-          : { segmenter: options.segmenter }),
-      });
-      const serial = await generation.generateInto(
-        serialId,
-        options.stream,
-        {
-          extractionPrompt: options.extractionPrompt,
-          ...(options.userLanguage === undefined
+      if (targetStage === "planned") {
+        await openedDocument.serials.createWithId(serialId);
+      } else if (targetStage === "sourced") {
+        await openedDocument.serials.createWithId(serialId);
+        await writeSerialSource(openedDocument, serialId, options.stream, {
+          ...(options.segmenter === undefined
             ? {}
-            : { userLanguage: options.userLanguage }),
-        },
-        serialProgressTracker,
-      );
+            : { segmenter: options.segmenter }),
+        });
+      } else {
+        const serialProgressTracker = progressTracker.createSerialTracker({
+          id: serialId,
+        });
+        const generation = new SerialGeneration({
+          document: openedDocument,
+          llm: requireDigestLLM(options.llm, targetStage),
+          ...(options.logDirPath === undefined
+            ? {}
+            : { logDirPath: options.logDirPath }),
+          ...(options.segmenter === undefined
+            ? {}
+            : { segmenter: options.segmenter }),
+        });
+
+        if (targetStage === "graphed") {
+          await openedDocument.serials.createWithId(serialId);
+          await generation.buildTopologyInto(
+            serialId,
+            options.stream,
+            {
+              extractionPrompt: options.extractionPrompt,
+              ...(options.userLanguage === undefined
+                ? {}
+                : { userLanguage: options.userLanguage }),
+            },
+            serialProgressTracker,
+          );
+        } else {
+          await generation.generateInto(
+            serialId,
+            options.stream,
+            {
+              extractionPrompt: options.extractionPrompt,
+              ...(options.userLanguage === undefined
+                ? {}
+                : { userLanguage: options.userLanguage }),
+            },
+            serialProgressTracker,
+          );
+        }
+      }
 
       await openedDocument.writeBookMeta({
         version: BOOK_META_VERSION,
@@ -130,7 +160,7 @@ export async function digestTextStreamSession<T>(
         version: TOC_FILE_VERSION,
         items: [
           {
-            serialId: serial.id,
+            serialId,
             children: [],
             ...(normalizedTitle === undefined
               ? {}
@@ -175,8 +205,11 @@ async function digestSourceSession<T>(
       document,
       digestProgressTracker: progressTracker,
       extractionPrompt: options.extractionPrompt,
-      llm: options.llm,
+      ...(options.llm === undefined ? {} : { llm: options.llm }),
       path: options.path,
+      ...(options.targetStage === undefined
+        ? {}
+        : { targetStage: options.targetStage }),
       ...(options.logDirPath === undefined
         ? {}
         : { logDirPath: options.logDirPath }),
@@ -219,4 +252,15 @@ function normalizeTitle(title: string | null | undefined): string | undefined {
   const normalized = title?.trim();
 
   return normalized === undefined || normalized === "" ? undefined : normalized;
+}
+
+function requireDigestLLM(
+  llm: LLM<SpineDigestScope> | undefined,
+  targetStage: ChapterStage,
+): LLM<SpineDigestScope> {
+  if (llm === undefined) {
+    throw new Error(`LLM is required to digest source to ${targetStage}.`);
+  }
+
+  return llm;
 }

--- a/src/facade/digest.ts
+++ b/src/facade/digest.ts
@@ -87,7 +87,7 @@ export async function digestTextStreamSession<T>(
   return await withTemporaryDocumentSession(async (document, directoryPath) => {
     await document.openSession(async (openedDocument) => {
       const serialId = await openedDocument.peekNextSerialId();
-      const normalizedTitle = normalizeTitle(options.title) ?? "Section 1";
+      const normalizedTitle = normalizeTitle(options.title);
       const serialProgressTracker = progressTracker.createSerialTracker({
         id: serialId,
       });
@@ -130,9 +130,11 @@ export async function digestTextStreamSession<T>(
         version: TOC_FILE_VERSION,
         items: [
           {
-            title: normalizedTitle,
             serialId: serial.id,
             children: [],
+            ...(normalizedTitle === undefined
+              ? {}
+              : { title: normalizedTitle }),
           },
         ],
       });

--- a/src/facade/import.ts
+++ b/src/facade/import.ts
@@ -5,8 +5,8 @@ import {
   SerialGeneration,
   discoverSerial,
   type GenerateSerialOptions,
-  type Serial,
   type SerialGenerationOptions,
+  writeSerialSource,
 } from "../serial.js";
 import {
   TOC_FILE_VERSION,
@@ -18,21 +18,32 @@ import {
   type TocFile,
   type TocItem,
 } from "../source/index.js";
+import type { ChapterStage } from "./chapter.js";
 
 export interface ImportSourceOptions
-  extends GenerateSerialOptions, Omit<SerialGenerationOptions, "document"> {
+  extends
+    GenerateSerialOptions,
+    Omit<SerialGenerationOptions, "document" | "llm"> {
   readonly adapter: SourceAdapter;
   readonly digestProgressTracker?: DigestProgressTracker;
   readonly document: Document;
+  readonly llm?: SerialGenerationOptions["llm"];
   readonly path: string;
+  readonly targetStage?: ImportSourceStage;
 }
 
 export interface ImportedSource {
   readonly cover: SourceAsset | undefined;
   readonly meta: BookMeta;
-  readonly serials: readonly Serial[];
+  readonly serials: readonly ImportedSerial[];
   readonly toc: TocFile;
 }
+
+export interface ImportedSerial {
+  readonly id: number;
+}
+
+export type ImportSourceStage = ChapterStage;
 
 interface PlannedSection {
   readonly section: SourceSection;
@@ -78,18 +89,25 @@ export async function importSourceDocument(
       }),
     ],
   } satisfies TocFile;
-  const generation = new SerialGeneration({
-    document: options.document,
-    llm: options.llm,
-    ...(options.logDirPath === undefined
-      ? {}
-      : { logDirPath: options.logDirPath }),
-    ...(options.segmenter === undefined
-      ? {}
-      : { segmenter: options.segmenter }),
-  });
+  const targetStage = options.targetStage ?? "summarized";
+  const generation =
+    targetStage === "planned" || targetStage === "sourced"
+      ? undefined
+      : new SerialGeneration({
+          document: options.document,
+          llm: requireImportLLM(options.llm, targetStage),
+          ...(options.logDirPath === undefined
+            ? {}
+            : { logDirPath: options.logDirPath }),
+          ...(options.segmenter === undefined
+            ? {}
+            : { segmenter: options.segmenter }),
+        });
 
-  if (options.digestProgressTracker !== undefined) {
+  if (
+    options.digestProgressTracker !== undefined &&
+    targetStage !== "planned"
+  ) {
     const discoveries = await discoverPlannedSections(plannedSections, {
       ...(options.segmenter === undefined
         ? {}
@@ -102,8 +120,9 @@ export async function importSourceDocument(
   const serials = await generatePlannedSerials(plannedSections, {
     document: options.document,
     extractionPrompt: options.extractionPrompt,
-    generation,
+    ...(generation === undefined ? {} : { generation }),
     serialConcurrency: resolveSerialGenerationConcurrency(options.llm),
+    targetStage,
     ...(options.digestProgressTracker === undefined
       ? {}
       : { digestProgressTracker: options.digestProgressTracker }),
@@ -135,11 +154,24 @@ async function generatePlannedSerials(
     readonly digestProgressTracker?: DigestProgressTracker;
     readonly document: Document;
     readonly extractionPrompt: string;
-    readonly generation: SerialGeneration;
+    readonly generation?: SerialGeneration;
     readonly serialConcurrency: number;
+    readonly targetStage: ImportSourceStage;
     readonly userLanguage?: GenerateSerialOptions["userLanguage"];
   },
-): Promise<Serial[]> {
+): Promise<ImportedSerial[]> {
+  if (options.targetStage === "planned") {
+    await options.document.openSession(async (document) => {
+      for (const plannedSection of plannedSections) {
+        await document.serials.createWithId(plannedSection.serialId);
+      }
+    });
+
+    return plannedSections.map((plannedSection) => ({
+      id: plannedSection.serialId,
+    }));
+  }
+
   const limiter = new AsyncSemaphore(options.serialConcurrency);
   const serials = await Promise.all(
     plannedSections.map(async (plannedSection) => {
@@ -154,7 +186,49 @@ async function generatePlannedSerials(
               id: plannedSection.serialId,
             });
           const serial = await context.run(async () => {
-            return await options.generation.generateInto(
+            if (options.targetStage === "sourced") {
+              await options.document.serials.createWithId(
+                plannedSection.serialId,
+              );
+              await writeSerialSource(
+                options.document,
+                plannedSection.serialId,
+                await plannedSection.section.open(),
+              );
+
+              return {
+                id: plannedSection.serialId,
+              } satisfies ImportedSerial;
+            }
+
+            if (options.targetStage === "graphed") {
+              await options.document.serials.createWithId(
+                plannedSection.serialId,
+              );
+              await requireSerialGeneration(
+                options.generation,
+                options.targetStage,
+              ).buildTopologyInto(
+                plannedSection.serialId,
+                await plannedSection.section.open(),
+                {
+                  extractionPrompt: options.extractionPrompt,
+                  ...(options.userLanguage === undefined
+                    ? {}
+                    : { userLanguage: options.userLanguage }),
+                },
+                serialProgressTracker,
+              );
+
+              return {
+                id: plannedSection.serialId,
+              } satisfies ImportedSerial;
+            }
+
+            return await requireSerialGeneration(
+              options.generation,
+              options.targetStage,
+            ).generateInto(
               plannedSection.serialId,
               await plannedSection.section.open(),
               {
@@ -323,4 +397,28 @@ function resolveSerialGenerationConcurrency(
   }
 
   return llm.config.concurrent;
+}
+
+function requireImportLLM(
+  llm: ImportSourceOptions["llm"],
+  targetStage: ImportSourceStage,
+): NonNullable<ImportSourceOptions["llm"]> {
+  if (llm === undefined) {
+    throw new Error(`LLM is required to import source to ${targetStage}.`);
+  }
+
+  return llm;
+}
+
+function requireSerialGeneration(
+  generation: SerialGeneration | undefined,
+  targetStage: ImportSourceStage,
+): SerialGeneration {
+  if (generation === undefined) {
+    throw new Error(
+      `Internal error: serial generation is required for ${targetStage}.`,
+    );
+  }
+
+  return generation;
 }

--- a/src/facade/import.ts
+++ b/src/facade/import.ts
@@ -180,7 +180,7 @@ async function generatePlannedSerials(
 }
 
 function planTocItems(input: {
-  readonly fallbackTitle: string | null;
+  readonly fallbackTitle: string | null | undefined;
   readonly plannedSections: PlannedSection[];
   readonly sections: readonly SourceSection[];
   readonly serialIdAllocator: SerialIdAllocator;
@@ -188,9 +188,7 @@ function planTocItems(input: {
   return input.sections.map((section, index) =>
     planTocItem({
       fallbackTitle:
-        input.sections.length === 1
-          ? input.fallbackTitle
-          : createSectionFallbackTitle([index]),
+        input.sections.length === 1 ? input.fallbackTitle : undefined,
       indexPath: [index],
       plannedSections: input.plannedSections,
       section,
@@ -200,7 +198,7 @@ function planTocItems(input: {
 }
 
 function planTocItem(input: {
-  readonly fallbackTitle: string | null;
+  readonly fallbackTitle: string | null | undefined;
   readonly indexPath: readonly number[];
   readonly plannedSections: PlannedSection[];
   readonly section: SourceSection;
@@ -211,7 +209,7 @@ function planTocItem(input: {
     : undefined;
   const children = input.section.children.map((child, index) =>
     planTocItem({
-      fallbackTitle: createSectionFallbackTitle([...input.indexPath, index]),
+      fallbackTitle: undefined,
       indexPath: [...input.indexPath, index],
       plannedSections: input.plannedSections,
       section: child,
@@ -226,18 +224,14 @@ function planTocItem(input: {
     });
   }
 
+  const title =
+    normalizeTitle(input.section.title) ?? normalizeTitle(input.fallbackTitle);
+
   return {
-    title:
-      normalizeTitle(input.section.title) ??
-      normalizeTitle(input.fallbackTitle) ??
-      createSectionFallbackTitle(input.indexPath),
+    ...(title === undefined ? {} : { title }),
     ...(serialId === undefined ? {} : { serialId }),
     children,
   };
-}
-
-function createSectionFallbackTitle(indexPath: readonly number[]): string {
-  return `Section ${indexPath.map((value) => value + 1).join(".")}`;
 }
 
 function normalizeTitle(title: string | null | undefined): string | undefined {

--- a/src/facade/index.ts
+++ b/src/facade/index.ts
@@ -16,6 +16,7 @@ export {
 } from "./app.js";
 export {
   addChapter,
+  advanceChapterStages,
   CHAPTER_STAGES,
   generateChapterGraph,
   generateChapterSummary,
@@ -28,6 +29,8 @@ export {
 } from "./chapter.js";
 export type {
   AddChapterOptions,
+  AdvanceChapterStagesOptions,
+  AdvanceChapterStagesResult,
   ChapterDetails,
   ChapterEntry,
   ChapterStage,

--- a/src/facade/index.ts
+++ b/src/facade/index.ts
@@ -14,5 +14,25 @@ export {
   type SpineDigestSourceSessionOptions,
   type SpineDigestTextStreamSessionOptions,
 } from "./app.js";
+export {
+  addChapter,
+  CHAPTER_STAGES,
+  generateChapterGraph,
+  generateChapterSummary,
+  getChapterDetails,
+  listChapters,
+  removeChapter,
+  resetChapter,
+  setChapterSource,
+  setChapterSummary,
+} from "./chapter.js";
+export type {
+  AddChapterOptions,
+  ChapterDetails,
+  ChapterEntry,
+  ChapterStage,
+  GenerateChapterGraphOptions,
+  GenerateChapterSummaryOptions,
+} from "./chapter.js";
 export { SpineDigest } from "./spine-digest.js";
 export type { SpineDigestSerialEntry } from "./types.js";

--- a/src/facade/spine-digest-file.ts
+++ b/src/facade/spine-digest-file.ts
@@ -1,10 +1,10 @@
-import { mkdtemp, rm } from "fs/promises";
-import { join, resolve } from "path";
+import { mkdir, mkdtemp, rename, rm } from "fs/promises";
+import { dirname, join, resolve } from "path";
 import { tmpdir } from "os";
 
 import { DirectoryDocument } from "../document/index.js";
 
-import { extractSdpubArchive } from "./archive.js";
+import { extractSdpubArchive, writeSdpubArchive } from "./archive.js";
 import { SpineDigest } from "./spine-digest.js";
 
 export class SpineDigestFile {
@@ -39,6 +39,46 @@ export class SpineDigestFile {
       if (options.documentDirPath === undefined) {
         await rm(directoryPath, { force: true, recursive: true });
       }
+    }
+  }
+
+  public async openEditableSession<T>(
+    operation: (document: DirectoryDocument) => Promise<T> | T,
+  ): Promise<T> {
+    const directoryPath = await mkdtemp(join(tmpdir(), "spinedigest-edit-"));
+
+    try {
+      await extractSdpubArchive(this.#path, directoryPath);
+
+      const document = await DirectoryDocument.open(directoryPath);
+
+      try {
+        const result = await operation(document);
+        const temporaryOutputDirectoryPath = await mkdtemp(
+          join(tmpdir(), "spinedigest-save-"),
+        );
+        const temporaryOutputPath = join(
+          temporaryOutputDirectoryPath,
+          "document.sdpub",
+        );
+
+        try {
+          await document.flush();
+          await writeSdpubArchive(directoryPath, temporaryOutputPath);
+          await mkdir(dirname(this.#path), { recursive: true });
+          await rename(temporaryOutputPath, this.#path);
+        } finally {
+          await rm(temporaryOutputDirectoryPath, {
+            force: true,
+            recursive: true,
+          });
+        }
+        return result;
+      } finally {
+        await document.release();
+      }
+    } finally {
+      await rm(directoryPath, { force: true, recursive: true });
     }
   }
 }

--- a/src/facade/spine-digest.ts
+++ b/src/facade/spine-digest.ts
@@ -7,7 +7,7 @@ import type {
   TocItem,
 } from "../source/index.js";
 
-import { writeSdpubArchive } from "./archive.js";
+import { readSdpubArchiveFormatVersion, writeSdpubArchive } from "./archive.js";
 import type { SpineDigestSerialEntry } from "./types.js";
 
 export class SpineDigest {
@@ -46,6 +46,10 @@ export class SpineDigest {
 
   public async readToc(): Promise<TocFile | undefined> {
     return await this.#document.readToc();
+  }
+
+  public async readArchiveFormatVersion(): Promise<number> {
+    return await readSdpubArchiveFormatVersion(this.#documentDirectoryPath);
   }
 
   public async listSerials(): Promise<readonly SpineDigestSerialEntry[]> {

--- a/src/facade/spine-digest.ts
+++ b/src/facade/spine-digest.ts
@@ -106,7 +106,8 @@ async function collectSerialEntries(
   const entries: SpineDigestSerialEntry[] = [];
 
   for (const item of items) {
-    const tocPath = [...ancestorTitles, item.title];
+    const title = item.title?.trim() || `Chapter ${item.serialId ?? "group"}`;
+    const tocPath = [...ancestorTitles, title];
 
     if (item.serialId !== undefined) {
       entries.push({
@@ -114,7 +115,7 @@ async function collectSerialEntries(
           await document.getSerialFragments(item.serialId).listFragmentIds()
         ).length,
         serialId: item.serialId,
-        title: item.title,
+        title,
         tocPath,
       });
     }

--- a/src/facade/types.ts
+++ b/src/facade/types.ts
@@ -1,6 +1,6 @@
 export interface SpineDigestSerialEntry {
   readonly fragmentCount: number;
   readonly serialId: number;
-  readonly title: string;
+  readonly title: string | null;
   readonly tocPath: readonly string[];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,13 @@
 export { Language } from "./common/language.js";
+export {
+  createSpineDigestTaskId,
+  SpineDigestTask,
+  SpineDigestTaskContext,
+  SPINE_DIGEST_CONTEXT_VERSION,
+  type SpineDigestTaskContextOptions,
+  type SpineDigestTaskIdentity,
+  type SpineDigestTaskType,
+} from "./context/index.js";
 export { LLMPaymentRequiredError } from "./llm/index.js";
 export {
   type DigestProgressEvent,

--- a/src/output/epub/content.ts
+++ b/src/output/epub/content.ts
@@ -24,10 +24,10 @@ export function createFallbackSection(
 export function createSectionDocument(
   serialId: number,
   language: string,
-  title: string,
+  title: string | null | undefined,
   summary: string,
 ): EpubSection {
-  const normalizedTitle = title.trim() || `Section ${serialId}`;
+  const normalizedTitle = title?.trim() || `Section ${serialId}`;
 
   return {
     href: `text/serial-${serialId}.xhtml`,

--- a/src/output/epub/navigation.ts
+++ b/src/output/epub/navigation.ts
@@ -14,7 +14,7 @@ export function buildNavItems(
       item.serialId === undefined
         ? undefined
         : sectionMap.get(item.serialId)?.href,
-    title: item.title,
+    title: item.title?.trim() || `Section ${item.serialId ?? 1}`,
   }));
 }
 

--- a/src/output/plain-text.ts
+++ b/src/output/plain-text.ts
@@ -57,7 +57,9 @@ async function renderTocItem(
   document: ReadonlyDocument,
   item: TocItem,
 ): Promise<string | undefined> {
-  const parts = [item.title.trim()].filter((value) => value !== "");
+  const parts = [item.title?.trim()].filter(
+    (value): value is string => value !== undefined && value !== "",
+  );
 
   if (item.serialId !== undefined) {
     const summary = await document.readSummary(item.serialId);

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -52,6 +52,12 @@ export interface GenerateSerialOptions {
   readonly userLanguage?: Language;
 }
 
+export type BuildSerialTopologyOptions = GenerateSerialOptions;
+
+export interface BuildSerialSummaryOptions {
+  readonly userLanguage?: Language;
+}
+
 export interface SerialDiscovery {
   readonly fragments: number;
   readonly words: number;
@@ -155,6 +161,30 @@ export class SerialGeneration {
       options,
       progressTracker,
     );
+  }
+
+  public async buildTopologyInto(
+    serialId: number,
+    stream: ReaderTextStream,
+    options: BuildSerialTopologyOptions,
+    progressTracker?: SerialProgressTracker,
+  ): Promise<void> {
+    await this.#buildTopology(
+      serialId,
+      stream,
+      options.extractionPrompt,
+      options.userLanguage,
+      progressTracker,
+    );
+  }
+
+  public async buildSummary(
+    serialId: number,
+    options: BuildSerialSummaryOptions = {},
+  ): Promise<Serial> {
+    const summary = await this.#buildSummary(serialId, options.userLanguage);
+
+    return new Serial(this.#document, serialId, summary);
   }
 
   async #generatePrepared(

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -58,6 +58,10 @@ export interface BuildSerialSummaryOptions {
   readonly userLanguage?: Language;
 }
 
+export interface WriteSerialSourceOptions {
+  readonly segmenter?: ReaderSegmenter;
+}
+
 export interface SerialDiscovery {
   readonly fragments: number;
   readonly words: number;
@@ -100,6 +104,32 @@ export async function discoverSerial(input: {
     fragments,
     words,
   };
+}
+
+export async function writeSerialSource(
+  document: Document,
+  serialId: number,
+  stream: ReaderTextStream,
+  options: WriteSerialSourceOptions = {},
+): Promise<void> {
+  const serialFragments = document.getSerialFragments(serialId);
+
+  for await (const fragment of streamFragments({
+    maxWordsCount: DEFAULT_FRAGMENT_WORDS_COUNT,
+    stream: segmentTextStream(stream, {
+      ...(options.segmenter === undefined
+        ? {}
+        : { adapter: options.segmenter }),
+    }),
+  })) {
+    const fragmentDraft = await serialFragments.createDraft();
+
+    for (const sentence of fragment.sentences) {
+      fragmentDraft.addSentence(sentence.text, sentence.wordsCount);
+    }
+
+    await fragmentDraft.commit();
+  }
 }
 
 export class SerialGeneration {

--- a/src/source/toc.ts
+++ b/src/source/toc.ts
@@ -3,13 +3,13 @@ import { z } from "zod";
 export const TOC_FILE_VERSION = 1;
 
 export interface TocItem {
-  readonly title: string;
+  readonly title?: string | null | undefined;
   readonly serialId?: number | undefined;
   readonly children: readonly TocItem[];
 }
 
 export const tocItemSchema: z.ZodType<TocItem> = z.object({
-  title: z.string().min(1),
+  title: z.string().min(1).nullable().optional(),
   serialId: z.number().int().nonnegative().optional(),
   children: z.lazy(() => z.array(tocItemSchema)),
 });

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -99,6 +99,29 @@ describe("cli/args", () => {
     );
   });
 
+  it("parses --stage for sdpub output conversion", () => {
+    expect(
+      parseCLIArguments([
+        "--input",
+        "book.epub",
+        "--output",
+        "book.sdpub",
+        "--stage",
+        "sourced",
+      ]),
+    ).toStrictEqual({
+      args: {
+        help: false,
+        inputPath: "book.epub",
+        outputPath: "book.sdpub",
+        targetStage: "sourced",
+        verbose: false,
+      },
+      help: false,
+      kind: "convert",
+    });
+  });
+
   it("parses --llm for runtime-configurable commands", () => {
     expect(parseCLIArguments(["--llm", '{"model":"cli-model"}'])).toStrictEqual(
       {
@@ -243,6 +266,43 @@ describe("cli/args", () => {
     });
   });
 
+  it("parses sdpub stage actions", () => {
+    expect(
+      parseCLIArguments([
+        "sdpub",
+        "stage",
+        "advance",
+        "book.sdpub",
+        "--chapter",
+        "3",
+        "--to",
+        "graphed",
+        "--prompt",
+        "Focus on claims",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "advance",
+        chapterId: 3,
+        path: "book.sdpub",
+        prompt: "Focus on claims",
+        targetStage: "graphed",
+      },
+      help: false,
+      kind: "sdpub-stage",
+    });
+    expect(
+      parseCLIArguments(["sdpub", "stage", "pending", "book.sdpub"]),
+    ).toStrictEqual({
+      args: {
+        action: "pending",
+        path: "book.sdpub",
+      },
+      help: false,
+      kind: "sdpub-stage",
+    });
+  });
+
   it("prints sdpub help text", () => {
     expect(parseCLIArguments(["sdpub", "--help"])).toStrictEqual({
       help: true,
@@ -309,10 +369,10 @@ describe("cli/args", () => {
 
   it("rejects invalid sdpub usage", () => {
     expect(() => parseCLIArguments(["sdpub"])).toThrow(
-      "Missing sdpub subcommand. Expected one of info, toc, list, cat, cover, meta, chapter.\nSee: spinedigest sdpub --help",
+      "Missing sdpub subcommand. Expected one of info, toc, list, cat, cover, meta, stage, chapter.\nSee: spinedigest sdpub --help",
     );
     expect(() => parseCLIArguments(["sdpub", "inspect"])).toThrow(
-      "Invalid sdpub subcommand: inspect. Expected one of info, toc, list, cat, cover, meta, chapter.\nSee: spinedigest sdpub --help",
+      "Invalid sdpub subcommand: inspect. Expected one of info, toc, list, cat, cover, meta, stage, chapter.\nSee: spinedigest sdpub --help",
     );
     expect(() => parseCLIArguments(["sdpub", "inspect", "extra"])).toThrow(
       "Unexpected positional arguments: extra.\nSee: spinedigest sdpub --help",
@@ -420,6 +480,36 @@ describe("cli/args", () => {
     );
   });
 
+  it("rejects invalid sdpub stage usage", () => {
+    expect(() => parseCLIArguments(["sdpub", "stage"])).toThrow(
+      "Missing sdpub stage action.\nSee: spinedigest sdpub stage --help",
+    );
+    expect(() =>
+      parseCLIArguments([
+        "sdpub",
+        "stage",
+        "advance",
+        "book.sdpub",
+        "--to",
+        "x",
+      ]),
+    ).toThrow(
+      "Invalid --to: x. Expected planned, sourced, graphed, or summarized.\nSee: spinedigest sdpub stage --help",
+    );
+    expect(() =>
+      parseCLIArguments([
+        "sdpub",
+        "stage",
+        "pending",
+        "book.sdpub",
+        "--prompt",
+        "unused",
+      ]),
+    ).toThrow(
+      "The `sdpub stage pending` action does not support --prompt.\nSee: spinedigest sdpub stage --help",
+    );
+  });
+
   it("rejects invalid help usage", () => {
     expect(() => parseCLIArguments(["help", "unknown"])).toThrow(
       "Invalid help topic: unknown. Expected one of overview, task, command, format, config, env, config-file, runtime, recipe, troubleshoot, ai, sdpub.\nSee: spinedigest --help",
@@ -460,6 +550,7 @@ describe("cli/args", () => {
     expect(rootHelpText).toContain("spinedigest help config-file");
     expect(rootHelpText).toContain("spinedigest sdpub info --help");
     expect(rootHelpText).toContain("[--verbose|-v] [--help|-h]");
+    expect(rootHelpText).toContain("[--stage <stage>]");
     expect(rootHelpText).toContain("`-h` is the short form of `--help`");
     expect(rootHelpText).toContain("`-v` is the short form of `--verbose`");
     expect(rootHelpText).toContain(
@@ -521,6 +612,7 @@ describe("cli/args", () => {
     );
     expect(sdpubHelpText).toContain("These subcommands do not call an LLM");
     expect(sdpubHelpText).toContain("[--help|-h]");
+    expect(renderSdpubSubcommandHelpText("stage")).toContain("advance <path>");
     expect(renderSdpubSubcommandHelpText("cover")).toContain(
       "refuses to write binary data to an interactive terminal",
     );

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -610,7 +610,12 @@ describe("cli/args", () => {
     expect(renderHelpTopicText("config-file")).toContain(
       "JSON boolean, either `true` or `false`",
     );
-    expect(sdpubHelpText).toContain("These subcommands do not call an LLM");
+    expect(sdpubHelpText).toContain(
+      "sdpub stage advance` calls an LLM provider",
+    );
+    expect(sdpubHelpText).toContain(
+      "Inspection commands and metadata/tree edits do not call an LLM provider",
+    );
     expect(sdpubHelpText).toContain("[--help|-h]");
     expect(renderSdpubSubcommandHelpText("stage")).toContain("advance <path>");
     expect(renderSdpubSubcommandHelpText("cover")).toContain(

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -147,6 +147,75 @@ describe("cli/args", () => {
     });
   });
 
+  it("parses sdpub chapter edit actions", () => {
+    expect(
+      parseCLIArguments([
+        "sdpub",
+        "chapter",
+        "set-source",
+        "book.sdpub",
+        "--chapter",
+        "12",
+        "--input",
+        "chapter.md",
+        "--input-format",
+        "markdown",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "set-source",
+        chapterId: 12,
+        inputFormat: "markdown",
+        inputPath: "chapter.md",
+        path: "book.sdpub",
+      },
+      help: false,
+      kind: "sdpub-chapter",
+    });
+    expect(
+      parseCLIArguments([
+        "sdpub",
+        "chapter",
+        "add",
+        "book.sdpub",
+        "--title",
+        "Chapter 1",
+        "--parent",
+        "3",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "add",
+        parentChapterId: 3,
+        path: "book.sdpub",
+        title: "Chapter 1",
+      },
+      help: false,
+      kind: "sdpub-chapter",
+    });
+    expect(
+      parseCLIArguments([
+        "sdpub",
+        "chapter",
+        "reset",
+        "book.sdpub",
+        "--chapter",
+        "12",
+        "--to",
+        "sourced",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "reset",
+        chapterId: 12,
+        path: "book.sdpub",
+        resetStage: "sourced",
+      },
+      help: false,
+      kind: "sdpub-chapter",
+    });
+  });
+
   it("prints sdpub help text", () => {
     expect(parseCLIArguments(["sdpub", "--help"])).toStrictEqual({
       help: true,
@@ -213,10 +282,10 @@ describe("cli/args", () => {
 
   it("rejects invalid sdpub usage", () => {
     expect(() => parseCLIArguments(["sdpub"])).toThrow(
-      "Missing sdpub subcommand. Expected one of info, toc, list, cat, cover.\nSee: spinedigest sdpub --help",
+      "Missing sdpub subcommand. Expected one of info, toc, list, cat, cover, chapter.\nSee: spinedigest sdpub --help",
     );
     expect(() => parseCLIArguments(["sdpub", "inspect"])).toThrow(
-      "Invalid sdpub subcommand: inspect. Expected one of info, toc, list, cat, cover.\nSee: spinedigest sdpub --help",
+      "Invalid sdpub subcommand: inspect. Expected one of info, toc, list, cat, cover, chapter.\nSee: spinedigest sdpub --help",
     );
     expect(() => parseCLIArguments(["sdpub", "inspect", "extra"])).toThrow(
       "Unexpected positional arguments: extra.\nSee: spinedigest sdpub --help",
@@ -259,6 +328,43 @@ describe("cli/args", () => {
       ]),
     ).toThrow(
       "Invalid --serial: x. Expected a non-negative integer.\nSee: spinedigest sdpub cat --help",
+    );
+  });
+
+  it("rejects invalid sdpub chapter usage", () => {
+    expect(() => parseCLIArguments(["sdpub", "chapter"])).toThrow(
+      "Missing sdpub chapter action.\nSee: spinedigest sdpub chapter --help",
+    );
+    expect(() =>
+      parseCLIArguments(["sdpub", "chapter", "set-source", "book.sdpub"]),
+    ).toThrow(
+      "Missing --chapter. `sdpub chapter set-source` requires a chapter id.\nSee: spinedigest sdpub chapter --help",
+    );
+    expect(() =>
+      parseCLIArguments([
+        "sdpub",
+        "chapter",
+        "set-source",
+        "book.sdpub",
+        "--chapter",
+        "1",
+      ]),
+    ).toThrow(
+      "Missing --input-format. `sdpub chapter set-source` requires txt or markdown.\nSee: spinedigest sdpub chapter --help",
+    );
+    expect(() =>
+      parseCLIArguments([
+        "sdpub",
+        "chapter",
+        "reset",
+        "book.sdpub",
+        "--chapter",
+        "1",
+        "--to",
+        "summarized",
+      ]),
+    ).toThrow(
+      "`sdpub chapter reset` does not support --to summarized.\nSee: spinedigest sdpub chapter --help",
     );
   });
 

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -145,6 +145,33 @@ describe("cli/args", () => {
       help: false,
       kind: "sdpub",
     });
+    expect(
+      parseCLIArguments([
+        "sdpub",
+        "meta",
+        "--input",
+        "book.sdpub",
+        "--title",
+        "  Updated Book  ",
+        "--author",
+        "Ari Lantern",
+        "--author",
+        "Bea North",
+        "--clear-description",
+      ]),
+    ).toStrictEqual({
+      args: {
+        inputPath: "book.sdpub",
+        metaPatch: {
+          authors: ["Ari Lantern", "Bea North"],
+          clearDescription: true,
+          title: "Updated Book",
+        },
+        subcommand: "meta",
+      },
+      help: false,
+      kind: "sdpub",
+    });
   });
 
   it("parses sdpub chapter edit actions", () => {
@@ -282,10 +309,10 @@ describe("cli/args", () => {
 
   it("rejects invalid sdpub usage", () => {
     expect(() => parseCLIArguments(["sdpub"])).toThrow(
-      "Missing sdpub subcommand. Expected one of info, toc, list, cat, cover, chapter.\nSee: spinedigest sdpub --help",
+      "Missing sdpub subcommand. Expected one of info, toc, list, cat, cover, meta, chapter.\nSee: spinedigest sdpub --help",
     );
     expect(() => parseCLIArguments(["sdpub", "inspect"])).toThrow(
-      "Invalid sdpub subcommand: inspect. Expected one of info, toc, list, cat, cover, chapter.\nSee: spinedigest sdpub --help",
+      "Invalid sdpub subcommand: inspect. Expected one of info, toc, list, cat, cover, meta, chapter.\nSee: spinedigest sdpub --help",
     );
     expect(() => parseCLIArguments(["sdpub", "inspect", "extra"])).toThrow(
       "Unexpected positional arguments: extra.\nSee: spinedigest sdpub --help",
@@ -328,6 +355,31 @@ describe("cli/args", () => {
       ]),
     ).toThrow(
       "Invalid --serial: x. Expected a non-negative integer.\nSee: spinedigest sdpub cat --help",
+    );
+    expect(() =>
+      parseCLIArguments([
+        "sdpub",
+        "info",
+        "--input",
+        "book.sdpub",
+        "--title",
+        "Updated",
+      ]),
+    ).toThrow(
+      "The `sdpub info` subcommand does not support metadata edit flags.\nSee: spinedigest sdpub info --help",
+    );
+    expect(() =>
+      parseCLIArguments([
+        "sdpub",
+        "meta",
+        "--input",
+        "book.sdpub",
+        "--title",
+        "Updated",
+        "--clear-title",
+      ]),
+    ).toThrow(
+      "Cannot combine --title with --clear-title.\nSee: spinedigest sdpub meta --help",
     );
   });
 
@@ -473,6 +525,7 @@ describe("cli/args", () => {
       "refuses to write binary data to an interactive terminal",
     );
     expect(renderSdpubSubcommandHelpText("cover")).toContain("[--help|-h]");
+    expect(renderSdpubSubcommandHelpText("meta")).toContain("--clear-authors");
   });
 
   it("supports a first-contact recovery chain from root help to parse failures", () => {

--- a/test/cli/convert.test.ts
+++ b/test/cli/convert.test.ts
@@ -240,6 +240,7 @@ describe("cli/convert", () => {
       extractionPrompt: "Keep the main beats",
       sourceFormat: "txt",
       stream: mockStdinStream,
+      targetStage: "summarized",
     });
     expect(cliMockState.digestCalls.textStream[0]).not.toHaveProperty(
       "onProgress",
@@ -286,6 +287,7 @@ describe("cli/convert", () => {
       {
         extractionPrompt: "CLI prompt",
         path: "/tmp/book.txt",
+        targetStage: "summarized",
       },
     ]);
   });
@@ -382,6 +384,7 @@ describe("cli/convert", () => {
         documentDirPath: "/tmp/kept-digest",
         extractionPrompt: "Keep the main beats",
         path: "/tmp/book.epub",
+        targetStage: "summarized",
       },
     ]);
     expect(cliMockState.resetDigestDirCalls).toStrictEqual([
@@ -411,6 +414,59 @@ describe("cli/convert", () => {
 
     expect(cliMockState.appConstructorOptions).toHaveLength(0);
     expect(cliMockState.digestCalls.txt).toHaveLength(0);
+  });
+
+  it("creates sourced sdpub output without llm configuration", async () => {
+    cliMockState.config = {};
+
+    await runConvertCommand({
+      help: false,
+      inputPath: "/tmp/book.txt",
+      outputPath: "/tmp/output.sdpub",
+      targetStage: "sourced",
+      verbose: false,
+    });
+
+    expect(cliMockState.appConstructorOptions).toStrictEqual([{}]);
+    expect(cliMockState.buildLLMOptionsConfig).toHaveLength(0);
+    expect(cliMockState.digestCalls.txt).toStrictEqual([
+      {
+        path: "/tmp/book.txt",
+        targetStage: "sourced",
+      },
+    ]);
+    expect(cliMockState.exportCalls).toStrictEqual([
+      {
+        method: "saveAs",
+        path: "/tmp/output.sdpub",
+      },
+    ]);
+  });
+
+  it("rejects --stage outside source-to-sdpub conversion", async () => {
+    await expect(
+      runConvertCommand({
+        help: false,
+        inputPath: "/tmp/book.txt",
+        outputPath: "/tmp/output.txt",
+        targetStage: "sourced",
+        verbose: false,
+      }),
+    ).rejects.toThrow(
+      "--stage is only supported when output format is sdpub.\nSee: spinedigest help command",
+    );
+
+    await expect(
+      runConvertCommand({
+        help: false,
+        inputPath: "/tmp/book.sdpub",
+        outputPath: "/tmp/output.sdpub",
+        targetStage: "sourced",
+        verbose: false,
+      }),
+    ).rejects.toThrow(
+      "--stage is only supported when creating .sdpub from source input.\nSee: spinedigest help command",
+    );
   });
 
   it("rejects stdin input when the format cannot be inferred", async () => {

--- a/test/cli/main.test.ts
+++ b/test/cli/main.test.ts
@@ -15,9 +15,11 @@ const mainMockState = vi.hoisted(() => ({
   statusRunCalls: 0,
   statusRunArgs: [] as unknown[],
   sdpubRunCalls: [] as unknown[],
+  sdpubStageRunCalls: [] as unknown[],
   runError: undefined as Error | undefined,
   statusRunError: undefined as Error | undefined,
   sdpubRunError: undefined as Error | undefined,
+  sdpubStageRunError: undefined as Error | undefined,
 }));
 
 vi.mock("../../src/cli/args.js", () => ({
@@ -67,6 +69,18 @@ vi.mock("../../src/cli/sdpub.js", () => ({
   }),
 }));
 
+vi.mock("../../src/cli/sdpub-stage.js", () => ({
+  runSdpubStageCommand: vi.fn((args: unknown) => {
+    mainMockState.sdpubStageRunCalls.push(args);
+
+    if (mainMockState.sdpubStageRunError !== undefined) {
+      return Promise.reject(mainMockState.sdpubStageRunError);
+    }
+
+    return Promise.resolve();
+  }),
+}));
+
 import { main } from "../../src/cli/main.js";
 import { LLMPaymentRequiredError } from "../../src/llm/index.js";
 
@@ -91,9 +105,11 @@ describe("cli/main", () => {
     mainMockState.statusRunCalls = 0;
     mainMockState.statusRunArgs.length = 0;
     mainMockState.sdpubRunCalls.length = 0;
+    mainMockState.sdpubStageRunCalls.length = 0;
     mainMockState.runError = undefined;
     mainMockState.statusRunError = undefined;
     mainMockState.sdpubRunError = undefined;
+    mainMockState.sdpubStageRunError = undefined;
     process.exitCode = 0;
     stdoutChunks = [];
     stderrChunks = [];
@@ -202,6 +218,28 @@ describe("cli/main", () => {
       {
         inputPath: "/tmp/book.sdpub",
         subcommand: "list",
+      },
+    ]);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("runs the sdpub stage command for stage actions", async () => {
+    mainMockState.argsResult = {
+      args: {
+        action: "pending",
+        path: "/tmp/book.sdpub",
+      },
+      help: false,
+      kind: "sdpub-stage",
+    };
+
+    await main();
+
+    expect(mainMockState.runCalls).toHaveLength(0);
+    expect(mainMockState.sdpubStageRunCalls).toStrictEqual([
+      {
+        action: "pending",
+        path: "/tmp/book.sdpub",
       },
     ]);
     expect(process.exitCode).toBe(0);

--- a/test/cli/sdpub-chapter.test.ts
+++ b/test/cli/sdpub-chapter.test.ts
@@ -1,0 +1,337 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const chapterMockState = vi.hoisted(() => ({
+  addCalls: [] as unknown[],
+  editableCalls: [] as string[],
+  generatedGraphCalls: [] as unknown[],
+  generatedSummaryCalls: [] as unknown[],
+  inputFileContent: "file content",
+  listEntries: [
+    {
+      chapterId: 1,
+      childCount: 1,
+      depth: 0,
+      fragmentCount: 0,
+      stage: "planned",
+      title: "Part I",
+      tocPath: ["Part I"],
+    },
+    {
+      chapterId: 2,
+      childCount: 0,
+      depth: 1,
+      fragmentCount: 2,
+      stage: "sourced",
+      title: "Chapter 1",
+      tocPath: ["Part I", "Chapter 1"],
+    },
+  ],
+  loadConfigCalls: [] as unknown[],
+  removeCalls: [] as unknown[],
+  resetCalls: [] as unknown[],
+  setSourceCalls: [] as Array<{
+    readonly chapterId: number;
+    readonly streamText: string;
+  }>,
+  setSummaryCalls: [] as unknown[],
+  sourceFileStream: ["source file content"],
+  stdinStream: ["stdin content"],
+  textWrites: [] as string[],
+}));
+
+const chapterDetails = {
+  chapterId: 2,
+  childCount: 0,
+  depth: 1,
+  fragmentCount: 2,
+  graphReady: false,
+  hasSummary: false,
+  stage: "sourced",
+  title: "Chapter 1",
+  tocPath: ["Part I", "Chapter 1"],
+};
+
+vi.mock("../../src/facade/spine-digest-file.js", () => ({
+  SpineDigestFile: class {
+    readonly #path: string;
+
+    public constructor(path: string) {
+      this.#path = path;
+    }
+
+    public async openEditableSession(
+      operation: (document: unknown) => Promise<unknown>,
+    ): Promise<unknown> {
+      chapterMockState.editableCalls.push(this.#path);
+      return await operation({});
+    }
+  },
+}));
+
+vi.mock("../../src/facade/index.js", () => ({
+  addChapter: vi.fn((_document: unknown, options: unknown) => {
+    chapterMockState.addCalls.push(options);
+    return Promise.resolve({
+      ...chapterDetails,
+      chapterId: 3,
+      stage: "planned",
+      title: "New Chapter",
+    });
+  }),
+  generateChapterGraph: vi.fn(
+    (_document: unknown, chapterId: number, options: unknown) => {
+      chapterMockState.generatedGraphCalls.push({
+        chapterId,
+        options,
+      });
+      return Promise.resolve({
+        ...chapterDetails,
+        graphReady: true,
+        stage: "graphed",
+      });
+    },
+  ),
+  generateChapterSummary: vi.fn(
+    (_document: unknown, chapterId: number, options: unknown) => {
+      chapterMockState.generatedSummaryCalls.push({
+        chapterId,
+        options,
+      });
+      return Promise.resolve({
+        ...chapterDetails,
+        graphReady: true,
+        hasSummary: true,
+        stage: "summarized",
+      });
+    },
+  ),
+  getChapterDetails: vi.fn(() => Promise.resolve(chapterDetails)),
+  listChapters: vi.fn(() => Promise.resolve(chapterMockState.listEntries)),
+  removeChapter: vi.fn(
+    (_document: unknown, chapterId: number, options: unknown) => {
+      chapterMockState.removeCalls.push({
+        chapterId,
+        options,
+      });
+      return Promise.resolve();
+    },
+  ),
+  resetChapter: vi.fn(
+    (_document: unknown, chapterId: number, stage: string) => {
+      chapterMockState.resetCalls.push({
+        chapterId,
+        stage,
+      });
+      return Promise.resolve({
+        ...chapterDetails,
+        stage,
+      });
+    },
+  ),
+  setChapterSource: vi.fn(
+    async (
+      _document: unknown,
+      chapterId: number,
+      stream: AsyncIterable<string>,
+    ) => {
+      let streamText = "";
+
+      for await (const chunk of stream) {
+        streamText += chunk;
+      }
+
+      chapterMockState.setSourceCalls.push({
+        chapterId,
+        streamText,
+      });
+      return chapterDetails;
+    },
+  ),
+  setChapterSummary: vi.fn(
+    (_document: unknown, chapterId: number, summary: string) => {
+      chapterMockState.setSummaryCalls.push({
+        chapterId,
+        summary,
+      });
+      return Promise.resolve({
+        ...chapterDetails,
+        hasSummary: true,
+        stage: "summarized",
+      });
+    },
+  ),
+}));
+
+vi.mock("../../src/cli/config.js", () => ({
+  loadCLIConfig: vi.fn((options?: unknown) => {
+    chapterMockState.loadConfigCalls.push(options);
+    return Promise.resolve({
+      llm: {
+        model: "gpt-test",
+        provider: "openai",
+      },
+      prompt: "Config prompt",
+    });
+  }),
+}));
+
+vi.mock("../../src/cli/llm.js", () => ({
+  buildLLMOptions: vi.fn(() => ({
+    model: {},
+  })),
+}));
+
+vi.mock("../../src/common/data-dir.js", () => ({
+  resolveDataDirPath: vi.fn(() => "/tmp/data"),
+}));
+
+vi.mock("../../src/llm/index.js", () => ({
+  LLM: class {
+    public constructor(_options: unknown) {}
+  },
+}));
+
+vi.mock("../../src/cli/io.js", () => ({
+  readTextStreamFromStdin: vi.fn(() => chapterMockState.stdinStream),
+  writeTextToStdout: vi.fn((text: string) => {
+    chapterMockState.textWrites.push(text);
+    return Promise.resolve();
+  }),
+}));
+
+vi.mock("fs/promises", () => ({
+  readFile: vi.fn(() => Promise.resolve(chapterMockState.inputFileContent)),
+}));
+
+vi.mock("fs", () => ({
+  createReadStream: vi.fn(() => chapterMockState.sourceFileStream),
+}));
+
+import { runSdpubChapterCommand } from "../../src/cli/sdpub-chapter.js";
+
+describe("cli/sdpub-chapter", () => {
+  const originalStdinIsTTY = process.stdin.isTTY;
+
+  beforeEach(() => {
+    chapterMockState.addCalls.length = 0;
+    chapterMockState.editableCalls.length = 0;
+    chapterMockState.generatedGraphCalls.length = 0;
+    chapterMockState.generatedSummaryCalls.length = 0;
+    chapterMockState.loadConfigCalls.length = 0;
+    chapterMockState.removeCalls.length = 0;
+    chapterMockState.resetCalls.length = 0;
+    chapterMockState.setSourceCalls.length = 0;
+    chapterMockState.setSummaryCalls.length = 0;
+    chapterMockState.textWrites.length = 0;
+    setStdinTTY(false);
+  });
+
+  afterEach(() => {
+    setStdinTTY(originalStdinIsTTY);
+  });
+
+  it("prints chapter list with stages", async () => {
+    await runSdpubChapterCommand({
+      action: "list",
+      path: "/tmp/book.sdpub",
+    });
+
+    expect(chapterMockState.editableCalls).toStrictEqual(["/tmp/book.sdpub"]);
+    expect(chapterMockState.textWrites).toStrictEqual([
+      "[1] planned    Part I\n  [2] sourced    Chapter 1\n",
+    ]);
+  });
+
+  it("adds a chapter and prints the new chapter id", async () => {
+    await runSdpubChapterCommand({
+      action: "add",
+      parentChapterId: 1,
+      path: "/tmp/book.sdpub",
+      title: "New Chapter",
+    });
+
+    expect(chapterMockState.addCalls).toStrictEqual([
+      {
+        parentChapterId: 1,
+        title: "New Chapter",
+      },
+    ]);
+    expect(chapterMockState.textWrites[0]).toContain("Chapter: 3\n");
+  });
+
+  it("reads source content from --input", async () => {
+    await runSdpubChapterCommand({
+      action: "set-source",
+      chapterId: 2,
+      inputFormat: "markdown",
+      inputPath: "/tmp/chapter.md",
+      path: "/tmp/book.sdpub",
+    });
+
+    expect(chapterMockState.setSourceCalls).toStrictEqual([
+      {
+        chapterId: 2,
+        streamText: "source file content",
+      },
+    ]);
+  });
+
+  it("reads summary content from --input", async () => {
+    await runSdpubChapterCommand({
+      action: "set-summary",
+      chapterId: 2,
+      inputPath: "/tmp/summary.txt",
+      path: "/tmp/book.sdpub",
+    });
+
+    expect(chapterMockState.setSummaryCalls).toStrictEqual([
+      {
+        chapterId: 2,
+        summary: "file content",
+      },
+    ]);
+  });
+
+  it("passes prompt to generate-graph", async () => {
+    await runSdpubChapterCommand({
+      action: "generate-graph",
+      chapterId: 2,
+      path: "/tmp/book.sdpub",
+      prompt: "CLI prompt",
+    });
+
+    expect(chapterMockState.generatedGraphCalls).toHaveLength(1);
+    expect(chapterMockState.generatedGraphCalls[0]).toMatchObject({
+      chapterId: 2,
+      options: {
+        extractionPrompt: "CLI prompt",
+      },
+    });
+  });
+
+  it("removes chapters recursively when requested", async () => {
+    await runSdpubChapterCommand({
+      action: "remove",
+      chapterId: 1,
+      path: "/tmp/book.sdpub",
+      recursive: true,
+    });
+
+    expect(chapterMockState.removeCalls).toStrictEqual([
+      {
+        chapterId: 1,
+        options: {
+          recursive: true,
+        },
+      },
+    ]);
+    expect(chapterMockState.textWrites).toStrictEqual(["Removed chapter 1.\n"]);
+  });
+});
+
+function setStdinTTY(value: boolean | undefined): void {
+  Object.defineProperty(process.stdin, "isTTY", {
+    configurable: true,
+    value,
+  });
+}

--- a/test/cli/sdpub-stage.test.ts
+++ b/test/cli/sdpub-stage.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const stageMockState = vi.hoisted(() => ({
+  advancedCalls: [] as unknown[],
+  editableCalls: [] as string[],
+  listEntries: [
+    {
+      chapterId: 1,
+      childCount: 0,
+      depth: 0,
+      fragmentCount: 0,
+      stage: "summarized",
+      title: "Done",
+      tocPath: ["Done"],
+    },
+    {
+      chapterId: 2,
+      childCount: 0,
+      depth: 0,
+      fragmentCount: 2,
+      stage: "sourced",
+      title: "Todo",
+      tocPath: ["Todo"],
+    },
+  ],
+  loadConfigCalls: [] as unknown[],
+  textWrites: [] as string[],
+}));
+
+vi.mock("../../src/facade/spine-digest-file.js", () => ({
+  SpineDigestFile: class {
+    readonly #path: string;
+
+    public constructor(path: string) {
+      this.#path = path;
+    }
+
+    public async openEditableSession(
+      operation: (document: unknown) => Promise<unknown>,
+    ): Promise<unknown> {
+      stageMockState.editableCalls.push(this.#path);
+      return await operation({});
+    }
+  },
+}));
+
+vi.mock("../../src/facade/index.js", () => ({
+  advanceChapterStages: vi.fn((_document: unknown, options: unknown) => {
+    stageMockState.advancedCalls.push(options);
+    return Promise.resolve({
+      advanced: [stageMockState.listEntries[1]],
+      pending: [],
+      skipped: [],
+    });
+  }),
+  listChapters: vi.fn(() => Promise.resolve(stageMockState.listEntries)),
+}));
+
+vi.mock("../../src/cli/config.js", () => ({
+  loadCLIConfig: vi.fn((options?: unknown) => {
+    stageMockState.loadConfigCalls.push(options);
+    return Promise.resolve({
+      llm: {
+        model: "gpt-test",
+        provider: "openai",
+      },
+      prompt: "Config prompt",
+    });
+  }),
+}));
+
+vi.mock("../../src/cli/llm.js", () => ({
+  buildLLMOptions: vi.fn(() => ({
+    model: {},
+  })),
+}));
+
+vi.mock("../../src/common/data-dir.js", () => ({
+  resolveDataDirPath: vi.fn(() => "/tmp/data"),
+}));
+
+vi.mock("../../src/llm/index.js", () => ({
+  LLM: class {
+    public constructor(_options: unknown) {}
+  },
+}));
+
+vi.mock("../../src/cli/io.js", () => ({
+  writeTextToStdout: vi.fn((text: string) => {
+    stageMockState.textWrites.push(text);
+    return Promise.resolve();
+  }),
+}));
+
+import { runSdpubStageCommand } from "../../src/cli/sdpub-stage.js";
+
+describe("cli/sdpub-stage", () => {
+  beforeEach(() => {
+    stageMockState.advancedCalls.length = 0;
+    stageMockState.editableCalls.length = 0;
+    stageMockState.loadConfigCalls.length = 0;
+    stageMockState.textWrites.length = 0;
+  });
+
+  it("prints pending chapters", async () => {
+    await runSdpubStageCommand({
+      action: "pending",
+      path: "/tmp/book.sdpub",
+    });
+
+    expect(stageMockState.editableCalls).toStrictEqual(["/tmp/book.sdpub"]);
+    expect(stageMockState.textWrites).toStrictEqual(["[2] sourced    Todo\n"]);
+  });
+
+  it("advances to summarized by default", async () => {
+    await runSdpubStageCommand({
+      action: "advance",
+      chapterId: 2,
+      path: "/tmp/book.sdpub",
+      prompt: "CLI prompt",
+    });
+
+    expect(stageMockState.advancedCalls).toHaveLength(1);
+    expect(stageMockState.advancedCalls[0]).toMatchObject({
+      chapterId: 2,
+      extractionPrompt: "CLI prompt",
+      targetStage: "summarized",
+    });
+    expect(stageMockState.textWrites).toStrictEqual([
+      "Advanced: 1\nPending: 0\nSkipped: 0\n",
+    ]);
+  });
+
+  it("accepts advancing to planned as a no-op without loading config", async () => {
+    await runSdpubStageCommand({
+      action: "advance",
+      path: "/tmp/book.sdpub",
+      targetStage: "planned",
+    });
+
+    expect(stageMockState.loadConfigCalls).toHaveLength(0);
+    expect(stageMockState.advancedCalls).toHaveLength(0);
+    expect(stageMockState.textWrites).toStrictEqual([
+      "Advanced: 0\nPending: 0\nSkipped: 0\n",
+    ]);
+  });
+});

--- a/test/cli/sdpub.test.ts
+++ b/test/cli/sdpub.test.ts
@@ -190,6 +190,7 @@ describe("cli/sdpub", () => {
     expect(sdpubMockState.openCalls).toStrictEqual(["/tmp/book.sdpub"]);
     expect(sdpubMockState.textWrites).toStrictEqual([
       [
+        "Archive Format Version: 1",
         "Title: Fixture Book",
         "Authors: Ari Lantern, Bea North",
         "Language: en",
@@ -358,6 +359,7 @@ describe("cli/sdpub", () => {
 
 interface MockDigest {
   listSerials(): Promise<readonly unknown[]>;
+  readArchiveFormatVersion(): Promise<number>;
   readCover(): Promise<typeof sdpubMockState.cover>;
   readMeta(): Promise<typeof sdpubMockState.meta>;
   readSerialSummary(serialId: number): Promise<string>;
@@ -372,6 +374,7 @@ interface MockEditableDocument {
 function createMockDigest(): MockDigest {
   return {
     listSerials: () => Promise.resolve(sdpubMockState.serialEntries),
+    readArchiveFormatVersion: () => Promise.resolve(1),
     readCover: () => Promise.resolve(sdpubMockState.cover),
     readMeta: () => Promise.resolve(sdpubMockState.meta),
     readSerialSummary: (serialId: number) => {

--- a/test/cli/sdpub.test.ts
+++ b/test/cli/sdpub.test.ts
@@ -25,6 +25,8 @@ const sdpubMockState = vi.hoisted(() => ({
     version: 1,
   },
   openCalls: [] as string[],
+  editableCalls: [] as string[],
+  replacedMeta: [] as unknown[],
   serialEntries: [
     {
       fragmentCount: 2,
@@ -75,6 +77,30 @@ vi.mock("../../src/index.js", () => ({
   },
 }));
 
+vi.mock("../../src/facade/spine-digest-file.js", () => ({
+  SpineDigestFile: class {
+    readonly #path: string;
+
+    public constructor(path: string) {
+      this.#path = path;
+    }
+
+    public async openEditableSession(
+      operation: (document: MockEditableDocument) => Promise<unknown>,
+    ): Promise<unknown> {
+      sdpubMockState.editableCalls.push(this.#path);
+      return await operation({
+        readBookMeta: () => Promise.resolve(sdpubMockState.meta),
+        replaceBookMeta: (meta: unknown) => {
+          sdpubMockState.replacedMeta.push(meta);
+          sdpubMockState.meta = meta as typeof sdpubMockState.meta;
+          return Promise.resolve();
+        },
+      });
+    }
+  },
+}));
+
 vi.mock("../../src/cli/io.js", () => ({
   writeBinaryToStdout: vi.fn((data: Uint8Array) => {
     sdpubMockState.binaryWrites.push(data);
@@ -109,7 +135,9 @@ describe("cli/sdpub", () => {
       title: "Fixture Book",
       version: 1,
     };
+    sdpubMockState.editableCalls.length = 0;
     sdpubMockState.openCalls.length = 0;
+    sdpubMockState.replacedMeta.length = 0;
     sdpubMockState.serialEntries = [
       {
         fragmentCount: 2,
@@ -239,6 +267,68 @@ describe("cli/sdpub", () => {
     ]);
   });
 
+  it("renders book metadata", async () => {
+    await runSdpubCommand({
+      inputPath: "/tmp/book.sdpub",
+      subcommand: "meta",
+    });
+
+    expect(sdpubMockState.openCalls).toStrictEqual(["/tmp/book.sdpub"]);
+    expect(sdpubMockState.textWrites).toStrictEqual([
+      [
+        "Source Format: epub",
+        "Title: Fixture Book",
+        "Authors: Ari Lantern, Bea North",
+        "Language: en",
+        "Identifier: urn:test:sdpub-cli",
+        "Publisher: Open Sample Press",
+        "Published At: 2026-01-01",
+        "Description: Fixture description",
+        "",
+      ].join("\n"),
+    ]);
+  });
+
+  it("updates book metadata in place and prints the result", async () => {
+    await runSdpubCommand({
+      inputPath: "/tmp/book.sdpub",
+      metaPatch: {
+        authors: ["Cy Lake"],
+        clearDescription: true,
+        title: "Updated Fixture",
+      },
+      subcommand: "meta",
+    });
+
+    expect(sdpubMockState.editableCalls).toStrictEqual(["/tmp/book.sdpub"]);
+    expect(sdpubMockState.replacedMeta).toStrictEqual([
+      {
+        authors: ["Cy Lake"],
+        description: null,
+        identifier: "urn:test:sdpub-cli",
+        language: "en",
+        publishedAt: "2026-01-01",
+        publisher: "Open Sample Press",
+        sourceFormat: "epub",
+        title: "Updated Fixture",
+        version: 1,
+      },
+    ]);
+    expect(sdpubMockState.textWrites).toStrictEqual([
+      [
+        "Source Format: epub",
+        "Title: Updated Fixture",
+        "Authors: Cy Lake",
+        "Language: en",
+        "Identifier: urn:test:sdpub-cli",
+        "Publisher: Open Sample Press",
+        "Published At: 2026-01-01",
+        "Description: [none]",
+        "",
+      ].join("\n"),
+    ]);
+  });
+
   it("rejects binary cover output to an interactive terminal", async () => {
     setStdoutTTY(true);
 
@@ -272,6 +362,11 @@ interface MockDigest {
   readMeta(): Promise<typeof sdpubMockState.meta>;
   readSerialSummary(serialId: number): Promise<string>;
   readToc(): Promise<typeof sdpubMockState.toc>;
+}
+
+interface MockEditableDocument {
+  readBookMeta(): Promise<typeof sdpubMockState.meta>;
+  replaceBookMeta(meta: unknown): Promise<void>;
 }
 
 function createMockDigest(): MockDigest {

--- a/test/context/task-context.test.ts
+++ b/test/context/task-context.test.ts
@@ -1,0 +1,189 @@
+import { access, readFile, writeFile } from "fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  createSpineDigestTaskId,
+  SpineDigestTaskContext,
+} from "../../src/context/index.js";
+import { withTempDir } from "../helpers/temp.js";
+
+describe("context/task-context", () => {
+  it("derives task ids from source, parameters, task type, and context version", () => {
+    const base = createSpineDigestTaskId({
+      normalizedSource: "Alpha beta.",
+      parameters: {
+        sampling: {
+          temperature: 0.2,
+        },
+      },
+      taskType: "source-to-graph",
+    });
+
+    expect(base).toHaveLength(128);
+    expect(
+      createSpineDigestTaskId({
+        normalizedSource: "Alpha beta.",
+        parameters: {
+          sampling: {
+            temperature: 0.2,
+          },
+        },
+        taskType: "source-to-graph",
+      }),
+    ).toBe(base);
+    expect(
+      createSpineDigestTaskId({
+        normalizedSource: "Alpha beta.",
+        parameters: {
+          sampling: {
+            temperature: 0.2,
+          },
+        },
+        taskType: "source-graph-to-summary",
+      }),
+    ).not.toBe(base);
+    expect(
+      createSpineDigestTaskId({
+        normalizedSource: "Alpha beta.",
+        parameters: {
+          sampling: {
+            temperature: 0.2,
+          },
+        },
+        taskType: "source-to-graph",
+        version: 2,
+      }),
+    ).not.toBe(base);
+  });
+
+  it("removes a task directory after a successful run", async () => {
+    await withTempDir("spinedigest-context-", async (path) => {
+      const context = new SpineDigestTaskContext({
+        rootDirPath: path,
+      });
+      let taskPath = "";
+
+      const value = await context.runTask(
+        {
+          normalizedSource: "Alpha beta.",
+          parameters: {
+            sampling: {},
+          },
+          taskType: "source-to-graph",
+        },
+        async (task) => {
+          taskPath = task.path;
+          await writeFile(`${task.artifactDirPath}/artifact.txt`, "done");
+          return 42;
+        },
+      );
+
+      expect(value).toBe(42);
+      await expect(access(taskPath)).rejects.toThrow();
+    });
+  });
+
+  it("keeps a task directory when a run fails", async () => {
+    await withTempDir("spinedigest-context-", async (path) => {
+      const context = new SpineDigestTaskContext({
+        rootDirPath: path,
+      });
+      let taskPath = "";
+
+      await expect(
+        context.runTask(
+          {
+            normalizedSource: "Alpha beta.",
+            parameters: {},
+            taskType: "source-to-graph",
+          },
+          async (task) => {
+            taskPath = task.path;
+            await writeFile(`${task.artifactDirPath}/artifact.txt`, "partial");
+            throw new Error("stop");
+          },
+        ),
+      ).rejects.toThrow("stop");
+
+      await expect(access(taskPath)).resolves.toBe(undefined);
+      await expect(
+        readFile(`${taskPath}/artifacts/artifact.txt`, "utf8"),
+      ).resolves.toBe("partial");
+      await expect(
+        readFile(`${taskPath}/status.json`, "utf8"),
+      ).resolves.toContain('"status": "running"');
+    });
+  });
+
+  it("reuses the same task directory for the same identity after failure", async () => {
+    await withTempDir("spinedigest-context-", async (path) => {
+      const context = new SpineDigestTaskContext({
+        rootDirPath: path,
+      });
+      const identity = {
+        normalizedSource: "Alpha beta.",
+        parameters: {
+          sampling: {
+            temperature: 0.2,
+          },
+        },
+        taskType: "source-to-graph" as const,
+      };
+      let failedTaskPath = "";
+
+      await expect(
+        context.runTask(identity, async (task) => {
+          failedTaskPath = task.path;
+          await writeFile(`${task.artifactDirPath}/artifact.txt`, "partial");
+          throw new Error("stop");
+        }),
+      ).rejects.toThrow("stop");
+
+      const result = await context.runTask(identity, async (task) => {
+        expect(task.path).toBe(failedTaskPath);
+        await expect(
+          readFile(`${task.artifactDirPath}/artifact.txt`, "utf8"),
+        ).resolves.toBe("partial");
+        await writeFile(`${task.artifactDirPath}/artifact.txt`, "complete");
+        return "ok";
+      });
+
+      expect(result).toBe("ok");
+      await expect(access(failedTaskPath)).rejects.toThrow();
+    });
+  });
+
+  it("reads a running task status", async () => {
+    await withTempDir("spinedigest-context-", async (path) => {
+      const context = new SpineDigestTaskContext({
+        rootDirPath: path,
+      });
+      let status:
+        | Awaited<
+            ReturnType<ReturnType<typeof context.createTask>["readStatus"]>
+          >
+        | undefined;
+
+      await expect(
+        context.runTask(
+          {
+            normalizedSource: "Alpha beta.",
+            parameters: {},
+            taskType: "source-graph-to-summary",
+          },
+          async (task) => {
+            status = await task.readStatus();
+            throw new Error("stop");
+          },
+        ),
+      ).rejects.toThrow("stop");
+
+      expect(status).toMatchObject({
+        status: "running",
+        version: 1,
+      });
+      expect(status?.startedAt).toEqual(expect.any(String));
+    });
+  });
+});

--- a/test/document/directory-document.test.ts
+++ b/test/document/directory-document.test.ts
@@ -132,6 +132,51 @@ describe("document/directory-document", () => {
     });
   });
 
+  it("replaces existing book metadata", async () => {
+    await withTempDir("spinedigest-document-", async (path) => {
+      const document = await DirectoryDocument.open(path);
+
+      try {
+        await document.openSession(async (openedDocument) => {
+          await openedDocument.writeBookMeta({
+            authors: ["Ari Lantern"],
+            description: null,
+            identifier: null,
+            language: null,
+            publishedAt: null,
+            publisher: null,
+            sourceFormat: "txt",
+            title: "Original",
+            version: 1,
+          });
+        });
+
+        await document.openSession(async (openedDocument) => {
+          await openedDocument.replaceBookMeta({
+            authors: ["Bea North"],
+            description: "Updated",
+            identifier: null,
+            language: "en",
+            publishedAt: null,
+            publisher: null,
+            sourceFormat: "txt",
+            title: "Replacement",
+            version: 1,
+          });
+        });
+
+        await expect(document.readBookMeta()).resolves.toMatchObject({
+          authors: ["Bea North"],
+          description: "Updated",
+          language: "en",
+          title: "Replacement",
+        });
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
   it("rolls back owned serial resources when a document context is disposed without completion", async () => {
     await withTempDir("spinedigest-document-", async (path) => {
       const document = await DirectoryDocument.open(path);

--- a/test/facade/archive.test.ts
+++ b/test/facade/archive.test.ts
@@ -1,4 +1,8 @@
+import { createWriteStream } from "fs";
 import { mkdir, readFile, writeFile } from "fs/promises";
+import { dirname } from "path";
+import { finished } from "stream/promises";
+import { ZipFile } from "yazl";
 
 import { describe, expect, it } from "vitest";
 
@@ -48,6 +52,9 @@ describe("facade/archive", () => {
       await writeSdpubArchive(sourceDir, archivePath);
       await extractSdpubArchive(archivePath, extractDir);
 
+      expect(
+        JSON.parse(await readFile(`${extractDir}/manifest.json`, "utf8")),
+      ).toEqual({ formatVersion: 1 });
       expect(await readFile(`${extractDir}/database.db`, "utf8")).toBe(
         "sqlite",
       );
@@ -97,4 +104,66 @@ describe("facade/archive", () => {
       );
     });
   });
+
+  it("accepts archives that omit the manifest as format version 1", async () => {
+    await withTempDir("spinedigest-archive-", async (path) => {
+      const archivePath = `${path}/legacy.sdpub`;
+      const extractDir = `${path}/extract`;
+      const zipFile = new ZipFile();
+
+      zipFile.addBuffer(Buffer.from("sqlite", "utf8"), "database.db");
+      await writeZipFile(zipFile, archivePath);
+
+      await extractSdpubArchive(archivePath, extractDir);
+
+      expect(await readFile(`${extractDir}/database.db`, "utf8")).toBe(
+        "sqlite",
+      );
+    });
+  });
+
+  it("rejects archives with unsupported manifest versions", async () => {
+    await withTempDir("spinedigest-archive-", async (path) => {
+      const archivePath = `${path}/future.sdpub`;
+      const zipFile = new ZipFile();
+
+      zipFile.addBuffer(
+        Buffer.from('{"formatVersion":2}', "utf8"),
+        "manifest.json",
+      );
+      zipFile.addBuffer(Buffer.from("sqlite", "utf8"), "database.db");
+      await writeZipFile(zipFile, archivePath);
+
+      await expect(
+        extractSdpubArchive(archivePath, `${path}/extract`),
+      ).rejects.toThrow("Unsupported SDPUB format version in manifest.json.");
+    });
+  });
+
+  it("rejects archives with malformed manifest files", async () => {
+    await withTempDir("spinedigest-archive-", async (path) => {
+      const archivePath = `${path}/malformed.sdpub`;
+      const zipFile = new ZipFile();
+
+      zipFile.addBuffer(Buffer.from("not json", "utf8"), "manifest.json");
+      zipFile.addBuffer(Buffer.from("sqlite", "utf8"), "database.db");
+      await writeZipFile(zipFile, archivePath);
+
+      await expect(
+        extractSdpubArchive(archivePath, `${path}/extract`),
+      ).rejects.toThrow();
+    });
+  });
 });
+
+async function writeZipFile(zipFile: ZipFile, path: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+
+  const output = createWriteStream(path);
+  const outputDone = finished(output);
+  const zipDone = finished(zipFile.outputStream);
+
+  zipFile.outputStream.pipe(output);
+  zipFile.end();
+  await Promise.all([outputDone, zipDone]);
+}

--- a/test/facade/chapter.test.ts
+++ b/test/facade/chapter.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { DirectoryDocument } from "../../src/document/index.js";
 import {
   addChapter,
+  advanceChapterStages,
   getChapterDetails,
   listChapters,
   removeChapter,
@@ -196,6 +197,59 @@ describe("facade/chapter", () => {
 
         await expect(listChapters(document)).resolves.toStrictEqual([]);
         await expect(document.serials.listIds()).resolves.toStrictEqual([]);
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("advances stages idempotently without resetting planned chapters", async () => {
+    await withTempDir("spinedigest-chapter-", async (path) => {
+      const document = await DirectoryDocument.open(path);
+
+      try {
+        const chapter = await addChapter(document, {
+          title: "Draft",
+        });
+
+        const noop = await advanceChapterStages(document, {
+          extractionPrompt: "Keep key beats",
+          llm: {} as never,
+          targetStage: "planned",
+        });
+
+        expect(noop.advanced).toStrictEqual([]);
+        expect(noop.pending).toMatchObject([
+          {
+            chapterId: chapter.chapterId,
+            stage: "planned",
+          },
+        ]);
+        expect(
+          await getChapterDetails(document, chapter.chapterId),
+        ).toMatchObject({
+          stage: "planned",
+        });
+
+        const skipped = await advanceChapterStages(document, {
+          extractionPrompt: "Keep key beats",
+          llm: {} as never,
+          targetStage: "summarized",
+        });
+
+        expect(skipped.advanced).toStrictEqual([]);
+        expect(skipped.pending).toMatchObject([
+          {
+            chapterId: chapter.chapterId,
+            stage: "planned",
+          },
+        ]);
+        expect(skipped.skipped).toMatchObject([
+          {
+            chapterId: chapter.chapterId,
+            stage: "planned",
+          },
+        ]);
       } finally {
         await document.release();
       }

--- a/test/facade/chapter.test.ts
+++ b/test/facade/chapter.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+
+import { DirectoryDocument } from "../../src/document/index.js";
+import {
+  addChapter,
+  getChapterDetails,
+  listChapters,
+  removeChapter,
+  resetChapter,
+  setChapterSource,
+  setChapterSummary,
+} from "../../src/facade/chapter.js";
+import { withTempDir } from "../helpers/temp.js";
+
+describe("facade/chapter", () => {
+  it("adds planned chapters into a tree and lists their stages", async () => {
+    await withTempDir("spinedigest-chapter-", async (path) => {
+      const document = await DirectoryDocument.open(path);
+
+      try {
+        await document.openSession(async (openedDocument) => {
+          await openedDocument.writeToc({
+            items: [],
+            version: 1,
+          });
+        });
+
+        const parent = await addChapter(document, {
+          title: "Part I",
+        });
+        const child = await addChapter(document, {
+          parentChapterId: parent.chapterId,
+          title: "Chapter 1",
+        });
+
+        expect(parent).toMatchObject({
+          chapterId: 1,
+          stage: "planned",
+          title: "Part I",
+        });
+        expect(child).toMatchObject({
+          chapterId: 2,
+          stage: "planned",
+          title: "Chapter 1",
+        });
+        expect(await listChapters(document)).toMatchObject([
+          {
+            chapterId: 1,
+            depth: 0,
+            stage: "planned",
+            title: "Part I",
+          },
+          {
+            chapterId: 2,
+            depth: 1,
+            stage: "planned",
+            title: "Chapter 1",
+          },
+        ]);
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("normalizes legacy grouping nodes into planned chapters", async () => {
+    await withTempDir("spinedigest-chapter-", async (path) => {
+      const document = await DirectoryDocument.open(path);
+
+      try {
+        await document.openSession(async (openedDocument) => {
+          await openedDocument.createSerial();
+          await openedDocument.writeToc({
+            items: [
+              {
+                children: [
+                  {
+                    children: [],
+                    serialId: 1,
+                    title: "Chapter 1",
+                  },
+                ],
+                title: "Part I",
+              },
+            ],
+            version: 1,
+          });
+        });
+
+        expect(await listChapters(document)).toMatchObject([
+          {
+            chapterId: 2,
+            depth: 0,
+            stage: "planned",
+            title: "Part I",
+          },
+          {
+            chapterId: 1,
+            depth: 1,
+            stage: "planned",
+            title: "Chapter 1",
+          },
+        ]);
+        expect(await document.readToc()).toMatchObject({
+          items: [
+            {
+              serialId: 2,
+              title: "Part I",
+            },
+          ],
+        });
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("sets source and summary through explicit stages", async () => {
+    await withTempDir("spinedigest-chapter-", async (path) => {
+      const document = await DirectoryDocument.open(path);
+
+      try {
+        const chapter = await addChapter(document, {
+          title: "Chapter 1",
+        });
+        const sourced = await setChapterSource(document, chapter.chapterId, [
+          "Alpha beta.",
+        ]);
+
+        expect(sourced.stage).toBe("sourced");
+        await document.serials.setTopologyReady(chapter.chapterId);
+
+        expect(
+          await getChapterDetails(document, chapter.chapterId),
+        ).toMatchObject({
+          stage: "graphed",
+        });
+
+        const summarized = await setChapterSummary(
+          document,
+          chapter.chapterId,
+          "Summary",
+        );
+
+        expect(summarized.stage).toBe("summarized");
+
+        const resetToGraph = await resetChapter(
+          document,
+          chapter.chapterId,
+          "graphed",
+        );
+
+        expect(resetToGraph.stage).toBe("graphed");
+
+        const resetToSource = await resetChapter(
+          document,
+          chapter.chapterId,
+          "sourced",
+        );
+
+        expect(resetToSource.stage).toBe("sourced");
+
+        const resetToPlanned = await resetChapter(
+          document,
+          chapter.chapterId,
+          "planned",
+        );
+
+        expect(resetToPlanned.stage).toBe("planned");
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("requires recursive removal for chapters with children", async () => {
+    await withTempDir("spinedigest-chapter-", async (path) => {
+      const document = await DirectoryDocument.open(path);
+
+      try {
+        const parent = await addChapter(document, {
+          title: "Part I",
+        });
+        await addChapter(document, {
+          parentChapterId: parent.chapterId,
+          title: "Chapter 1",
+        });
+
+        await expect(removeChapter(document, parent.chapterId)).rejects.toThrow(
+          "has child chapters",
+        );
+
+        await removeChapter(document, parent.chapterId, {
+          recursive: true,
+        });
+
+        await expect(listChapters(document)).resolves.toStrictEqual([]);
+        await expect(document.serials.listIds()).resolves.toStrictEqual([]);
+      } finally {
+        await document.release();
+      }
+    });
+  });
+});

--- a/test/facade/digest.test.ts
+++ b/test/facade/digest.test.ts
@@ -189,7 +189,7 @@ describe("facade/digest", () => {
     ).rejects.toThrow();
   });
 
-  it("keeps custom text-stream session directories and uses a fallback toc title", async () => {
+  it("keeps custom text-stream session directories and omits an empty toc title", async () => {
     await withTempDir("spinedigest-digest-", async (path) => {
       const documentDirPath = `${path}/custom-document`;
 
@@ -214,7 +214,6 @@ describe("facade/digest", () => {
               {
                 children: [],
                 serialId: 1,
-                title: "Section 1",
               },
             ],
             version: 1,

--- a/test/facade/import.test.ts
+++ b/test/facade/import.test.ts
@@ -20,6 +20,10 @@ const serialMockState = vi.hoisted(() => ({
     readonly serialId: number;
     readonly streamText: string;
   }>,
+  writeSourceCalls: [] as Array<{
+    readonly serialId: number;
+    readonly streamText: string;
+  }>,
   releaseSerials: new Map<number, () => void>(),
   startedResolvers: new Map<number, () => void>(),
   startedSignals: new Map<number, Promise<void>>(),
@@ -85,6 +89,26 @@ vi.mock("../../src/serial.js", () => ({
       return { id: serialId };
     }
   },
+  writeSerialSource: async (
+    document: DirectoryDocument,
+    serialId: number,
+    stream: AsyncIterable<string> | Iterable<string>,
+  ) => {
+    let streamText = "";
+
+    for await (const chunk of stream) {
+      streamText += chunk;
+    }
+
+    serialMockState.writeSourceCalls.push({
+      serialId,
+      streamText,
+    });
+    const draft = await document.getSerialFragments(serialId).createDraft();
+
+    draft.addSentence(streamText, 1);
+    await draft.commit();
+  },
 }));
 
 describe("facade/import", () => {
@@ -96,6 +120,7 @@ describe("facade/import", () => {
     serialMockState.startedResolvers.clear();
     serialMockState.startedSignals.clear();
     serialMockState.startedSerialIds.length = 0;
+    serialMockState.writeSourceCalls.length = 0;
   });
 
   it("imports source sections into an empty document with optional toc titles", async () => {
@@ -221,6 +246,82 @@ describe("facade/import", () => {
             title: "Single Section Book",
           },
         ]);
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("imports source documents to planned without opening section content", async () => {
+    await withTempDir("spinedigest-import-", async (path) => {
+      const document = await DirectoryDocument.open(`${path}/document`);
+      const openCounts = new Map<string, number>();
+
+      try {
+        const imported = await importSourceDocument(
+          createSourceDocument({
+            meta: createBookMeta(),
+            sections: [
+              createSourceSection({
+                hasContent: true,
+                openCounts,
+                streamText: "Should not be opened",
+                title: "Draft",
+              }),
+            ],
+          }),
+          {
+            document,
+            extractionPrompt: "Keep key beats",
+            targetStage: "planned",
+          },
+        );
+
+        expect(imported.serials.map((serial) => serial.id)).toStrictEqual([1]);
+        expect(openCounts.get("Draft")).toBeUndefined();
+        expect(serialMockState.generateIntoCalls).toHaveLength(0);
+        expect(serialMockState.writeSourceCalls).toHaveLength(0);
+        expect(await document.readSummary(1)).toBeUndefined();
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("imports source documents to sourced without graph or summary generation", async () => {
+    await withTempDir("spinedigest-import-", async (path) => {
+      const document = await DirectoryDocument.open(`${path}/document`);
+
+      try {
+        await importSourceDocument(
+          createSourceDocument({
+            meta: createBookMeta(),
+            sections: [
+              createSourceSection({
+                hasContent: true,
+                streamText: "Source only",
+                title: "Source Chapter",
+              }),
+            ],
+          }),
+          {
+            document,
+            extractionPrompt: "Keep key beats",
+            targetStage: "sourced",
+          },
+        );
+
+        expect(serialMockState.generateIntoCalls).toHaveLength(0);
+        expect(serialMockState.writeSourceCalls).toStrictEqual([
+          {
+            serialId: 1,
+            streamText: "Source only",
+          },
+        ]);
+        expect(
+          await document.getSerialFragments(1).listFragmentIds(),
+        ).toStrictEqual([0]);
+        expect(await document.readSummary(1)).toBeUndefined();
       } finally {
         await document.release();
       }

--- a/test/facade/import.test.ts
+++ b/test/facade/import.test.ts
@@ -98,7 +98,7 @@ describe("facade/import", () => {
     serialMockState.startedSerialIds.length = 0;
   });
 
-  it("imports source sections into an empty document with planned toc titles", async () => {
+  it("imports source sections into an empty document with optional toc titles", async () => {
     await withTempDir("spinedigest-import-", async (path) => {
       const document = await DirectoryDocument.open(`${path}/document`);
       const meta = createBookMeta({
@@ -147,15 +147,12 @@ describe("facade/import", () => {
               {
                 children: [],
                 serialId: 1,
-                title: "Section 1.1",
               },
             ],
-            title: "Section 1",
           },
           {
             children: [],
             serialId: 2,
-            title: "Section 2",
           },
         ]);
 

--- a/test/output/epub-book.test.ts
+++ b/test/output/epub-book.test.ts
@@ -126,6 +126,50 @@ describe("output/epub/book", () => {
     });
   });
 
+  it("uses fallback section titles for untitled toc items", async () => {
+    await withTempDir("spinedigest-epub-book-", async (path) => {
+      const document = await DirectoryDocument.open(`${path}/document`);
+
+      try {
+        await document.openSession(async (openedDocument) => {
+          await openedDocument.createSerial();
+          await openedDocument.writeBookMeta({
+            authors: [],
+            description: null,
+            identifier: null,
+            language: null,
+            publishedAt: null,
+            publisher: null,
+            sourceFormat: "txt",
+            title: null,
+            version: 1,
+          });
+          await openedDocument.writeSummary(1, "Untitled summary");
+          await openedDocument.writeToc({
+            items: [
+              {
+                children: [],
+                serialId: 1,
+              },
+            ],
+            version: 1,
+          });
+        });
+
+        const book = await buildEpubBook(document);
+
+        expect(book.sections[0]).toMatchObject({
+          id: "serial-1",
+          title: "Section 1",
+        });
+        expect(book.navXhtml).toContain("Section 1");
+        expect(book.packageOpf).toContain("Untitled");
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
   it("throws when book meta is missing", async () => {
     await withTempDir("spinedigest-epub-book-", async (path) => {
       const document = await DirectoryDocument.open(path);

--- a/test/output/plain-text.test.ts
+++ b/test/output/plain-text.test.ts
@@ -48,6 +48,37 @@ describe("output/plain-text", () => {
     });
   });
 
+  it("omits headings for untitled toc items", async () => {
+    await withTempDir("spinedigest-output-", async (path) => {
+      const document = await DirectoryDocument.open(`${path}/document`);
+
+      try {
+        await document.openSession(async (openedDocument) => {
+          await openedDocument.writeSummary(1, "Untitled summary");
+          await openedDocument.writeToc({
+            items: [
+              {
+                children: [],
+                serialId: 1,
+              },
+            ],
+            version: 1,
+          });
+        });
+
+        const outputPath = `${path}/result/book.txt`;
+        await writePlainText({
+          document,
+          path: outputPath,
+        });
+
+        expect(await readFile(outputPath, "utf8")).toBe("Untitled summary\n");
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
   it("throws when toc or required summaries are missing", async () => {
     await withTempDir("spinedigest-output-", async (path) => {
       const missingTocDocument = await DirectoryDocument.open(`${path}/no-toc`);

--- a/test/serial.test.ts
+++ b/test/serial.test.ts
@@ -223,6 +223,106 @@ describe("serial", () => {
       }
     });
   });
+
+  it("can build topology and summary as separate phases", async () => {
+    await withTempDir("spinedigest-serial-", async (path) => {
+      const document = await DirectoryDocument.open(path);
+
+      readerSegmentMock.mockReturnValueOnce(
+        createSentenceStream([
+          {
+            offset: 0,
+            text: "Alpha beta.",
+            wordsCount: 2,
+          },
+        ]),
+      );
+
+      try {
+        const generation = new SerialGeneration({
+          document,
+          llm: {} as never,
+        });
+
+        await document.serials.createWithId(1);
+        await generation.buildTopologyInto(1, [], {
+          extractionPrompt: "Keep key beats",
+        });
+
+        expect(await document.readSummary(1)).toBeUndefined();
+        expect(await document.serials.getById(1)).toMatchObject({
+          topologyReady: true,
+        });
+
+        const serial = await generation.buildSummary(1);
+
+        expect(serial.getSummary()).toBe("Alpha beta.");
+        expect(await document.readSummary(1)).toBe("Alpha beta.");
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("does not build a summary before topology is ready", async () => {
+    await withTempDir("spinedigest-serial-", async (path) => {
+      const document = await DirectoryDocument.open(path);
+
+      try {
+        await document.serials.createWithId(1);
+
+        await expect(
+          new SerialGeneration({
+            document,
+            llm: {} as never,
+          }).buildSummary(1),
+        ).rejects.toThrow("Serial 1 is not ready for summary");
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("reuses an existing summary without recompressing", async () => {
+    await withTempDir("spinedigest-serial-", async (path) => {
+      const document = await DirectoryDocument.open(path);
+
+      readerSegmentMock.mockReturnValueOnce(
+        createSentenceStream([
+          {
+            offset: 0,
+            text: "Alpha beta.",
+            wordsCount: 2,
+          },
+          {
+            offset: 11,
+            text: "Gamma delta.",
+            wordsCount: 2,
+          },
+        ]),
+      );
+
+      try {
+        const generation = new SerialGeneration({
+          document,
+          llm: {} as never,
+        });
+
+        await document.serials.createWithId(1);
+        await generation.buildTopologyInto(1, [], {
+          extractionPrompt: "Keep key beats",
+        });
+        await document.writeSummary(1, "Existing summary");
+
+        const serial = await generation.buildSummary(1);
+
+        expect(serial.getSummary()).toBe("Existing summary");
+        expect(compressTextMock).not.toHaveBeenCalled();
+      } finally {
+        await document.release();
+      }
+    });
+  });
 });
 
 function createSentenceStream(


### PR DESCRIPTION
## Summary
- refactor task context caching around deterministic task hashes
- add editable SDPUB chapter, metadata, stage, and archive manifest support
- add staged conversion/advance workflows plus CLI help and docs updates

## Validation
- pnpm run lint:fix
- pnpm verify
- pnpm test:run