### PR TITLE
Improve SDPUB agent help

### DIFF
--- a/data/help/commands/root.jinja
+++ b/data/help/commands/root.jinja
@@ -8,7 +8,7 @@ Purpose:
   Digesting source input uses an LLM pipeline. Re-opening an existing .sdpub archive does not.
 
 Usage:
-  spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose|-v] [--help|-h]
+  spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose|-v] [--help|-h] [--version]
   spinedigest status [--llm <json>] [--help|-h]
   spinedigest sdpub <info|toc|list|cat|cover|meta> --input <path> [options] [--help|-h]
   spinedigest sdpub chapter <action> <path> [options] [--help|-h]
@@ -23,6 +23,7 @@ Help contract:
 Flag aliases:
   - `-h` is the short form of `--help` on every command and subcommand.
   - `-v` is the short form of `--verbose` on the main convert command.
+  - `--version` prints the CLI package version and exits.
 
 Common paths:
   Source input -> digest -> markdown | txt | epub | .sdpub

--- a/data/help/commands/root.jinja
+++ b/data/help/commands/root.jinja
@@ -7,6 +7,13 @@ Purpose:
   Distill long-form EPUB, Markdown, or plain text into compressed output.
   Digesting source input uses an LLM pipeline. Re-opening an existing .sdpub archive does not.
 
+Default command:
+  `spinedigest` without a subcommand is the convenience digest/export command.
+  It reads from `--input <path>`, or from stdin when `--input` is omitted.
+  It writes to `--output <path>`, or to stdout when `--output` is omitted.
+  If no arguments are passed in an interactive terminal, it prints this help page.
+  Stream input/output formats cannot be inferred, so pass `--input-format` and `--output-format` for pipes.
+
 Usage:
   spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose|-v] [--help|-h] [--version]
   spinedigest status [--llm <json>] [--help|-h]
@@ -27,6 +34,7 @@ Flag aliases:
 
 Common paths:
   Source input -> digest -> markdown | txt | epub | .sdpub
+  Piped txt/markdown -> digest -> stdout text
   Config status -> validate merged config -> print masked JSON
   .sdpub input -> re-export or inspect without re-running the digest pipeline
 

--- a/data/help/commands/sdpub/cat.jinja
+++ b/data/help/commands/sdpub/cat.jinja
@@ -4,7 +4,7 @@ Command: spinedigest sdpub cat
 sdpub cat
 
 Purpose:
-  Print the summary text for one serial id.
+  Print the final summary text for one summarized serial id.
 
 Usage:
   spinedigest sdpub cat --input <path> --serial <id> [--llm <json>] [--help|-h]
@@ -16,4 +16,7 @@ Output shape:
   - Plain summary text only
 
 Notes:
-  - Use `spinedigest sdpub list --input <path>` to discover valid serial ids.
+  - The serial must have a summary.
+  - Planned, sourced, or graphed chapters are not ready for `cat`.
+  - Use `spinedigest sdpub list --input <path>` to discover summarized serial ids.
+  - Use `spinedigest sdpub stage pending <path>` to find unfinished chapters.

--- a/data/help/commands/sdpub/cat.jinja
+++ b/data/help/commands/sdpub/cat.jinja
@@ -4,19 +4,21 @@ Command: spinedigest sdpub cat
 sdpub cat
 
 Purpose:
-  Print the final summary text for one summarized serial id.
+  Print the final summary text for one completed chapter through the legacy serial reader.
 
 Usage:
   spinedigest sdpub cat --input <path> --serial <id> [--llm <json>] [--help|-h]
 
 Required flags:
   --serial <id> must be a non-negative integer.
+  For chapter-backed content, this id matches the chapter id printed by `sdpub list`.
 
 Output shape:
   - Plain summary text only
 
 Notes:
-  - The serial must have a summary.
+  - `serial` is a legacy read-interface term; current editing and staging commands use chapter ids.
+  - The selected id must have a summary.
   - Planned, sourced, or graphed chapters are not ready for `cat`.
-  - Use `spinedigest sdpub list --input <path>` to discover summarized serial ids.
+  - Use `spinedigest sdpub list --input <path>` to discover completed summaries.
   - Use `spinedigest sdpub stage pending <path>` to find unfinished chapters.

--- a/data/help/commands/sdpub/chapter.jinja
+++ b/data/help/commands/sdpub/chapter.jinja
@@ -26,8 +26,11 @@ Input rules:
   - `reset --to` accepts `planned`, `sourced`, or `graphed`.
   - Structure edits, `set-source`, `set-summary`, and `reset` do not call an LLM provider.
   - To generate graph or summary for a chapter, use `spinedigest sdpub stage advance <path> --chapter <id> --to <stage>`.
+  - Append `--help` after an action for action-specific details, for example `spinedigest sdpub chapter reset --help`.
 
 See also:
   - spinedigest sdpub chapter list <path>
+  - spinedigest sdpub chapter set-source --help
+  - spinedigest sdpub chapter set-summary --help
   - spinedigest sdpub stage --help
   - spinedigest help sdpub

--- a/data/help/commands/sdpub/chapter.jinja
+++ b/data/help/commands/sdpub/chapter.jinja
@@ -1,3 +1,4 @@
+Help Type: command
 Command: spinedigest sdpub chapter
 
 Edit chapters inside an existing `.sdpub` archive.
@@ -26,6 +27,7 @@ Input rules:
   - `reset --to` accepts `planned`, `sourced`, or `graphed`.
   - Structure edits, `set-source`, `set-summary`, and `reset` do not call an LLM provider.
   - To generate graph or summary for a chapter, use `spinedigest sdpub stage advance <path> --chapter <id> --to <stage>`.
+  - Legacy `generate-graph` and `generate-summary` action names are accepted for compatibility, but `sdpub stage advance` is the documented path.
   - Append `--help` after an action for action-specific details, for example `spinedigest sdpub chapter reset --help`.
 
 See also:

--- a/data/help/commands/sdpub/chapter/add.jinja
+++ b/data/help/commands/sdpub/chapter/add.jinja
@@ -1,0 +1,29 @@
+Help Type: command
+Command: spinedigest sdpub chapter add
+
+sdpub chapter add
+
+Purpose:
+  Insert a new planned chapter into an existing `.sdpub` chapter tree.
+
+Usage:
+  spinedigest sdpub chapter add <path> [--title <title>] [--parent <id>] [--llm <json>] [--help|-h]
+
+Behavior:
+  - Creates a planned chapter with no source, graph, or summary.
+  - Omitting `--title` creates an untitled planned chapter.
+  - Omitting `--parent` adds the chapter at the top level.
+  - `--parent <id>` adds the chapter under an existing chapter.
+  - Does not call an LLM provider.
+
+Output shape:
+  Prints the new chapter status.
+  The `Chapter: <id>` line is the new chapter id for later commands.
+
+Typical next step:
+  spinedigest sdpub chapter set-source <path> --chapter <id> --input <file> --input-format txt
+
+See also:
+  - spinedigest sdpub chapter list --help
+  - spinedigest sdpub chapter set-source --help
+  - spinedigest help sdpub

--- a/data/help/commands/sdpub/chapter/list.jinja
+++ b/data/help/commands/sdpub/chapter/list.jinja
@@ -1,0 +1,29 @@
+Help Type: command
+Command: spinedigest sdpub chapter list
+
+sdpub chapter list
+
+Purpose:
+  List every chapter in the `.sdpub` chapter tree.
+
+Usage:
+  spinedigest sdpub chapter list <path> [--llm <json>] [--help|-h]
+
+Output shape:
+  [<chapterId>] <stage> <title-or-[untitled]>
+
+Behavior:
+  - Includes summarized and unfinished chapters.
+  - Indents child chapters under their parent.
+  - The bracketed number is the chapter id used by `sdpub chapter` and `sdpub stage --chapter`.
+  - Does not call an LLM provider.
+  - Does not mutate chapter content or summaries.
+
+Use this before mutation:
+  Discover ids with:
+    spinedigest sdpub chapter list <path>
+
+See also:
+  - spinedigest sdpub stage pending --help
+  - spinedigest sdpub chapter status --help
+  - spinedigest help sdpub

--- a/data/help/commands/sdpub/chapter/remove.jinja
+++ b/data/help/commands/sdpub/chapter/remove.jinja
@@ -1,0 +1,25 @@
+Help Type: command
+Command: spinedigest sdpub chapter remove
+
+sdpub chapter remove
+
+Purpose:
+  Remove a chapter from the `.sdpub` chapter tree.
+
+Usage:
+  spinedigest sdpub chapter remove <path> --chapter <id> [--recursive] [--llm <json>] [--help|-h]
+
+Behavior:
+  - Removes the target chapter from the TOC tree.
+  - Removes that chapter's source fragments, graph data, and summary.
+  - Fails when the chapter has children unless `--recursive` is provided.
+  - With `--recursive`, removes the whole selected subtree and its stored data.
+  - Does not call an LLM provider.
+
+Safety:
+  This is a destructive in-place edit. Use `sdpub chapter list` first and keep your own copy if the archive is important.
+
+See also:
+  - spinedigest sdpub chapter list --help
+  - spinedigest sdpub chapter reset --help
+  - spinedigest help sdpub

--- a/data/help/commands/sdpub/chapter/reset.jinja
+++ b/data/help/commands/sdpub/chapter/reset.jinja
@@ -1,0 +1,26 @@
+Help Type: command
+Command: spinedigest sdpub chapter reset
+
+sdpub chapter reset
+
+Purpose:
+  Move a chapter backward by deleting later-stage artifacts.
+
+Usage:
+  spinedigest sdpub chapter reset <path> --chapter <id> --to <stage> [--llm <json>] [--help|-h]
+
+Targets:
+  planned     Delete source fragments, graph data, and summary.
+  sourced     Keep source fragments; delete graph data and summary.
+  graphed     Keep source fragments and graph data; delete summary.
+
+Behavior:
+  - `--to summarized` is not supported because reset is a backward operation.
+  - Reset is destructive and may discard work.
+  - Does not call an LLM provider.
+  - After reset, use `sdpub stage advance` to move forward safely.
+
+See also:
+  - spinedigest sdpub stage advance --help
+  - spinedigest sdpub chapter status --help
+  - spinedigest help sdpub

--- a/data/help/commands/sdpub/chapter/set-source.jinja
+++ b/data/help/commands/sdpub/chapter/set-source.jinja
@@ -1,0 +1,33 @@
+Help Type: command
+Command: spinedigest sdpub chapter set-source
+
+sdpub chapter set-source
+
+Purpose:
+  Fill a planned chapter with normalized source text.
+
+Usage:
+  spinedigest sdpub chapter set-source <path> --chapter <id> [--input <path>] --input-format <format> [--llm <json>] [--help|-h]
+
+Input:
+  - `--input-format` must be `txt` or `markdown`.
+  - If `--input` is omitted, source text is read from stdin.
+
+Preconditions:
+  - The chapter must be `planned`.
+  - To replace source on a later-stage chapter, first reset it to `planned`.
+
+Behavior:
+  - Writes normalized source fragments.
+  - Moves the chapter to `sourced`.
+  - Does not generate graph data.
+  - Does not generate or modify a summary.
+  - Does not call an LLM provider.
+
+Typical next step:
+  spinedigest sdpub stage advance <path> --chapter <id> --to graphed
+
+See also:
+  - spinedigest sdpub chapter reset --help
+  - spinedigest sdpub stage advance --help
+  - spinedigest help sdpub

--- a/data/help/commands/sdpub/chapter/set-summary.jinja
+++ b/data/help/commands/sdpub/chapter/set-summary.jinja
@@ -1,0 +1,29 @@
+Help Type: command
+Command: spinedigest sdpub chapter set-summary
+
+sdpub chapter set-summary
+
+Purpose:
+  Fill a graphed chapter with a manual final summary.
+
+Usage:
+  spinedigest sdpub chapter set-summary <path> --chapter <id> [--input <path>] [--llm <json>] [--help|-h]
+
+Input:
+  - If `--input` is omitted, summary text is read from stdin.
+  - Summary text is stored as the final serial summary.
+
+Preconditions:
+  - The chapter must be `graphed`.
+  - If the chapter is `sourced`, run:
+    spinedigest sdpub stage advance <path> --chapter <id> --to graphed
+
+Behavior:
+  - Moves the chapter to `summarized`.
+  - Does not generate or modify graph data.
+  - Does not call an LLM provider.
+
+See also:
+  - spinedigest sdpub stage advance --help
+  - spinedigest sdpub chapter status --help
+  - spinedigest help sdpub

--- a/data/help/commands/sdpub/chapter/set-summary.jinja
+++ b/data/help/commands/sdpub/chapter/set-summary.jinja
@@ -11,7 +11,7 @@ Usage:
 
 Input:
   - If `--input` is omitted, summary text is read from stdin.
-  - Summary text is stored as the final serial summary.
+  - Summary text is stored as the chapter's final summary.
 
 Preconditions:
   - The chapter must be `graphed`.

--- a/data/help/commands/sdpub/chapter/status.jinja
+++ b/data/help/commands/sdpub/chapter/status.jinja
@@ -1,0 +1,31 @@
+Help Type: command
+Command: spinedigest sdpub chapter status
+
+sdpub chapter status
+
+Purpose:
+  Print one chapter's current stage and stored artifacts.
+
+Usage:
+  spinedigest sdpub chapter status <path> --chapter <id> [--llm <json>] [--help|-h]
+
+Output shape:
+  Chapter: <id>
+  Title: <title-or-[untitled]>
+  Stage: <planned|sourced|graphed|summarized>
+  Fragments: <count>
+  Children: <count>
+  Graph: yes|no
+  Summary: yes|no
+
+Behavior:
+  - Does not call an LLM provider.
+  - Does not mutate the archive.
+  - `Fragments` is the number of stored normalized fragment records for that chapter.
+  - `Graph` reports whether graph/topology data is present.
+  - `Summary` reports whether the final serial summary file is present.
+
+See also:
+  - spinedigest sdpub chapter list --help
+  - spinedigest sdpub stage advance --help
+  - spinedigest help sdpub

--- a/data/help/commands/sdpub/chapter/status.jinja
+++ b/data/help/commands/sdpub/chapter/status.jinja
@@ -23,7 +23,7 @@ Behavior:
   - Does not mutate the archive.
   - `Fragments` is the number of stored normalized fragment records for that chapter.
   - `Graph` reports whether graph/topology data is present.
-  - `Summary` reports whether the final serial summary file is present.
+  - `Summary` reports whether the final chapter summary is present.
 
 See also:
   - spinedigest sdpub chapter list --help

--- a/data/help/commands/sdpub/index.jinja
+++ b/data/help/commands/sdpub/index.jinja
@@ -28,6 +28,16 @@ Shared behavior:
   - Inspection commands and metadata/tree edits do not call an LLM provider.
   - `-h` is available as the short form of `--help`.
 
+Path convention:
+  - Use `--input <path>` for `info`, `toc`, `list`, `cat`, `cover`, and `meta`.
+  - Use positional `<path>` for `stage` and `chapter`.
+  - `.sdpub` is a ZIP archive, but routine automation should not unzip and edit it directly. Use this command family instead.
+
+Mutation safety:
+  - Mutating commands edit archives in place.
+  - Do not run multiple mutating commands against the same archive concurrently.
+  - Keep your own copy before destructive actions such as `chapter remove` or `chapter reset`.
+
 Subcommands:
 {% for command in sdpubCommands %}
   {{ command.name }}:

--- a/data/help/commands/sdpub/index.jinja
+++ b/data/help/commands/sdpub/index.jinja
@@ -29,8 +29,9 @@ Shared behavior:
   - `-h` is available as the short form of `--help`.
 
 Path convention:
-  - Use `--input <path>` for `info`, `toc`, `list`, `cat`, `cover`, and `meta`.
-  - Use positional `<path>` for `stage` and `chapter`.
+  - Use `--input <path>` for read-oriented commands: `info`, `toc`, `list`, `cat`, `cover`, and `meta`.
+  - Use positional `<path>` for operated-document commands: `stage` and `chapter`.
+  - This split follows the top-level option style for inspection, while mutating/stage commands treat the archive as the document being operated on.
   - `.sdpub` is a ZIP archive, but routine automation should not unzip and edit it directly. Use this command family instead.
 
 Mutation safety:

--- a/data/help/commands/sdpub/info.jinja
+++ b/data/help/commands/sdpub/info.jinja
@@ -4,7 +4,7 @@ Command: spinedigest sdpub info
 sdpub info
 
 Purpose:
-  Print archive metadata and high-level summary counts.
+  Print archive metadata and high-level chapter/summary counts.
 
 Usage:
   spinedigest sdpub info --input <path> [--llm <json>] [--help|-h]
@@ -21,7 +21,8 @@ Output shape:
   - Description
   - Cover presence and cover metadata
   - Top-level section count
-  - Referenced serial count
+  - Referenced chapter count
+  - Summarized chapter count
   - Total fragment count
 
 Notes:

--- a/data/help/commands/sdpub/list.jinja
+++ b/data/help/commands/sdpub/list.jinja
@@ -4,7 +4,7 @@ Command: spinedigest sdpub list
 sdpub list
 
 Purpose:
-  List the serial summaries referenced by the TOC.
+  List summarized serials that can be read with `sdpub cat`.
 
 Usage:
   spinedigest sdpub list --input <path> [--llm <json>] [--help|-h]
@@ -14,4 +14,6 @@ Output shape:
 
 Notes:
   - The TOC path is joined with ` / `.
-  - If the archive references no serials, the command prints `No serials referenced by TOC.`
+  - Listed ids are suitable for `spinedigest sdpub cat --serial <id>`.
+  - Use `sdpub chapter list` when you need editable chapter ids for staged or unfinished chapters.
+  - If the archive references no summarized serials, the command prints `No serials referenced by TOC.`

--- a/data/help/commands/sdpub/list.jinja
+++ b/data/help/commands/sdpub/list.jinja
@@ -4,16 +4,16 @@ Command: spinedigest sdpub list
 sdpub list
 
 Purpose:
-  List summarized serials that can be read with `sdpub cat`.
+  List summarized chapters that can be read with `sdpub cat`.
 
 Usage:
   spinedigest sdpub list --input <path> [--llm <json>] [--help|-h]
 
 Output shape:
-  [<serialId>] <TOC path> (fragments: <count>)
+  [<id>] <TOC path> (fragments: <count>)
 
 Notes:
   - The TOC path is joined with ` / `.
-  - Listed ids are suitable for `spinedigest sdpub cat --serial <id>`.
+  - Listed ids are completed chapter ids. The legacy `sdpub cat` command reads them with `--serial <id>`.
   - Use `sdpub chapter list` when you need editable chapter ids for staged or unfinished chapters.
-  - If the archive references no summarized serials, the command prints `No serials referenced by TOC.`
+  - If the archive has no completed summaries, the command prints `No summarized chapters available.`

--- a/data/help/commands/sdpub/stage.jinja
+++ b/data/help/commands/sdpub/stage.jinja
@@ -26,6 +26,7 @@ Behavior:
   - `planned` chapters are skipped by graph and summary generation because they have no source.
   - `--prompt <text>` is used when graph generation is needed.
   - `--llm <json>` can provide the LLM configuration needed by graph or summary generation.
+  - Append `--help` after an action for action-specific details, for example `spinedigest sdpub stage advance --help`.
 
 Examples:
   spinedigest sdpub stage pending ./book.sdpub

--- a/data/help/commands/sdpub/stage/advance.jinja
+++ b/data/help/commands/sdpub/stage/advance.jinja
@@ -1,0 +1,41 @@
+Help Type: command
+Command: spinedigest sdpub stage advance
+
+sdpub stage advance
+
+Purpose:
+  Safely move chapters forward through the `.sdpub` lifecycle.
+
+Usage:
+  spinedigest sdpub stage advance <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>] [--help|-h]
+
+Stages:
+  planned     Chapter exists, but no source is stored.
+  sourced     Normalized source fragments are stored.
+  graphed     Source plus generated graph are stored.
+  summarized  Source, graph, and final summary are stored.
+
+Behavior:
+  - If `--to` is omitted, the target is `summarized`.
+  - Advancement is idempotent: chapters already at or beyond the target stage are left unchanged.
+  - `--to planned` is accepted as a no-op for scripts that compute target stages dynamically.
+  - `--chapter <id>` limits work to that chapter and its descendants.
+  - Planned chapters are skipped because they have no source.
+  - Advancing from `sourced` to `graphed` calls an LLM provider.
+  - Advancing from `graphed` to `summarized` calls an LLM provider.
+  - Advancing never resets or deletes later-stage data.
+
+Output shape:
+  - `Advanced`: number of chapters moved forward.
+  - `Pending`: number of selected chapters still below the requested target.
+  - `Skipped`: number of planned chapters skipped because they have no source.
+  - Pending chapter lines use `[<chapterId>] <stage> <TOC path>`.
+
+When planned chapters are skipped:
+  Add source before advancing again:
+    spinedigest sdpub chapter set-source <path> --chapter <id> --input <file> --input-format txt
+
+See also:
+  - spinedigest sdpub stage pending --help
+  - spinedigest sdpub chapter set-source --help
+  - spinedigest help sdpub

--- a/data/help/commands/sdpub/stage/pending.jinja
+++ b/data/help/commands/sdpub/stage/pending.jinja
@@ -1,0 +1,30 @@
+Help Type: command
+Command: spinedigest sdpub stage pending
+
+sdpub stage pending
+
+Purpose:
+  List chapters that are not yet summarized.
+
+Usage:
+  spinedigest sdpub stage pending <path> [--llm <json>] [--help|-h]
+
+Output shape:
+  [<chapterId>] <stage> <TOC path>
+
+Behavior:
+  - Prints only chapters whose stage is not `summarized`.
+  - Prints `No pending chapters.` when every chapter is summarized.
+  - Does not call an LLM provider.
+  - Does not mutate the archive.
+
+Next actions:
+  - For `planned` chapters, add source first:
+    spinedigest sdpub chapter set-source <path> --chapter <id> --input <file> --input-format txt
+  - For `sourced` or `graphed` chapters, advance safely:
+    spinedigest sdpub stage advance <path> --chapter <id> --to summarized
+
+See also:
+  - spinedigest sdpub stage advance --help
+  - spinedigest sdpub chapter list --help
+  - spinedigest help sdpub

--- a/data/help/commands/sdpub/toc.jinja
+++ b/data/help/commands/sdpub/toc.jinja
@@ -12,8 +12,11 @@ Usage:
 Output shape:
   - Document title first, when available
   - Indented TOC items
-  - `[serial N]` markers on items linked to a serial summary
+  - `[serial N]` markers on items linked to chapter-backed serial data
 
 Notes:
   - The command fails if the archive has no TOC.
   - Empty TOCs print `No TOC items.`
+  - A `[serial N]` marker does not guarantee that `sdpub cat --serial N` is ready; `cat` requires a summary.
+  - Use `sdpub list` to discover ids ready for `cat`.
+  - Use `sdpub chapter list` or `sdpub stage pending` to inspect unfinished chapters.

--- a/data/help/commands/sdpub/toc.jinja
+++ b/data/help/commands/sdpub/toc.jinja
@@ -12,11 +12,11 @@ Usage:
 Output shape:
   - Document title first, when available
   - Indented TOC items
-  - `[serial N]` markers on items linked to chapter-backed serial data
+  - `[chapter N]` markers on items linked to editable chapter content
 
 Notes:
   - The command fails if the archive has no TOC.
   - Empty TOCs print `No TOC items.`
-  - A `[serial N]` marker does not guarantee that `sdpub cat --serial N` is ready; `cat` requires a summary.
-  - Use `sdpub list` to discover ids ready for `cat`.
+  - A `[chapter N]` marker does not guarantee that `sdpub cat --serial N` is ready; `cat` requires a completed summary.
+  - Use `sdpub list` to discover completed summaries ready for `cat`.
   - Use `sdpub chapter list` or `sdpub stage pending` to inspect unfinished chapters.

--- a/data/help/topics/ai.jinja
+++ b/data/help/topics/ai.jinja
@@ -34,8 +34,10 @@ Navigation:
 Stable terms:
   - digest: a new processing run from source input
   - .sdpub: a reusable processed archive
-  - serial: one digestible summary unit referenced by the TOC
-  - TOC path: the section path that points to a serial
+  - chapter: the current editable unit inside a .sdpub TOC
+  - chapter id: the numeric id used by `sdpub chapter ...` and `sdpub stage --chapter`
+  - serial: legacy/read-interface term still used by `sdpub cat --serial`
+  - TOC path: the section path for a chapter or completed summary
 
 Safety reminders:
   - Do not use stdin for `.sdpub` inspection; only `sdpub chapter set-source` and `set-summary` accept content from stdin.

--- a/data/help/topics/command.jinja
+++ b/data/help/topics/command.jinja
@@ -4,7 +4,7 @@ Topic: command
 Command Reference
 
 Main convert command:
-  spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose|-v] [--help|-h]
+  spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose|-v] [--help|-h] [--version]
 
 Status command:
   spinedigest status [--llm <json>] [--help|-h]
@@ -22,6 +22,7 @@ Main flags:
   --stage <stage>         For .sdpub output, stop at planned, sourced, graphed, or summarized.
   --verbose, -v           Write diagnostic logs to stderr.
   --help, -h              Print entry help.
+  --version               Print the CLI package version and exit.
 
 sdpub inspection and metadata commands:
   spinedigest sdpub info --input <path> [--llm <json>]

--- a/data/help/topics/command.jinja
+++ b/data/help/topics/command.jinja
@@ -6,6 +6,11 @@ Command Reference
 Main convert command:
   spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose|-v] [--help|-h] [--version]
 
+Default command behavior:
+  `spinedigest` without a subcommand is the convenience digest/export command.
+  It reads stdin when `--input` is omitted and writes stdout when `--output` is omitted.
+  Use explicit format flags for streams because there is no filename extension to inspect.
+
 Status command:
   spinedigest status [--llm <json>] [--help|-h]
     Validate and print the masked merged config.
@@ -46,7 +51,7 @@ sdpub chapter commands:
   spinedigest sdpub chapter set-summary <path> --chapter <id> [--input <path>] [--llm <json>]
 
 sdpub-specific flags:
-  --serial <id>          Required by `spinedigest sdpub cat`; must be a non-negative integer.
+  --serial <id>          Legacy read flag required by `spinedigest sdpub cat`; for chapter-backed content it matches the chapter id.
   --chapter <id>         Numeric chapter id printed by `sdpub chapter list` or `add`.
   --parent <id>          Parent chapter id for `sdpub chapter add`.
   --to <stage>           Target stage for `sdpub stage advance` or `sdpub chapter reset`.

--- a/data/help/topics/format.jinja
+++ b/data/help/topics/format.jinja
@@ -22,6 +22,12 @@ Output rules:
   - `sdpub meta` edits book metadata in place when metadata edit flags are present.
   - `sdpub stage` and `sdpub chapter` edit existing archives in place when their action changes data.
 
+Output readiness by `.sdpub` stage:
+  - planned: inspect and edit only; add source before generation.
+  - sourced: inspect, edit, or advance; re-export and `sdpub cat` are not ready.
+  - graphed: inspect, edit, advance, or set a manual summary; re-export and `sdpub cat` are not ready.
+  - summarized: inspect, re-export, and read summaries with `sdpub cat`.
+
 Inference:
   - If `--input-format` is omitted, input format is inferred from the file extension.
   - If `--output-format` is omitted, output format is inferred from the file extension.

--- a/data/help/topics/overview.jinja
+++ b/data/help/topics/overview.jinja
@@ -19,8 +19,14 @@ Mental model:
   4. Archive command path:
      `spinedigest sdpub ...` inspects or edits existing archives.
 
+Default command:
+  `spinedigest` without a subcommand is the convenience digest/export command.
+  It reads from `--input <path>` or stdin, and writes to `--output <path>` or stdout.
+  In an interactive terminal, a bare `spinedigest` prints root help instead of trying to digest empty stdin.
+
 Think in terms of intent:
   - Use source input when you want a new digest.
+  - Use a pipe only for non-interactive txt or markdown streams with explicit format flags.
   - Use .sdpub input when you want deterministic reuse of a previous digest.
   - Use `sdpub` subcommands when you want to inspect or edit an archive, not export it.
 

--- a/data/help/topics/recipe.jinja
+++ b/data/help/topics/recipe.jinja
@@ -33,10 +33,10 @@ Advance a staged archive to summaries:
 Add an empty planned chapter:
   spinedigest sdpub chapter add ./book.sdpub --title "Appendix"
 
-List archive serial ids:
+List completed summaries:
   spinedigest sdpub list --input ./book.sdpub
 
-Read one serial summary:
+Read one completed summary through the legacy serial reader:
   spinedigest sdpub cat --input ./book.sdpub --serial 12
 
 Write the cover to a file:

--- a/data/help/topics/runtime.jinja
+++ b/data/help/topics/runtime.jinja
@@ -23,6 +23,12 @@ Digest workspace:
   - The target directory is removed before each run, then rebuilt as the working digest directory.
   - With the top-level convert command, `.sdpub` input ignores `--digest-dir`; with the `sdpub` subcommands, `--digest-dir` is rejected and cannot be used.
 
+In-place archive edits:
+  - `sdpub meta`, `sdpub stage advance`, and mutating `sdpub chapter` actions edit archives in place.
+  - Do not run multiple mutating `sdpub` commands against the same archive concurrently.
+  - Writes are staged through a temporary archive and renamed into place, but no backup file is created.
+  - Keep your own copy before destructive commands such as `sdpub chapter remove` or `sdpub chapter reset`.
+
 Binary safety:
   - `sdpub cover` refuses to write binary cover data to an interactive terminal.
 

--- a/data/help/topics/runtime.jinja
+++ b/data/help/topics/runtime.jinja
@@ -6,6 +6,7 @@ Runtime Behavior
 Streams:
   - If `--input` is omitted, the CLI reads stdin.
   - If `--output` is omitted, the CLI writes stdout.
+  - A bare `spinedigest` in an interactive terminal prints root help.
   - Interactive stdin is rejected for source digest runs.
   - `sdpub chapter set-source` and `set-summary` read stdin when their `--input` flag is omitted.
   - `--verbose` cannot be used when digest output goes to stdout.

--- a/data/help/topics/sdpub.jinja
+++ b/data/help/topics/sdpub.jinja
@@ -4,7 +4,69 @@ Topic: sdpub
 sdpub Help Topic
 
 Purpose:
-  This topic points to the command-help pages for `.sdpub` inspection, metadata editing, stage advancement, and chapter editing.
+  Explain the `.sdpub` archive model and route safe CLI operations.
+
+Primary rule:
+  Treat `.sdpub` as an editable document managed by SpineDigest commands.
+  It is physically a ZIP archive, but agents should not unzip and edit files directly unless they are building an external reader or validator.
+  Use `spinedigest sdpub ...` commands for inspection and in-place edits.
+
+Archive model:
+  - Document metadata is edited with `sdpub meta`.
+  - The TOC is a chapter tree. Each editable chapter has a numeric chapter id.
+  - A chapter may store normalized source fragments, graph data, and a final summary.
+  - A cover, when present, can be read with `sdpub cover`.
+  - `manifest.json` stores the archive format version. Missing manifest means format version 1.
+  - `database.db` is internal state for SpineDigest. Do not edit it directly from automation.
+
+Chapter lifecycle:
+  planned     Chapter exists in the TOC, but has no source.
+  sourced     Normalized source fragments are stored.
+  graphed     Source plus generated graph/topology data are stored.
+  summarized  Source, graph, and final summary are stored.
+
+Readiness by stage:
+  - planned: inspect, edit structure, or set source.
+  - sourced: inspect, edit, or advance to graph/summary.
+  - graphed: inspect, edit, advance to summary, or set a manual summary.
+  - summarized: inspect, export, and use `sdpub cat`.
+
+Identifiers:
+  - `chapter id` is used by `sdpub chapter ...` and `sdpub stage --chapter`.
+  - `serial id` is used by older read commands such as `sdpub cat --serial`.
+  - In the current editable model, chapter ids and serial ids share the same numeric id for chapter-backed content.
+  - Prefer `sdpub chapter list` when selecting a chapter to edit.
+  - Prefer `sdpub list` when selecting a summarized serial to read with `sdpub cat`.
+
+Fragments:
+  A fragment is a normalized internal text unit stored for a chapter.
+  Fragment counts are useful for diagnostics and rough size checks, but they are not the original source file's chapter count.
+
+Read-only commands:
+  - `sdpub info --input <path>`
+  - `sdpub toc --input <path>`
+  - `sdpub list --input <path>`
+  - `sdpub cat --input <path> --serial <id>`
+  - `sdpub cover --input <path>`
+  - `sdpub stage pending <path>`
+  - `sdpub chapter list <path>`
+  - `sdpub chapter status <path> --chapter <id>`
+
+Mutating commands:
+  - `sdpub meta --input <path> [metadata options]`
+  - `sdpub stage advance <path> [options]`
+  - `sdpub chapter add|remove|reset|set-source|set-summary <path> [options]`
+
+LLM behavior:
+  - Inspection, metadata edits, chapter tree edits, `set-source`, `set-summary`, and `reset` do not call an LLM provider.
+  - `sdpub stage advance` calls an LLM provider when it needs graph or summary generation.
+  - Creating `.sdpub` with `--stage planned` or `--stage sourced` does not call an LLM provider.
+
+Mutation safety:
+  - Mutating commands edit archives in place.
+  - Do not run multiple mutating `sdpub` commands against the same archive concurrently.
+  - Writes are staged through a temporary archive and renamed into place, but no backup file is created.
+  - Keep your own copy before destructive commands such as `chapter remove` or `chapter reset`.
 
 Command help entry points:
   - spinedigest sdpub --help
@@ -19,12 +81,13 @@ Command help entry points:
 
 Use this topic when:
   - You know `.sdpub` is relevant, but you have not yet chosen the exact archive command.
-  - You want to jump from topic help into command help.
+  - You need enough conceptual context to operate through the CLI without directly editing ZIP contents.
 
 Where to go next:
-  - Need archive-vs-source mental model:
-    spinedigest help overview
-  - Need task-level guidance on when to generate or reuse `.sdpub`:
+  - Need task-level workflows:
     spinedigest help task
   - Need the command-family overview:
     spinedigest sdpub --help
+  - Need action-specific mutation details:
+    spinedigest sdpub chapter set-source --help
+    spinedigest sdpub stage advance --help

--- a/data/help/topics/sdpub.jinja
+++ b/data/help/topics/sdpub.jinja
@@ -31,12 +31,16 @@ Readiness by stage:
   - graphed: inspect, edit, advance to summary, or set a manual summary.
   - summarized: inspect, export, and use `sdpub cat`.
 
-Identifiers:
-  - `chapter id` is used by `sdpub chapter ...` and `sdpub stage --chapter`.
-  - `serial id` is used by older read commands such as `sdpub cat --serial`.
-  - In the current editable model, chapter ids and serial ids share the same numeric id for chapter-backed content.
-  - Prefer `sdpub chapter list` when selecting a chapter to edit.
-  - Prefer `sdpub list` when selecting a summarized serial to read with `sdpub cat`.
+Primary model:
+  Current editable `.sdpub` archives are organized around chapters.
+  Use chapter ids with `sdpub chapter ...` and `sdpub stage --chapter`.
+  Prefer `sdpub chapter list` when selecting a chapter to inspect, edit, or advance.
+
+Legacy term: serial
+  Some read commands and older archive internals use `serial` for summary-bearing content.
+  `sdpub cat` still uses the legacy flag name `--serial`.
+  For chapter-backed content, the serial id currently matches the chapter id.
+  Use `sdpub list` and `sdpub cat --serial` only to read completed summaries through the legacy read interface.
 
 Fragments:
   A fragment is a normalized internal text unit stored for a chapter.
@@ -45,8 +49,8 @@ Fragments:
 Read-only commands:
   - `sdpub info --input <path>`
   - `sdpub toc --input <path>`
-  - `sdpub list --input <path>`
-  - `sdpub cat --input <path> --serial <id>`
+  - `sdpub list --input <path>` for completed summaries
+  - `sdpub cat --input <path> --serial <id>` for legacy summary reading
   - `sdpub cover --input <path>`
   - `sdpub stage pending <path>`
   - `sdpub chapter list <path>`

--- a/data/help/topics/task.jinja
+++ b/data/help/topics/task.jinja
@@ -16,12 +16,14 @@ Digest source material into .sdpub:
     spinedigest --input <source> --output <digest.sdpub> --stage <planned|sourced|graphed|summarized>
 
 Re-export an existing .sdpub:
-  Use when the digest already exists and you only need markdown, txt, or EPUB output.
+  Use when the archive is summarized and you only need markdown, txt, or EPUB output.
   Command shape:
     spinedigest --input <digest.sdpub> --output <target>
+  If re-export fails with a missing summary, inspect unfinished chapters:
+    spinedigest sdpub stage pending <digest.sdpub>
 
 Inspect archive structure:
-  Use when you need format version, metadata, TOC, serial ids, one serial summary, or raw cover bytes.
+  Use when you need format version, metadata, TOC, summarized serial ids, one serial summary, or raw cover bytes.
   Command shape:
     spinedigest sdpub <info|toc|list|cat|cover|meta> --input <digest.sdpub>
 
@@ -34,6 +36,12 @@ Advance staged .sdpub chapters:
   Use when an archive has planned, sourced, or graphed chapters and you want to continue safely.
   Command shape:
     spinedigest sdpub stage advance <digest.sdpub> --to summarized
+
+Manual staged workflow:
+  1. Create or add planned chapters.
+  2. Fill source with `sdpub chapter set-source`.
+  3. Generate graph with `sdpub stage advance --to graphed`.
+  4. Set a manual summary or advance to `summarized`.
 
 Pipe text through stdin/stdout:
   Use only for txt or markdown streams in non-interactive contexts.

--- a/data/help/topics/task.jinja
+++ b/data/help/topics/task.jinja
@@ -4,9 +4,15 @@ Topic: task
 Task Guide
 
 Digest source material into markdown:
-  Use when the input is EPUB, Markdown, txt, or stdin and you want a new compressed text result.
+  Use when the input is EPUB, Markdown, txt, or non-interactive stdin and you want a new compressed text result.
   Command shape:
     spinedigest --input <source> --output <digest.md>
+
+Convenience stream path:
+  Pipe txt/markdown into `spinedigest` and write compressed text to stdout.
+  Use explicit `--input-format` and `--output-format` because stream formats cannot be inferred.
+  Command shape:
+    cat <chapter.txt> | spinedigest --input-format txt --output-format markdown
 
 Digest source material into .sdpub:
   Use when you want a reusable archive for future export or inspection.
@@ -23,7 +29,7 @@ Re-export an existing .sdpub:
     spinedigest sdpub stage pending <digest.sdpub>
 
 Inspect archive structure:
-  Use when you need format version, metadata, TOC, summarized serial ids, one serial summary, or raw cover bytes.
+  Use when you need format version, metadata, TOC, completed summaries, or raw cover bytes.
   Command shape:
     spinedigest sdpub <info|toc|list|cat|cover|meta> --input <digest.sdpub>
 
@@ -42,11 +48,6 @@ Manual staged workflow:
   2. Fill source with `sdpub chapter set-source`.
   3. Generate graph with `sdpub stage advance --to graphed`.
   4. Set a manual summary or advance to `summarized`.
-
-Pipe text through stdin/stdout:
-  Use only for txt or markdown streams in non-interactive contexts.
-  Command shape:
-    cat <chapter.txt> | spinedigest --input-format txt --output-format markdown
 
 Where to go next:
   - Need copyable examples for these workflows:

--- a/docs/en/ai-agents.md
+++ b/docs/en/ai-agents.md
@@ -55,6 +55,7 @@ Then follow the topic pages you need, such as:
 - Exit behavior: non-zero on failure
 - Error channel: plain text on `stderr`
 - LLM required: yes for source digestion, no for `.sdpub` re-export
+- `.sdpub` editing: use `spinedigest sdpub ...` commands; do not unzip and mutate archive internals directly for routine edits
 
 ## Recommended Execution Strategy
 
@@ -63,6 +64,7 @@ Then follow the topic pages you need, such as:
 3. Reuse `.sdpub` for follow-up exports to avoid re-digesting the original file.
 4. Use `stdin` only in non-interactive pipelines.
 5. Set `--input-format` or `--output-format` when file extensions are missing or ambiguous.
+6. Before editing `.sdpub` chapters, run `spinedigest help sdpub` and the specific command's `--help`.
 
 ## Source Checkout Commands
 
@@ -111,6 +113,7 @@ Agents that already have a runtime LLM client descriptor can pass it with `--llm
 - prefer `.sdpub` when downstream format decisions are unknown
 - prefer explicit format flags when generating temporary files without extensions
 - treat `.sdpub` as the cheapest reusable intermediate artifact
+- treat `.sdpub` as a managed archive: inspect and mutate it through CLI commands, even though the file is physically ZIP
 
 ## Related Docs
 

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -10,18 +10,22 @@ Installed CLI:
 
 ```bash
 spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose]
+spinedigest --version
 spinedigest status [--llm <json>]
 spinedigest sdpub <info|toc|list|cat|cover|meta> --input <path> [--serial <id>] [--llm <json>]
 spinedigest sdpub stage <pending|advance> <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>]
+spinedigest sdpub chapter <list|status|add|remove|reset|set-source|set-summary> <path> [options]
 ```
 
 From a source checkout:
 
 ```bash
 pnpm dev -- [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose]
+pnpm dev -- --version
 pnpm dev -- status [--llm <json>]
 pnpm dev -- sdpub <info|toc|list|cat|cover|meta> --input <path> [--serial <id>] [--llm <json>]
 pnpm dev -- sdpub stage <pending|advance> <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>]
+pnpm dev -- sdpub chapter <list|status|add|remove|reset|set-source|set-summary> <path> [options]
 ```
 
 ## Flags
@@ -35,13 +39,14 @@ pnpm dev -- sdpub stage <pending|advance> <path> [--to <stage>] [--chapter <id>]
 - `--prompt <text>`: one-off extraction prompt override for the current digest run
 - `--stage <stage>`: create `.sdpub` output up to `planned`, `sourced`, `graphed`, or `summarized`
 - `--verbose`: write diagnostic logs to `stderr`
+- `--version`: print the installed package version
 - `-h`, `--help`: print help text
 
 The main conversion command does not support positional arguments.
 
-The `sdpub` inspection interface uses positional subcommands: `spinedigest sdpub <subcommand>`.
+The `sdpub` interface uses positional subcommands: `spinedigest sdpub <subcommand>`.
 
-The `sdpub` inspection subcommands only accept `--input`, except `cat` also requires `--serial` and `meta` accepts metadata edit flags.
+Read-oriented `sdpub` subcommands use `--input`, except `cat` also requires `--serial` and `meta` accepts metadata edit flags. `sdpub stage` and `sdpub chapter` edit existing archives in place and take the archive path as a positional argument.
 
 `--prompt` affects digest generation from source inputs and graph generation through `spinedigest sdpub stage advance`.
 
@@ -130,6 +135,14 @@ spinedigest sdpub cat --input ./book.sdpub --serial 12
 spinedigest sdpub cover --input ./book.sdpub > ./cover.png
 spinedigest sdpub meta --input ./book.sdpub
 spinedigest sdpub stage pending ./book.sdpub
+spinedigest sdpub chapter list ./book.sdpub
+```
+
+Edit and advance an `.sdpub` archive:
+
+```bash
+spinedigest sdpub chapter add ./book.sdpub --title "Appendix"
+spinedigest sdpub chapter set-source ./book.sdpub --chapter 3 --input ./appendix.md --input-format markdown
 spinedigest sdpub stage advance ./book.sdpub --to summarized
 ```
 
@@ -232,18 +245,28 @@ SpineDigest can override config values with environment variables:
 
 ## `.sdpub` Behavior
 
-`.sdpub` is a portable archive of a processed digest document.
+`.sdpub` is a portable archive of a processed digest document. It is physically a ZIP file, but routine automation should treat it as a SpineDigest-managed document and use `spinedigest sdpub ...` commands instead of editing ZIP contents directly.
 
 When the input is `.sdpub`:
 
 - SpineDigest opens the saved digest state
 - no LLM configuration is required
-- you can export to `.txt`, `.md`, or `.epub`
-- you can inspect metadata, TOC, serials, serial text, and cover data through `spinedigest sdpub ...`
+- if the archive is summarized, you can export to `.txt`, `.md`, or `.epub`
+- you can inspect metadata, TOC, summarized serials, serial text, cover data, pending chapters, and chapter stages through `spinedigest sdpub ...`
 
 When the output is `.sdpub`:
 
 - SpineDigest saves the processed digest document for later reuse
+- `--stage planned|sourced|graphed|summarized` controls how far the archive is prepared
+
+Chapter stages:
+
+- `planned`: the chapter exists in the TOC but has no source
+- `sourced`: normalized source fragments are stored
+- `graphed`: graph data is stored, but no final summary exists yet
+- `summarized`: final summary exists and the chapter is ready for re-export or `sdpub cat`
+
+Use `spinedigest help sdpub` for the archive model, stage lifecycle, id rules, mutation safety, and command routing.
 
 ## Failure Modes
 
@@ -255,9 +278,10 @@ Expect a plain-text error message on `stderr` and a non-zero exit code when:
 - `--verbose` is used while writing output to `stdout`
 - no LLM configuration is available for a digest operation
 - `spinedigest sdpub cat` is used without `--serial`
-- `sdpub` inspection subcommands are used with unsupported flags such as `--output`, `--output-format`, `--prompt`, or `--verbose`
+- `sdpub` subcommands are used with unsupported flags such as `--output`, `--output-format`, `--prompt`, or `--verbose`
 - `spinedigest sdpub cover` tries to write binary data to an interactive terminal
 - `spinedigest sdpub cover` is used on an archive without a cover
+- `.sdpub` re-export or `sdpub cat` is attempted before the selected chapters are summarized
 - provider-specific configuration is invalid
 
 ## Related Docs

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -44,6 +44,8 @@ pnpm dev -- sdpub chapter <list|status|add|remove|reset|set-source|set-summary> 
 
 The main conversion command does not support positional arguments.
 
+`spinedigest` without a subcommand is the convenience digest/export command. It reads from `--input <path>` or stdin, and writes to `--output <path>` or stdout. In an interactive terminal, a bare `spinedigest` prints help instead of trying to digest stdin.
+
 The `sdpub` interface uses positional subcommands: `spinedigest sdpub <subcommand>`.
 
 Read-oriented `sdpub` subcommands use `--input`, except `cat` also requires `--serial` and `meta` accepts metadata edit flags. `sdpub stage` and `sdpub chapter` edit existing archives in place and take the archive path as a positional argument.
@@ -252,7 +254,7 @@ When the input is `.sdpub`:
 - SpineDigest opens the saved digest state
 - no LLM configuration is required
 - if the archive is summarized, you can export to `.txt`, `.md`, or `.epub`
-- you can inspect metadata, TOC, summarized serials, serial text, cover data, pending chapters, and chapter stages through `spinedigest sdpub ...`
+- you can inspect metadata, TOC, completed summaries, cover data, pending chapters, and chapter stages through `spinedigest sdpub ...`
 
 When the output is `.sdpub`:
 

--- a/docs/sdpub.md
+++ b/docs/sdpub.md
@@ -6,6 +6,13 @@ persisted digest documents.
 It is written for implementations that need to inspect, parse, validate,
 or render `.sdpub` files outside the SpineDigest runtime.
 
+This is not the recommended guide for routine archive editing. `.sdpub`
+is physically a ZIP file, but automation that wants to add chapters,
+change metadata, set source text, reset stages, or advance generation
+should use `spinedigest sdpub ...` commands. Direct ZIP mutation is for
+external readers, validators, recovery tooling, or format experiments
+that intentionally take responsibility for preserving every invariant.
+
 ## Overview
 
 An `.sdpub` file is a ZIP archive that stores a serialized

--- a/docs/zh-CN/ai-agents.md
+++ b/docs/zh-CN/ai-agents.md
@@ -55,6 +55,7 @@ spinedigest help ai
 - 退出行为：失败时返回非零
 - 错误通道：在 `stderr` 输出纯文本
 - 是否需要 LLM：处理源文件时需要；重新导出 `.sdpub` 时不需要
+- `.sdpub` 编辑：使用 `spinedigest sdpub ...` 命令；常规编辑不要直接解压并改写归档内部文件
 
 ## 推荐执行策略
 
@@ -63,6 +64,7 @@ spinedigest help ai
 3. 后续导出时优先复用 `.sdpub`，避免再次处理原始文件。
 4. 只在非交互式流水线中使用 `stdin`。
 5. 当文件缺少扩展名或格式不明确时，显式设置 `--input-format` 或 `--output-format`。
+6. 编辑 `.sdpub` 章节前，先运行 `spinedigest help sdpub` 和具体命令的 `--help`。
 
 ## 从源码仓库运行
 
@@ -111,6 +113,7 @@ SpineDigest 至少需要：
 - 如果下游还没决定最终输出格式，优先使用 `.sdpub`
 - 当生成的临时文件没有明确扩展名时，优先显式传格式参数
 - 把 `.sdpub` 当成最便宜、最适合复用的中间产物
+- 把 `.sdpub` 当成托管归档：即便它在物理上是 ZIP，也通过 CLI 命令检查和修改
 
 ## 相关文档
 

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -10,18 +10,22 @@ SpineDigest 的设计重心是命令行使用。
 
 ```bash
 spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose]
+spinedigest --version
 spinedigest status [--llm <json>]
 spinedigest sdpub <info|toc|list|cat|cover|meta> --input <path> [--serial <id>] [--llm <json>]
 spinedigest sdpub stage <pending|advance> <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>]
+spinedigest sdpub chapter <list|status|add|remove|reset|set-source|set-summary> <path> [options]
 ```
 
 在源码仓库中运行时：
 
 ```bash
 pnpm dev -- [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose]
+pnpm dev -- --version
 pnpm dev -- status [--llm <json>]
 pnpm dev -- sdpub <info|toc|list|cat|cover|meta> --input <path> [--serial <id>] [--llm <json>]
 pnpm dev -- sdpub stage <pending|advance> <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>]
+pnpm dev -- sdpub chapter <list|status|add|remove|reset|set-source|set-summary> <path> [options]
 ```
 
 ## 参数
@@ -35,13 +39,14 @@ pnpm dev -- sdpub stage <pending|advance> <path> [--to <stage>] [--chapter <id>]
 - `--prompt <text>`：为当前这次 digest 临时覆盖 extraction prompt
 - `--stage <stage>`：把 `.sdpub` 输出生成到 `planned`、`sourced`、`graphed` 或 `summarized`
 - `--verbose`：把诊断日志输出到 `stderr`
+- `--version`：打印已安装包版本
 - `-h`, `--help`：打印帮助文本
 
 主转换命令不支持 positional arguments。
 
-`sdpub` 检查接口本身使用 positional subcommands：`spinedigest sdpub <subcommand>`。
+`sdpub` 接口本身使用 positional subcommands：`spinedigest sdpub <subcommand>`。
 
-`sdpub` 检查子命令只接受 `--input`，其中 `cat` 还要求提供 `--serial`，`meta` 额外接受 metadata 编辑参数。
+偏读取的 `sdpub` 子命令使用 `--input`，其中 `cat` 还要求提供 `--serial`，`meta` 额外接受 metadata 编辑参数。`sdpub stage` 和 `sdpub chapter` 会原地编辑已有归档，并把归档路径作为 positional argument。
 
 `--prompt` 影响从源输入生成 digest 的过程，也会影响 `spinedigest sdpub stage advance` 中的 graph 生成。
 
@@ -130,6 +135,14 @@ spinedigest sdpub cat --input ./book.sdpub --serial 12
 spinedigest sdpub cover --input ./book.sdpub > ./cover.png
 spinedigest sdpub meta --input ./book.sdpub
 spinedigest sdpub stage pending ./book.sdpub
+spinedigest sdpub chapter list ./book.sdpub
+```
+
+编辑并推进 `.sdpub` 归档：
+
+```bash
+spinedigest sdpub chapter add ./book.sdpub --title "Appendix"
+spinedigest sdpub chapter set-source ./book.sdpub --chapter 3 --input ./appendix.md --input-format markdown
 spinedigest sdpub stage advance ./book.sdpub --to summarized
 ```
 
@@ -232,18 +245,28 @@ SpineDigest 支持通过环境变量覆盖配置值：
 
 ## `.sdpub` 行为
 
-`.sdpub` 是处理后 digest 文档的可移植归档格式。
+`.sdpub` 是处理后 digest 文档的可移植归档格式。它在物理上是 ZIP 文件，但常规自动化应把它视为由 SpineDigest 管理的文档，通过 `spinedigest sdpub ...` 命令操作，而不是直接编辑 ZIP 内部文件。
 
 当输入是 `.sdpub` 时：
 
 - SpineDigest 会直接打开已经保存的 digest 状态
 - 不需要 LLM 配置
-- 可以导出为 `.txt`、`.md` 或 `.epub`
-- 也可以通过 `spinedigest sdpub ...` 检查元信息、TOC、serial、serial 文本和封面数据
+- 如果归档已经 summarized，可以导出为 `.txt`、`.md` 或 `.epub`
+- 也可以通过 `spinedigest sdpub ...` 检查元信息、TOC、已完成 serial、serial 文本、封面数据、未完成章节和章节阶段
 
 当输出是 `.sdpub` 时：
 
 - SpineDigest 会保存这份处理后的 digest 文档，以便后续复用
+- `--stage planned|sourced|graphed|summarized` 控制归档预先处理到哪个阶段
+
+章节阶段：
+
+- `planned`：章节已经存在于 TOC，但还没有原文
+- `sourced`：已经保存 normalized source fragments
+- `graphed`：已经保存 graph 数据，但还没有最终摘要
+- `summarized`：已经有最终摘要，可以重新导出或用 `sdpub cat` 读取
+
+归档模型、阶段生命周期、id 规则、原地修改安全性和命令路由，见 `spinedigest help sdpub`。
 
 ## 失败场景
 
@@ -255,9 +278,10 @@ SpineDigest 支持通过环境变量覆盖配置值：
 - 在写入 `stdout` 时同时使用了 `--verbose`
 - digest 操作缺少 LLM 配置
 - `spinedigest sdpub cat` 缺少 `--serial`
-- `sdpub` 检查子命令使用了不支持的参数，例如 `--output`、`--output-format`、`--prompt` 或 `--verbose`
+- `sdpub` 子命令使用了不支持的参数，例如 `--output`、`--output-format`、`--prompt` 或 `--verbose`
 - `spinedigest sdpub cover` 试图向交互式终端输出二进制数据
 - `spinedigest sdpub cover` 针对一个没有封面的归档运行
+- `.sdpub` 重新导出或 `sdpub cat` 的目标章节还没有 summarized
 - provider 相关配置不合法
 
 ## 相关文档

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -44,6 +44,8 @@ pnpm dev -- sdpub chapter <list|status|add|remove|reset|set-source|set-summary> 
 
 主转换命令不支持 positional arguments。
 
+没有 subcommand 的 `spinedigest` 是便捷 digest/export 命令。它从 `--input <path>` 或 stdin 读取，并写入 `--output <path>` 或 stdout。在交互式终端中，裸 `spinedigest` 会打印 help，而不是尝试 digest stdin。
+
 `sdpub` 接口本身使用 positional subcommands：`spinedigest sdpub <subcommand>`。
 
 偏读取的 `sdpub` 子命令使用 `--input`，其中 `cat` 还要求提供 `--serial`，`meta` 额外接受 metadata 编辑参数。`sdpub stage` 和 `sdpub chapter` 会原地编辑已有归档，并把归档路径作为 positional argument。
@@ -252,7 +254,7 @@ SpineDigest 支持通过环境变量覆盖配置值：
 - SpineDigest 会直接打开已经保存的 digest 状态
 - 不需要 LLM 配置
 - 如果归档已经 summarized，可以导出为 `.txt`、`.md` 或 `.epub`
-- 也可以通过 `spinedigest sdpub ...` 检查元信息、TOC、已完成 serial、serial 文本、封面数据、未完成章节和章节阶段
+- 也可以通过 `spinedigest sdpub ...` 检查元信息、TOC、已完成摘要、封面数据、未完成章节和章节阶段
 
 当输出是 `.sdpub` 时：
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -11,7 +11,9 @@ import {
   parseHelpTopic,
   renderHelpTopicText,
   renderMainHelpText,
+  renderSdpubChapterActionHelpText,
   renderStatusHelpText,
+  renderSdpubStageActionHelpText,
   renderSdpubHelpText,
   renderSdpubSubcommandHelpText,
   SDPUB_SUBCOMMANDS,
@@ -114,6 +116,10 @@ interface SdpubMetaFlagValues {
 }
 
 export type ParsedCLIArguments =
+  | {
+      readonly help: false;
+      readonly kind: "version";
+    }
   | {
       readonly args: CLIArguments;
       readonly help: false;
@@ -270,9 +276,19 @@ export function parseCLIArguments(
         short: "v",
         type: "boolean",
       },
+      version: {
+        type: "boolean",
+      },
     },
     strict: true,
   });
+
+  if (values.version === true) {
+    return {
+      help: false,
+      kind: "version",
+    };
+  }
 
   if (positionals[0] === "help") {
     return parseHelpArguments(positionals.slice(1), values);
@@ -609,6 +625,14 @@ function parseSdpubChapterArguments(
   }
 
   if (help) {
+    if (isSdpubChapterAction(action)) {
+      return {
+        help: true,
+        helpText: renderSdpubChapterActionHelpText(action),
+        kind: "sdpub-chapter",
+      };
+    }
+
     return {
       help: true,
       helpText: renderSdpubSubcommandHelpText("chapter"),
@@ -710,6 +734,14 @@ function parseSdpubStageArguments(
   }
 
   if (help) {
+    if (isSdpubStageAction(action)) {
+      return {
+        help: true,
+        helpText: renderSdpubStageActionHelpText(action),
+        kind: "sdpub-stage",
+      };
+    }
+
     return {
       help: true,
       helpText: renderSdpubSubcommandHelpText("stage"),

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -305,7 +305,7 @@ export function parseCLIArguments(
   if (positionals.length > 0) {
     throw new Error(
       withHelpRoute(
-        `Unexpected positional arguments: ${positionals.join(" ")}. Use --input and --output instead.`,
+        `Unexpected positional argument or unknown command: ${positionals.join(" ")}. The default command reads from stdin or --input; it does not accept positional input paths. Use --input <path>, or see available subcommands with \`spinedigest --help\`.`,
         CLI_HELP_ROUTES.command,
       ),
     );
@@ -411,9 +411,13 @@ function parseSdpubArguments(
   }
 
   if (positionals.length > 1) {
+    const message = isKnownSubcommand
+      ? `Unexpected positional arguments: ${positionals.slice(1).join(" ")}. The \`sdpub ${subcommand}\` subcommand uses --input <path>; it does not accept a positional archive path.`
+      : `Unexpected positional arguments: ${positionals.slice(1).join(" ")}.`;
+
     throw new Error(
       withHelpRoute(
-        `Unexpected positional arguments: ${positionals.slice(1).join(" ")}.`,
+        message,
         isKnownSubcommand
           ? sdpubSubcommandHelpRoute(subcommand)
           : CLI_HELP_ROUTES.sdpub,
@@ -624,15 +628,23 @@ function parseSdpubChapterArguments(
     );
   }
 
-  if (help) {
-    if (isSdpubChapterAction(action)) {
+  if (help && isSdpubChapterAction(action)) {
+    if (action === "generate-graph" || action === "generate-summary") {
       return {
         help: true,
-        helpText: renderSdpubChapterActionHelpText(action),
+        helpText: renderSdpubSubcommandHelpText("chapter"),
         kind: "sdpub-chapter",
       };
     }
 
+    return {
+      help: true,
+      helpText: renderSdpubChapterActionHelpText(action),
+      kind: "sdpub-chapter",
+    };
+  }
+
+  if (help && action === undefined) {
     return {
       help: true,
       helpText: renderSdpubSubcommandHelpText("chapter"),
@@ -645,7 +657,7 @@ function parseSdpubChapterArguments(
       withHelpRoute(
         action === undefined
           ? "Missing sdpub chapter action."
-          : `Invalid sdpub chapter action: ${action}.`,
+          : `Invalid sdpub chapter action: ${action}. Expected one of list, status, add, remove, reset, set-source, set-summary.`,
         helpRoute,
       ),
     );
@@ -733,15 +745,15 @@ function parseSdpubStageArguments(
     );
   }
 
-  if (help) {
-    if (isSdpubStageAction(action)) {
-      return {
-        help: true,
-        helpText: renderSdpubStageActionHelpText(action),
-        kind: "sdpub-stage",
-      };
-    }
+  if (help && isSdpubStageAction(action)) {
+    return {
+      help: true,
+      helpText: renderSdpubStageActionHelpText(action),
+      kind: "sdpub-stage",
+    };
+  }
 
+  if (help && action === undefined) {
     return {
       help: true,
       helpText: renderSdpubSubcommandHelpText("stage"),
@@ -754,7 +766,7 @@ function parseSdpubStageArguments(
       withHelpRoute(
         action === undefined
           ? "Missing sdpub stage action."
-          : `Invalid sdpub stage action: ${action}.`,
+          : `Invalid sdpub stage action: ${action}. Expected one of advance, pending.`,
         helpRoute,
       ),
     );

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -3,6 +3,7 @@ import { createEnv } from "../common/template.js";
 
 import { CLI_FORMATS } from "./formats.js";
 import { CLI_HELP_ROUTES, withHelpRoute } from "./errors.js";
+import type { CLISdpubChapterAction, CLISdpubStageAction } from "./args.js";
 
 export const HELP_TOPICS = [
   "overview",
@@ -163,6 +164,18 @@ export function renderSdpubSubcommandHelpText(
   subcommand: SDPubSubcommand,
 ): string {
   return renderHelpTemplate(`help/commands/sdpub/${subcommand}`);
+}
+
+export function renderSdpubChapterActionHelpText(
+  action: CLISdpubChapterAction,
+): string {
+  return renderHelpTemplate(`help/commands/sdpub/chapter/${action}`);
+}
+
+export function renderSdpubStageActionHelpText(
+  action: CLISdpubStageAction,
+): string {
+  return renderHelpTemplate(`help/commands/sdpub/stage/${action}`);
 }
 
 export function parseHelpTopic(value: string): HelpTopic {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -99,15 +99,15 @@ const SDPUB_SUBCOMMAND_METADATA: readonly {
   },
   {
     name: "toc",
-    summary: "Print the TOC tree, including any referenced serial ids.",
+    summary: "Print the TOC tree, including chapter id markers.",
   },
   {
     name: "list",
-    summary: "List serial ids with their TOC paths and fragment counts.",
+    summary: "List summarized chapters that are ready for cat.",
   },
   {
     name: "cat",
-    summary: "Print the summary text for one serial id.",
+    summary: "Print one completed summary through the legacy --serial reader.",
   },
   {
     name: "cover",

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -6,6 +6,7 @@ import { runSdpubChapterCommand } from "./sdpub-chapter.js";
 import { runSdpubStageCommand } from "./sdpub-stage.js";
 import { LLMPaymentRequiredError } from "../llm/index.js";
 import { formatError } from "../utils/node-error.js";
+import { readCLIVersion } from "./version.js";
 
 export async function main(): Promise<void> {
   try {
@@ -17,6 +18,9 @@ export async function main(): Promise<void> {
     }
 
     switch (parsed.kind) {
+      case "version":
+        process.stdout.write(`${readCLIVersion()}\n`);
+        return;
       case "convert":
         await runConvertCommand(parsed.args);
         return;

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,5 +1,6 @@
 import { parseCLIArguments } from "./args.js";
 import { runConvertCommand } from "./convert.js";
+import { renderMainHelpText } from "./help.js";
 import { runStatusCommand } from "./status.js";
 import { runSdpubCommand } from "./sdpub.js";
 import { runSdpubChapterCommand } from "./sdpub-chapter.js";
@@ -10,6 +11,11 @@ import { readCLIVersion } from "./version.js";
 
 export async function main(): Promise<void> {
   try {
+    if (shouldPrintDefaultHelp()) {
+      process.stdout.write(`${renderMainHelpText()}\n`);
+      return;
+    }
+
     const parsed = parseCLIArguments();
 
     if (parsed.help) {
@@ -45,6 +51,10 @@ export async function main(): Promise<void> {
     process.stderr.write(`${formatCLIError(error)}\n`);
     process.exitCode = 1;
   }
+}
+
+function shouldPrintDefaultHelp(): boolean {
+  return process.argv.slice(2).length === 0 && process.stdin.isTTY === true;
 }
 
 function formatCLIError(error: unknown): string {

--- a/src/cli/sdpub-stage.ts
+++ b/src/cli/sdpub-stage.ts
@@ -84,6 +84,13 @@ async function writeAdvanceResult(
     lines.push("", "Pending chapters:");
     lines.push(...result.pending.map(formatChapterEntry));
   }
+  if (result.skipped.some((entry) => entry.stage === "planned")) {
+    lines.push(
+      "",
+      "Next: set source for planned chapters, then advance again.",
+      "Example: spinedigest sdpub chapter set-source <path> --chapter <id> --input <file> --input-format txt",
+    );
+  }
 
   await writeTextToStdout(`${lines.join("\n")}\n`);
 }

--- a/src/cli/sdpub.ts
+++ b/src/cli/sdpub.ts
@@ -120,7 +120,7 @@ async function writeSdpubSerialList(digest: SpineDigest): Promise<void> {
   const serials = await digest.listSerials();
 
   if (serials.length === 0) {
-    await writeTextToStdout("No serials referenced by TOC.\n");
+    await writeTextToStdout("No summarized serials available.\n");
     return;
   }
 

--- a/src/cli/sdpub.ts
+++ b/src/cli/sdpub.ts
@@ -54,6 +54,8 @@ async function writeSdpubInfo(digest: SpineDigest): Promise<void> {
       throw error;
     }),
   ]);
+  const referencedChapterCount =
+    toc === undefined ? 0 : countReferencedChapters(toc.items);
   const lines: string[] = [];
 
   lines.push(`Archive Format Version: ${formatVersion}`);
@@ -77,7 +79,8 @@ async function writeSdpubInfo(digest: SpineDigest): Promise<void> {
     }
 
     lines.push(`Top-level Sections: ${toc.items.length}`);
-    lines.push(`Referenced Serials: ${serials.length}`);
+    lines.push(`Referenced Chapters: ${referencedChapterCount}`);
+    lines.push(`Summarized Chapters: ${serials.length}`);
     lines.push(
       `Fragments: ${serials.reduce(
         (total, serial) => total + serial.fragmentCount,
@@ -120,7 +123,7 @@ async function writeSdpubSerialList(digest: SpineDigest): Promise<void> {
   const serials = await digest.listSerials();
 
   if (serials.length === 0) {
-    await writeTextToStdout("No summarized serials available.\n");
+    await writeTextToStdout("No summarized chapters available.\n");
     return;
   }
 
@@ -251,6 +254,16 @@ async function requireToc(digest: SpineDigest): Promise<TocFile> {
   return toc;
 }
 
+function countReferencedChapters(items: readonly TocItem[]): number {
+  return items.reduce(
+    (total, item) =>
+      total +
+      (item.serialId === undefined ? 0 : 1) +
+      countReferencedChapters(item.children),
+    0,
+  );
+}
+
 function renderTocLines(
   items: readonly TocItem[],
   depth = 0,
@@ -260,7 +273,7 @@ function renderTocLines(
   for (const item of items) {
     lines.push(
       `${"  ".repeat(depth)}${item.title?.trim() || "[untitled]"}${
-        item.serialId === undefined ? "" : ` [serial ${item.serialId}]`
+        item.serialId === undefined ? "" : ` [chapter ${item.serialId}]`
       }`,
     );
     lines.push(...renderTocLines(item.children, depth + 1));

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "fs";
+import { dirname, join } from "path";
+
+import { resolveDataDirPath } from "../common/data-dir.js";
+
+export function readCLIVersion(): string {
+  const packageJSONPath = join(dirname(resolveDataDirPath()), "package.json");
+  const parsed: unknown = JSON.parse(readFileSync(packageJSONPath, "utf8"));
+
+  if (
+    typeof parsed === "object" &&
+    parsed !== null &&
+    "version" in parsed &&
+    typeof parsed.version === "string"
+  ) {
+    return parsed.version;
+  }
+
+  throw new Error(`Invalid package version in ${packageJSONPath}`);
+}

--- a/src/facade/chapter.ts
+++ b/src/facade/chapter.ts
@@ -129,7 +129,9 @@ export async function addChapter(
     } else if (
       !appendChildToChapter(toc.items, options.parentChapterId, chapterItem)
     ) {
-      throw new Error(`Chapter ${options.parentChapterId} does not exist.`);
+      throw new Error(
+        `Chapter ${options.parentChapterId} does not exist. Use \`spinedigest sdpub chapter list <path>\` to discover chapter ids.`,
+      );
     }
 
     await openedDocument.replaceToc(toc);
@@ -207,7 +209,9 @@ export async function getChapterDetails(
   const entry = entries.find((item) => item.chapterId === chapterId);
 
   if (entry === undefined) {
-    throw new Error(`Chapter ${chapterId} does not exist.`);
+    throw new Error(
+      `Chapter ${chapterId} does not exist. Use \`spinedigest sdpub chapter list <path>\` to discover chapter ids.`,
+    );
   }
 
   const serial = await document.serials.getById(chapterId);
@@ -242,7 +246,9 @@ export async function removeChapter(
     });
 
     if (!result.removed) {
-      throw new Error(`Chapter ${chapterId} does not exist.`);
+      throw new Error(
+        `Chapter ${chapterId} does not exist. Use \`spinedigest sdpub chapter list <path>\` to discover chapter ids.`,
+      );
     }
 
     toc.items = result.items;
@@ -458,7 +464,9 @@ async function selectChapterEntries(
   const selectedIds = await collectChapterSubtreeIds(document, chapterId);
 
   if (selectedIds.size === 0) {
-    throw new Error(`Chapter ${chapterId} does not exist.`);
+    throw new Error(
+      `Chapter ${chapterId} does not exist. Use \`spinedigest sdpub chapter list <path>\` to discover chapter ids.`,
+    );
   }
 
   return entries.filter((entry) => selectedIds.has(entry.chapterId));

--- a/src/facade/spine-digest.ts
+++ b/src/facade/spine-digest.ts
@@ -69,13 +69,17 @@ export class SpineDigest {
       const record = await document.serials.getById(serialId);
 
       if (record === undefined) {
-        throw new Error(`Serial ${serialId} does not exist`);
+        throw new Error(
+          `Serial ${serialId} does not exist. Use \`spinedigest sdpub list --input <path>\` to discover summarized serial ids.`,
+        );
       }
 
       const summary = await document.readSummary(serialId);
 
       if (summary === undefined) {
-        throw new Error(`Serial ${serialId} summary is missing`);
+        throw new Error(
+          `Serial ${serialId} summary is missing. Run \`spinedigest sdpub stage pending <path>\` to inspect unfinished chapters.`,
+        );
       }
 
       return summary;
@@ -114,14 +118,18 @@ async function collectSerialEntries(
     const tocPath = [...ancestorTitles, title];
 
     if (item.serialId !== undefined) {
-      entries.push({
-        fragmentCount: (
-          await document.getSerialFragments(item.serialId).listFragmentIds()
-        ).length,
-        serialId: item.serialId,
-        title,
-        tocPath,
-      });
+      const summary = await document.readSummary(item.serialId);
+
+      if (summary !== undefined) {
+        entries.push({
+          fragmentCount: (
+            await document.getSerialFragments(item.serialId).listFragmentIds()
+          ).length,
+          serialId: item.serialId,
+          title,
+          tocPath,
+        });
+      }
     }
 
     entries.push(

--- a/src/facade/spine-digest.ts
+++ b/src/facade/spine-digest.ts
@@ -70,7 +70,7 @@ export class SpineDigest {
 
       if (record === undefined) {
         throw new Error(
-          `Serial ${serialId} does not exist. Use \`spinedigest sdpub list --input <path>\` to discover summarized serial ids.`,
+          `No completed summary exists for id ${serialId}. Use \`spinedigest sdpub list --input <path>\` to discover ids ready for \`sdpub cat --serial\`.`,
         );
       }
 
@@ -78,7 +78,7 @@ export class SpineDigest {
 
       if (summary === undefined) {
         throw new Error(
-          `Serial ${serialId} summary is missing. Run \`spinedigest sdpub stage pending <path>\` to inspect unfinished chapters.`,
+          `Chapter ${serialId} summary is missing. Run \`spinedigest sdpub stage pending <path>\` to inspect unfinished chapters.`,
         );
       }
 

--- a/src/output/epub/book.ts
+++ b/src/output/epub/book.ts
@@ -72,7 +72,9 @@ async function collectSections(
       const summary = await document.readSummary(item.serialId);
 
       if (summary === undefined) {
-        throw new Error(`Serial ${item.serialId} summary is missing`);
+        throw new Error(
+          `Serial ${item.serialId} summary is missing. Run \`spinedigest sdpub stage pending <path>\` to inspect unfinished chapters.`,
+        );
       }
 
       const section = createSectionDocument(

--- a/src/output/epub/book.ts
+++ b/src/output/epub/book.ts
@@ -73,7 +73,7 @@ async function collectSections(
 
       if (summary === undefined) {
         throw new Error(
-          `Serial ${item.serialId} summary is missing. Run \`spinedigest sdpub stage pending <path>\` to inspect unfinished chapters.`,
+          `Chapter ${item.serialId} summary is missing. Run \`spinedigest sdpub stage pending <path>\` to inspect unfinished chapters.`,
         );
       }
 

--- a/src/output/plain-text.ts
+++ b/src/output/plain-text.ts
@@ -65,7 +65,9 @@ async function renderTocItem(
     const summary = await document.readSummary(item.serialId);
 
     if (summary === undefined) {
-      throw new Error(`Serial ${item.serialId} summary is missing`);
+      throw new Error(
+        `Serial ${item.serialId} summary is missing. Run \`spinedigest sdpub stage pending <path>\` to inspect unfinished chapters.`,
+      );
     }
     if (summary.trim() !== "") {
       parts.push(summary.trim());

--- a/src/output/plain-text.ts
+++ b/src/output/plain-text.ts
@@ -66,7 +66,7 @@ async function renderTocItem(
 
     if (summary === undefined) {
       throw new Error(
-        `Serial ${item.serialId} summary is missing. Run \`spinedigest sdpub stage pending <path>\` to inspect unfinished chapters.`,
+        `Chapter ${item.serialId} summary is missing. Run \`spinedigest sdpub stage pending <path>\` to inspect unfinished chapters.`,
       );
     }
     if (summary.trim() !== "") {

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -576,7 +576,9 @@ export async function readSerial(
   const summary = await document.readSummary(serialId);
 
   if (summary === undefined) {
-    throw new Error(`Serial ${serialId} summary is missing`);
+    throw new Error(
+      `Serial ${serialId} summary is missing. Run \`spinedigest sdpub stage pending <path>\` to inspect unfinished chapters.`,
+    );
   }
 
   return new Serial(document, serialId, summary);
@@ -599,7 +601,9 @@ async function getSerialRecord(
   const record = await document.serials.getById(serialId);
 
   if (record === undefined) {
-    throw new Error(`Serial ${serialId} does not exist`);
+    throw new Error(
+      `Serial ${serialId} does not exist. Use \`spinedigest sdpub list --input <path>\` to discover summarized serial ids.`,
+    );
   }
 
   return record;

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -577,7 +577,7 @@ export async function readSerial(
 
   if (summary === undefined) {
     throw new Error(
-      `Serial ${serialId} summary is missing. Run \`spinedigest sdpub stage pending <path>\` to inspect unfinished chapters.`,
+      `Chapter ${serialId} summary is missing. Run \`spinedigest sdpub stage pending <path>\` to inspect unfinished chapters.`,
     );
   }
 
@@ -602,7 +602,7 @@ async function getSerialRecord(
 
   if (record === undefined) {
     throw new Error(
-      `Serial ${serialId} does not exist. Use \`spinedigest sdpub list --input <path>\` to discover summarized serial ids.`,
+      `Chapter ${serialId} does not exist. Use \`spinedigest sdpub chapter list <path>\` to discover chapter ids.`,
     );
   }
 

--- a/src/utils/node-error.ts
+++ b/src/utils/node-error.ts
@@ -30,6 +30,22 @@ function describeError(error: Error): string {
     typeof errnoError.code === "string" && errnoError.code !== ""
       ? errnoError.code
       : undefined;
+  const path =
+    typeof errnoError.path === "string" && errnoError.path !== ""
+      ? errnoError.path
+      : undefined;
+
+  if (code === "ENOENT") {
+    return path === undefined
+      ? "File not found (ENOENT)"
+      : `File not found: ${path} (ENOENT)`;
+  }
+
+  if (code === "EACCES" || code === "EPERM") {
+    return path === undefined
+      ? `Permission denied (${code})`
+      : `Permission denied: ${path} (${code})`;
+  }
 
   if (message === "") {
     return code === undefined ? error.name : `${error.name} (${code})`;

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import { parseCLIArguments } from "../../src/cli/args.js";
 import {
+  renderSdpubChapterActionHelpText,
+  renderSdpubStageActionHelpText,
   renderHelpTopicText,
   renderMainHelpText,
   renderStatusHelpText,
@@ -55,6 +57,13 @@ describe("cli/args", () => {
       },
       help: false,
       kind: "convert",
+    });
+  });
+
+  it("parses --version", () => {
+    expect(parseCLIArguments(["--version"])).toStrictEqual({
+      help: false,
+      kind: "version",
     });
   });
 
@@ -350,6 +359,20 @@ describe("cli/args", () => {
       helpText: renderSdpubSubcommandHelpText("info"),
       kind: "sdpub",
     });
+    expect(
+      parseCLIArguments(["sdpub", "chapter", "set-summary", "--help"]),
+    ).toStrictEqual({
+      help: true,
+      helpText: renderSdpubChapterActionHelpText("set-summary"),
+      kind: "sdpub-chapter",
+    });
+    expect(
+      parseCLIArguments(["sdpub", "stage", "advance", "--help"]),
+    ).toStrictEqual({
+      help: true,
+      helpText: renderSdpubStageActionHelpText("advance"),
+      kind: "sdpub-stage",
+    });
   });
 
   it("rejects positional arguments", () => {
@@ -574,6 +597,7 @@ describe("cli/args", () => {
     );
     expect(commandHelpText).toContain("--verbose, -v");
     expect(commandHelpText).toContain("--help, -h");
+    expect(commandHelpText).toContain("--version");
     for (const flag of [
       "--input <path>",
       "--output <path>",
@@ -618,11 +642,20 @@ describe("cli/args", () => {
     );
     expect(sdpubHelpText).toContain("[--help|-h]");
     expect(renderSdpubSubcommandHelpText("stage")).toContain("advance <path>");
+    expect(renderSdpubStageActionHelpText("advance")).toContain(
+      "Advancement is idempotent",
+    );
+    expect(renderSdpubChapterActionHelpText("set-summary")).toContain(
+      "The chapter must be `graphed`",
+    );
     expect(renderSdpubSubcommandHelpText("cover")).toContain(
       "refuses to write binary data to an interactive terminal",
     );
     expect(renderSdpubSubcommandHelpText("cover")).toContain("[--help|-h]");
     expect(renderSdpubSubcommandHelpText("meta")).toContain("--clear-authors");
+    expect(renderHelpTopicText("sdpub")).toContain(
+      "agents should not unzip and edit files directly",
+    );
   });
 
   it("supports a first-contact recovery chain from root help to parse failures", () => {

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -377,7 +377,7 @@ describe("cli/args", () => {
 
   it("rejects positional arguments", () => {
     expect(() => parseCLIArguments(["book.epub"])).toThrow(
-      "Unexpected positional arguments: book.epub. Use --input and --output instead.\nSee: spinedigest help command",
+      "Unexpected positional argument or unknown command: book.epub. The default command reads from stdin or --input; it does not accept positional input paths. Use --input <path>, or see available subcommands with `spinedigest --help`.\nSee: spinedigest help command",
     );
   });
 
@@ -399,6 +399,9 @@ describe("cli/args", () => {
     );
     expect(() => parseCLIArguments(["sdpub", "inspect", "extra"])).toThrow(
       "Unexpected positional arguments: extra.\nSee: spinedigest sdpub --help",
+    );
+    expect(() => parseCLIArguments(["sdpub", "info", "book.sdpub"])).toThrow(
+      "Unexpected positional arguments: book.sdpub. The `sdpub info` subcommand uses --input <path>; it does not accept a positional archive path.\nSee: spinedigest sdpub info --help",
     );
     expect(() =>
       parseCLIArguments(["sdpub", "info", "--output", "out.txt"]),
@@ -674,3 +677,11 @@ describe("cli/args", () => {
     );
   });
 });
+expect(() =>
+  parseCLIArguments(["sdpub", "chapter", "bogus", "--help"]),
+).toThrow(
+  "Invalid sdpub chapter action: bogus. Expected one of list, status, add, remove, reset, set-source, set-summary.\nSee: spinedigest sdpub chapter --help",
+);
+expect(() => parseCLIArguments(["sdpub", "stage", "bogus", "--help"])).toThrow(
+  "Invalid sdpub stage action: bogus. Expected one of advance, pending.\nSee: spinedigest sdpub stage --help",
+);

--- a/test/cli/main.test.ts
+++ b/test/cli/main.test.ts
@@ -179,6 +179,24 @@ describe("cli/main", () => {
     expect(process.exitCode).toBe(0);
   });
 
+  it("prints the package version and skips commands", async () => {
+    mainMockState.argsResult = {
+      help: false,
+      kind: "version",
+    };
+
+    await main();
+
+    expect(stdoutChunks).toHaveLength(1);
+    expect(stdoutChunks[0]).toMatch(/^\d+\.\d+\.\d+\n$/u);
+    expect(stderrChunks).toStrictEqual([]);
+    expect(mainMockState.runCalls).toHaveLength(0);
+    expect(mainMockState.statusRunCalls).toBe(0);
+    expect(mainMockState.sdpubRunCalls).toHaveLength(0);
+    expect(mainMockState.sdpubStageRunCalls).toHaveLength(0);
+    expect(process.exitCode).toBe(0);
+  });
+
   it("runs the status command for status execution", async () => {
     mainMockState.argsResult = {
       args: {

--- a/test/cli/main.test.ts
+++ b/test/cli/main.test.ts
@@ -82,10 +82,13 @@ vi.mock("../../src/cli/sdpub-stage.js", () => ({
 }));
 
 import { main } from "../../src/cli/main.js";
+import { renderMainHelpText } from "../../src/cli/help.js";
 import { LLMPaymentRequiredError } from "../../src/llm/index.js";
 
 describe("cli/main", () => {
   const originalExitCode = process.exitCode;
+  const originalArgv = process.argv;
+  const originalStdinIsTTY = process.stdin.isTTY;
   let stdoutWrite: MockInstance;
   let stderrWrite: MockInstance;
   let stdoutChunks: string[];
@@ -111,6 +114,8 @@ describe("cli/main", () => {
     mainMockState.sdpubRunError = undefined;
     mainMockState.sdpubStageRunError = undefined;
     process.exitCode = 0;
+    process.argv = ["node", "spinedigest"];
+    setStdinTTY(false);
     stdoutChunks = [];
     stderrChunks = [];
     stdoutWrite = vi
@@ -131,6 +136,21 @@ describe("cli/main", () => {
     stdoutWrite.mockRestore();
     stderrWrite.mockRestore();
     process.exitCode = originalExitCode;
+    process.argv = originalArgv;
+    setStdinTTY(originalStdinIsTTY);
+  });
+
+  it("prints root help for a bare interactive invocation", async () => {
+    setStdinTTY(true);
+
+    await main();
+
+    expect(stdoutChunks).toStrictEqual([`${renderMainHelpText()}\n`]);
+    expect(stderrChunks).toStrictEqual([]);
+    expect(mainMockState.runCalls).toHaveLength(0);
+    expect(mainMockState.statusRunCalls).toBe(0);
+    expect(mainMockState.sdpubRunCalls).toHaveLength(0);
+    expect(process.exitCode).toBe(0);
   });
 
   it("prints help text and skips conversion when --help is used", async () => {
@@ -382,3 +402,10 @@ describe("cli/main", () => {
     expect(process.exitCode).toBe(1);
   });
 });
+
+function setStdinTTY(value: boolean | undefined): void {
+  Object.defineProperty(process.stdin, "isTTY", {
+    configurable: true,
+    value,
+  });
+}

--- a/test/cli/sdpub.test.ts
+++ b/test/cli/sdpub.test.ts
@@ -204,7 +204,8 @@ describe("cli/sdpub", () => {
         "Cover Path: images/cover.png",
         "",
         "Top-level Sections: 1",
-        "Referenced Serials: 2",
+        "Referenced Chapters: 2",
+        "Summarized Chapters: 2",
         "Fragments: 3",
         "",
       ].join("\n"),
@@ -222,8 +223,8 @@ describe("cli/sdpub", () => {
         "Fixture Book",
         "",
         "Part I",
-        "  Chapter 1 [serial 1]",
-        "  Chapter 2 [serial 2]",
+        "  Chapter 1 [chapter 1]",
+        "  Chapter 2 [chapter 2]",
         "",
       ].join("\n"),
     ]);
@@ -241,6 +242,19 @@ describe("cli/sdpub", () => {
         "[2] Part I / Chapter 2 (fragments: 1)",
         "",
       ].join("\n"),
+    ]);
+  });
+
+  it("prints a chapter-oriented empty list message", async () => {
+    sdpubMockState.serialEntries = [];
+
+    await runSdpubCommand({
+      inputPath: "/tmp/book.sdpub",
+      subcommand: "list",
+    });
+
+    expect(sdpubMockState.textWrites).toStrictEqual([
+      "No summarized chapters available.\n",
     ]);
   });
 

--- a/test/facade/spine-digest.test.ts
+++ b/test/facade/spine-digest.test.ts
@@ -124,6 +124,48 @@ describe("facade/spine-digest", () => {
       ).rejects.toThrow();
     });
   });
+
+  it("lists only serials with summaries for cat-ready output", async () => {
+    await withTempDir("spinedigest-facade-", async (path) => {
+      const document = await DirectoryDocument.open(`${path}/document`);
+
+      try {
+        await document.openSession(async (openedDocument) => {
+          await openedDocument.createSerial();
+          await openedDocument.createSerial();
+          await openedDocument.writeSummary(1, "Summary one");
+          await openedDocument.writeToc({
+            items: [
+              {
+                children: [],
+                serialId: 1,
+                title: "Ready",
+              },
+              {
+                children: [],
+                serialId: 2,
+                title: "Pending",
+              },
+            ],
+            version: 1,
+          });
+        });
+
+        const digest = new SpineDigest(document, document.path);
+
+        expect(await digest.listSerials()).toStrictEqual([
+          {
+            fragmentCount: 0,
+            serialId: 1,
+            title: "Ready",
+            tocPath: ["Ready"],
+          },
+        ]);
+      } finally {
+        await document.release();
+      }
+    });
+  });
 });
 
 async function seedDocument(document: DirectoryDocument): Promise<void> {

--- a/test/output/epub-book.test.ts
+++ b/test/output/epub-book.test.ts
@@ -249,7 +249,7 @@ describe("output/epub/book", () => {
         });
 
         await expect(buildEpubBook(document)).rejects.toThrow(
-          "Serial 7 summary is missing",
+          "Chapter 7 summary is missing",
         );
       } finally {
         await document.release();

--- a/test/output/plain-text.test.ts
+++ b/test/output/plain-text.test.ts
@@ -112,7 +112,7 @@ describe("output/plain-text", () => {
             document: missingSummaryDocument,
             path: `${path}/missing-summary.txt`,
           }),
-        ).rejects.toThrow("Serial 7 summary is missing");
+        ).rejects.toThrow("Chapter 7 summary is missing");
       } finally {
         await missingTocDocument.release();
         await missingSummaryDocument.release();

--- a/test/utils/enum.test.ts
+++ b/test/utils/enum.test.ts
@@ -4,7 +4,6 @@ import {
   createEnumValueAsserter,
   createEnumValueGuard,
 } from "../../src/utils/enum.js";
-import { isNodeError } from "../../src/utils/node-error.js";
 
 enum DemoEnum {
   Alpha = "alpha",
@@ -24,13 +23,5 @@ describe("utils/enum", () => {
 
     expect(expectDemoEnum("beta")).toBe("beta");
     expect(() => expectDemoEnum("gamma")).toThrow("Unknown demo enum: gamma");
-  });
-});
-
-describe("utils/node-error", () => {
-  it("detects Error instances only", () => {
-    expect(isNodeError(new Error("boom"))).toBe(true);
-    expect(isNodeError({ code: "ENOENT" })).toBe(false);
-    expect(isNodeError("boom")).toBe(false);
   });
 });

--- a/test/utils/node-error.test.ts
+++ b/test/utils/node-error.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { formatError, isNodeError } from "../../src/utils/node-error.js";
+
+describe("utils/node-error", () => {
+  it("detects Error instances only", () => {
+    expect(isNodeError(new Error("boom"))).toBe(true);
+    expect(isNodeError({ code: "ENOENT" })).toBe(false);
+    expect(isNodeError("boom")).toBe(false);
+  });
+
+  it("formats missing files without exposing Node stack wording", () => {
+    const error = Object.assign(
+      new Error("ENOENT: no such file or directory"),
+      {
+        code: "ENOENT",
+        path: "/tmp/missing.sdpub",
+      },
+    );
+
+    expect(formatError(error)).toBe(
+      "File not found: /tmp/missing.sdpub (ENOENT)",
+    );
+  });
+
+  it("formats permission errors with the affected path", () => {
+    const error = Object.assign(new Error("permission denied"), {
+      code: "EACCES",
+      path: "/tmp/private.sdpub",
+    });
+
+    expect(formatError(error)).toBe(
+      "Permission denied: /tmp/private.sdpub (EACCES)",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- expand the built-in .sdpub concept help and add action-level stage/chapter help pages
- document .sdpub as a SpineDigest-managed ZIP archive that routine automation should edit through CLI commands
- add --version and improve file/permission error formatting for CLI-friendly recovery
- sync public CLI and AI-agent docs with the staged .sdpub workflow

## Verification
- pnpm verify
- pnpm test:run
- pnpm build
- node dist/cli.js --version
- node dist/cli.js help sdpub
- node dist/cli.js sdpub chapter set-source --help
- node dist/cli.js sdpub cat --input /tmp/no-such.sdpub --serial 1