### PR TITLE
Improve sdpub agent inspection workflows

### DIFF
--- a/data/help/commands/sdpub/cat.jinja
+++ b/data/help/commands/sdpub/cat.jinja
@@ -4,20 +4,19 @@ Command: spinedigest sdpub cat
 sdpub cat
 
 Purpose:
-  Print the final summary text for one completed chapter through the legacy serial reader.
+  Print the final summary text for one completed chapter.
 
 Usage:
-  spinedigest sdpub cat --input <path> --serial <id> [--llm <json>] [--help|-h]
+  spinedigest sdpub cat --input <path> --chapter <id> [--llm <json>] [--help|-h]
 
 Required flags:
-  --serial <id> must be a non-negative integer.
-  For chapter-backed content, this id matches the chapter id printed by `sdpub list`.
+  --chapter <id> must be a non-negative integer.
+  Use the chapter id printed by `sdpub list`.
 
 Output shape:
   - Plain summary text only
 
 Notes:
-  - `serial` is a legacy read-interface term; current editing and staging commands use chapter ids.
   - The selected id must have a summary.
   - Planned, sourced, or graphed chapters are not ready for `cat`.
   - Use `spinedigest sdpub list --input <path>` to discover completed summaries.

--- a/data/help/commands/sdpub/cat.jinja
+++ b/data/help/commands/sdpub/cat.jinja
@@ -19,5 +19,6 @@ Output shape:
 Notes:
   - The selected id must have a summary.
   - Planned, sourced, or graphed chapters are not ready for `cat`.
-  - Use `spinedigest sdpub list --input <path>` to discover completed summaries.
+  - Use `spinedigest sdpub list --input <path>` to discover chapter ids and cat-ready chapters.
+  - Redirect output to a temporary file when you want to inspect or edit with normal file tools.
   - Use `spinedigest sdpub stage pending <path>` to find unfinished chapters.

--- a/data/help/commands/sdpub/chapter.jinja
+++ b/data/help/commands/sdpub/chapter.jinja
@@ -14,7 +14,7 @@ Usage:
 
 Chapter stages:
   planned     TOC chapter exists, but no source is stored.
-  sourced     Normalized source fragments are stored.
+  sourced     Normalized source text is stored.
   graphed     Source plus generated graph are stored.
   summarized  Source, graph, and final summary are stored.
 

--- a/data/help/commands/sdpub/chapter/remove.jinja
+++ b/data/help/commands/sdpub/chapter/remove.jinja
@@ -11,7 +11,7 @@ Usage:
 
 Behavior:
   - Removes the target chapter from the TOC tree.
-  - Removes that chapter's source fragments, graph data, and summary.
+  - Removes that chapter's source text, graph data, and summary.
   - Fails when the chapter has children unless `--recursive` is provided.
   - With `--recursive`, removes the whole selected subtree and its stored data.
   - Does not call an LLM provider.

--- a/data/help/commands/sdpub/chapter/reset.jinja
+++ b/data/help/commands/sdpub/chapter/reset.jinja
@@ -10,9 +10,9 @@ Usage:
   spinedigest sdpub chapter reset <path> --chapter <id> --to <stage> [--llm <json>] [--help|-h]
 
 Targets:
-  planned     Delete source fragments, graph data, and summary.
-  sourced     Keep source fragments; delete graph data and summary.
-  graphed     Keep source fragments and graph data; delete summary.
+  planned     Delete source text, graph data, and summary.
+  sourced     Keep source text; delete graph data and summary.
+  graphed     Keep source text and graph data; delete summary.
 
 Behavior:
   - `--to summarized` is not supported because reset is a backward operation.

--- a/data/help/commands/sdpub/chapter/set-source.jinja
+++ b/data/help/commands/sdpub/chapter/set-source.jinja
@@ -18,7 +18,7 @@ Preconditions:
   - To replace source on a later-stage chapter, first reset it to `planned`.
 
 Behavior:
-  - Writes normalized source fragments.
+  - Writes normalized source text.
   - Moves the chapter to `sourced`.
   - Does not generate graph data.
   - Does not generate or modify a summary.

--- a/data/help/commands/sdpub/chapter/set-summary.jinja
+++ b/data/help/commands/sdpub/chapter/set-summary.jinja
@@ -12,6 +12,7 @@ Usage:
 Input:
   - If `--input` is omitted, summary text is read from stdin.
   - Summary text is stored as the chapter's final summary.
+  - A common workflow is `sdpub cat > /tmp/summary.md`, edit the file, then pass it back with `--input`.
 
 Preconditions:
   - The chapter must be `graphed`.

--- a/data/help/commands/sdpub/chapter/status.jinja
+++ b/data/help/commands/sdpub/chapter/status.jinja
@@ -22,7 +22,7 @@ Behavior:
   - Does not call an LLM provider.
   - Does not mutate the archive.
   - `Source Units` is the number of stored source records for that chapter.
-  - `Graph` reports whether graph/topology data is present.
+  - `Graph` reports whether chapter graph data is present.
   - `Summary` reports whether the final chapter summary is present.
 
 See also:

--- a/data/help/commands/sdpub/chapter/status.jinja
+++ b/data/help/commands/sdpub/chapter/status.jinja
@@ -13,7 +13,7 @@ Output shape:
   Chapter: <id>
   Title: <title-or-[untitled]>
   Stage: <planned|sourced|graphed|summarized>
-  Fragments: <count>
+  Source Units: <count>
   Children: <count>
   Graph: yes|no
   Summary: yes|no
@@ -21,7 +21,7 @@ Output shape:
 Behavior:
   - Does not call an LLM provider.
   - Does not mutate the archive.
-  - `Fragments` is the number of stored normalized fragment records for that chapter.
+  - `Source Units` is the number of stored source records for that chapter.
   - `Graph` reports whether graph/topology data is present.
   - `Summary` reports whether the final chapter summary is present.
 

--- a/data/help/commands/sdpub/cover.jinja
+++ b/data/help/commands/sdpub/cover.jinja
@@ -16,3 +16,10 @@ Notes:
   - Redirect or pipe stdout.
   - The command refuses to write binary data to an interactive terminal.
   - The command fails if the archive has no cover.
+  - Use `sdpub info` first when you need the stored cover media type or original cover path.
+  - For multimodal agents, project the cover to a normal image file, then inspect that file with image/OCR tools.
+
+Examples:
+  spinedigest sdpub info --input ./book.sdpub
+  spinedigest sdpub cover --input ./book.sdpub > /tmp/cover.jpg
+  spinedigest sdpub cover --input ./book.sdpub > /tmp/cover.png

--- a/data/help/commands/sdpub/graph.jinja
+++ b/data/help/commands/sdpub/graph.jinja
@@ -1,0 +1,43 @@
+Help Type: command
+Command: spinedigest sdpub graph
+
+sdpub graph
+
+Purpose:
+  Explore a chapter graph with Git-like read-only commands.
+
+Usage:
+  spinedigest sdpub graph status <path> --chapter <id> [--llm <json>] [--help|-h]
+  spinedigest sdpub graph log <path> --chapter <id> [--limit <n>] [--llm <json>] [--help|-h]
+  spinedigest sdpub graph show <path> --chapter <id> <node> [--llm <json>] [--help|-h]
+  spinedigest sdpub graph grep <path> --chapter <id> <pattern> [--llm <json>] [--help|-h]
+  spinedigest sdpub graph neighbors <path> --chapter <id> <node> [--llm <json>] [--help|-h]
+  spinedigest sdpub graph blame <path> --chapter <id> <node> [--llm <json>] [--help|-h]
+  spinedigest sdpub graph path <path> --chapter <id> <from> <to> [--llm <json>] [--help|-h]
+
+Model:
+  - The chapter graph is a read-only exploration view over generated graph data.
+  - A node is a digest graph node with a numeric id, label, content, weight, and source evidence.
+  - Edges represent directed relationships between nodes.
+  - Use `sdpub graph log` to discover node ids, then `show`, `neighbors`, `blame`, or `path`.
+
+Git-like command map:
+  status     Show whether graph data exists and count nodes/edges.
+  log        List graph nodes in a compact one-line form.
+  show       Show one node with content, neighbors, and source evidence.
+  grep       Search node labels, content, and source evidence.
+  neighbors  Show incoming and outgoing adjacent nodes.
+  blame      Show the source sentences behind one node.
+  path       Find a directed path between two nodes.
+
+Behavior:
+  - Does not call an LLM provider.
+  - Does not mutate the archive.
+  - Does not expose or require ZIP internals.
+  - Does not support `--json` in this first graph reader.
+
+See also:
+  - spinedigest sdpub list --help
+  - spinedigest sdpub graph log --help
+  - spinedigest sdpub graph show --help
+  - spinedigest help sdpub

--- a/data/help/commands/sdpub/graph.jinja
+++ b/data/help/commands/sdpub/graph.jinja
@@ -16,14 +16,27 @@ Usage:
   spinedigest sdpub graph path <path> --chapter <id> <from> <to> [--llm <json>] [--help|-h]
 
 Model:
-  - The chapter graph is a read-only exploration view over generated graph data.
-  - A node is a digest graph node with a numeric id, label, content, weight, and source evidence.
+  - The chapter graph is a read-only exploration view over generated chapter graph data.
+  - A node has a numeric id, label, content, and source evidence.
   - Edges represent directed relationships between nodes.
   - Use `sdpub graph log` to discover node ids, then `show`, `neighbors`, `blame`, or `path`.
 
+Shortest successful path:
+  1. List chapters:
+     spinedigest sdpub list --input ./book.sdpub
+  2. Check whether one chapter has a graph:
+     spinedigest sdpub graph status ./book.sdpub --chapter 12
+  3. If `Graph: no`, generate chapter graph data first:
+     spinedigest sdpub stage advance ./book.sdpub --chapter 12 --to graphed
+  4. Discover node ids:
+     spinedigest sdpub graph log ./book.sdpub --chapter 12 --limit 10
+  5. Read one node and its source evidence:
+     spinedigest sdpub graph show ./book.sdpub --chapter 12 84
+     spinedigest sdpub graph blame ./book.sdpub --chapter 12 84
+
 Git-like command map:
   status     Show whether graph data exists and count nodes/edges.
-  log        List graph nodes in a compact one-line form.
+  log        List nodes in a compact one-line form.
   show       Show one node with content, neighbors, and source evidence.
   grep       Search node labels, content, and source evidence.
   neighbors  Show incoming and outgoing adjacent nodes.

--- a/data/help/commands/sdpub/graph/blame.jinja
+++ b/data/help/commands/sdpub/graph/blame.jinja
@@ -1,0 +1,21 @@
+Help Type: command
+Command: spinedigest sdpub graph blame
+
+sdpub graph blame
+
+Purpose:
+  Show the source sentences behind one graph node.
+
+Usage:
+  spinedigest sdpub graph blame <path> --chapter <id> <node> [--help|-h]
+
+Output shape:
+  <sentence-id> <source sentence>
+
+Notes:
+  - This is the graph-reader equivalent of source attribution.
+  - Sentence ids are diagnostic anchors, not a public editing API.
+
+See also:
+  - spinedigest sdpub graph show --help
+  - spinedigest sdpub cat --help

--- a/data/help/commands/sdpub/graph/blame.jinja
+++ b/data/help/commands/sdpub/graph/blame.jinja
@@ -4,7 +4,7 @@ Command: spinedigest sdpub graph blame
 sdpub graph blame
 
 Purpose:
-  Show the source sentences behind one graph node.
+  Show the source sentences behind one node.
 
 Usage:
   spinedigest sdpub graph blame <path> --chapter <id> <node> [--help|-h]

--- a/data/help/commands/sdpub/graph/grep.jinja
+++ b/data/help/commands/sdpub/graph/grep.jinja
@@ -1,0 +1,21 @@
+Help Type: command
+Command: spinedigest sdpub graph grep
+
+sdpub graph grep
+
+Purpose:
+  Search graph node labels, content, and source evidence.
+
+Usage:
+  spinedigest sdpub graph grep <path> --chapter <id> <pattern> [--help|-h]
+
+Output shape:
+  [<node>] <weight> <label> - <content> matches:<fields>
+
+Notes:
+  - Search is case-insensitive.
+  - Matching fields are `label`, `content`, and `evidence`.
+
+See also:
+  - spinedigest sdpub graph log --help
+  - spinedigest sdpub graph show --help

--- a/data/help/commands/sdpub/graph/grep.jinja
+++ b/data/help/commands/sdpub/graph/grep.jinja
@@ -4,13 +4,13 @@ Command: spinedigest sdpub graph grep
 sdpub graph grep
 
 Purpose:
-  Search graph node labels, content, and source evidence.
+  Search node labels, content, and source evidence.
 
 Usage:
   spinedigest sdpub graph grep <path> --chapter <id> <pattern> [--help|-h]
 
 Output shape:
-  [<node>] <weight> <label> - <content> matches:<fields>
+  [<node>] <label> - <content> matches:<fields>
 
 Notes:
   - Search is case-insensitive.

--- a/data/help/commands/sdpub/graph/log.jinja
+++ b/data/help/commands/sdpub/graph/log.jinja
@@ -1,0 +1,22 @@
+Help Type: command
+Command: spinedigest sdpub graph log
+
+sdpub graph log
+
+Purpose:
+  List chapter graph nodes in a compact Git-like one-line form.
+
+Usage:
+  spinedigest sdpub graph log <path> --chapter <id> [--limit <n>] [--help|-h]
+
+Output shape:
+  [<node>] <weight> <label> - <content>
+
+Notes:
+  - Nodes are ordered by descending weight.
+  - `--limit` defaults to 20.
+  - Use node ids with `show`, `neighbors`, `blame`, and `path`.
+
+See also:
+  - spinedigest sdpub graph show --help
+  - spinedigest sdpub graph grep --help

--- a/data/help/commands/sdpub/graph/log.jinja
+++ b/data/help/commands/sdpub/graph/log.jinja
@@ -4,16 +4,16 @@ Command: spinedigest sdpub graph log
 sdpub graph log
 
 Purpose:
-  List chapter graph nodes in a compact Git-like one-line form.
+  List nodes in a compact Git-like one-line form.
 
 Usage:
   spinedigest sdpub graph log <path> --chapter <id> [--limit <n>] [--help|-h]
 
 Output shape:
-  [<node>] <weight> <label> - <content>
+  [<node>] <label> - <content>
 
 Notes:
-  - Nodes are ordered by descending weight.
+  - Nodes are ordered by internal relevance.
   - `--limit` defaults to 20.
   - Use node ids with `show`, `neighbors`, `blame`, and `path`.
 

--- a/data/help/commands/sdpub/graph/neighbors.jinja
+++ b/data/help/commands/sdpub/graph/neighbors.jinja
@@ -1,0 +1,22 @@
+Help Type: command
+Command: spinedigest sdpub graph neighbors
+
+sdpub graph neighbors
+
+Purpose:
+  Show incoming and outgoing adjacent nodes for one graph node.
+
+Usage:
+  spinedigest sdpub graph neighbors <path> --chapter <id> <node> [--help|-h]
+
+Output shape:
+  <- [<node>] <weight> <label>
+  -> [<node>] <weight> <label>
+
+Notes:
+  - `<-` means the listed node points into the selected node.
+  - `->` means the selected node points to the listed node.
+
+See also:
+  - spinedigest sdpub graph show --help
+  - spinedigest sdpub graph path --help

--- a/data/help/commands/sdpub/graph/neighbors.jinja
+++ b/data/help/commands/sdpub/graph/neighbors.jinja
@@ -4,14 +4,14 @@ Command: spinedigest sdpub graph neighbors
 sdpub graph neighbors
 
 Purpose:
-  Show incoming and outgoing adjacent nodes for one graph node.
+  Show incoming and outgoing adjacent nodes for one node.
 
 Usage:
   spinedigest sdpub graph neighbors <path> --chapter <id> <node> [--help|-h]
 
 Output shape:
-  <- [<node>] <weight> <label>
-  -> [<node>] <weight> <label>
+  <- [<node>] <label>
+  -> [<node>] <label>
 
 Notes:
   - `<-` means the listed node points into the selected node.

--- a/data/help/commands/sdpub/graph/path.jinja
+++ b/data/help/commands/sdpub/graph/path.jinja
@@ -1,0 +1,23 @@
+Help Type: command
+Command: spinedigest sdpub graph path
+
+sdpub graph path
+
+Purpose:
+  Find a directed path between two graph nodes.
+
+Usage:
+  spinedigest sdpub graph path <path> --chapter <id> <from> <to> [--help|-h]
+
+Output shape:
+  [<node>] <weight> <label> - <content>
+    -> <edge-weight>
+  [<node>] <weight> <label> - <content>
+
+Notes:
+  - The first implementation returns a shortest directed path by edge count.
+  - If no directed path exists, the command prints `No path from <from> to <to>.`
+
+See also:
+  - spinedigest sdpub graph neighbors --help
+  - spinedigest sdpub graph log --help

--- a/data/help/commands/sdpub/graph/path.jinja
+++ b/data/help/commands/sdpub/graph/path.jinja
@@ -4,15 +4,15 @@ Command: spinedigest sdpub graph path
 sdpub graph path
 
 Purpose:
-  Find a directed path between two graph nodes.
+  Find a directed path between two nodes.
 
 Usage:
   spinedigest sdpub graph path <path> --chapter <id> <from> <to> [--help|-h]
 
 Output shape:
-  [<node>] <weight> <label> - <content>
-    -> <edge-weight>
-  [<node>] <weight> <label> - <content>
+  [<node>] <label> - <content>
+    ->
+  [<node>] <label> - <content>
 
 Notes:
   - The first implementation returns a shortest directed path by edge count.

--- a/data/help/commands/sdpub/graph/show.jinja
+++ b/data/help/commands/sdpub/graph/show.jinja
@@ -1,0 +1,21 @@
+Help Type: command
+Command: spinedigest sdpub graph show
+
+sdpub graph show
+
+Purpose:
+  Show one graph node with readable content, adjacent nodes, and source evidence.
+
+Usage:
+  spinedigest sdpub graph show <path> --chapter <id> <node> [--help|-h]
+
+Output includes:
+  - Node id and label
+  - Weight, word count, and optional importance/retention
+  - Node content
+  - Incoming and outgoing neighbors
+  - A short source evidence preview
+
+See also:
+  - spinedigest sdpub graph blame --help
+  - spinedigest sdpub graph neighbors --help

--- a/data/help/commands/sdpub/graph/show.jinja
+++ b/data/help/commands/sdpub/graph/show.jinja
@@ -4,14 +4,13 @@ Command: spinedigest sdpub graph show
 sdpub graph show
 
 Purpose:
-  Show one graph node with readable content, adjacent nodes, and source evidence.
+  Show one node with readable content, adjacent nodes, and source evidence.
 
 Usage:
   spinedigest sdpub graph show <path> --chapter <id> <node> [--help|-h]
 
 Output includes:
   - Node id and label
-  - Weight, word count, and optional importance/retention
   - Node content
   - Incoming and outgoing neighbors
   - A short source evidence preview

--- a/data/help/commands/sdpub/graph/status.jinja
+++ b/data/help/commands/sdpub/graph/status.jinja
@@ -1,0 +1,20 @@
+Help Type: command
+Command: spinedigest sdpub graph status
+
+sdpub graph status
+
+Purpose:
+  Show whether a chapter graph exists and how large it is.
+
+Usage:
+  spinedigest sdpub graph status <path> --chapter <id> [--help|-h]
+
+Output shape:
+  Chapter: <id>
+  Graph: yes|no
+  Nodes: <count>
+  Edges: <count>
+
+See also:
+  - spinedigest sdpub graph log --help
+  - spinedigest sdpub chapter status --help

--- a/data/help/commands/sdpub/index.jinja
+++ b/data/help/commands/sdpub/index.jinja
@@ -15,6 +15,7 @@ Usage:
   spinedigest sdpub meta --input <path> [metadata options] [--llm <json>] [--help|-h]
   spinedigest sdpub stage <action> <path> [options] [--help|-h]
   spinedigest sdpub chapter <action> <path> [options] [--help|-h]
+  spinedigest sdpub graph <action> <path> --chapter <id> [options] [--help|-h]
 
 Shared behavior:
   - Inspection subcommands use `--input <path>` for an existing `.sdpub` archive.
@@ -24,16 +25,16 @@ Shared behavior:
   - `chapter set-source` and `chapter set-summary` can read content from stdin when `--input` is omitted.
   - `--digest-dir`, `--output`, `--output-format`, and `--verbose` are not supported.
   - `--prompt` is only supported by `sdpub stage advance`.
-  - `--json` is only supported by `sdpub list`.
+  - `--json` is only supported by `sdpub list` and `sdpub meta`.
   - `sdpub stage advance` calls an LLM provider when graph or summary generation is needed.
   - Inspection commands and metadata/tree edits do not call an LLM provider.
   - `-h` is available as the short form of `--help`.
 
 Path convention:
   - Use `--input <path>` for read-oriented commands: `info`, `toc`, `list`, `cat`, `cover`, and `meta`.
-  - Use positional `<path>` for operated-document commands: `stage` and `chapter`.
+  - Use positional `<path>` for operated-document commands: `stage`, `chapter`, and `graph`.
   - This keeps `chapter set-source` and `chapter set-summary` free to use `--input` for the text being inserted.
-  - Mutating/stage commands treat the archive as the document being operated on.
+  - Operated-document commands treat the archive as the document being operated on.
   - `.sdpub` is a ZIP archive, but routine automation should not unzip and edit it directly. Use this command family instead.
 
 Mutation safety:

--- a/data/help/commands/sdpub/index.jinja
+++ b/data/help/commands/sdpub/index.jinja
@@ -9,7 +9,7 @@ Purpose:
 Usage:
   spinedigest sdpub info --input <path> [--llm <json>] [--help|-h]
   spinedigest sdpub toc --input <path> [--llm <json>] [--help|-h]
-  spinedigest sdpub list --input <path> [--llm <json>] [--help|-h]
+  spinedigest sdpub list --input <path> [--json] [--llm <json>] [--help|-h]
   spinedigest sdpub cat --input <path> --chapter <id> [--llm <json>] [--help|-h]
   spinedigest sdpub cover --input <path> [--llm <json>] [--help|-h]
   spinedigest sdpub meta --input <path> [metadata options] [--llm <json>] [--help|-h]
@@ -24,6 +24,7 @@ Shared behavior:
   - `chapter set-source` and `chapter set-summary` can read content from stdin when `--input` is omitted.
   - `--digest-dir`, `--output`, `--output-format`, and `--verbose` are not supported.
   - `--prompt` is only supported by `sdpub stage advance`.
+  - `--json` is only supported by `sdpub list`.
   - `sdpub stage advance` calls an LLM provider when graph or summary generation is needed.
   - Inspection commands and metadata/tree edits do not call an LLM provider.
   - `-h` is available as the short form of `--help`.

--- a/data/help/commands/sdpub/index.jinja
+++ b/data/help/commands/sdpub/index.jinja
@@ -10,7 +10,7 @@ Usage:
   spinedigest sdpub info --input <path> [--llm <json>] [--help|-h]
   spinedigest sdpub toc --input <path> [--llm <json>] [--help|-h]
   spinedigest sdpub list --input <path> [--llm <json>] [--help|-h]
-  spinedigest sdpub cat --input <path> --serial <id> [--llm <json>] [--help|-h]
+  spinedigest sdpub cat --input <path> --chapter <id> [--llm <json>] [--help|-h]
   spinedigest sdpub cover --input <path> [--llm <json>] [--help|-h]
   spinedigest sdpub meta --input <path> [metadata options] [--llm <json>] [--help|-h]
   spinedigest sdpub stage <action> <path> [options] [--help|-h]
@@ -31,7 +31,8 @@ Shared behavior:
 Path convention:
   - Use `--input <path>` for read-oriented commands: `info`, `toc`, `list`, `cat`, `cover`, and `meta`.
   - Use positional `<path>` for operated-document commands: `stage` and `chapter`.
-  - This split follows the top-level option style for inspection, while mutating/stage commands treat the archive as the document being operated on.
+  - This keeps `chapter set-source` and `chapter set-summary` free to use `--input` for the text being inserted.
+  - Mutating/stage commands treat the archive as the document being operated on.
   - `.sdpub` is a ZIP archive, but routine automation should not unzip and edit it directly. Use this command family instead.
 
 Mutation safety:

--- a/data/help/commands/sdpub/info.jinja
+++ b/data/help/commands/sdpub/info.jinja
@@ -23,9 +23,9 @@ Output shape:
   - Top-level section count
   - Referenced chapter count
   - Summarized chapter count
-  - Total fragment count
+  - Total source unit count
 
 Notes:
   - Archives without `manifest.json` are reported as archive format version 1.
-  - Missing metadata fields are omitted.
-  - If no document metadata exists, the command prints a fallback message.
+  - Missing metadata fields are printed as `[none]`, matching `sdpub meta`.
+  - If no document metadata exists, metadata fields are printed as `[none]`.

--- a/data/help/commands/sdpub/list.jinja
+++ b/data/help/commands/sdpub/list.jinja
@@ -4,16 +4,20 @@ Command: spinedigest sdpub list
 sdpub list
 
 Purpose:
-  List summarized chapters that can be read with `sdpub cat`.
+  List the chapter tree with ids and readiness for `sdpub cat`.
 
 Usage:
   spinedigest sdpub list --input <path> [--llm <json>] [--help|-h]
+  spinedigest sdpub list --input <path> --json [--llm <json>] [--help|-h]
 
 Output shape:
-  [<id>] <TOC path> (fragments: <count>)
+  [<chapterId>] <title>
+    [<chapterId>] <title> (<stage>)
 
 Notes:
-  - The TOC path is joined with ` / `.
-  - Listed ids are completed chapter ids. `sdpub cat` reads them with `--chapter <id>`.
-  - Use `sdpub chapter list` when you need editable chapter ids for staged or unfinished chapters.
-  - If the archive has no completed summaries, the command prints `No summarized chapters available.`
+  - The bracketed number is the chapter id.
+  - Text output preserves the chapter tree with indentation.
+  - Summarized chapters omit the stage marker and can be read with `sdpub cat --chapter <id>`.
+  - Planned, sourced, and graphed chapters show their stage in parentheses.
+  - `--json` prints `chapters`, including `chapterId`, `title`, `stage`, `depth`, `tocPath`, `childCount`, and `catReady`.
+  - If the archive has no chapters, the command prints `No chapters.`

--- a/data/help/commands/sdpub/list.jinja
+++ b/data/help/commands/sdpub/list.jinja
@@ -14,6 +14,6 @@ Output shape:
 
 Notes:
   - The TOC path is joined with ` / `.
-  - Listed ids are completed chapter ids. The legacy `sdpub cat` command reads them with `--serial <id>`.
+  - Listed ids are completed chapter ids. `sdpub cat` reads them with `--chapter <id>`.
   - Use `sdpub chapter list` when you need editable chapter ids for staged or unfinished chapters.
   - If the archive has no completed summaries, the command prints `No summarized chapters available.`

--- a/data/help/commands/sdpub/meta.jinja
+++ b/data/help/commands/sdpub/meta.jinja
@@ -8,6 +8,7 @@ Purpose:
 
 Usage:
   spinedigest sdpub meta --input <path> [--llm <json>] [--help|-h]
+  spinedigest sdpub meta --input <path> --json [--llm <json>] [--help|-h]
   spinedigest sdpub meta --input <path> [metadata options] [--llm <json>] [--help|-h]
 
 Metadata options:
@@ -28,14 +29,17 @@ Metadata options:
 
 Behavior:
   - Without metadata options, this command prints the current metadata.
+  - `--json` prints read-only structured metadata and cannot be combined with metadata options.
   - With metadata options, this command edits the archive in place and then prints the updated metadata.
   - `--author` replaces the entire author list; pass it once per author.
   - `version` and `sourceFormat` are preserved and cannot be edited by this command.
   - Empty string metadata values are rejected. Use the matching `--clear-*` flag instead.
+  - Literal values such as `unknown` are printed as stored metadata values, not interpreted as missing.
   - This command does not call an LLM provider.
 
 Examples:
   spinedigest sdpub meta --input ./book.sdpub
+  spinedigest sdpub meta --input ./book.sdpub --json
   spinedigest sdpub meta --input ./book.sdpub --title "New Title"
   spinedigest sdpub meta --input ./book.sdpub --author "Author One" --author "Author Two"
   spinedigest sdpub meta --input ./book.sdpub --clear-title --clear-description

--- a/data/help/commands/sdpub/stage.jinja
+++ b/data/help/commands/sdpub/stage.jinja
@@ -12,7 +12,7 @@ Usage:
 
 Stages:
   planned     Chapter exists, but no source is stored.
-  sourced     Normalized source fragments are stored.
+  sourced     Normalized source text is stored.
   graphed     Source plus generated graph are stored.
   summarized  Source, graph, and final summary are stored.
 

--- a/data/help/commands/sdpub/stage/advance.jinja
+++ b/data/help/commands/sdpub/stage/advance.jinja
@@ -11,7 +11,7 @@ Usage:
 
 Stages:
   planned     Chapter exists, but no source is stored.
-  sourced     Normalized source fragments are stored.
+  sourced     Normalized source text is stored.
   graphed     Source plus generated graph are stored.
   summarized  Source, graph, and final summary are stored.
 

--- a/data/help/commands/sdpub/stage/advance.jinja
+++ b/data/help/commands/sdpub/stage/advance.jinja
@@ -23,6 +23,7 @@ Behavior:
   - Planned chapters are skipped because they have no source.
   - Advancing from `sourced` to `graphed` calls an LLM provider.
   - Advancing from `graphed` to `summarized` calls an LLM provider.
+  - Progress and long-step heartbeat messages are written to stderr.
   - Advancing never resets or deletes later-stage data.
 
 Output shape:

--- a/data/help/commands/sdpub/toc.jinja
+++ b/data/help/commands/sdpub/toc.jinja
@@ -18,5 +18,5 @@ Notes:
   - The command fails if the archive has no TOC.
   - Empty TOCs print `No TOC items.`
   - A `[chapter N]` marker does not guarantee that `sdpub cat --chapter N` is ready; `cat` requires a completed summary.
-  - Use `sdpub list` to discover completed summaries ready for `cat`.
+  - Use `sdpub list` to discover chapter ids and cat-ready chapters.
   - Use `sdpub chapter list` or `sdpub stage pending` to inspect unfinished chapters.

--- a/data/help/commands/sdpub/toc.jinja
+++ b/data/help/commands/sdpub/toc.jinja
@@ -17,6 +17,6 @@ Output shape:
 Notes:
   - The command fails if the archive has no TOC.
   - Empty TOCs print `No TOC items.`
-  - A `[chapter N]` marker does not guarantee that `sdpub cat --serial N` is ready; `cat` requires a completed summary.
+  - A `[chapter N]` marker does not guarantee that `sdpub cat --chapter N` is ready; `cat` requires a completed summary.
   - Use `sdpub list` to discover completed summaries ready for `cat`.
   - Use `sdpub chapter list` or `sdpub stage pending` to inspect unfinished chapters.

--- a/data/help/topics/ai.jinja
+++ b/data/help/topics/ai.jinja
@@ -36,6 +36,7 @@ Stable terms:
   - .sdpub: a reusable processed archive
   - chapter: the current editable unit inside a .sdpub TOC
   - chapter id: the numeric id used by `sdpub chapter ...` and `sdpub stage --chapter`
+  - graph node: a read-only chapter graph node discovered with `sdpub graph log`
   - TOC path: the section path for a chapter or completed summary
 
 Safety reminders:
@@ -48,6 +49,11 @@ File workflow:
   - Read a summary with `spinedigest sdpub cat --input <archive.sdpub> --chapter <id> > /tmp/summary.md`.
   - Write a revised summary back with `spinedigest sdpub chapter set-summary <archive.sdpub> --chapter <id> --input /tmp/summary.md`.
   - Do not inspect or edit the `.sdpub` ZIP internals for routine summary edits.
+
+Graph workflow:
+  - Use `spinedigest sdpub graph status <archive.sdpub> --chapter <id>` to check graph availability.
+  - Use `spinedigest sdpub graph log <archive.sdpub> --chapter <id>` to discover node ids.
+  - Use `show`, `grep`, `neighbors`, `blame`, and `path` as Git-like read-only graph exploration commands.
 
 Discovery rule:
   - If a user question sounds like task selection, format support, config setup, runtime behavior, failure diagnosis, or `.sdpub` commands, read the matching help topic before guessing.

--- a/data/help/topics/ai.jinja
+++ b/data/help/topics/ai.jinja
@@ -36,7 +36,7 @@ Stable terms:
   - .sdpub: a reusable processed archive
   - chapter: the current editable unit inside a .sdpub TOC
   - chapter id: the numeric id used by `sdpub chapter ...` and `sdpub stage --chapter`
-  - graph node: a read-only chapter graph node discovered with `sdpub graph log`
+  - node: a read-only chapter graph item discovered with `sdpub graph log`
   - TOC path: the section path for a chapter or completed summary
 
 Safety reminders:
@@ -53,7 +53,7 @@ File workflow:
 Graph workflow:
   - Use `spinedigest sdpub graph status <archive.sdpub> --chapter <id>` to check graph availability.
   - Use `spinedigest sdpub graph log <archive.sdpub> --chapter <id>` to discover node ids.
-  - Use `show`, `grep`, `neighbors`, `blame`, and `path` as Git-like read-only graph exploration commands.
+  - Use `show`, `grep`, `neighbors`, `blame`, and `path` as Git-like read-only chapter graph commands.
 
 Cover workflow:
   - Use `spinedigest sdpub info --input <archive.sdpub>` to see whether a cover exists and which media type is stored.

--- a/data/help/topics/ai.jinja
+++ b/data/help/topics/ai.jinja
@@ -43,5 +43,11 @@ Safety reminders:
   - Do not combine `--verbose` with stdout digest output.
   - Do not send `sdpub cover` binary output to an interactive terminal.
 
+File workflow:
+  - Prefer projecting chapter summaries into ordinary temporary files, then use your normal file tools.
+  - Read a summary with `spinedigest sdpub cat --input <archive.sdpub> --chapter <id> > /tmp/summary.md`.
+  - Write a revised summary back with `spinedigest sdpub chapter set-summary <archive.sdpub> --chapter <id> --input /tmp/summary.md`.
+  - Do not inspect or edit the `.sdpub` ZIP internals for routine summary edits.
+
 Discovery rule:
   - If a user question sounds like task selection, format support, config setup, runtime behavior, failure diagnosis, or `.sdpub` commands, read the matching help topic before guessing.

--- a/data/help/topics/ai.jinja
+++ b/data/help/topics/ai.jinja
@@ -36,7 +36,6 @@ Stable terms:
   - .sdpub: a reusable processed archive
   - chapter: the current editable unit inside a .sdpub TOC
   - chapter id: the numeric id used by `sdpub chapter ...` and `sdpub stage --chapter`
-  - serial: legacy/read-interface term still used by `sdpub cat --serial`
   - TOC path: the section path for a chapter or completed summary
 
 Safety reminders:

--- a/data/help/topics/ai.jinja
+++ b/data/help/topics/ai.jinja
@@ -55,5 +55,10 @@ Graph workflow:
   - Use `spinedigest sdpub graph log <archive.sdpub> --chapter <id>` to discover node ids.
   - Use `show`, `grep`, `neighbors`, `blame`, and `path` as Git-like read-only graph exploration commands.
 
+Cover workflow:
+  - Use `spinedigest sdpub info --input <archive.sdpub>` to see whether a cover exists and which media type is stored.
+  - Project the cover to a normal image file, for example `spinedigest sdpub cover --input <archive.sdpub> > /tmp/cover.jpg`.
+  - If you have multimodal tools, inspect the exported image file rather than the `.sdpub` archive internals.
+
 Discovery rule:
   - If a user question sounds like task selection, format support, config setup, runtime behavior, failure diagnosis, or `.sdpub` commands, read the matching help topic before guessing.

--- a/data/help/topics/command.jinja
+++ b/data/help/topics/command.jinja
@@ -50,9 +50,19 @@ sdpub chapter commands:
   spinedigest sdpub chapter set-source <path> --chapter <id> [--input <path>] --input-format <format> [--llm <json>]
   spinedigest sdpub chapter set-summary <path> --chapter <id> [--input <path>] [--llm <json>]
 
+sdpub graph commands:
+  spinedigest sdpub graph status <path> --chapter <id> [--llm <json>]
+  spinedigest sdpub graph log <path> --chapter <id> [--limit <n>] [--llm <json>]
+  spinedigest sdpub graph show <path> --chapter <id> <node> [--llm <json>]
+  spinedigest sdpub graph grep <path> --chapter <id> <pattern> [--llm <json>]
+  spinedigest sdpub graph neighbors <path> --chapter <id> <node> [--llm <json>]
+  spinedigest sdpub graph blame <path> --chapter <id> <node> [--llm <json>]
+  spinedigest sdpub graph path <path> --chapter <id> <from> <to> [--llm <json>]
+
 sdpub-specific flags:
   --chapter <id>         Numeric chapter id printed by `sdpub list`, `sdpub chapter list`, or `sdpub chapter add`.
-  --json                 Print `sdpub list` as structured JSON.
+  --json                 Print supported read commands as structured JSON.
+  --limit <n>            Limit `sdpub graph log` output.
   --parent <id>          Parent chapter id for `sdpub chapter add`.
   --to <stage>           Target stage for `sdpub stage advance` or `sdpub chapter reset`.
 

--- a/data/help/topics/command.jinja
+++ b/data/help/topics/command.jinja
@@ -33,7 +33,7 @@ sdpub inspection and metadata commands:
   spinedigest sdpub info --input <path> [--llm <json>]
   spinedigest sdpub toc --input <path> [--llm <json>]
   spinedigest sdpub list --input <path> [--llm <json>]
-  spinedigest sdpub cat --input <path> --serial <id> [--llm <json>]
+  spinedigest sdpub cat --input <path> --chapter <id> [--llm <json>]
   spinedigest sdpub cover --input <path> [--llm <json>]
   spinedigest sdpub meta --input <path> [metadata options] [--llm <json>]
 
@@ -51,8 +51,7 @@ sdpub chapter commands:
   spinedigest sdpub chapter set-summary <path> --chapter <id> [--input <path>] [--llm <json>]
 
 sdpub-specific flags:
-  --serial <id>          Legacy read flag required by `spinedigest sdpub cat`; for chapter-backed content it matches the chapter id.
-  --chapter <id>         Numeric chapter id printed by `sdpub chapter list` or `add`.
+  --chapter <id>         Numeric chapter id printed by `sdpub list`, `sdpub chapter list`, or `sdpub chapter add`.
   --parent <id>          Parent chapter id for `sdpub chapter add`.
   --to <stage>           Target stage for `sdpub stage advance` or `sdpub chapter reset`.
 

--- a/data/help/topics/command.jinja
+++ b/data/help/topics/command.jinja
@@ -32,7 +32,7 @@ Main flags:
 sdpub inspection and metadata commands:
   spinedigest sdpub info --input <path> [--llm <json>]
   spinedigest sdpub toc --input <path> [--llm <json>]
-  spinedigest sdpub list --input <path> [--llm <json>]
+  spinedigest sdpub list --input <path> [--json] [--llm <json>]
   spinedigest sdpub cat --input <path> --chapter <id> [--llm <json>]
   spinedigest sdpub cover --input <path> [--llm <json>]
   spinedigest sdpub meta --input <path> [metadata options] [--llm <json>]
@@ -52,6 +52,7 @@ sdpub chapter commands:
 
 sdpub-specific flags:
   --chapter <id>         Numeric chapter id printed by `sdpub list`, `sdpub chapter list`, or `sdpub chapter add`.
+  --json                 Print `sdpub list` as structured JSON.
   --parent <id>          Parent chapter id for `sdpub chapter add`.
   --to <stage>           Target stage for `sdpub stage advance` or `sdpub chapter reset`.
 

--- a/data/help/topics/recipe.jinja
+++ b/data/help/topics/recipe.jinja
@@ -42,6 +42,10 @@ List chapters as JSON:
 Read one completed chapter summary:
   spinedigest sdpub cat --input ./book.sdpub --chapter 12
 
+Explore one chapter graph:
+  spinedigest sdpub graph log ./book.sdpub --chapter 12
+  spinedigest sdpub graph show ./book.sdpub --chapter 12 84
+
 Edit one completed chapter summary with normal file tools:
   spinedigest sdpub cat --input ./book.sdpub --chapter 12 > /tmp/chapter-12.md
   # edit /tmp/chapter-12.md with your editor or automation

--- a/data/help/topics/recipe.jinja
+++ b/data/help/topics/recipe.jinja
@@ -33,11 +33,19 @@ Advance a staged archive to summaries:
 Add an empty planned chapter:
   spinedigest sdpub chapter add ./book.sdpub --title "Appendix"
 
-List completed summaries:
+List chapters:
   spinedigest sdpub list --input ./book.sdpub
+
+List chapters as JSON:
+  spinedigest sdpub list --input ./book.sdpub --json
 
 Read one completed chapter summary:
   spinedigest sdpub cat --input ./book.sdpub --chapter 12
+
+Edit one completed chapter summary with normal file tools:
+  spinedigest sdpub cat --input ./book.sdpub --chapter 12 > /tmp/chapter-12.md
+  # edit /tmp/chapter-12.md with your editor or automation
+  spinedigest sdpub chapter set-summary ./book.sdpub --chapter 12 --input /tmp/chapter-12.md
 
 Write the cover to a file:
   spinedigest sdpub cover --input ./book.sdpub > ./cover.bin

--- a/data/help/topics/recipe.jinja
+++ b/data/help/topics/recipe.jinja
@@ -51,8 +51,9 @@ Edit one completed chapter summary with normal file tools:
   # edit /tmp/chapter-12.md with your editor or automation
   spinedigest sdpub chapter set-summary ./book.sdpub --chapter 12 --input /tmp/chapter-12.md
 
-Write the cover to a file:
-  spinedigest sdpub cover --input ./book.sdpub > ./cover.bin
+Write the cover to an image file:
+  spinedigest sdpub info --input ./book.sdpub
+  spinedigest sdpub cover --input ./book.sdpub > ./cover.jpg
 
 Where to go next:
   - Need to choose the right workflow before copying a command:

--- a/data/help/topics/recipe.jinja
+++ b/data/help/topics/recipe.jinja
@@ -36,8 +36,8 @@ Add an empty planned chapter:
 List completed summaries:
   spinedigest sdpub list --input ./book.sdpub
 
-Read one completed summary through the legacy serial reader:
-  spinedigest sdpub cat --input ./book.sdpub --serial 12
+Read one completed chapter summary:
+  spinedigest sdpub cat --input ./book.sdpub --chapter 12
 
 Write the cover to a file:
   spinedigest sdpub cover --input ./book.sdpub > ./cover.bin

--- a/data/help/topics/runtime.jinja
+++ b/data/help/topics/runtime.jinja
@@ -17,6 +17,7 @@ Exit behavior:
 
 Progress and diagnostics:
   - Normal progress rendering uses stderr when the digest path is active, stderr is a TTY, and `--verbose` is off.
+  - `sdpub stage advance` writes chapter advancement progress and long-step heartbeat messages to stderr.
   - `--verbose` writes diagnostic logs to stderr.
 
 Digest workspace:

--- a/data/help/topics/sdpub.jinja
+++ b/data/help/topics/sdpub.jinja
@@ -18,6 +18,7 @@ Archive model:
   - A cover, when present, can be read with `sdpub cover`.
   - `manifest.json` stores the archive format version. Missing manifest means format version 1.
   - `database.db` is internal state for SpineDigest. Do not edit it directly from automation.
+  - Chapter graph data can be explored with `sdpub graph ...`; routine users should not read SQLite directly.
 
 Chapter lifecycle:
   planned     Chapter exists in the TOC, but has no source.
@@ -49,6 +50,7 @@ Read-only commands:
   - `sdpub stage pending <path>`
   - `sdpub chapter list <path>`
   - `sdpub chapter status <path> --chapter <id>`
+  - `sdpub graph status|log|show|grep|neighbors|blame|path <path> --chapter <id> ...`
 
 Mutating commands:
   - `sdpub meta --input <path> [metadata options]`
@@ -76,6 +78,7 @@ Command help entry points:
   - spinedigest sdpub meta --help
   - spinedigest sdpub stage --help
   - spinedigest sdpub chapter --help
+  - spinedigest sdpub graph --help
 
 Use this topic when:
   - You know `.sdpub` is relevant, but you have not yet chosen the exact archive command.

--- a/data/help/topics/sdpub.jinja
+++ b/data/help/topics/sdpub.jinja
@@ -23,7 +23,7 @@ Archive model:
 Chapter lifecycle:
   planned     Chapter exists in the TOC, but has no source.
   sourced     Normalized source data is stored.
-  graphed     Source plus generated graph/topology data are stored.
+  graphed     Source plus generated chapter graph data are stored.
   summarized  Source, graph, and final summary are stored.
 
 Readiness by stage:

--- a/data/help/topics/sdpub.jinja
+++ b/data/help/topics/sdpub.jinja
@@ -15,7 +15,7 @@ Archive model:
   - Document metadata is edited with `sdpub meta`.
   - The TOC is a chapter tree. Each editable chapter has a numeric chapter id.
   - A chapter may store normalized source data, graph data, and a final summary.
-  - A cover, when present, can be read with `sdpub cover`.
+  - A cover, when present, can be projected to a normal image file with `sdpub cover`.
   - `manifest.json` stores the archive format version. Missing manifest means format version 1.
   - `database.db` is internal state for SpineDigest. Do not edit it directly from automation.
   - Chapter graph data can be explored with `sdpub graph ...`; routine users should not read SQLite directly.

--- a/data/help/topics/sdpub.jinja
+++ b/data/help/topics/sdpub.jinja
@@ -14,14 +14,14 @@ Primary rule:
 Archive model:
   - Document metadata is edited with `sdpub meta`.
   - The TOC is a chapter tree. Each editable chapter has a numeric chapter id.
-  - A chapter may store normalized source fragments, graph data, and a final summary.
+  - A chapter may store normalized source data, graph data, and a final summary.
   - A cover, when present, can be read with `sdpub cover`.
   - `manifest.json` stores the archive format version. Missing manifest means format version 1.
   - `database.db` is internal state for SpineDigest. Do not edit it directly from automation.
 
 Chapter lifecycle:
   planned     Chapter exists in the TOC, but has no source.
-  sourced     Normalized source fragments are stored.
+  sourced     Normalized source data is stored.
   graphed     Source plus generated graph/topology data are stored.
   summarized  Source, graph, and final summary are stored.
 
@@ -36,14 +36,14 @@ Primary model:
   Use chapter ids with `sdpub chapter ...` and `sdpub stage --chapter`.
   Prefer `sdpub chapter list` when selecting a chapter to inspect, edit, or advance.
 
-Fragments:
-  A fragment is a normalized internal text unit stored for a chapter.
-  Fragment counts are useful for diagnostics and rough size checks, but they are not the original source file's chapter count.
+Stored source:
+  Source stored in `.sdpub` is normalized processing data, not a verbatim copy of the original EPUB, Markdown, or text file.
+  Routine automation should use chapter-level commands rather than ZIP internals.
 
 Read-only commands:
   - `sdpub info --input <path>`
   - `sdpub toc --input <path>`
-  - `sdpub list --input <path>` for completed summaries
+  - `sdpub list --input <path>` for the chapter tree and cat-ready chapters
   - `sdpub cat --input <path> --chapter <id>` for one completed chapter summary
   - `sdpub cover --input <path>`
   - `sdpub stage pending <path>`

--- a/data/help/topics/sdpub.jinja
+++ b/data/help/topics/sdpub.jinja
@@ -36,12 +36,6 @@ Primary model:
   Use chapter ids with `sdpub chapter ...` and `sdpub stage --chapter`.
   Prefer `sdpub chapter list` when selecting a chapter to inspect, edit, or advance.
 
-Legacy term: serial
-  Some read commands and older archive internals use `serial` for summary-bearing content.
-  `sdpub cat` still uses the legacy flag name `--serial`.
-  For chapter-backed content, the serial id currently matches the chapter id.
-  Use `sdpub list` and `sdpub cat --serial` only to read completed summaries through the legacy read interface.
-
 Fragments:
   A fragment is a normalized internal text unit stored for a chapter.
   Fragment counts are useful for diagnostics and rough size checks, but they are not the original source file's chapter count.
@@ -50,7 +44,7 @@ Read-only commands:
   - `sdpub info --input <path>`
   - `sdpub toc --input <path>`
   - `sdpub list --input <path>` for completed summaries
-  - `sdpub cat --input <path> --serial <id>` for legacy summary reading
+  - `sdpub cat --input <path> --chapter <id>` for one completed chapter summary
   - `sdpub cover --input <path>`
   - `sdpub stage pending <path>`
   - `sdpub chapter list <path>`

--- a/data/help/topics/task.jinja
+++ b/data/help/topics/task.jinja
@@ -33,6 +33,12 @@ Inspect archive structure:
   Command shape:
     spinedigest sdpub <info|toc|list|cat|cover|meta> --input <digest.sdpub>
 
+Explore a chapter graph:
+  Use when a chapter is graphed or summarized and you want to inspect generated graph nodes without reading SQLite directly.
+  Command shape:
+    spinedigest sdpub graph log <digest.sdpub> --chapter <id>
+    spinedigest sdpub graph show <digest.sdpub> --chapter <id> <node>
+
 Edit archive chapters:
   Use when you need to add, remove, reset, or fill individual chapters.
   Command shape:

--- a/data/help/topics/task.jinja
+++ b/data/help/topics/task.jinja
@@ -35,7 +35,7 @@ Inspect archive structure:
   For a cover image, inspect metadata first and redirect `sdpub cover` to a normal image file.
 
 Explore a chapter graph:
-  Use when a chapter is graphed or summarized and you want to inspect generated graph nodes without reading SQLite directly.
+  Use when a chapter is graphed or summarized and you want to inspect generated chapter graph data without reading SQLite directly.
   Command shape:
     spinedigest sdpub graph log <digest.sdpub> --chapter <id>
     spinedigest sdpub graph show <digest.sdpub> --chapter <id> <node>

--- a/data/help/topics/task.jinja
+++ b/data/help/topics/task.jinja
@@ -29,7 +29,7 @@ Re-export an existing .sdpub:
     spinedigest sdpub stage pending <digest.sdpub>
 
 Inspect archive structure:
-  Use when you need format version, metadata, TOC, completed summaries, or raw cover bytes.
+  Use when you need format version, metadata, TOC, chapter tree, or raw cover bytes.
   Command shape:
     spinedigest sdpub <info|toc|list|cat|cover|meta> --input <digest.sdpub>
 

--- a/data/help/topics/task.jinja
+++ b/data/help/topics/task.jinja
@@ -32,6 +32,7 @@ Inspect archive structure:
   Use when you need format version, metadata, TOC, chapter tree, or raw cover bytes.
   Command shape:
     spinedigest sdpub <info|toc|list|cat|cover|meta> --input <digest.sdpub>
+  For a cover image, inspect metadata first and redirect `sdpub cover` to a normal image file.
 
 Explore a chapter graph:
   Use when a chapter is graphed or summarized and you want to inspect generated graph nodes without reading SQLite directly.

--- a/data/help/topics/troubleshoot.jinja
+++ b/data/help/topics/troubleshoot.jinja
@@ -27,7 +27,7 @@ sdpub command failure:
   Check:
     Inspection commands such as `info`, `toc`, `list`, `cat`, `cover`, and `meta` require `--input <path>`.
     `stage` and `chapter` actions require the `.sdpub` path as a positional argument.
-    `cat` requires `--serial <id>`.
+    `cat` requires `--chapter <id>`.
     Chapter-specific actions usually require `--chapter <id>`.
 
 Binary cover output blocked:

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -15,6 +15,7 @@ spinedigest status [--llm <json>]
 spinedigest sdpub <info|toc|list|cat|cover|meta> --input <path> [--chapter <id>] [--json] [--llm <json>]
 spinedigest sdpub stage <pending|advance> <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>]
 spinedigest sdpub chapter <list|status|add|remove|reset|set-source|set-summary> <path> [options]
+spinedigest sdpub graph <status|log|show|grep|neighbors|blame|path> <path> --chapter <id> [options]
 ```
 
 From a source checkout:
@@ -26,6 +27,7 @@ pnpm dev -- status [--llm <json>]
 pnpm dev -- sdpub <info|toc|list|cat|cover|meta> --input <path> [--chapter <id>] [--json] [--llm <json>]
 pnpm dev -- sdpub stage <pending|advance> <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>]
 pnpm dev -- sdpub chapter <list|status|add|remove|reset|set-source|set-summary> <path> [options]
+pnpm dev -- sdpub graph <status|log|show|grep|neighbors|blame|path> <path> --chapter <id> [options]
 ```
 
 ## Flags
@@ -39,6 +41,7 @@ pnpm dev -- sdpub chapter <list|status|add|remove|reset|set-source|set-summary> 
 - `--prompt <text>`: one-off extraction prompt override for the current digest run
 - `--stage <stage>`: create `.sdpub` output up to `planned`, `sourced`, `graphed`, or `summarized`
 - `--json`: print `sdpub list` as structured JSON
+- `--limit <n>`: limit `sdpub graph log` output
 - `--verbose`: write diagnostic logs to `stderr`
 - `--version`: print the installed package version
 - `-h`, `--help`: print help text
@@ -49,7 +52,7 @@ The main conversion command does not support positional arguments.
 
 The `sdpub` interface uses positional subcommands: `spinedigest sdpub <subcommand>`.
 
-Read-oriented `sdpub` subcommands use `--input`, except `cat` also requires `--chapter` and `meta` accepts metadata edit flags. `sdpub stage` and `sdpub chapter` edit existing archives in place and take the archive path as a positional argument.
+Read-oriented `sdpub` subcommands use `--input`, except `cat` also requires `--chapter` and `meta` accepts metadata edit flags. `sdpub stage`, `sdpub chapter`, and `sdpub graph` take the archive path as a positional argument.
 
 `--prompt` affects digest generation from source inputs and graph generation through `spinedigest sdpub stage advance`.
 

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -12,7 +12,7 @@ Installed CLI:
 spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose]
 spinedigest --version
 spinedigest status [--llm <json>]
-spinedigest sdpub <info|toc|list|cat|cover|meta> --input <path> [--serial <id>] [--llm <json>]
+spinedigest sdpub <info|toc|list|cat|cover|meta> --input <path> [--chapter <id>] [--llm <json>]
 spinedigest sdpub stage <pending|advance> <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>]
 spinedigest sdpub chapter <list|status|add|remove|reset|set-source|set-summary> <path> [options]
 ```
@@ -23,7 +23,7 @@ From a source checkout:
 pnpm dev -- [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose]
 pnpm dev -- --version
 pnpm dev -- status [--llm <json>]
-pnpm dev -- sdpub <info|toc|list|cat|cover|meta> --input <path> [--serial <id>] [--llm <json>]
+pnpm dev -- sdpub <info|toc|list|cat|cover|meta> --input <path> [--chapter <id>] [--llm <json>]
 pnpm dev -- sdpub stage <pending|advance> <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>]
 pnpm dev -- sdpub chapter <list|status|add|remove|reset|set-source|set-summary> <path> [options]
 ```
@@ -48,7 +48,7 @@ The main conversion command does not support positional arguments.
 
 The `sdpub` interface uses positional subcommands: `spinedigest sdpub <subcommand>`.
 
-Read-oriented `sdpub` subcommands use `--input`, except `cat` also requires `--serial` and `meta` accepts metadata edit flags. `sdpub stage` and `sdpub chapter` edit existing archives in place and take the archive path as a positional argument.
+Read-oriented `sdpub` subcommands use `--input`, except `cat` also requires `--chapter` and `meta` accepts metadata edit flags. `sdpub stage` and `sdpub chapter` edit existing archives in place and take the archive path as a positional argument.
 
 `--prompt` affects digest generation from source inputs and graph generation through `spinedigest sdpub stage advance`.
 
@@ -133,7 +133,7 @@ Inspect an `.sdpub` archive:
 spinedigest sdpub info --input ./book.sdpub
 spinedigest sdpub toc --input ./book.sdpub
 spinedigest sdpub list --input ./book.sdpub
-spinedigest sdpub cat --input ./book.sdpub --serial 12
+spinedigest sdpub cat --input ./book.sdpub --chapter 12
 spinedigest sdpub cover --input ./book.sdpub > ./cover.png
 spinedigest sdpub meta --input ./book.sdpub
 spinedigest sdpub stage pending ./book.sdpub
@@ -279,7 +279,7 @@ Expect a plain-text error message on `stderr` and a non-zero exit code when:
 - `stdin` or `stdout` is used with a non-text format
 - `--verbose` is used while writing output to `stdout`
 - no LLM configuration is available for a digest operation
-- `spinedigest sdpub cat` is used without `--serial`
+- `spinedigest sdpub cat` is used without `--chapter`
 - `sdpub` subcommands are used with unsupported flags such as `--output`, `--output-format`, `--prompt`, or `--verbose`
 - `spinedigest sdpub cover` tries to write binary data to an interactive terminal
 - `spinedigest sdpub cover` is used on an archive without a cover

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -12,7 +12,7 @@ Installed CLI:
 spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose]
 spinedigest --version
 spinedigest status [--llm <json>]
-spinedigest sdpub <info|toc|list|cat|cover|meta> --input <path> [--chapter <id>] [--llm <json>]
+spinedigest sdpub <info|toc|list|cat|cover|meta> --input <path> [--chapter <id>] [--json] [--llm <json>]
 spinedigest sdpub stage <pending|advance> <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>]
 spinedigest sdpub chapter <list|status|add|remove|reset|set-source|set-summary> <path> [options]
 ```
@@ -23,7 +23,7 @@ From a source checkout:
 pnpm dev -- [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose]
 pnpm dev -- --version
 pnpm dev -- status [--llm <json>]
-pnpm dev -- sdpub <info|toc|list|cat|cover|meta> --input <path> [--chapter <id>] [--llm <json>]
+pnpm dev -- sdpub <info|toc|list|cat|cover|meta> --input <path> [--chapter <id>] [--json] [--llm <json>]
 pnpm dev -- sdpub stage <pending|advance> <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>]
 pnpm dev -- sdpub chapter <list|status|add|remove|reset|set-source|set-summary> <path> [options]
 ```
@@ -38,6 +38,7 @@ pnpm dev -- sdpub chapter <list|status|add|remove|reset|set-source|set-summary> 
 - `--llm <json>`: inline LLM client JSON for this invocation
 - `--prompt <text>`: one-off extraction prompt override for the current digest run
 - `--stage <stage>`: create `.sdpub` output up to `planned`, `sourced`, `graphed`, or `summarized`
+- `--json`: print `sdpub list` as structured JSON
 - `--verbose`: write diagnostic logs to `stderr`
 - `--version`: print the installed package version
 - `-h`, `--help`: print help text
@@ -254,7 +255,7 @@ When the input is `.sdpub`:
 - SpineDigest opens the saved digest state
 - no LLM configuration is required
 - if the archive is summarized, you can export to `.txt`, `.md`, or `.epub`
-- you can inspect metadata, TOC, completed summaries, cover data, pending chapters, and chapter stages through `spinedigest sdpub ...`
+- you can inspect metadata, TOC, chapter tree, cover data, pending chapters, and chapter stages through `spinedigest sdpub ...`
 
 When the output is `.sdpub`:
 
@@ -264,7 +265,7 @@ When the output is `.sdpub`:
 Chapter stages:
 
 - `planned`: the chapter exists in the TOC but has no source
-- `sourced`: normalized source fragments are stored
+- `sourced`: normalized source text is stored
 - `graphed`: graph data is stored, but no final summary exists yet
 - `summarized`: final summary exists and the chapter is ready for re-export or `sdpub cat`
 

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -15,6 +15,7 @@ spinedigest status [--llm <json>]
 spinedigest sdpub <info|toc|list|cat|cover|meta> --input <path> [--chapter <id>] [--json] [--llm <json>]
 spinedigest sdpub stage <pending|advance> <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>]
 spinedigest sdpub chapter <list|status|add|remove|reset|set-source|set-summary> <path> [options]
+spinedigest sdpub graph <status|log|show|grep|neighbors|blame|path> <path> --chapter <id> [options]
 ```
 
 在源码仓库中运行时：
@@ -26,6 +27,7 @@ pnpm dev -- status [--llm <json>]
 pnpm dev -- sdpub <info|toc|list|cat|cover|meta> --input <path> [--chapter <id>] [--json] [--llm <json>]
 pnpm dev -- sdpub stage <pending|advance> <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>]
 pnpm dev -- sdpub chapter <list|status|add|remove|reset|set-source|set-summary> <path> [options]
+pnpm dev -- sdpub graph <status|log|show|grep|neighbors|blame|path> <path> --chapter <id> [options]
 ```
 
 ## 参数
@@ -39,6 +41,7 @@ pnpm dev -- sdpub chapter <list|status|add|remove|reset|set-source|set-summary> 
 - `--prompt <text>`：为当前这次 digest 临时覆盖 extraction prompt
 - `--stage <stage>`：把 `.sdpub` 输出生成到 `planned`、`sourced`、`graphed` 或 `summarized`
 - `--json`：把 `sdpub list` 输出为结构化 JSON
+- `--limit <n>`：限制 `sdpub graph log` 的输出数量
 - `--verbose`：把诊断日志输出到 `stderr`
 - `--version`：打印已安装包版本
 - `-h`, `--help`：打印帮助文本
@@ -49,7 +52,7 @@ pnpm dev -- sdpub chapter <list|status|add|remove|reset|set-source|set-summary> 
 
 `sdpub` 接口本身使用 positional subcommands：`spinedigest sdpub <subcommand>`。
 
-偏读取的 `sdpub` 子命令使用 `--input`，其中 `cat` 还要求提供 `--chapter`，`meta` 额外接受 metadata 编辑参数。`sdpub stage` 和 `sdpub chapter` 会原地编辑已有归档，并把归档路径作为 positional argument。
+偏读取的 `sdpub` 子命令使用 `--input`，其中 `cat` 还要求提供 `--chapter`，`meta` 额外接受 metadata 编辑参数。`sdpub stage`、`sdpub chapter` 和 `sdpub graph` 会把归档路径作为 positional argument。
 
 `--prompt` 影响从源输入生成 digest 的过程，也会影响 `spinedigest sdpub stage advance` 中的 graph 生成。
 

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -12,7 +12,7 @@ SpineDigest 的设计重心是命令行使用。
 spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose]
 spinedigest --version
 spinedigest status [--llm <json>]
-spinedigest sdpub <info|toc|list|cat|cover|meta> --input <path> [--chapter <id>] [--llm <json>]
+spinedigest sdpub <info|toc|list|cat|cover|meta> --input <path> [--chapter <id>] [--json] [--llm <json>]
 spinedigest sdpub stage <pending|advance> <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>]
 spinedigest sdpub chapter <list|status|add|remove|reset|set-source|set-summary> <path> [options]
 ```
@@ -23,7 +23,7 @@ spinedigest sdpub chapter <list|status|add|remove|reset|set-source|set-summary> 
 pnpm dev -- [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose]
 pnpm dev -- --version
 pnpm dev -- status [--llm <json>]
-pnpm dev -- sdpub <info|toc|list|cat|cover|meta> --input <path> [--chapter <id>] [--llm <json>]
+pnpm dev -- sdpub <info|toc|list|cat|cover|meta> --input <path> [--chapter <id>] [--json] [--llm <json>]
 pnpm dev -- sdpub stage <pending|advance> <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>]
 pnpm dev -- sdpub chapter <list|status|add|remove|reset|set-source|set-summary> <path> [options]
 ```
@@ -38,6 +38,7 @@ pnpm dev -- sdpub chapter <list|status|add|remove|reset|set-source|set-summary> 
 - `--llm <json>`：为当前这次调用传入 inline LLM client JSON
 - `--prompt <text>`：为当前这次 digest 临时覆盖 extraction prompt
 - `--stage <stage>`：把 `.sdpub` 输出生成到 `planned`、`sourced`、`graphed` 或 `summarized`
+- `--json`：把 `sdpub list` 输出为结构化 JSON
 - `--verbose`：把诊断日志输出到 `stderr`
 - `--version`：打印已安装包版本
 - `-h`, `--help`：打印帮助文本
@@ -254,7 +255,7 @@ SpineDigest 支持通过环境变量覆盖配置值：
 - SpineDigest 会直接打开已经保存的 digest 状态
 - 不需要 LLM 配置
 - 如果归档已经 summarized，可以导出为 `.txt`、`.md` 或 `.epub`
-- 也可以通过 `spinedigest sdpub ...` 检查元信息、TOC、已完成摘要、封面数据、未完成章节和章节阶段
+- 也可以通过 `spinedigest sdpub ...` 检查元信息、TOC、章节树、封面数据、未完成章节和章节阶段
 
 当输出是 `.sdpub` 时：
 
@@ -264,7 +265,7 @@ SpineDigest 支持通过环境变量覆盖配置值：
 章节阶段：
 
 - `planned`：章节已经存在于 TOC，但还没有原文
-- `sourced`：已经保存 normalized source fragments
+- `sourced`：已经保存规范化后的原文
 - `graphed`：已经保存 graph 数据，但还没有最终摘要
 - `summarized`：已经有最终摘要，可以重新导出或用 `sdpub cat` 读取
 

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -12,7 +12,7 @@ SpineDigest 的设计重心是命令行使用。
 spinedigest [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose]
 spinedigest --version
 spinedigest status [--llm <json>]
-spinedigest sdpub <info|toc|list|cat|cover|meta> --input <path> [--serial <id>] [--llm <json>]
+spinedigest sdpub <info|toc|list|cat|cover|meta> --input <path> [--chapter <id>] [--llm <json>]
 spinedigest sdpub stage <pending|advance> <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>]
 spinedigest sdpub chapter <list|status|add|remove|reset|set-source|set-summary> <path> [options]
 ```
@@ -23,7 +23,7 @@ spinedigest sdpub chapter <list|status|add|remove|reset|set-source|set-summary> 
 pnpm dev -- [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <stage>] [--verbose]
 pnpm dev -- --version
 pnpm dev -- status [--llm <json>]
-pnpm dev -- sdpub <info|toc|list|cat|cover|meta> --input <path> [--serial <id>] [--llm <json>]
+pnpm dev -- sdpub <info|toc|list|cat|cover|meta> --input <path> [--chapter <id>] [--llm <json>]
 pnpm dev -- sdpub stage <pending|advance> <path> [--to <stage>] [--chapter <id>] [--prompt <text>] [--llm <json>]
 pnpm dev -- sdpub chapter <list|status|add|remove|reset|set-source|set-summary> <path> [options]
 ```
@@ -48,7 +48,7 @@ pnpm dev -- sdpub chapter <list|status|add|remove|reset|set-source|set-summary> 
 
 `sdpub` 接口本身使用 positional subcommands：`spinedigest sdpub <subcommand>`。
 
-偏读取的 `sdpub` 子命令使用 `--input`，其中 `cat` 还要求提供 `--serial`，`meta` 额外接受 metadata 编辑参数。`sdpub stage` 和 `sdpub chapter` 会原地编辑已有归档，并把归档路径作为 positional argument。
+偏读取的 `sdpub` 子命令使用 `--input`，其中 `cat` 还要求提供 `--chapter`，`meta` 额外接受 metadata 编辑参数。`sdpub stage` 和 `sdpub chapter` 会原地编辑已有归档，并把归档路径作为 positional argument。
 
 `--prompt` 影响从源输入生成 digest 的过程，也会影响 `spinedigest sdpub stage advance` 中的 graph 生成。
 
@@ -133,7 +133,7 @@ spinedigest --input ./book.sdpub --output ./digest.txt
 spinedigest sdpub info --input ./book.sdpub
 spinedigest sdpub toc --input ./book.sdpub
 spinedigest sdpub list --input ./book.sdpub
-spinedigest sdpub cat --input ./book.sdpub --serial 12
+spinedigest sdpub cat --input ./book.sdpub --chapter 12
 spinedigest sdpub cover --input ./book.sdpub > ./cover.png
 spinedigest sdpub meta --input ./book.sdpub
 spinedigest sdpub stage pending ./book.sdpub
@@ -279,7 +279,7 @@ SpineDigest 支持通过环境变量覆盖配置值：
 - 对非文本格式使用了 `stdin` 或 `stdout`
 - 在写入 `stdout` 时同时使用了 `--verbose`
 - digest 操作缺少 LLM 配置
-- `spinedigest sdpub cat` 缺少 `--serial`
+- `spinedigest sdpub cat` 缺少 `--chapter`
 - `sdpub` 子命令使用了不支持的参数，例如 `--output`、`--output-format`、`--prompt` 或 `--verbose`
 - `spinedigest sdpub cover` 试图向交互式终端输出二进制数据
 - `spinedigest sdpub cover` 针对一个没有封面的归档运行

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -12,6 +12,7 @@ import {
   renderHelpTopicText,
   renderMainHelpText,
   renderSdpubChapterActionHelpText,
+  renderSdpubGraphActionHelpText,
   renderStatusHelpText,
   renderSdpubStageActionHelpText,
   renderSdpubHelpText,
@@ -99,6 +100,27 @@ export interface CLISdpubStageArguments {
   readonly targetStage?: ChapterStage;
 }
 
+export type CLISdpubGraphAction =
+  | "blame"
+  | "grep"
+  | "log"
+  | "neighbors"
+  | "path"
+  | "show"
+  | "status";
+
+export interface CLISdpubGraphArguments {
+  readonly action: CLISdpubGraphAction;
+  readonly chapterId: number;
+  readonly fromNodeId?: number;
+  readonly limit?: number;
+  readonly llmJSON?: string;
+  readonly nodeId?: number;
+  readonly path: string;
+  readonly pattern?: string;
+  readonly toNodeId?: number;
+}
+
 interface SdpubMetaFlagValues {
   readonly author?: readonly string[];
   readonly "clear-authors"?: boolean;
@@ -162,6 +184,16 @@ export type ParsedCLIArguments =
       readonly help: true;
       readonly helpText: string;
       readonly kind: "sdpub-stage";
+    }
+  | {
+      readonly args: CLISdpubGraphArguments;
+      readonly help: false;
+      readonly kind: "sdpub-graph";
+    }
+  | {
+      readonly help: true;
+      readonly helpText: string;
+      readonly kind: "sdpub-graph";
     }
   | {
       readonly help: true;
@@ -229,6 +261,9 @@ export function parseCLIArguments(
         type: "string",
       },
       "input-format": {
+        type: "string",
+      },
+      limit: {
         type: "string",
       },
       language: {
@@ -385,6 +420,7 @@ function parseSdpubArguments(
     readonly "input-format"?: string;
     readonly json?: boolean;
     readonly language?: string;
+    readonly limit?: string;
     readonly llm?: string;
     readonly output?: string;
     readonly "output-format"?: string;
@@ -410,6 +446,9 @@ function parseSdpubArguments(
   }
   if (subcommand === "stage") {
     return parseSdpubStageArguments(positionals.slice(1), values);
+  }
+  if (subcommand === "graph") {
+    return parseSdpubGraphArguments(positionals.slice(1), values);
   }
 
   if (positionals.length > 1) {
@@ -617,6 +656,7 @@ function parseSdpubChapterArguments(
     readonly "input-format"?: string;
     readonly json?: boolean;
     readonly language?: string;
+    readonly limit?: string;
     readonly llm?: string;
     readonly output?: string;
     readonly "output-format"?: string;
@@ -638,6 +678,7 @@ function parseSdpubChapterArguments(
 
   rejectSdpubChapterFlag("digest-dir", values["digest-dir"]);
   rejectSdpubChapterFlag("json", values.json);
+  rejectSdpubChapterFlag("limit", values.limit);
   rejectSdpubChapterFlag("output", values.output);
   rejectSdpubChapterFlag("output-format", values["output-format"]);
   rejectSdpubChapterFlag("stage", values.stage);
@@ -729,6 +770,7 @@ function parseSdpubStageArguments(
     readonly "input-format"?: string;
     readonly json?: boolean;
     readonly language?: string;
+    readonly limit?: string;
     readonly llm?: string;
     readonly output?: string;
     readonly "output-format"?: string;
@@ -752,6 +794,7 @@ function parseSdpubStageArguments(
   rejectSdpubStageFlag("input", values.input);
   rejectSdpubStageFlag("input-format", values["input-format"]);
   rejectSdpubStageFlag("json", values.json);
+  rejectSdpubStageFlag("limit", values.limit);
   rejectSdpubStageFlag("output", values.output);
   rejectSdpubStageFlag("output-format", values["output-format"]);
   rejectSdpubStageFlag("parent", values.parent);
@@ -848,6 +891,116 @@ function parseSdpubStageArguments(
         kind: "sdpub-stage",
       };
   }
+}
+
+function parseSdpubGraphArguments(
+  positionals: readonly string[],
+  values: {
+    readonly author?: readonly string[];
+    readonly chapter?: string;
+    readonly "clear-authors"?: boolean;
+    readonly "clear-description"?: boolean;
+    readonly "clear-identifier"?: boolean;
+    readonly "clear-language"?: boolean;
+    readonly "clear-published-at"?: boolean;
+    readonly "clear-publisher"?: boolean;
+    readonly "clear-title"?: boolean;
+    readonly description?: string;
+    readonly "digest-dir"?: string;
+    readonly help?: boolean;
+    readonly identifier?: string;
+    readonly input?: string;
+    readonly "input-format"?: string;
+    readonly json?: boolean;
+    readonly language?: string;
+    readonly limit?: string;
+    readonly llm?: string;
+    readonly output?: string;
+    readonly "output-format"?: string;
+    readonly parent?: string;
+    readonly "published-at"?: string;
+    readonly publisher?: string;
+    readonly prompt?: string;
+    readonly recursive?: boolean;
+    readonly stage?: string;
+    readonly title?: string;
+    readonly to?: string;
+    readonly verbose?: boolean;
+  },
+): ParsedCLIArguments {
+  const help = values.help ?? false;
+  const action = positionals[0];
+  const path = positionals[1];
+  const helpRoute = "spinedigest sdpub graph --help";
+
+  rejectSdpubGraphFlag("digest-dir", values["digest-dir"]);
+  rejectSdpubGraphFlag("input", values.input);
+  rejectSdpubGraphFlag("input-format", values["input-format"]);
+  rejectSdpubGraphFlag("json", values.json);
+  rejectSdpubGraphFlag("output", values.output);
+  rejectSdpubGraphFlag("output-format", values["output-format"]);
+  rejectSdpubGraphFlag("parent", values.parent);
+  rejectSdpubGraphFlag("prompt", values.prompt);
+  rejectSdpubGraphFlag("recursive", values.recursive);
+  rejectSdpubGraphFlag("stage", values.stage);
+  rejectSdpubGraphFlag("title", values.title);
+  rejectSdpubGraphFlag("to", values.to);
+  rejectSdpubGraphMetaFlags(values);
+  if (values.verbose) {
+    throw new Error(
+      withHelpRoute(
+        "The `sdpub graph` command does not support --verbose.",
+        helpRoute,
+      ),
+    );
+  }
+
+  if (help && isSdpubGraphAction(action)) {
+    return {
+      help: true,
+      helpText: renderSdpubGraphActionHelpText(action),
+      kind: "sdpub-graph",
+    };
+  }
+
+  if (help && action === undefined) {
+    return {
+      help: true,
+      helpText: renderSdpubSubcommandHelpText("graph"),
+      kind: "sdpub-graph",
+    };
+  }
+
+  if (!isSdpubGraphAction(action)) {
+    throw new Error(
+      withHelpRoute(
+        action === undefined
+          ? "Missing sdpub graph action."
+          : `Invalid sdpub graph action: ${action}. Expected one of status, log, show, grep, neighbors, blame, path.`,
+        helpRoute,
+      ),
+    );
+  }
+  if (path === undefined || path === "-") {
+    throw new Error(
+      withHelpRoute(
+        "`spinedigest sdpub graph` requires a .sdpub path positional argument.",
+        helpRoute,
+      ),
+    );
+  }
+
+  return {
+    args: normalizeSdpubGraphArguments(
+      action,
+      path,
+      positionals.slice(2),
+      values,
+      helpRoute,
+    ),
+    help: false,
+    kind: "sdpub-graph",
+  };
 }
 
 function normalizeSdpubChapterArguments(
@@ -1116,6 +1269,114 @@ function normalizeSdpubChapterArguments(
   }
 }
 
+function normalizeSdpubGraphArguments(
+  action: CLISdpubGraphAction,
+  path: string,
+  actionPositionals: readonly string[],
+  values: {
+    readonly chapter?: string;
+    readonly limit?: string;
+    readonly llm?: string;
+  },
+  helpRoute: string,
+): CLISdpubGraphArguments {
+  const chapterId =
+    values.chapter === undefined
+      ? undefined
+      : parseSerialId(values.chapter, "--chapter", helpRoute);
+  const limit =
+    values.limit === undefined
+      ? undefined
+      : parsePositiveInteger(values.limit, "--limit", helpRoute);
+
+  if (chapterId === undefined) {
+    throw new Error(
+      withHelpRoute(
+        "Missing --chapter. `sdpub graph` requires a chapter id.",
+        helpRoute,
+      ),
+    );
+  }
+
+  switch (action) {
+    case "status":
+      rejectGraphActionPositionals(actionPositionals, action, helpRoute);
+      rejectGraphActionLimit(limit, action, helpRoute);
+      return {
+        action,
+        chapterId,
+        ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
+        path,
+      };
+    case "log":
+      rejectGraphActionPositionals(actionPositionals, action, helpRoute);
+      return {
+        action,
+        chapterId,
+        ...(limit === undefined ? {} : { limit }),
+        ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
+        path,
+      };
+    case "show":
+    case "neighbors":
+    case "blame":
+      rejectGraphActionLimit(limit, action, helpRoute);
+      if (actionPositionals.length !== 1) {
+        throw new Error(
+          withHelpRoute(
+            `\`sdpub graph ${action}\` requires exactly one node id.`,
+            helpRoute,
+          ),
+        );
+      }
+
+      return {
+        action,
+        chapterId,
+        ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
+        nodeId: parseSerialId(actionPositionals[0]!, "<node>", helpRoute),
+        path,
+      };
+    case "grep":
+      rejectGraphActionLimit(limit, action, helpRoute);
+      if (actionPositionals.length !== 1) {
+        throw new Error(
+          withHelpRoute(
+            "`sdpub graph grep` requires exactly one search pattern.",
+            helpRoute,
+          ),
+        );
+      }
+
+      return {
+        action,
+        chapterId,
+        ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
+        path,
+        pattern: actionPositionals[0]!,
+      };
+    case "path":
+      rejectGraphActionLimit(limit, action, helpRoute);
+      if (actionPositionals.length !== 2) {
+        throw new Error(
+          withHelpRoute(
+            "`sdpub graph path` requires exactly two node ids.",
+            helpRoute,
+          ),
+        );
+      }
+
+      return {
+        action,
+        chapterId,
+        fromNodeId: parseSerialId(actionPositionals[0]!, "<from>", helpRoute),
+        ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
+        path,
+        toNodeId: parseSerialId(actionPositionals[1]!, "<to>", helpRoute),
+      };
+  }
+}
+
 function parseHelpArguments(
   positionals: readonly string[],
   values: {
@@ -1135,6 +1396,7 @@ function parseHelpArguments(
     readonly "input-format"?: string;
     readonly json?: boolean;
     readonly language?: string;
+    readonly limit?: string;
     readonly llm?: string;
     readonly output?: string;
     readonly "output-format"?: string;
@@ -1149,6 +1411,7 @@ function parseHelpArguments(
   rejectHelpFlag("input", values.input);
   rejectHelpFlag("input-format", values["input-format"]);
   rejectHelpFlag("json", values.json);
+  rejectHelpFlag("limit", values.limit);
   rejectHelpFlag("llm", values.llm);
   rejectHelpFlag("output", values.output);
   rejectHelpFlag("output-format", values["output-format"]);
@@ -1208,6 +1471,7 @@ function parseStatusArguments(
     readonly "input-format"?: string;
     readonly json?: boolean;
     readonly language?: string;
+    readonly limit?: string;
     readonly llm?: string;
     readonly output?: string;
     readonly "output-format"?: string;
@@ -1222,6 +1486,7 @@ function parseStatusArguments(
   rejectStatusFlag("input", values.input);
   rejectStatusFlag("input-format", values["input-format"]);
   rejectStatusFlag("json", values.json);
+  rejectStatusFlag("limit", values.limit);
   rejectStatusFlag("output", values.output);
   rejectStatusFlag("output-format", values["output-format"]);
   rejectStatusFlag("prompt", values.prompt);
@@ -1303,6 +1568,20 @@ function isSdpubStageAction(
   return value === "advance" || value === "pending";
 }
 
+function isSdpubGraphAction(
+  value: string | undefined,
+): value is CLISdpubGraphAction {
+  return (
+    value === "blame" ||
+    value === "grep" ||
+    value === "log" ||
+    value === "neighbors" ||
+    value === "path" ||
+    value === "show" ||
+    value === "status"
+  );
+}
+
 function parseChapterStage(
   value: string,
   flag: string,
@@ -1338,6 +1617,25 @@ function parseChapterInputFormat(
       helpRoute,
     ),
   );
+}
+
+function parsePositiveInteger(
+  value: string,
+  flag: string,
+  helpRoute: string,
+): number {
+  const parsed = parseSerialId(value, flag, helpRoute);
+
+  if (parsed === 0) {
+    throw new Error(
+      withHelpRoute(
+        `Invalid ${flag}: ${value}. Expected a positive integer.`,
+        helpRoute,
+      ),
+    );
+  }
+
+  return parsed;
 }
 
 function parseResetStage(
@@ -1590,6 +1888,20 @@ function rejectSdpubStageFlag(
   }
 }
 
+function rejectSdpubGraphFlag(
+  name: string,
+  value: boolean | string | undefined,
+): void {
+  if (value !== undefined) {
+    throw new Error(
+      withHelpRoute(
+        `The \`sdpub graph\` command does not support --${name}.`,
+        "spinedigest sdpub graph --help",
+      ),
+    );
+  }
+}
+
 function rejectConvertMetaFlags(values: SdpubMetaFlagValues): void {
   for (const flag of listPresentMetaFlags(values)) {
     throw new Error(
@@ -1618,6 +1930,17 @@ function rejectSdpubStageMetaFlags(values: SdpubMetaFlagValues): void {
       withHelpRoute(
         `The \`sdpub stage\` command does not support ${flag}.`,
         "spinedigest sdpub stage --help",
+      ),
+    );
+  }
+}
+
+function rejectSdpubGraphMetaFlags(values: SdpubMetaFlagValues): void {
+  for (const flag of listPresentMetaFlags(values)) {
+    throw new Error(
+      withHelpRoute(
+        `The \`sdpub graph\` command does not support ${flag}.`,
+        "spinedigest sdpub graph --help",
       ),
     );
   }
@@ -1687,6 +2010,36 @@ function requireChapterId(
     throw new Error(
       withHelpRoute(
         `Missing --chapter. \`sdpub chapter ${action}\` requires a chapter id.`,
+        helpRoute,
+      ),
+    );
+  }
+}
+
+function rejectGraphActionPositionals(
+  actionPositionals: readonly string[],
+  action: CLISdpubGraphAction,
+  helpRoute: string,
+): void {
+  if (actionPositionals.length > 0) {
+    throw new Error(
+      withHelpRoute(
+        `The \`sdpub graph ${action}\` action does not accept node or pattern arguments.`,
+        helpRoute,
+      ),
+    );
+  }
+}
+
+function rejectGraphActionLimit(
+  limit: number | undefined,
+  action: CLISdpubGraphAction,
+  helpRoute: string,
+): void {
+  if (limit !== undefined) {
+    throw new Error(
+      withHelpRoute(
+        `The \`sdpub graph ${action}\` action does not support --limit.`,
         helpRoute,
       ),
     );

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -35,6 +35,7 @@ export interface CLIArguments {
 
 export interface CLISdpubArguments {
   readonly inputPath: string;
+  readonly json?: boolean;
   readonly llmJSON?: string;
   readonly metaPatch?: SdpubMetaPatch;
   readonly chapterId?: number;
@@ -233,6 +234,9 @@ export function parseCLIArguments(
       language: {
         type: "string",
       },
+      json: {
+        type: "boolean",
+      },
       llm: {
         type: "string",
       },
@@ -309,6 +313,7 @@ export function parseCLIArguments(
   }
 
   rejectConvertMetaFlags(values);
+  rejectConvertFlag("json", values.json);
 
   const args = {
     ...(values["digest-dir"] === undefined
@@ -378,6 +383,7 @@ function parseSdpubArguments(
     readonly identifier?: string;
     readonly input?: string;
     readonly "input-format"?: string;
+    readonly json?: boolean;
     readonly language?: string;
     readonly llm?: string;
     readonly output?: string;
@@ -498,6 +504,26 @@ function parseSdpubArguments(
     );
   }
   const metaPatch = parseSdpubMetaPatch(values, parsedSubcommand);
+  if (
+    values.json === true &&
+    parsedSubcommand !== "list" &&
+    parsedSubcommand !== "meta"
+  ) {
+    throw new Error(
+      withHelpRoute(
+        `The \`sdpub ${parsedSubcommand}\` subcommand does not support --json.`,
+        sdpubSubcommandHelpRoute(parsedSubcommand),
+      ),
+    );
+  }
+  if (values.json === true && metaPatch !== undefined) {
+    throw new Error(
+      withHelpRoute(
+        "`sdpub meta --json` is read-only and cannot be combined with metadata edit flags.",
+        sdpubSubcommandHelpRoute("meta"),
+      ),
+    );
+  }
   if (values.verbose) {
     throw new Error(
       withHelpRoute(
@@ -560,6 +586,7 @@ function parseSdpubArguments(
   return {
     args: {
       inputPath: inputPath!,
+      ...(values.json === undefined ? {} : { json: values.json }),
       ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
       ...(metaPatch === undefined ? {} : { metaPatch }),
       ...(chapterId === undefined ? {} : { chapterId }),
@@ -588,6 +615,7 @@ function parseSdpubChapterArguments(
     readonly identifier?: string;
     readonly input?: string;
     readonly "input-format"?: string;
+    readonly json?: boolean;
     readonly language?: string;
     readonly llm?: string;
     readonly output?: string;
@@ -609,6 +637,7 @@ function parseSdpubChapterArguments(
   const helpRoute = "spinedigest sdpub chapter --help";
 
   rejectSdpubChapterFlag("digest-dir", values["digest-dir"]);
+  rejectSdpubChapterFlag("json", values.json);
   rejectSdpubChapterFlag("output", values.output);
   rejectSdpubChapterFlag("output-format", values["output-format"]);
   rejectSdpubChapterFlag("stage", values.stage);
@@ -698,6 +727,7 @@ function parseSdpubStageArguments(
     readonly identifier?: string;
     readonly input?: string;
     readonly "input-format"?: string;
+    readonly json?: boolean;
     readonly language?: string;
     readonly llm?: string;
     readonly output?: string;
@@ -721,6 +751,7 @@ function parseSdpubStageArguments(
   rejectSdpubStageFlag("digest-dir", values["digest-dir"]);
   rejectSdpubStageFlag("input", values.input);
   rejectSdpubStageFlag("input-format", values["input-format"]);
+  rejectSdpubStageFlag("json", values.json);
   rejectSdpubStageFlag("output", values.output);
   rejectSdpubStageFlag("output-format", values["output-format"]);
   rejectSdpubStageFlag("parent", values.parent);
@@ -1102,6 +1133,7 @@ function parseHelpArguments(
     readonly identifier?: string;
     readonly input?: string;
     readonly "input-format"?: string;
+    readonly json?: boolean;
     readonly language?: string;
     readonly llm?: string;
     readonly output?: string;
@@ -1116,6 +1148,7 @@ function parseHelpArguments(
   rejectHelpFlag("digest-dir", values["digest-dir"]);
   rejectHelpFlag("input", values.input);
   rejectHelpFlag("input-format", values["input-format"]);
+  rejectHelpFlag("json", values.json);
   rejectHelpFlag("llm", values.llm);
   rejectHelpFlag("output", values.output);
   rejectHelpFlag("output-format", values["output-format"]);
@@ -1173,6 +1206,7 @@ function parseStatusArguments(
     readonly identifier?: string;
     readonly input?: string;
     readonly "input-format"?: string;
+    readonly json?: boolean;
     readonly language?: string;
     readonly llm?: string;
     readonly output?: string;
@@ -1187,6 +1221,7 @@ function parseStatusArguments(
   rejectStatusFlag("digest-dir", values["digest-dir"]);
   rejectStatusFlag("input", values.input);
   rejectStatusFlag("input-format", values["input-format"]);
+  rejectStatusFlag("json", values.json);
   rejectStatusFlag("output", values.output);
   rejectStatusFlag("output-format", values["output-format"]);
   rejectStatusFlag("prompt", values.prompt);
@@ -1498,6 +1533,20 @@ function rejectActionBooleanFlag(
   }
 }
 
+function rejectConvertFlag(
+  name: string,
+  value: boolean | string | undefined,
+): void {
+  if (value !== undefined) {
+    throw new Error(
+      withHelpRoute(
+        `The main convert command does not support --${name}.`,
+        CLI_HELP_ROUTES.command,
+      ),
+    );
+  }
+}
+
 function rejectSdpubStageActionFlag(
   value: string | undefined,
   flag: string,
@@ -1513,7 +1562,10 @@ function rejectSdpubStageActionFlag(
   }
 }
 
-function rejectSdpubChapterFlag(name: string, value: string | undefined): void {
+function rejectSdpubChapterFlag(
+  name: string,
+  value: boolean | string | undefined,
+): void {
   if (value !== undefined) {
     throw new Error(
       withHelpRoute(
@@ -1641,7 +1693,10 @@ function requireChapterId(
   }
 }
 
-function rejectHelpFlag(name: string, value: string | undefined): void {
+function rejectHelpFlag(
+  name: string,
+  value: boolean | string | undefined,
+): void {
   if (value !== undefined) {
     throw new Error(
       withHelpRoute(
@@ -1652,7 +1707,10 @@ function rejectHelpFlag(name: string, value: string | undefined): void {
   }
 }
 
-function rejectStatusFlag(name: string, value: string | undefined): void {
+function rejectStatusFlag(
+  name: string,
+  value: boolean | string | undefined,
+): void {
   if (value !== undefined) {
     throw new Error(
       withHelpRoute(

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -37,7 +37,7 @@ export interface CLISdpubArguments {
   readonly inputPath: string;
   readonly llmJSON?: string;
   readonly metaPatch?: SdpubMetaPatch;
-  readonly serialId?: number;
+  readonly chapterId?: number;
   readonly subcommand: Exclude<SDPubSubcommand, "chapter">;
 }
 
@@ -245,9 +245,6 @@ export function parseCLIArguments(
       prompt: {
         type: "string",
       },
-      serial: {
-        type: "string",
-      },
       stage: {
         type: "string",
       },
@@ -390,7 +387,6 @@ function parseSdpubArguments(
     readonly publisher?: string;
     readonly prompt?: string;
     readonly recursive?: boolean;
-    readonly serial?: string;
     readonly stage?: string;
     readonly title?: string;
     readonly to?: string;
@@ -511,27 +507,27 @@ function parseSdpubArguments(
     );
   }
 
-  const serialId =
-    values.serial === undefined
+  const chapterId =
+    values.chapter === undefined
       ? undefined
       : parseSerialId(
-          values.serial,
-          "--serial",
+          values.chapter,
+          "--chapter",
           sdpubSubcommandHelpRoute(parsedSubcommand),
         );
 
-  if (parsedSubcommand === "cat" && serialId === undefined && !help) {
+  if (parsedSubcommand === "cat" && chapterId === undefined && !help) {
     throw new Error(
       withHelpRoute(
-        "Missing --serial. `spinedigest sdpub cat` requires it.",
+        "Missing --chapter. `spinedigest sdpub cat` requires a chapter id.",
         sdpubSubcommandHelpRoute("cat"),
       ),
     );
   }
-  if (parsedSubcommand !== "cat" && serialId !== undefined) {
+  if (parsedSubcommand !== "cat" && chapterId !== undefined) {
     throw new Error(
       withHelpRoute(
-        `The \`sdpub ${parsedSubcommand}\` subcommand does not support --serial.`,
+        `The \`sdpub ${parsedSubcommand}\` subcommand does not support --chapter.`,
         sdpubSubcommandHelpRoute(parsedSubcommand),
       ),
     );
@@ -566,7 +562,7 @@ function parseSdpubArguments(
       inputPath: inputPath!,
       ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
       ...(metaPatch === undefined ? {} : { metaPatch }),
-      ...(serialId === undefined ? {} : { serialId }),
+      ...(chapterId === undefined ? {} : { chapterId }),
       subcommand: parsedSubcommand,
     },
     help: false,
@@ -601,7 +597,6 @@ function parseSdpubChapterArguments(
     readonly publisher?: string;
     readonly prompt?: string;
     readonly recursive?: boolean;
-    readonly serial?: string;
     readonly stage?: string;
     readonly title?: string;
     readonly to?: string;
@@ -616,7 +611,6 @@ function parseSdpubChapterArguments(
   rejectSdpubChapterFlag("digest-dir", values["digest-dir"]);
   rejectSdpubChapterFlag("output", values.output);
   rejectSdpubChapterFlag("output-format", values["output-format"]);
-  rejectSdpubChapterFlag("serial", values.serial);
   rejectSdpubChapterFlag("stage", values.stage);
   rejectSdpubChapterMetaFlags(values);
   if (values.verbose) {
@@ -713,7 +707,6 @@ function parseSdpubStageArguments(
     readonly publisher?: string;
     readonly prompt?: string;
     readonly recursive?: boolean;
-    readonly serial?: string;
     readonly stage?: string;
     readonly title?: string;
     readonly to?: string;
@@ -732,7 +725,6 @@ function parseSdpubStageArguments(
   rejectSdpubStageFlag("output-format", values["output-format"]);
   rejectSdpubStageFlag("parent", values.parent);
   rejectSdpubStageFlag("recursive", values.recursive);
-  rejectSdpubStageFlag("serial", values.serial);
   rejectSdpubStageFlag("stage", values.stage);
   rejectSdpubStageFlag("title", values.title);
   rejectSdpubStageMetaFlags(values);
@@ -1117,7 +1109,6 @@ function parseHelpArguments(
     readonly "published-at"?: string;
     readonly publisher?: string;
     readonly prompt?: string;
-    readonly serial?: string;
     readonly stage?: string;
     readonly verbose?: boolean;
   },
@@ -1129,7 +1120,6 @@ function parseHelpArguments(
   rejectHelpFlag("output", values.output);
   rejectHelpFlag("output-format", values["output-format"]);
   rejectHelpFlag("prompt", values.prompt);
-  rejectHelpFlag("serial", values.serial);
   rejectHelpFlag("stage", values.stage);
   rejectHelpMetaFlags(values);
 
@@ -1190,7 +1180,6 @@ function parseStatusArguments(
     readonly "published-at"?: string;
     readonly publisher?: string;
     readonly prompt?: string;
-    readonly serial?: string;
     readonly stage?: string;
     readonly verbose?: boolean;
   },
@@ -1201,7 +1190,6 @@ function parseStatusArguments(
   rejectStatusFlag("output", values.output);
   rejectStatusFlag("output-format", values["output-format"]);
   rejectStatusFlag("prompt", values.prompt);
-  rejectStatusFlag("serial", values.serial);
   rejectStatusFlag("stage", values.stage);
   rejectStatusMetaFlags(values);
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -3,7 +3,11 @@ import { createEnv } from "../common/template.js";
 
 import { CLI_FORMATS } from "./formats.js";
 import { CLI_HELP_ROUTES, withHelpRoute } from "./errors.js";
-import type { CLISdpubChapterAction, CLISdpubStageAction } from "./args.js";
+import type {
+  CLISdpubChapterAction,
+  CLISdpubGraphAction,
+  CLISdpubStageAction,
+} from "./args.js";
 
 export const HELP_TOPICS = [
   "overview",
@@ -31,6 +35,7 @@ export const SDPUB_SUBCOMMANDS = [
   "meta",
   "stage",
   "chapter",
+  "graph",
 ] as const;
 
 export type SDPubSubcommand = (typeof SDPUB_SUBCOMMANDS)[number];
@@ -125,6 +130,10 @@ const SDPUB_SUBCOMMAND_METADATA: readonly {
     name: "chapter",
     summary: "Edit the chapter tree and per-chapter digest stages.",
   },
+  {
+    name: "graph",
+    summary: "Explore a chapter graph with Git-like read-only commands.",
+  },
 ] as const;
 
 const HELP_TOPIC_TEMPLATE_NAMES: Readonly<Record<HelpTopic, string>> = {
@@ -176,6 +185,12 @@ export function renderSdpubStageActionHelpText(
   action: CLISdpubStageAction,
 ): string {
   return renderHelpTemplate(`help/commands/sdpub/stage/${action}`);
+}
+
+export function renderSdpubGraphActionHelpText(
+  action: CLISdpubGraphAction,
+): string {
+  return renderHelpTemplate(`help/commands/sdpub/graph/${action}`);
 }
 
 export function parseHelpTopic(value: string): HelpTopic {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -103,7 +103,7 @@ const SDPUB_SUBCOMMAND_METADATA: readonly {
   },
   {
     name: "list",
-    summary: "List summarized chapters that are ready for cat.",
+    summary: "List the chapter tree with ids and cat readiness.",
   },
   {
     name: "cat",

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -107,7 +107,7 @@ const SDPUB_SUBCOMMAND_METADATA: readonly {
   },
   {
     name: "cat",
-    summary: "Print one completed summary through the legacy --serial reader.",
+    summary: "Print one completed chapter summary.",
   },
   {
     name: "cover",

--- a/src/cli/io.ts
+++ b/src/cli/io.ts
@@ -18,6 +18,19 @@ export async function writeTextToStdout(text: string): Promise<void> {
   await pipeline(Readable.from([text]), process.stdout);
 }
 
+export async function writeTextToStderr(text: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    process.stderr.write(text, (error) => {
+      if (error === undefined || error === null) {
+        resolve();
+        return;
+      }
+
+      reject(error);
+    });
+  });
+}
+
 export async function writeBinaryToStdout(data: Uint8Array): Promise<void> {
   await pipeline(Readable.from([data]), process.stdout);
 }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -4,6 +4,7 @@ import { renderMainHelpText } from "./help.js";
 import { runStatusCommand } from "./status.js";
 import { runSdpubCommand } from "./sdpub.js";
 import { runSdpubChapterCommand } from "./sdpub-chapter.js";
+import { runSdpubGraphCommand } from "./sdpub-graph.js";
 import { runSdpubStageCommand } from "./sdpub-stage.js";
 import { LLMPaymentRequiredError } from "../llm/index.js";
 import { formatError } from "../utils/node-error.js";
@@ -42,6 +43,9 @@ export async function main(): Promise<void> {
         return;
       case "sdpub-stage":
         await runSdpubStageCommand(parsed.args);
+        return;
+      case "sdpub-graph":
+        await runSdpubGraphCommand(parsed.args);
         return;
       case "status":
         await runStatusCommand(parsed.args);

--- a/src/cli/progress.ts
+++ b/src/cli/progress.ts
@@ -344,7 +344,7 @@ function buildFragmentsLabel(
     return undefined;
   }
 
-  return `${formatNumber(completed)}/${formatNumber(total)} fragments`;
+  return `${formatNumber(completed)}/${formatNumber(total)} source units`;
 }
 
 function renderBar(completed: number, total: number): string {

--- a/src/cli/sdpub-chapter.ts
+++ b/src/cli/sdpub-chapter.ts
@@ -170,7 +170,7 @@ async function writeChapterDetails(details: ChapterDetails): Promise<void> {
     `Chapter: ${details.chapterId}`,
     `Title: ${details.title ?? "[untitled]"}`,
     `Stage: ${details.stage}`,
-    `Fragments: ${details.fragmentCount}`,
+    `Source Units: ${details.fragmentCount}`,
     `Children: ${details.childCount}`,
     `Graph: ${details.graphReady ? "yes" : "no"}`,
     `Summary: ${details.hasSummary ? "yes" : "no"}`,

--- a/src/cli/sdpub-graph.ts
+++ b/src/cli/sdpub-graph.ts
@@ -1,0 +1,256 @@
+import {
+  findGraphPath,
+  getGraphEvidence,
+  getGraphNode,
+  getGraphStatus,
+  listGraphNeighbors,
+  listGraphNodes,
+  searchGraphNodes,
+  type GraphEdge,
+  type GraphEvidenceLine,
+  type GraphNeighbor,
+  type GraphNode,
+  type GraphPathStep,
+  type GraphSearchHit,
+} from "../facade/index.js";
+import { SpineDigestFile } from "../facade/spine-digest-file.js";
+
+import type { CLISdpubGraphArguments } from "./args.js";
+import { writeTextToStdout } from "./io.js";
+
+const DEFAULT_LOG_LIMIT = 20;
+const SHOW_EVIDENCE_LIMIT = 3;
+
+export async function runSdpubGraphCommand(
+  args: CLISdpubGraphArguments,
+): Promise<void> {
+  await new SpineDigestFile(args.path).openEditableSession(async (document) => {
+    switch (args.action) {
+      case "status":
+        await writeTextToStdout(
+          formatStatus(await getGraphStatus(document, args.chapterId)),
+        );
+        return;
+      case "log":
+        await writeTextToStdout(
+          formatLog(
+            await listGraphNodes(document, args.chapterId),
+            args.limit ?? DEFAULT_LOG_LIMIT,
+          ),
+        );
+        return;
+      case "show": {
+        const [node, neighbors, evidence] = await Promise.all([
+          getGraphNode(document, args.chapterId, args.nodeId!),
+          listGraphNeighbors(document, args.chapterId, args.nodeId!),
+          getGraphEvidence(document, args.chapterId, args.nodeId!),
+        ]);
+
+        await writeTextToStdout(formatShow(node, neighbors, evidence));
+        return;
+      }
+      case "grep":
+        await writeTextToStdout(
+          formatSearchHits(
+            await searchGraphNodes(document, args.chapterId, args.pattern!),
+          ),
+        );
+        return;
+      case "neighbors":
+        await writeTextToStdout(
+          formatNeighbors(
+            args.nodeId!,
+            await listGraphNeighbors(document, args.chapterId, args.nodeId!),
+          ),
+        );
+        return;
+      case "blame":
+        await writeTextToStdout(
+          formatEvidence(
+            args.nodeId!,
+            await getGraphEvidence(document, args.chapterId, args.nodeId!),
+          ),
+        );
+        return;
+      case "path":
+        await writeTextToStdout(
+          formatPath(
+            args.fromNodeId!,
+            args.toNodeId!,
+            await findGraphPath(
+              document,
+              args.chapterId,
+              args.fromNodeId!,
+              args.toNodeId!,
+            ),
+          ),
+        );
+        return;
+    }
+  });
+}
+
+function formatStatus(status: {
+  readonly chapterId: number;
+  readonly edgeCount: number;
+  readonly graphReady: boolean;
+  readonly nodeCount: number;
+}): string {
+  return [
+    `Chapter: ${status.chapterId}`,
+    `Graph: ${status.graphReady ? "yes" : "no"}`,
+    `Nodes: ${status.nodeCount}`,
+    `Edges: ${status.edgeCount}`,
+    "",
+  ].join("\n");
+}
+
+function formatLog(nodes: readonly GraphNode[], limit: number): string {
+  if (nodes.length === 0) {
+    return "No graph nodes.\n";
+  }
+
+  return `${nodes.slice(0, limit).map(formatNodeOneLine).join("\n")}\n`;
+}
+
+function formatShow(
+  node: GraphNode,
+  neighbors: readonly GraphNeighbor[],
+  evidence: readonly GraphEvidenceLine[],
+): string {
+  const lines = [
+    formatNodeHeading(node),
+    `Weight: ${formatWeight(node.weight)}`,
+    `Words: ${node.wordsCount}`,
+  ];
+
+  appendOptional(lines, "Importance", node.importance);
+  appendOptional(lines, "Retention", node.retention);
+  lines.push("", "Content:", node.content, "");
+
+  if (neighbors.length === 0) {
+    lines.push("Neighbors:", "  [none]", "");
+  } else {
+    lines.push("Neighbors:");
+    lines.push(...neighbors.slice(0, 10).map(formatNeighborLine));
+    lines.push("");
+  }
+
+  if (evidence.length === 0) {
+    lines.push("Evidence:", "  [none]");
+  } else {
+    lines.push("Evidence:");
+    lines.push(
+      ...evidence
+        .slice(0, SHOW_EVIDENCE_LIMIT)
+        .map((line) => `  ${formatSentenceId(line.sentenceId)} ${line.text}`),
+    );
+    if (evidence.length > SHOW_EVIDENCE_LIMIT) {
+      lines.push(`  ... ${evidence.length - SHOW_EVIDENCE_LIMIT} more`);
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function formatSearchHits(hits: readonly GraphSearchHit[]): string {
+  if (hits.length === 0) {
+    return "No matches.\n";
+  }
+
+  return `${hits
+    .map(
+      (hit) =>
+        `${formatNodeOneLine(hit.node)} matches:${hit.matchedFields.join(",")}`,
+    )
+    .join("\n")}\n`;
+}
+
+function formatNeighbors(
+  nodeId: number,
+  neighbors: readonly GraphNeighbor[],
+): string {
+  if (neighbors.length === 0) {
+    return `Node ${nodeId} has no neighbors.\n`;
+  }
+
+  return `${neighbors.map(formatNeighborLine).join("\n")}\n`;
+}
+
+function formatEvidence(
+  nodeId: number,
+  evidence: readonly GraphEvidenceLine[],
+): string {
+  if (evidence.length === 0) {
+    return `Node ${nodeId} has no source evidence.\n`;
+  }
+
+  return `${evidence
+    .map((line) => `${formatSentenceId(line.sentenceId)} ${line.text}`)
+    .join("\n")}\n`;
+}
+
+function formatPath(
+  fromNodeId: number,
+  toNodeId: number,
+  steps: readonly GraphPathStep[],
+): string {
+  if (steps.length === 0) {
+    return `No path from ${fromNodeId} to ${toNodeId}.\n`;
+  }
+
+  const lines: string[] = [];
+
+  for (const [index, step] of steps.entries()) {
+    if (index > 0) {
+      lines.push(`  ${formatPathEdge(step.edge)}`);
+    }
+    lines.push(formatNodeOneLine(step.node));
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function formatNodeOneLine(node: GraphNode): string {
+  return `[${node.id}] ${formatWeight(node.weight)} ${node.label} - ${node.content}`;
+}
+
+function formatNodeHeading(node: GraphNode): string {
+  return `[${node.id}] ${node.label}`;
+}
+
+function formatNeighborLine(neighbor: GraphNeighbor): string {
+  const arrow = neighbor.direction === "incoming" ? "<-" : "->";
+  const edgeNodeId =
+    neighbor.direction === "incoming"
+      ? neighbor.edge.fromId
+      : neighbor.edge.toId;
+
+  return `  ${arrow} [${edgeNodeId}] ${formatWeight(neighbor.edge.weight)} ${neighbor.node.label}`;
+}
+
+function formatPathEdge(edge: GraphEdge | undefined): string {
+  if (edge === undefined) {
+    return "->";
+  }
+
+  return `-> ${formatWeight(edge.weight)}`;
+}
+
+function formatSentenceId(sentenceId: readonly number[]): string {
+  return sentenceId.join(".");
+}
+
+function formatWeight(value: number): string {
+  return value.toFixed(3);
+}
+
+function appendOptional(
+  lines: string[],
+  label: string,
+  value: string | undefined,
+): void {
+  if (value !== undefined) {
+    lines.push(`${label}: ${value}`);
+  }
+}

--- a/src/cli/sdpub-graph.ts
+++ b/src/cli/sdpub-graph.ts
@@ -6,7 +6,6 @@ import {
   listGraphNeighbors,
   listGraphNodes,
   searchGraphNodes,
-  type GraphEdge,
   type GraphEvidenceLine,
   type GraphNeighbor,
   type GraphNode,
@@ -107,7 +106,7 @@ function formatStatus(status: {
 
 function formatLog(nodes: readonly GraphNode[], limit: number): string {
   if (nodes.length === 0) {
-    return "No graph nodes.\n";
+    return "No nodes.\n";
   }
 
   return `${nodes.slice(0, limit).map(formatNodeOneLine).join("\n")}\n`;
@@ -118,14 +117,8 @@ function formatShow(
   neighbors: readonly GraphNeighbor[],
   evidence: readonly GraphEvidenceLine[],
 ): string {
-  const lines = [
-    formatNodeHeading(node),
-    `Weight: ${formatWeight(node.weight)}`,
-    `Words: ${node.wordsCount}`,
-  ];
+  const lines = [formatNodeHeading(node)];
 
-  appendOptional(lines, "Importance", node.importance);
-  appendOptional(lines, "Retention", node.retention);
   lines.push("", "Content:", node.content, "");
 
   if (neighbors.length === 0) {
@@ -203,7 +196,7 @@ function formatPath(
 
   for (const [index, step] of steps.entries()) {
     if (index > 0) {
-      lines.push(`  ${formatPathEdge(step.edge)}`);
+      lines.push(`  ${formatPathEdge()}`);
     }
     lines.push(formatNodeOneLine(step.node));
   }
@@ -212,7 +205,7 @@ function formatPath(
 }
 
 function formatNodeOneLine(node: GraphNode): string {
-  return `[${node.id}] ${formatWeight(node.weight)} ${node.label} - ${node.content}`;
+  return `[${node.id}] ${node.label} - ${node.content}`;
 }
 
 function formatNodeHeading(node: GraphNode): string {
@@ -226,31 +219,13 @@ function formatNeighborLine(neighbor: GraphNeighbor): string {
       ? neighbor.edge.fromId
       : neighbor.edge.toId;
 
-  return `  ${arrow} [${edgeNodeId}] ${formatWeight(neighbor.edge.weight)} ${neighbor.node.label}`;
+  return `  ${arrow} [${edgeNodeId}] ${neighbor.node.label}`;
 }
 
-function formatPathEdge(edge: GraphEdge | undefined): string {
-  if (edge === undefined) {
-    return "->";
-  }
-
-  return `-> ${formatWeight(edge.weight)}`;
+function formatPathEdge(): string {
+  return "->";
 }
 
 function formatSentenceId(sentenceId: readonly number[]): string {
   return sentenceId.join(".");
-}
-
-function formatWeight(value: number): string {
-  return value.toFixed(3);
-}
-
-function appendOptional(
-  lines: string[],
-  label: string,
-  value: string | undefined,
-): void {
-  if (value !== undefined) {
-    lines.push(`${label}: ${value}`);
-  }
 }

--- a/src/cli/sdpub-stage.ts
+++ b/src/cli/sdpub-stage.ts
@@ -1,13 +1,14 @@
 import {
   advanceChapterStages,
   listChapters,
+  type AdvanceChapterStagesProgressEvent,
   type AdvanceChapterStagesResult,
   type ChapterEntry,
 } from "../facade/index.js";
 import { SpineDigestFile } from "../facade/spine-digest-file.js";
 
 import type { CLISdpubStageArguments } from "./args.js";
-import { writeTextToStdout } from "./io.js";
+import { writeTextToStderr, writeTextToStdout } from "./io.js";
 import {
   createStageLLM,
   loadRequiredStageConfig,
@@ -40,22 +41,110 @@ export async function runSdpubStageCommand(
           }
 
           const config = await loadRequiredStageConfig(args);
-          const result = await advanceChapterStages(document, {
-            ...(args.chapterId === undefined
-              ? {}
-              : { chapterId: args.chapterId }),
-            extractionPrompt: resolveExtractionPrompt(
-              args.prompt ?? config.prompt,
-            ),
-            llm: createStageLLM(config),
-            targetStage,
-          });
+          const progressWriter = createStageAdvanceProgressWriter();
+          let result: AdvanceChapterStagesResult;
+
+          try {
+            result = await advanceChapterStages(document, {
+              ...(args.chapterId === undefined
+                ? {}
+                : { chapterId: args.chapterId }),
+              extractionPrompt: resolveExtractionPrompt(
+                args.prompt ?? config.prompt,
+              ),
+              llm: createStageLLM(config),
+              onProgress: progressWriter.onProgress,
+              targetStage,
+            });
+          } finally {
+            await progressWriter.stop();
+          }
 
           await writeAdvanceResult(result);
         },
       );
       return;
   }
+}
+
+function createStageAdvanceProgressWriter(input?: {
+  readonly heartbeatIntervalMs?: number;
+}): {
+  readonly onProgress: (
+    event: AdvanceChapterStagesProgressEvent,
+  ) => Promise<void>;
+  stop(): Promise<void>;
+} {
+  const heartbeatIntervalMs = input?.heartbeatIntervalMs ?? 15_000;
+  let heartbeat: NodeJS.Timeout | undefined;
+  let activeLabel: string | undefined;
+  let writeQueue = Promise.resolve();
+
+  const writeLine = async (line: string): Promise<void> => {
+    writeQueue = writeQueue
+      .catch(() => undefined)
+      .then(async () => {
+        await writeTextToStderr(`${line}\n`);
+      });
+    await writeQueue;
+  };
+
+  const clearHeartbeat = (): void => {
+    if (heartbeat !== undefined) {
+      clearInterval(heartbeat);
+      heartbeat = undefined;
+    }
+  };
+
+  const startHeartbeat = (label: string): void => {
+    clearHeartbeat();
+    activeLabel = label;
+    heartbeat = setInterval(() => {
+      const currentLabel = activeLabel;
+
+      if (currentLabel === undefined) {
+        return;
+      }
+
+      void writeLine(`Still ${currentLabel.toLowerCase()}...`);
+    }, heartbeatIntervalMs);
+    heartbeat.unref();
+  };
+
+  return {
+    async onProgress(event) {
+      switch (event.type) {
+        case "selected":
+          await writeLine(
+            `Selected ${event.totalChapters} ${event.totalChapters === 1 ? "chapter" : "chapters"}; target: ${event.targetStage}.`,
+          );
+          return;
+        case "skipped":
+          await writeLine(
+            `Skipping ${formatProgressChapter(event.chapter)}: source is missing.`,
+          );
+          return;
+        case "started": {
+          const label = `${formatProgressVerb(event.step)} for ${formatProgressChapter(event.chapter)}`;
+          startHeartbeat(label);
+          await writeLine(`${label}...`);
+          return;
+        }
+        case "completed":
+          clearHeartbeat();
+          activeLabel = undefined;
+          await writeLine(
+            `Finished ${formatProgressStep(event.step)} for ${formatProgressChapter(event.chapter)}.`,
+          );
+          return;
+      }
+    },
+    async stop() {
+      clearHeartbeat();
+      activeLabel = undefined;
+      await writeQueue.catch(() => undefined);
+    },
+  };
 }
 
 async function writePendingChapters(
@@ -105,4 +194,26 @@ function formatTocPath(entry: ChapterEntry): string {
   }
 
   return entry.tocPath.join(" / ");
+}
+
+function formatProgressChapter(entry: ChapterEntry): string {
+  return `chapter ${entry.chapterId} (${formatTocPath(entry)})`;
+}
+
+function formatProgressVerb(step: "graph" | "summary"): string {
+  switch (step) {
+    case "graph":
+      return "Generating graph";
+    case "summary":
+      return "Generating summary";
+  }
+}
+
+function formatProgressStep(step: "graph" | "summary"): string {
+  switch (step) {
+    case "graph":
+      return "graph";
+    case "summary":
+      return "summary";
+  }
 }

--- a/src/cli/sdpub.ts
+++ b/src/cli/sdpub.ts
@@ -1,6 +1,10 @@
 import { SpineDigestApp } from "../index.js";
 import { SpineDigestFile } from "../facade/spine-digest-file.js";
-import type { SpineDigest } from "../facade/index.js";
+import {
+  listChapters,
+  type ChapterEntry,
+  type SpineDigest,
+} from "../facade/index.js";
 import type { BookMeta, TocFile, TocItem } from "../source/index.js";
 
 import type { CLISdpubArguments, SdpubMetaPatch } from "./args.js";
@@ -9,6 +13,12 @@ import { writeBinaryToStdout, writeTextToStdout } from "./io.js";
 export async function runSdpubCommand(args: CLISdpubArguments): Promise<void> {
   if (args.subcommand === "meta" && args.metaPatch !== undefined) {
     await updateSdpubMeta(args.inputPath, args.metaPatch);
+    return;
+  }
+  if (args.subcommand === "list") {
+    await writeSdpubChapterList(args.inputPath, {
+      json: args.json ?? false,
+    });
     return;
   }
 
@@ -21,9 +31,6 @@ export async function runSdpubCommand(args: CLISdpubArguments): Promise<void> {
       case "toc":
         await writeSdpubToc(digest);
         return;
-      case "list":
-        await writeSdpubChapterList(digest);
-        return;
       case "cat":
         await writeTextToStdout(
           await digest.readSerialSummary(args.chapterId!),
@@ -33,7 +40,9 @@ export async function runSdpubCommand(args: CLISdpubArguments): Promise<void> {
         await writeSdpubCover(digest);
         return;
       case "meta":
-        await writeSdpubMeta(await digest.readMeta());
+        await writeSdpubMeta(await digest.readMeta(), {
+          json: args.json ?? false,
+        });
         return;
     }
   });
@@ -61,16 +70,7 @@ async function writeSdpubInfo(digest: SpineDigest): Promise<void> {
   const lines: string[] = [];
 
   lines.push(`Archive Format Version: ${formatVersion}`);
-  appendOptionalLine(lines, "Title", meta?.title);
-  if (meta?.authors.length !== undefined && meta.authors.length > 0) {
-    lines.push(`Authors: ${meta.authors.join(", ")}`);
-  }
-  appendOptionalLine(lines, "Language", meta?.language);
-  appendOptionalLine(lines, "Source Format", meta?.sourceFormat);
-  appendOptionalLine(lines, "Identifier", meta?.identifier);
-  appendOptionalLine(lines, "Publisher", meta?.publisher);
-  appendOptionalLine(lines, "Published At", meta?.publishedAt);
-  appendOptionalLine(lines, "Description", meta?.description);
+  appendMetaLines(lines, meta);
   lines.push(`Cover: ${cover === undefined ? "no" : "yes"}`);
   appendOptionalLine(lines, "Cover Media Type", cover?.mediaType);
   appendOptionalLine(lines, "Cover Path", cover?.path);
@@ -84,7 +84,7 @@ async function writeSdpubInfo(digest: SpineDigest): Promise<void> {
     lines.push(`Referenced Chapters: ${referencedChapterCount}`);
     lines.push(`Summarized Chapters: ${serials.length}`);
     lines.push(
-      `Fragments: ${serials.reduce(
+      `Source Units: ${serials.reduce(
         (total, serial) => total + serial.fragmentCount,
         0,
       )}`,
@@ -121,22 +121,29 @@ async function writeSdpubToc(digest: SpineDigest): Promise<void> {
   await writeTextToStdout(`${lines.join("\n")}\n`);
 }
 
-async function writeSdpubChapterList(digest: SpineDigest): Promise<void> {
-  const serials = await digest.listSerials();
+async function writeSdpubChapterList(
+  path: string,
+  options: { readonly json: boolean },
+): Promise<void> {
+  await new SpineDigestFile(path).openEditableSession(async (document) => {
+    const entries = await listChapters(document);
 
-  if (serials.length === 0) {
-    await writeTextToStdout("No summarized chapters available.\n");
-    return;
-  }
+    if (options.json) {
+      await writeTextToStdout(
+        `${JSON.stringify(formatChapterListJSON(entries), null, 2)}\n`,
+      );
+      return;
+    }
 
-  await writeTextToStdout(
-    `${serials
-      .map(
-        (serial) =>
-          `[${serial.serialId}] ${serial.tocPath.join(" / ")} (fragments: ${serial.fragmentCount})`,
-      )
-      .join("\n")}\n`,
-  );
+    if (entries.length === 0) {
+      await writeTextToStdout("No chapters.\n");
+      return;
+    }
+
+    await writeTextToStdout(
+      `${entries.map(formatChapterListLine).join("\n")}\n`,
+    );
+  });
 }
 
 async function writeSdpubCover(digest: SpineDigest): Promise<void> {
@@ -169,28 +176,29 @@ async function updateSdpubMeta(
     const updatedMeta = applySdpubMetaPatch(meta, patch);
 
     await document.replaceBookMeta(updatedMeta);
-    await writeSdpubMeta(updatedMeta);
+    await writeSdpubMeta(updatedMeta, { json: false });
   });
 }
 
-async function writeSdpubMeta(meta: BookMeta | undefined): Promise<void> {
+async function writeSdpubMeta(
+  meta: BookMeta | undefined,
+  options: { readonly json: boolean },
+): Promise<void> {
+  if (options.json) {
+    await writeTextToStdout(
+      `${JSON.stringify(formatMetaJSON(meta), null, 2)}\n`,
+    );
+    return;
+  }
+
   if (meta === undefined) {
     await writeTextToStdout("No document metadata is available.\n");
     return;
   }
 
-  const lines = [
-    `Source Format: ${meta.sourceFormat}`,
-    `Title: ${meta.title ?? "[none]"}`,
-    `Authors: ${
-      meta.authors.length === 0 ? "[none]" : meta.authors.join(", ")
-    }`,
-    `Language: ${meta.language ?? "[none]"}`,
-    `Identifier: ${meta.identifier ?? "[none]"}`,
-    `Publisher: ${meta.publisher ?? "[none]"}`,
-    `Published At: ${meta.publishedAt ?? "[none]"}`,
-    `Description: ${meta.description ?? "[none]"}`,
-  ];
+  const lines: string[] = [];
+
+  appendMetaLines(lines, meta);
 
   await writeTextToStdout(`${lines.join("\n")}\n`);
 }
@@ -223,6 +231,55 @@ function applySdpubMetaPatch(meta: BookMeta, patch: SdpubMetaPatch): BookMeta {
       patch.clearDescription === true
         ? null
         : (patch.description ?? meta.description),
+  };
+}
+
+function formatChapterListLine(entry: ChapterEntry): string {
+  const stageSuffix = entry.stage === "summarized" ? "" : ` (${entry.stage})`;
+  return `${"  ".repeat(entry.depth)}[${entry.chapterId}] ${entry.title ?? "[untitled]"}${stageSuffix}`;
+}
+
+function formatChapterListJSON(entries: readonly ChapterEntry[]): object {
+  return {
+    chapters: entries.map((entry) => ({
+      catReady: entry.stage === "summarized",
+      chapterId: entry.chapterId,
+      childCount: entry.childCount,
+      depth: entry.depth,
+      stage: entry.stage,
+      title: entry.title,
+      tocPath: entry.tocPath,
+    })),
+  };
+}
+
+function appendMetaLines(lines: string[], meta: BookMeta | undefined): void {
+  lines.push(`Source Format: ${meta?.sourceFormat ?? "[none]"}`);
+  lines.push(`Title: ${meta?.title ?? "[none]"}`);
+  lines.push(
+    `Authors: ${
+      meta?.authors.length === undefined || meta.authors.length === 0
+        ? "[none]"
+        : meta.authors.join(", ")
+    }`,
+  );
+  lines.push(`Language: ${meta?.language ?? "[none]"}`);
+  lines.push(`Identifier: ${meta?.identifier ?? "[none]"}`);
+  lines.push(`Publisher: ${meta?.publisher ?? "[none]"}`);
+  lines.push(`Published At: ${meta?.publishedAt ?? "[none]"}`);
+  lines.push(`Description: ${meta?.description ?? "[none]"}`);
+}
+
+function formatMetaJSON(meta: BookMeta | undefined): object {
+  return {
+    authors: meta?.authors ?? [],
+    description: meta?.description ?? null,
+    identifier: meta?.identifier ?? null,
+    language: meta?.language ?? null,
+    publishedAt: meta?.publishedAt ?? null,
+    publisher: meta?.publisher ?? null,
+    sourceFormat: meta?.sourceFormat ?? null,
+    title: meta?.title ?? null,
   };
 }
 

--- a/src/cli/sdpub.ts
+++ b/src/cli/sdpub.ts
@@ -22,10 +22,12 @@ export async function runSdpubCommand(args: CLISdpubArguments): Promise<void> {
         await writeSdpubToc(digest);
         return;
       case "list":
-        await writeSdpubSerialList(digest);
+        await writeSdpubChapterList(digest);
         return;
       case "cat":
-        await writeTextToStdout(await digest.readSerialSummary(args.serialId!));
+        await writeTextToStdout(
+          await digest.readSerialSummary(args.chapterId!),
+        );
         return;
       case "cover":
         await writeSdpubCover(digest);
@@ -119,7 +121,7 @@ async function writeSdpubToc(digest: SpineDigest): Promise<void> {
   await writeTextToStdout(`${lines.join("\n")}\n`);
 }
 
-async function writeSdpubSerialList(digest: SpineDigest): Promise<void> {
+async function writeSdpubChapterList(digest: SpineDigest): Promise<void> {
   const serials = await digest.listSerials();
 
   if (serials.length === 0) {

--- a/src/facade/chapter.ts
+++ b/src/facade/chapter.ts
@@ -39,9 +39,39 @@ export interface AdvanceChapterStagesOptions {
   readonly extractionPrompt: string;
   readonly llm: LLM<SpineDigestScope>;
   readonly logDirPath?: string;
+  readonly onProgress?: AdvanceChapterStagesProgressCallback;
   readonly targetStage: ChapterStage;
   readonly userLanguage?: Language;
 }
+
+export type AdvanceChapterStagesProgressCallback = (
+  event: AdvanceChapterStagesProgressEvent,
+) => void | Promise<void>;
+
+export type AdvanceChapterStagesProgressEvent =
+  | {
+      readonly type: "selected";
+      readonly targetStage: ChapterStage;
+      readonly totalChapters: number;
+    }
+  | {
+      readonly type: "skipped";
+      readonly chapter: ChapterEntry;
+      readonly reason: "planned";
+      readonly targetStage: ChapterStage;
+    }
+  | {
+      readonly type: "started";
+      readonly chapter: ChapterEntry;
+      readonly step: "graph" | "summary";
+      readonly targetStage: ChapterStage;
+    }
+  | {
+      readonly type: "completed";
+      readonly chapter: ChapterEntry;
+      readonly step: "graph" | "summary";
+      readonly targetStage: ChapterStage;
+    };
 
 export interface AdvanceChapterStagesResult {
   readonly advanced: readonly ChapterEntry[];
@@ -81,6 +111,12 @@ export async function advanceChapterStages(
 
   const advancedIds = new Set<number>();
   const entries = await selectChapterEntries(document, options.chapterId);
+  await emitAdvanceProgress(options, {
+    targetStage: options.targetStage,
+    totalChapters: entries.length,
+    type: "selected",
+  });
+  await emitPlannedSkips(entries, options);
 
   if (isStageBefore("sourced", options.targetStage)) {
     await advanceEntriesToGraphed(document, entries, options, {
@@ -409,6 +445,12 @@ async function advanceEntriesToGraphed(
       continue;
     }
 
+    await emitAdvanceProgress(options, {
+      chapter: entry,
+      step: "graph",
+      targetStage: options.targetStage,
+      type: "started",
+    });
     await generateChapterGraph(document, entry.chapterId, {
       extractionPrompt: options.extractionPrompt,
       llm: options.llm,
@@ -418,6 +460,12 @@ async function advanceEntriesToGraphed(
       ...(options.userLanguage === undefined
         ? {}
         : { userLanguage: options.userLanguage }),
+    });
+    await emitAdvanceProgress(options, {
+      chapter: entry,
+      step: "graph",
+      targetStage: options.targetStage,
+      type: "completed",
     });
     state.advancedIds.add(entry.chapterId);
   }
@@ -436,6 +484,12 @@ async function advanceEntriesToSummarized(
       continue;
     }
 
+    await emitAdvanceProgress(options, {
+      chapter: entry,
+      step: "summary",
+      targetStage: options.targetStage,
+      type: "started",
+    });
     await generateChapterSummary(document, entry.chapterId, {
       llm: options.llm,
       ...(options.logDirPath === undefined
@@ -444,6 +498,12 @@ async function advanceEntriesToSummarized(
       ...(options.userLanguage === undefined
         ? {}
         : { userLanguage: options.userLanguage }),
+    });
+    await emitAdvanceProgress(options, {
+      chapter: entry,
+      step: "summary",
+      targetStage: options.targetStage,
+      type: "completed",
     });
     state.advancedIds.add(entry.chapterId);
   }
@@ -512,6 +572,35 @@ function isStageBefore(
   targetStage: ChapterStage,
 ): boolean {
   return CHAPTER_STAGES.indexOf(stage) < CHAPTER_STAGES.indexOf(targetStage);
+}
+
+async function emitPlannedSkips(
+  entries: readonly ChapterEntry[],
+  options: AdvanceChapterStagesOptions,
+): Promise<void> {
+  for (const entry of entries) {
+    if (entry.stage !== "planned") {
+      continue;
+    }
+
+    await emitAdvanceProgress(options, {
+      chapter: entry,
+      reason: "planned",
+      targetStage: options.targetStage,
+      type: "skipped",
+    });
+  }
+}
+
+async function emitAdvanceProgress(
+  options: AdvanceChapterStagesOptions,
+  event: AdvanceChapterStagesProgressEvent,
+): Promise<void> {
+  try {
+    await options.onProgress?.(event);
+  } catch {
+    return;
+  }
 }
 
 async function resolveChapterStage(

--- a/src/facade/graph.ts
+++ b/src/facade/graph.ts
@@ -1,0 +1,345 @@
+import type {
+  ChunkImportance,
+  ChunkRecord,
+  ChunkRetention,
+  KnowledgeEdgeRecord,
+  ReadonlyDocument,
+  SentenceId,
+} from "../document/index.js";
+
+export interface GraphNode {
+  readonly content: string;
+  readonly id: number;
+  readonly importance?: ChunkImportance;
+  readonly label: string;
+  readonly retention?: ChunkRetention;
+  readonly sentenceIds: readonly SentenceId[];
+  readonly weight: number;
+  readonly wordsCount: number;
+}
+
+export interface GraphEdge {
+  readonly fromId: number;
+  readonly strength?: string;
+  readonly toId: number;
+  readonly weight: number;
+}
+
+export interface GraphEvidenceLine {
+  readonly sentenceId: SentenceId;
+  readonly text: string;
+}
+
+export interface GraphStatus {
+  readonly chapterId: number;
+  readonly edgeCount: number;
+  readonly graphReady: boolean;
+  readonly nodeCount: number;
+}
+
+export interface GraphSearchHit {
+  readonly node: GraphNode;
+  readonly matchedFields: readonly GraphSearchField[];
+}
+
+export type GraphSearchField = "content" | "evidence" | "label";
+
+export interface GraphNeighbor {
+  readonly direction: "incoming" | "outgoing";
+  readonly edge: GraphEdge;
+  readonly node: GraphNode;
+}
+
+export interface GraphPathStep {
+  readonly edge?: GraphEdge;
+  readonly node: GraphNode;
+}
+
+export async function getGraphStatus(
+  document: ReadonlyDocument,
+  chapterId: number,
+): Promise<GraphStatus> {
+  await requireChapter(document, chapterId);
+  const [serial, nodes, edges] = await Promise.all([
+    document.serials.getById(chapterId),
+    listGraphNodes(document, chapterId),
+    document.knowledgeEdges.listBySerial(chapterId),
+  ]);
+
+  return {
+    chapterId,
+    edgeCount: edges.length,
+    graphReady: serial?.topologyReady === true,
+    nodeCount: nodes.length,
+  };
+}
+
+export async function listGraphNodes(
+  document: ReadonlyDocument,
+  chapterId: number,
+): Promise<readonly GraphNode[]> {
+  await requireChapter(document, chapterId);
+  const chunks = await document.chunks.listBySerial(chapterId);
+
+  return chunks.map(formatGraphNode).sort(compareNodeByWeightDescending);
+}
+
+export async function getGraphNode(
+  document: ReadonlyDocument,
+  chapterId: number,
+  nodeId: number,
+): Promise<GraphNode> {
+  const node = formatGraphNode(
+    await requireChapterNode(document, chapterId, nodeId),
+  );
+
+  return node;
+}
+
+export async function searchGraphNodes(
+  document: ReadonlyDocument,
+  chapterId: number,
+  pattern: string,
+): Promise<readonly GraphSearchHit[]> {
+  const normalizedPattern = pattern.trim().toLowerCase();
+
+  if (normalizedPattern === "") {
+    return [];
+  }
+
+  const nodes = await listGraphNodes(document, chapterId);
+  const hits: GraphSearchHit[] = [];
+
+  for (const node of nodes) {
+    const evidence = await getGraphEvidence(document, chapterId, node.id);
+    const matchedFields: GraphSearchField[] = [];
+
+    if (node.label.toLowerCase().includes(normalizedPattern)) {
+      matchedFields.push("label");
+    }
+    if (node.content.toLowerCase().includes(normalizedPattern)) {
+      matchedFields.push("content");
+    }
+    if (
+      evidence.some((line) =>
+        line.text.toLowerCase().includes(normalizedPattern),
+      )
+    ) {
+      matchedFields.push("evidence");
+    }
+
+    if (matchedFields.length > 0) {
+      hits.push({ matchedFields, node });
+    }
+  }
+
+  return hits;
+}
+
+export async function listGraphNeighbors(
+  document: ReadonlyDocument,
+  chapterId: number,
+  nodeId: number,
+): Promise<readonly GraphNeighbor[]> {
+  await requireChapterNode(document, chapterId, nodeId);
+  const [incoming, outgoing] = await Promise.all([
+    document.knowledgeEdges.listIncoming(nodeId),
+    document.knowledgeEdges.listOutgoing(nodeId),
+  ]);
+  const neighbors = await Promise.all([
+    ...incoming.map(async (edge) => ({
+      direction: "incoming" as const,
+      edge: formatGraphEdge(edge),
+      node: formatGraphNode(
+        await requireChapterNode(document, chapterId, edge.fromId),
+      ),
+    })),
+    ...outgoing.map(async (edge) => ({
+      direction: "outgoing" as const,
+      edge: formatGraphEdge(edge),
+      node: formatGraphNode(
+        await requireChapterNode(document, chapterId, edge.toId),
+      ),
+    })),
+  ]);
+
+  return neighbors.sort(compareNeighbor);
+}
+
+export async function getGraphEvidence(
+  document: ReadonlyDocument,
+  chapterId: number,
+  nodeId: number,
+): Promise<readonly GraphEvidenceLine[]> {
+  const node = await requireChapterNode(document, chapterId, nodeId);
+  const lines = await Promise.all(
+    node.sentenceIds.map(async (sentenceId) => ({
+      sentenceId,
+      text: await document.getSentence(sentenceId),
+    })),
+  );
+
+  return lines;
+}
+
+export async function findGraphPath(
+  document: ReadonlyDocument,
+  chapterId: number,
+  fromNodeId: number,
+  toNodeId: number,
+): Promise<readonly GraphPathStep[]> {
+  await requireChapterNode(document, chapterId, fromNodeId);
+  await requireChapterNode(document, chapterId, toNodeId);
+
+  if (fromNodeId === toNodeId) {
+    return [{ node: await getGraphNode(document, chapterId, fromNodeId) }];
+  }
+
+  const edges = (await document.knowledgeEdges.listBySerial(chapterId)).map(
+    formatGraphEdge,
+  );
+  const outgoing = new Map<number, GraphEdge[]>();
+
+  for (const edge of edges) {
+    const existing = outgoing.get(edge.fromId) ?? [];
+
+    existing.push(edge);
+    outgoing.set(edge.fromId, existing);
+  }
+
+  const visited = new Set<number>([fromNodeId]);
+  const queue: number[] = [fromNodeId];
+  const previous = new Map<
+    number,
+    { readonly edge: GraphEdge; readonly id: number }
+  >();
+
+  while (queue.length > 0) {
+    const currentId = queue.shift()!;
+
+    for (const edge of outgoing.get(currentId) ?? []) {
+      if (visited.has(edge.toId)) {
+        continue;
+      }
+
+      visited.add(edge.toId);
+      previous.set(edge.toId, { edge, id: currentId });
+
+      if (edge.toId === toNodeId) {
+        return await buildPathSteps(
+          document,
+          chapterId,
+          fromNodeId,
+          toNodeId,
+          previous,
+        );
+      }
+
+      queue.push(edge.toId);
+    }
+  }
+
+  return [];
+}
+
+async function buildPathSteps(
+  document: ReadonlyDocument,
+  chapterId: number,
+  fromNodeId: number,
+  toNodeId: number,
+  previous: ReadonlyMap<
+    number,
+    { readonly edge: GraphEdge; readonly id: number }
+  >,
+): Promise<readonly GraphPathStep[]> {
+  const steps: Array<{ readonly edge?: GraphEdge; readonly nodeId: number }> = [
+    { nodeId: toNodeId },
+  ];
+  let currentId = toNodeId;
+
+  while (currentId !== fromNodeId) {
+    const previousStep = previous.get(currentId);
+
+    if (previousStep === undefined) {
+      return [];
+    }
+
+    steps.push({ edge: previousStep.edge, nodeId: previousStep.id });
+    currentId = previousStep.id;
+  }
+
+  steps.reverse();
+
+  return await Promise.all(
+    steps.map(async (step) => ({
+      ...(step.edge === undefined ? {} : { edge: step.edge }),
+      node: await getGraphNode(document, chapterId, step.nodeId),
+    })),
+  );
+}
+
+async function requireChapter(
+  document: ReadonlyDocument,
+  chapterId: number,
+): Promise<void> {
+  const serial = await document.serials.getById(chapterId);
+
+  if (serial === undefined) {
+    throw new Error(
+      `Chapter ${chapterId} does not exist. Use \`spinedigest sdpub list --input <path>\` to discover chapter ids.`,
+    );
+  }
+}
+
+async function requireChapterNode(
+  document: ReadonlyDocument,
+  chapterId: number,
+  nodeId: number,
+): Promise<ChunkRecord> {
+  const chunk = await document.chunks.getById(nodeId);
+
+  if (chunk === undefined || chunk.sentenceId[0] !== chapterId) {
+    throw new Error(
+      `Graph node ${nodeId} does not exist in chapter ${chapterId}. Use \`spinedigest sdpub graph log <path> --chapter ${chapterId}\` to discover node ids.`,
+    );
+  }
+
+  return chunk;
+}
+
+function formatGraphNode(chunk: ChunkRecord): GraphNode {
+  return {
+    content: chunk.content,
+    id: chunk.id,
+    label: chunk.label,
+    sentenceIds: chunk.sentenceIds,
+    weight: chunk.weight,
+    wordsCount: chunk.wordsCount,
+    ...(chunk.importance === undefined ? {} : { importance: chunk.importance }),
+    ...(chunk.retention === undefined ? {} : { retention: chunk.retention }),
+  };
+}
+
+function formatGraphEdge(edge: KnowledgeEdgeRecord): GraphEdge {
+  return {
+    fromId: edge.fromId,
+    toId: edge.toId,
+    weight: edge.weight,
+    ...(edge.strength === undefined ? {} : { strength: edge.strength }),
+  };
+}
+
+function compareNodeByWeightDescending(
+  left: GraphNode,
+  right: GraphNode,
+): number {
+  return right.weight - left.weight || left.id - right.id;
+}
+
+function compareNeighbor(left: GraphNeighbor, right: GraphNeighbor): number {
+  if (left.direction !== right.direction) {
+    return left.direction === "incoming" ? -1 : 1;
+  }
+
+  return right.edge.weight - left.edge.weight || left.node.id - right.node.id;
+}

--- a/src/facade/index.ts
+++ b/src/facade/index.ts
@@ -27,6 +27,15 @@ export {
   setChapterSource,
   setChapterSummary,
 } from "./chapter.js";
+export {
+  findGraphPath,
+  getGraphEvidence,
+  getGraphNode,
+  getGraphStatus,
+  listGraphNeighbors,
+  listGraphNodes,
+  searchGraphNodes,
+} from "./graph.js";
 export type {
   AddChapterOptions,
   AdvanceChapterStagesOptions,
@@ -37,5 +46,15 @@ export type {
   GenerateChapterGraphOptions,
   GenerateChapterSummaryOptions,
 } from "./chapter.js";
+export type {
+  GraphEdge,
+  GraphEvidenceLine,
+  GraphNeighbor,
+  GraphNode,
+  GraphPathStep,
+  GraphSearchField,
+  GraphSearchHit,
+  GraphStatus,
+} from "./graph.js";
 export { SpineDigest } from "./spine-digest.js";
 export type { SpineDigestSerialEntry } from "./types.js";

--- a/src/facade/index.ts
+++ b/src/facade/index.ts
@@ -39,6 +39,8 @@ export {
 export type {
   AddChapterOptions,
   AdvanceChapterStagesOptions,
+  AdvanceChapterStagesProgressCallback,
+  AdvanceChapterStagesProgressEvent,
   AdvanceChapterStagesResult,
   ChapterDetails,
   ChapterEntry,

--- a/test/cli/README.md
+++ b/test/cli/README.md
@@ -4,15 +4,15 @@ This note tracks how the CLI help system is expected to recover from common user
 
 ## Error Routing Coverage
 
-| Problem family | Representative failures                                                             | Expected help landing                                                 |
-| -------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| Command shape  | unexpected positional args, unsupported `help` flags                                | `spinedigest help command` or `spinedigest --help`                    |
-| `sdpub` usage  | missing subcommand, unsupported `sdpub` flags, missing `--serial`, stdin on `sdpub` | `spinedigest sdpub --help` or `spinedigest sdpub <subcommand> --help` |
-| Format rules   | unsupported `stdin`/`stdout` formats, missing format inference                      | `spinedigest help format`                                             |
-| Runtime rules  | interactive stdin refusal, `--verbose` with stdout output                           | `spinedigest help runtime`                                            |
-| LLM config     | missing provider/model, unsupported provider/baseURL combinations                   | `spinedigest help config`                                             |
-| Env overrides  | invalid provider values, invalid numeric/boolean/sampling env values                | `spinedigest help env`                                                |
-| Config file    | invalid JSON, invalid schema fields                                                 | `spinedigest help config-file`                                        |
+| Problem family | Representative failures                                                              | Expected help landing                                                 |
+| -------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| Command shape  | unexpected positional args, unsupported `help` flags                                 | `spinedigest help command` or `spinedigest --help`                    |
+| `sdpub` usage  | missing subcommand, unsupported `sdpub` flags, missing `--chapter`, stdin on `sdpub` | `spinedigest sdpub --help` or `spinedigest sdpub <subcommand> --help` |
+| Format rules   | unsupported `stdin`/`stdout` formats, missing format inference                       | `spinedigest help format`                                             |
+| Runtime rules  | interactive stdin refusal, `--verbose` with stdout output                            | `spinedigest help runtime`                                            |
+| LLM config     | missing provider/model, unsupported provider/baseURL combinations                    | `spinedigest help config`                                             |
+| Env overrides  | invalid provider values, invalid numeric/boolean/sampling env values                 | `spinedigest help env`                                                |
+| Config file    | invalid JSON, invalid schema fields                                                  | `spinedigest help config-file`                                        |
 
 ## Current Test Coverage
 

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { parseCLIArguments } from "../../src/cli/args.js";
 import {
   renderSdpubChapterActionHelpText,
+  renderSdpubGraphActionHelpText,
   renderSdpubStageActionHelpText,
   renderHelpTopicText,
   renderMainHelpText,
@@ -334,6 +335,75 @@ describe("cli/args", () => {
     });
   });
 
+  it("parses sdpub graph actions", () => {
+    expect(
+      parseCLIArguments([
+        "sdpub",
+        "graph",
+        "log",
+        "book.sdpub",
+        "--chapter",
+        "2",
+        "--limit",
+        "5",
+        "--llm",
+        '{"model":"cli-model"}',
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "log",
+        chapterId: 2,
+        limit: 5,
+        llmJSON: '{"model":"cli-model"}',
+        path: "book.sdpub",
+      },
+      help: false,
+      kind: "sdpub-graph",
+    });
+    expect(
+      parseCLIArguments([
+        "sdpub",
+        "graph",
+        "show",
+        "book.sdpub",
+        "--chapter",
+        "2",
+        "9",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "show",
+        chapterId: 2,
+        nodeId: 9,
+        path: "book.sdpub",
+      },
+      help: false,
+      kind: "sdpub-graph",
+    });
+    expect(
+      parseCLIArguments([
+        "sdpub",
+        "graph",
+        "path",
+        "book.sdpub",
+        "--chapter",
+        "2",
+        "9",
+        "11",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "path",
+        chapterId: 2,
+        fromNodeId: 9,
+        path: "book.sdpub",
+        toNodeId: 11,
+      },
+      help: false,
+      kind: "sdpub-graph",
+    });
+  });
+
   it("prints sdpub help text", () => {
     expect(parseCLIArguments(["sdpub", "--help"])).toStrictEqual({
       help: true,
@@ -395,6 +465,13 @@ describe("cli/args", () => {
       helpText: renderSdpubStageActionHelpText("advance"),
       kind: "sdpub-stage",
     });
+    expect(
+      parseCLIArguments(["sdpub", "graph", "show", "--help"]),
+    ).toStrictEqual({
+      help: true,
+      helpText: renderSdpubGraphActionHelpText("show"),
+      kind: "sdpub-graph",
+    });
   });
 
   it("rejects positional arguments", () => {
@@ -414,10 +491,10 @@ describe("cli/args", () => {
 
   it("rejects invalid sdpub usage", () => {
     expect(() => parseCLIArguments(["sdpub"])).toThrow(
-      "Missing sdpub subcommand. Expected one of info, toc, list, cat, cover, meta, stage, chapter.\nSee: spinedigest sdpub --help",
+      "Missing sdpub subcommand. Expected one of info, toc, list, cat, cover, meta, stage, chapter, graph.\nSee: spinedigest sdpub --help",
     );
     expect(() => parseCLIArguments(["sdpub", "inspect"])).toThrow(
-      "Invalid sdpub subcommand: inspect. Expected one of info, toc, list, cat, cover, meta, stage, chapter.\nSee: spinedigest sdpub --help",
+      "Invalid sdpub subcommand: inspect. Expected one of info, toc, list, cat, cover, meta, stage, chapter, graph.\nSee: spinedigest sdpub --help",
     );
     expect(() => parseCLIArguments(["sdpub", "inspect", "extra"])).toThrow(
       "Unexpected positional arguments: extra.\nSee: spinedigest sdpub --help",
@@ -506,6 +583,48 @@ describe("cli/args", () => {
       ]),
     ).toThrow(
       "Cannot combine --title with --clear-title.\nSee: spinedigest sdpub meta --help",
+    );
+  });
+
+  it("rejects invalid sdpub graph usage", () => {
+    expect(() => parseCLIArguments(["sdpub", "graph"])).toThrow(
+      "Missing sdpub graph action.\nSee: spinedigest sdpub graph --help",
+    );
+    expect(() =>
+      parseCLIArguments(["sdpub", "graph", "bogus", "book.sdpub"]),
+    ).toThrow(
+      "Invalid sdpub graph action: bogus. Expected one of status, log, show, grep, neighbors, blame, path.\nSee: spinedigest sdpub graph --help",
+    );
+    expect(() =>
+      parseCLIArguments(["sdpub", "graph", "log", "book.sdpub"]),
+    ).toThrow(
+      "Missing --chapter. `sdpub graph` requires a chapter id.\nSee: spinedigest sdpub graph --help",
+    );
+    expect(() =>
+      parseCLIArguments([
+        "sdpub",
+        "graph",
+        "show",
+        "book.sdpub",
+        "--chapter",
+        "2",
+      ]),
+    ).toThrow(
+      "`sdpub graph show` requires exactly one node id.\nSee: spinedigest sdpub graph --help",
+    );
+    expect(() =>
+      parseCLIArguments([
+        "sdpub",
+        "graph",
+        "status",
+        "book.sdpub",
+        "--chapter",
+        "2",
+        "--limit",
+        "5",
+      ]),
+    ).toThrow(
+      "The `sdpub graph status` action does not support --limit.\nSee: spinedigest sdpub graph --help",
     );
   });
 

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -178,6 +178,28 @@ describe("cli/args", () => {
       kind: "sdpub",
     });
     expect(
+      parseCLIArguments(["sdpub", "list", "--input", "book.sdpub", "--json"]),
+    ).toStrictEqual({
+      args: {
+        inputPath: "book.sdpub",
+        json: true,
+        subcommand: "list",
+      },
+      help: false,
+      kind: "sdpub",
+    });
+    expect(
+      parseCLIArguments(["sdpub", "meta", "--input", "book.sdpub", "--json"]),
+    ).toStrictEqual({
+      args: {
+        inputPath: "book.sdpub",
+        json: true,
+        subcommand: "meta",
+      },
+      help: false,
+      kind: "sdpub",
+    });
+    expect(
       parseCLIArguments([
         "sdpub",
         "meta",
@@ -412,6 +434,24 @@ describe("cli/args", () => {
       parseCLIArguments(["sdpub", "info", "--prompt", "Keep dialogue only"]),
     ).toThrow(
       "The `sdpub` subcommands do not support --prompt. It only applies to digest generation from source inputs.\nSee: spinedigest sdpub --help",
+    );
+    expect(() =>
+      parseCLIArguments(["sdpub", "info", "--input", "book.sdpub", "--json"]),
+    ).toThrow(
+      "The `sdpub info` subcommand does not support --json.\nSee: spinedigest sdpub info --help",
+    );
+    expect(() =>
+      parseCLIArguments([
+        "sdpub",
+        "meta",
+        "--input",
+        "book.sdpub",
+        "--json",
+        "--title",
+        "Updated",
+      ]),
+    ).toThrow(
+      "`sdpub meta --json` is read-only and cannot be combined with metadata edit flags.\nSee: spinedigest sdpub meta --help",
     );
     expect(() =>
       parseCLIArguments(["sdpub", "cat", "--input", "book.sdpub"]),

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -162,7 +162,7 @@ describe("cli/args", () => {
         "cat",
         "--input",
         "book.sdpub",
-        "--serial",
+        "--chapter",
         "12",
         "--llm",
         '{"model":"cli-model"}',
@@ -171,7 +171,7 @@ describe("cli/args", () => {
       args: {
         inputPath: "book.sdpub",
         llmJSON: '{"model":"cli-model"}',
-        serialId: 12,
+        chapterId: 12,
         subcommand: "cat",
       },
       help: false,
@@ -416,7 +416,7 @@ describe("cli/args", () => {
     expect(() =>
       parseCLIArguments(["sdpub", "cat", "--input", "book.sdpub"]),
     ).toThrow(
-      "Missing --serial. `spinedigest sdpub cat` requires it.\nSee: spinedigest sdpub cat --help",
+      "Missing --chapter. `spinedigest sdpub cat` requires a chapter id.\nSee: spinedigest sdpub cat --help",
     );
     expect(() =>
       parseCLIArguments([
@@ -424,11 +424,11 @@ describe("cli/args", () => {
         "list",
         "--input",
         "book.sdpub",
-        "--serial",
+        "--chapter",
         "2",
       ]),
     ).toThrow(
-      "The `sdpub list` subcommand does not support --serial.\nSee: spinedigest sdpub list --help",
+      "The `sdpub list` subcommand does not support --chapter.\nSee: spinedigest sdpub list --help",
     );
     expect(() =>
       parseCLIArguments([
@@ -436,11 +436,11 @@ describe("cli/args", () => {
         "cat",
         "--input",
         "book.sdpub",
-        "--serial",
+        "--chapter",
         "x",
       ]),
     ).toThrow(
-      "Invalid --serial: x. Expected a non-negative integer.\nSee: spinedigest sdpub cat --help",
+      "Invalid --chapter: x. Expected a non-negative integer.\nSee: spinedigest sdpub cat --help",
     );
     expect(() =>
       parseCLIArguments([
@@ -609,7 +609,7 @@ describe("cli/args", () => {
       "--digest-dir <path>",
       "--llm <json>",
       "--prompt <text>",
-      "--serial <id>",
+      "--chapter <id>",
     ]) {
       expect(commandHelpText).toContain(flag);
     }

--- a/test/cli/main.test.ts
+++ b/test/cli/main.test.ts
@@ -15,10 +15,12 @@ const mainMockState = vi.hoisted(() => ({
   statusRunCalls: 0,
   statusRunArgs: [] as unknown[],
   sdpubRunCalls: [] as unknown[],
+  sdpubGraphRunCalls: [] as unknown[],
   sdpubStageRunCalls: [] as unknown[],
   runError: undefined as Error | undefined,
   statusRunError: undefined as Error | undefined,
   sdpubRunError: undefined as Error | undefined,
+  sdpubGraphRunError: undefined as Error | undefined,
   sdpubStageRunError: undefined as Error | undefined,
 }));
 
@@ -81,6 +83,18 @@ vi.mock("../../src/cli/sdpub-stage.js", () => ({
   }),
 }));
 
+vi.mock("../../src/cli/sdpub-graph.js", () => ({
+  runSdpubGraphCommand: vi.fn((args: unknown) => {
+    mainMockState.sdpubGraphRunCalls.push(args);
+
+    if (mainMockState.sdpubGraphRunError !== undefined) {
+      return Promise.reject(mainMockState.sdpubGraphRunError);
+    }
+
+    return Promise.resolve();
+  }),
+}));
+
 import { main } from "../../src/cli/main.js";
 import { renderMainHelpText } from "../../src/cli/help.js";
 import { LLMPaymentRequiredError } from "../../src/llm/index.js";
@@ -108,10 +122,12 @@ describe("cli/main", () => {
     mainMockState.statusRunCalls = 0;
     mainMockState.statusRunArgs.length = 0;
     mainMockState.sdpubRunCalls.length = 0;
+    mainMockState.sdpubGraphRunCalls.length = 0;
     mainMockState.sdpubStageRunCalls.length = 0;
     mainMockState.runError = undefined;
     mainMockState.statusRunError = undefined;
     mainMockState.sdpubRunError = undefined;
+    mainMockState.sdpubGraphRunError = undefined;
     mainMockState.sdpubStageRunError = undefined;
     process.exitCode = 0;
     process.argv = ["node", "spinedigest"];
@@ -277,6 +293,30 @@ describe("cli/main", () => {
     expect(mainMockState.sdpubStageRunCalls).toStrictEqual([
       {
         action: "pending",
+        path: "/tmp/book.sdpub",
+      },
+    ]);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("runs the sdpub graph command for graph actions", async () => {
+    mainMockState.argsResult = {
+      args: {
+        action: "log",
+        chapterId: 2,
+        path: "/tmp/book.sdpub",
+      },
+      help: false,
+      kind: "sdpub-graph",
+    };
+
+    await main();
+
+    expect(mainMockState.runCalls).toHaveLength(0);
+    expect(mainMockState.sdpubGraphRunCalls).toStrictEqual([
+      {
+        action: "log",
+        chapterId: 2,
         path: "/tmp/book.sdpub",
       },
     ]);

--- a/test/cli/progress.test.ts
+++ b/test/cli/progress.test.ts
@@ -90,7 +90,7 @@ describe("cli/progress", () => {
       "Digest  [####........] 882 / 2,702 words",
       "------------------------",
       "#2 Chapter 2",
-      "       [##########..] 1,576 / 1,820 words (2/3 fragments)",
+      "       [##########..] 1,576 / 1,820 words (2/3 source units)",
     ]);
   });
 
@@ -160,7 +160,7 @@ describe("cli/progress", () => {
       "Digest  [............] 0 / 20 words",
       "------------------------",
       "#2 Chapter 2",
-      "       [######......] 5 / 10 words (1/2 fragments)",
+      "       [######......] 5 / 10 words (1/2 source units)",
     ]);
   });
 
@@ -226,7 +226,7 @@ describe("cli/progress", () => {
       "Digest  [##..........] 10 / 60 words",
       "------------------------",
       "#2 In progress",
-      "       [######......] 10 / 20 words (1/2 fragments)",
+      "       [######......] 10 / 20 words (1/2 source units)",
     ]);
   });
 
@@ -274,7 +274,7 @@ describe("cli/progress", () => {
       "Digest  [######......] 5 / 10 words",
       "------------------------",
       "#7 Line 1Line 2",
-      "       [######......] 5 / 10 words (1/2 fragments)",
+      "       [######......] 5 / 10 words (1/2 source units)",
     ]);
   });
 });

--- a/test/cli/sdpub-graph.test.ts
+++ b/test/cli/sdpub-graph.test.ts
@@ -1,0 +1,261 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const graphMockState = vi.hoisted(() => ({
+  editableCalls: [] as string[],
+  evidence: [
+    {
+      sentenceId: [2, 0, 1],
+      text: "Source sentence one.",
+    },
+    {
+      sentenceId: [2, 0, 2],
+      text: "Source sentence two.",
+    },
+  ],
+  neighbors: [
+    {
+      direction: "incoming",
+      edge: {
+        fromId: 7,
+        toId: 9,
+        weight: 0.4,
+      },
+      node: {
+        content: "Earlier context",
+        id: 7,
+        label: "Earlier",
+        sentenceIds: [[2, 0, 0]],
+        weight: 0.3,
+        wordsCount: 2,
+      },
+    },
+    {
+      direction: "outgoing",
+      edge: {
+        fromId: 9,
+        toId: 11,
+        weight: 0.6,
+      },
+      node: {
+        content: "Later context",
+        id: 11,
+        label: "Later",
+        sentenceIds: [[2, 0, 3]],
+        weight: 0.5,
+        wordsCount: 2,
+      },
+    },
+  ],
+  node: {
+    content: "Central graph node content",
+    id: 9,
+    importance: "important",
+    label: "Central",
+    retention: "focused",
+    sentenceIds: [
+      [2, 0, 1],
+      [2, 0, 2],
+    ],
+    weight: 0.9,
+    wordsCount: 4,
+  },
+  nodes: [
+    {
+      content: "Central graph node content",
+      id: 9,
+      importance: "important",
+      label: "Central",
+      retention: "focused",
+      sentenceIds: [
+        [2, 0, 1],
+        [2, 0, 2],
+      ],
+      weight: 0.9,
+      wordsCount: 4,
+    },
+    {
+      content: "Earlier context",
+      id: 7,
+      label: "Earlier",
+      sentenceIds: [[2, 0, 0]],
+      weight: 0.3,
+      wordsCount: 2,
+    },
+  ],
+  path: [] as unknown[],
+  searchHits: [] as unknown[],
+  textWrites: [] as string[],
+}));
+
+vi.mock("../../src/facade/spine-digest-file.js", () => ({
+  SpineDigestFile: class {
+    readonly #path: string;
+
+    public constructor(path: string) {
+      this.#path = path;
+    }
+
+    public async openEditableSession(
+      operation: (document: unknown) => Promise<unknown>,
+    ): Promise<unknown> {
+      graphMockState.editableCalls.push(this.#path);
+      return await operation({});
+    }
+  },
+}));
+
+vi.mock("../../src/facade/index.js", () => ({
+  findGraphPath: vi.fn(() => Promise.resolve(graphMockState.path)),
+  getGraphEvidence: vi.fn(() => Promise.resolve(graphMockState.evidence)),
+  getGraphNode: vi.fn(() => Promise.resolve(graphMockState.node)),
+  getGraphStatus: vi.fn(() =>
+    Promise.resolve({
+      chapterId: 2,
+      edgeCount: 2,
+      graphReady: true,
+      nodeCount: 3,
+    }),
+  ),
+  listGraphNeighbors: vi.fn(() => Promise.resolve(graphMockState.neighbors)),
+  listGraphNodes: vi.fn(() => Promise.resolve(graphMockState.nodes)),
+  searchGraphNodes: vi.fn(() => Promise.resolve(graphMockState.searchHits)),
+}));
+
+vi.mock("../../src/cli/io.js", () => ({
+  writeTextToStdout: vi.fn((text: string) => {
+    graphMockState.textWrites.push(text);
+    return Promise.resolve();
+  }),
+}));
+
+import { runSdpubGraphCommand } from "../../src/cli/sdpub-graph.js";
+
+describe("cli/sdpub-graph", () => {
+  beforeEach(() => {
+    graphMockState.editableCalls.length = 0;
+    graphMockState.path = [
+      {
+        node: graphMockState.nodes[0],
+      },
+      {
+        edge: {
+          fromId: 9,
+          toId: 11,
+          weight: 0.6,
+        },
+        node: {
+          content: "Later context",
+          id: 11,
+          label: "Later",
+          sentenceIds: [[2, 0, 3]],
+          weight: 0.5,
+          wordsCount: 2,
+        },
+      },
+    ];
+    graphMockState.searchHits = [
+      {
+        matchedFields: ["label", "content"],
+        node: graphMockState.node,
+      },
+    ];
+    graphMockState.textWrites.length = 0;
+  });
+
+  it("prints graph status", async () => {
+    await runSdpubGraphCommand({
+      action: "status",
+      chapterId: 2,
+      path: "/tmp/book.sdpub",
+    });
+
+    expect(graphMockState.editableCalls).toStrictEqual(["/tmp/book.sdpub"]);
+    expect(graphMockState.textWrites).toStrictEqual([
+      "Chapter: 2\nGraph: yes\nNodes: 3\nEdges: 2\n",
+    ]);
+  });
+
+  it("prints graph log lines with a limit", async () => {
+    await runSdpubGraphCommand({
+      action: "log",
+      chapterId: 2,
+      limit: 1,
+      path: "/tmp/book.sdpub",
+    });
+
+    expect(graphMockState.textWrites).toStrictEqual([
+      "[9] 0.900 Central - Central graph node content\n",
+    ]);
+  });
+
+  it("shows one graph node", async () => {
+    await runSdpubGraphCommand({
+      action: "show",
+      chapterId: 2,
+      nodeId: 9,
+      path: "/tmp/book.sdpub",
+    });
+
+    expect(graphMockState.textWrites[0]).toContain("[9] Central\n");
+    expect(graphMockState.textWrites[0]).toContain(
+      "Content:\nCentral graph node content\n",
+    );
+    expect(graphMockState.textWrites[0]).toContain("<- [7] 0.400 Earlier");
+    expect(graphMockState.textWrites[0]).toContain(
+      "2.0.1 Source sentence one.",
+    );
+  });
+
+  it("prints grep hits", async () => {
+    await runSdpubGraphCommand({
+      action: "grep",
+      chapterId: 2,
+      path: "/tmp/book.sdpub",
+      pattern: "central",
+    });
+
+    expect(graphMockState.textWrites).toStrictEqual([
+      "[9] 0.900 Central - Central graph node content matches:label,content\n",
+    ]);
+  });
+
+  it("prints neighbors", async () => {
+    await runSdpubGraphCommand({
+      action: "neighbors",
+      chapterId: 2,
+      nodeId: 9,
+      path: "/tmp/book.sdpub",
+    });
+
+    expect(graphMockState.textWrites).toStrictEqual([
+      "  <- [7] 0.400 Earlier\n  -> [11] 0.600 Later\n",
+    ]);
+  });
+
+  it("prints node evidence", async () => {
+    await runSdpubGraphCommand({
+      action: "blame",
+      chapterId: 2,
+      nodeId: 9,
+      path: "/tmp/book.sdpub",
+    });
+
+    expect(graphMockState.textWrites).toStrictEqual([
+      "2.0.1 Source sentence one.\n2.0.2 Source sentence two.\n",
+    ]);
+  });
+
+  it("prints a directed path", async () => {
+    await runSdpubGraphCommand({
+      action: "path",
+      chapterId: 2,
+      fromNodeId: 9,
+      path: "/tmp/book.sdpub",
+      toNodeId: 11,
+    });
+
+    expect(graphMockState.textWrites).toStrictEqual([
+      "[9] 0.900 Central - Central graph node content\n  -> 0.600\n[11] 0.500 Later - Later context\n",
+    ]);
+  });
+});

--- a/test/cli/sdpub-graph.test.ts
+++ b/test/cli/sdpub-graph.test.ts
@@ -47,7 +47,7 @@ const graphMockState = vi.hoisted(() => ({
     },
   ],
   node: {
-    content: "Central graph node content",
+    content: "Central node content",
     id: 9,
     importance: "important",
     label: "Central",
@@ -61,7 +61,7 @@ const graphMockState = vi.hoisted(() => ({
   },
   nodes: [
     {
-      content: "Central graph node content",
+      content: "Central node content",
       id: 9,
       importance: "important",
       label: "Central",
@@ -184,11 +184,11 @@ describe("cli/sdpub-graph", () => {
     });
 
     expect(graphMockState.textWrites).toStrictEqual([
-      "[9] 0.900 Central - Central graph node content\n",
+      "[9] Central - Central node content\n",
     ]);
   });
 
-  it("shows one graph node", async () => {
+  it("shows one node", async () => {
     await runSdpubGraphCommand({
       action: "show",
       chapterId: 2,
@@ -198,12 +198,15 @@ describe("cli/sdpub-graph", () => {
 
     expect(graphMockState.textWrites[0]).toContain("[9] Central\n");
     expect(graphMockState.textWrites[0]).toContain(
-      "Content:\nCentral graph node content\n",
+      "Content:\nCentral node content\n",
     );
-    expect(graphMockState.textWrites[0]).toContain("<- [7] 0.400 Earlier");
+    expect(graphMockState.textWrites[0]).toContain("<- [7] Earlier");
     expect(graphMockState.textWrites[0]).toContain(
       "2.0.1 Source sentence one.",
     );
+    expect(graphMockState.textWrites[0]).not.toContain("Weight:");
+    expect(graphMockState.textWrites[0]).not.toContain("Importance:");
+    expect(graphMockState.textWrites[0]).not.toContain("Retention:");
   });
 
   it("prints grep hits", async () => {
@@ -215,7 +218,7 @@ describe("cli/sdpub-graph", () => {
     });
 
     expect(graphMockState.textWrites).toStrictEqual([
-      "[9] 0.900 Central - Central graph node content matches:label,content\n",
+      "[9] Central - Central node content matches:label,content\n",
     ]);
   });
 
@@ -228,7 +231,7 @@ describe("cli/sdpub-graph", () => {
     });
 
     expect(graphMockState.textWrites).toStrictEqual([
-      "  <- [7] 0.400 Earlier\n  -> [11] 0.600 Later\n",
+      "  <- [7] Earlier\n  -> [11] Later\n",
     ]);
   });
 
@@ -255,7 +258,7 @@ describe("cli/sdpub-graph", () => {
     });
 
     expect(graphMockState.textWrites).toStrictEqual([
-      "[9] 0.900 Central - Central graph node content\n  -> 0.600\n[11] 0.500 Later - Later context\n",
+      "[9] Central - Central node content\n  ->\n[11] Later - Later context\n",
     ]);
   });
 });

--- a/test/cli/sdpub-stage.test.ts
+++ b/test/cli/sdpub-stage.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const stageMockState = vi.hoisted(() => ({
   advancedCalls: [] as unknown[],
   editableCalls: [] as string[],
+  errorWrites: [] as string[],
   listEntries: [
     {
       chapterId: 1,
@@ -86,6 +87,10 @@ vi.mock("../../src/llm/index.js", () => ({
 }));
 
 vi.mock("../../src/cli/io.js", () => ({
+  writeTextToStderr: vi.fn((text: string) => {
+    stageMockState.errorWrites.push(text);
+    return Promise.resolve();
+  }),
   writeTextToStdout: vi.fn((text: string) => {
     stageMockState.textWrites.push(text);
     return Promise.resolve();
@@ -98,6 +103,7 @@ describe("cli/sdpub-stage", () => {
   beforeEach(() => {
     stageMockState.advancedCalls.length = 0;
     stageMockState.editableCalls.length = 0;
+    stageMockState.errorWrites.length = 0;
     stageMockState.loadConfigCalls.length = 0;
     stageMockState.textWrites.length = 0;
   });
@@ -126,6 +132,36 @@ describe("cli/sdpub-stage", () => {
       extractionPrompt: "CLI prompt",
       targetStage: "summarized",
     });
+    const onProgress = (
+      stageMockState.advancedCalls[0] as {
+        readonly onProgress?: (event: unknown) => Promise<void>;
+      }
+    ).onProgress;
+    expect(onProgress).toBeTypeOf("function");
+
+    await onProgress?.({
+      targetStage: "summarized",
+      totalChapters: 1,
+      type: "selected",
+    });
+    await onProgress?.({
+      chapter: stageMockState.listEntries[1],
+      step: "graph",
+      targetStage: "summarized",
+      type: "started",
+    });
+    await onProgress?.({
+      chapter: stageMockState.listEntries[1],
+      step: "graph",
+      targetStage: "summarized",
+      type: "completed",
+    });
+
+    expect(stageMockState.errorWrites).toStrictEqual([
+      "Selected 1 chapter; target: summarized.\n",
+      "Generating graph for chapter 2 (Todo)...\n",
+      "Finished graph for chapter 2 (Todo).\n",
+    ]);
     expect(stageMockState.textWrites).toStrictEqual([
       "Advanced: 1\nPending: 0\nSkipped: 0\n",
     ]);
@@ -140,6 +176,7 @@ describe("cli/sdpub-stage", () => {
 
     expect(stageMockState.loadConfigCalls).toHaveLength(0);
     expect(stageMockState.advancedCalls).toHaveLength(0);
+    expect(stageMockState.errorWrites).toStrictEqual([]);
     expect(stageMockState.textWrites).toStrictEqual([
       "Advanced: 0\nPending: 0\nSkipped: 0\n",
     ]);

--- a/test/cli/sdpub.test.ts
+++ b/test/cli/sdpub.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type * as FacadeModule from "../../src/facade/index.js";
+import type { BookMeta } from "../../src/source/index.js";
+
 const sdpubMockState = vi.hoisted(() => ({
   binaryWrites: [] as Uint8Array[],
   cover: {
@@ -23,8 +26,37 @@ const sdpubMockState = vi.hoisted(() => ({
     sourceFormat: "epub",
     title: "Fixture Book",
     version: 1,
-  },
+  } as BookMeta,
   openCalls: [] as string[],
+  listEntries: [
+    {
+      chapterId: 10,
+      childCount: 2,
+      depth: 0,
+      fragmentCount: 0,
+      stage: "planned",
+      title: "Part I",
+      tocPath: ["Part I"],
+    },
+    {
+      chapterId: 1,
+      childCount: 0,
+      depth: 1,
+      fragmentCount: 2,
+      stage: "summarized",
+      title: "Chapter 1",
+      tocPath: ["Part I", "Chapter 1"],
+    },
+    {
+      chapterId: 2,
+      childCount: 0,
+      depth: 1,
+      fragmentCount: 1,
+      stage: "graphed",
+      title: "Chapter 2",
+      tocPath: ["Part I", "Chapter 2"],
+    },
+  ],
   editableCalls: [] as string[],
   replacedMeta: [] as unknown[],
   serialEntries: [
@@ -90,6 +122,7 @@ vi.mock("../../src/facade/spine-digest-file.js", () => ({
     ): Promise<unknown> {
       sdpubMockState.editableCalls.push(this.#path);
       return await operation({
+        listChapters: () => Promise.resolve(sdpubMockState.listEntries),
         readBookMeta: () => Promise.resolve(sdpubMockState.meta),
         replaceBookMeta: (meta: unknown) => {
           sdpubMockState.replacedMeta.push(meta);
@@ -100,6 +133,15 @@ vi.mock("../../src/facade/spine-digest-file.js", () => ({
     }
   },
 }));
+
+vi.mock("../../src/facade/index.js", async (importOriginal) => {
+  const original = await importOriginal<typeof FacadeModule>();
+
+  return {
+    ...original,
+    listChapters: (document: MockEditableDocument) => document.listChapters(),
+  };
+});
 
 vi.mock("../../src/cli/io.js", () => ({
   writeBinaryToStdout: vi.fn((data: Uint8Array) => {
@@ -136,6 +178,35 @@ describe("cli/sdpub", () => {
       version: 1,
     };
     sdpubMockState.editableCalls.length = 0;
+    sdpubMockState.listEntries = [
+      {
+        chapterId: 10,
+        childCount: 2,
+        depth: 0,
+        fragmentCount: 0,
+        stage: "planned",
+        title: "Part I",
+        tocPath: ["Part I"],
+      },
+      {
+        chapterId: 1,
+        childCount: 0,
+        depth: 1,
+        fragmentCount: 2,
+        stage: "summarized",
+        title: "Chapter 1",
+        tocPath: ["Part I", "Chapter 1"],
+      },
+      {
+        chapterId: 2,
+        childCount: 0,
+        depth: 1,
+        fragmentCount: 1,
+        stage: "graphed",
+        title: "Chapter 2",
+        tocPath: ["Part I", "Chapter 2"],
+      },
+    ];
     sdpubMockState.openCalls.length = 0;
     sdpubMockState.replacedMeta.length = 0;
     sdpubMockState.serialEntries = [
@@ -191,10 +262,10 @@ describe("cli/sdpub", () => {
     expect(sdpubMockState.textWrites).toStrictEqual([
       [
         "Archive Format Version: 1",
+        "Source Format: epub",
         "Title: Fixture Book",
         "Authors: Ari Lantern, Bea North",
         "Language: en",
-        "Source Format: epub",
         "Identifier: urn:test:sdpub-cli",
         "Publisher: Open Sample Press",
         "Published At: 2026-01-01",
@@ -206,10 +277,37 @@ describe("cli/sdpub", () => {
         "Top-level Sections: 1",
         "Referenced Chapters: 2",
         "Summarized Chapters: 2",
-        "Fragments: 3",
+        "Source Units: 3",
         "",
       ].join("\n"),
     ]);
+  });
+
+  it("renders missing sdpub info metadata fields as none", async () => {
+    sdpubMockState.meta = {
+      authors: [],
+      description: null,
+      identifier: null,
+      language: null,
+      publishedAt: null,
+      publisher: null,
+      sourceFormat: "markdown",
+      title: null,
+      version: 1,
+    };
+
+    await runSdpubCommand({
+      inputPath: "/tmp/book.sdpub",
+      subcommand: "info",
+    });
+
+    expect(sdpubMockState.textWrites[0]).toContain("Title: [none]");
+    expect(sdpubMockState.textWrites[0]).toContain("Authors: [none]");
+    expect(sdpubMockState.textWrites[0]).toContain("Language: [none]");
+    expect(sdpubMockState.textWrites[0]).toContain("Identifier: [none]");
+    expect(sdpubMockState.textWrites[0]).toContain("Publisher: [none]");
+    expect(sdpubMockState.textWrites[0]).toContain("Published At: [none]");
+    expect(sdpubMockState.textWrites[0]).toContain("Description: [none]");
   });
 
   it("renders the toc tree", async () => {
@@ -236,26 +334,66 @@ describe("cli/sdpub", () => {
       subcommand: "list",
     });
 
+    expect(sdpubMockState.editableCalls).toStrictEqual(["/tmp/book.sdpub"]);
     expect(sdpubMockState.textWrites).toStrictEqual([
       [
-        "[1] Part I / Chapter 1 (fragments: 2)",
-        "[2] Part I / Chapter 2 (fragments: 1)",
+        "[10] Part I (planned)",
+        "  [1] Chapter 1",
+        "  [2] Chapter 2 (graphed)",
         "",
       ].join("\n"),
     ]);
   });
 
+  it("renders chapter list JSON", async () => {
+    await runSdpubCommand({
+      inputPath: "/tmp/book.sdpub",
+      json: true,
+      subcommand: "list",
+    });
+
+    expect(JSON.parse(sdpubMockState.textWrites[0]!)).toStrictEqual({
+      chapters: [
+        {
+          catReady: false,
+          chapterId: 10,
+          childCount: 2,
+          depth: 0,
+          stage: "planned",
+          title: "Part I",
+          tocPath: ["Part I"],
+        },
+        {
+          catReady: true,
+          chapterId: 1,
+          childCount: 0,
+          depth: 1,
+          stage: "summarized",
+          title: "Chapter 1",
+          tocPath: ["Part I", "Chapter 1"],
+        },
+        {
+          catReady: false,
+          chapterId: 2,
+          childCount: 0,
+          depth: 1,
+          stage: "graphed",
+          title: "Chapter 2",
+          tocPath: ["Part I", "Chapter 2"],
+        },
+      ],
+    });
+  });
+
   it("prints a chapter-oriented empty list message", async () => {
-    sdpubMockState.serialEntries = [];
+    sdpubMockState.listEntries = [];
 
     await runSdpubCommand({
       inputPath: "/tmp/book.sdpub",
       subcommand: "list",
     });
 
-    expect(sdpubMockState.textWrites).toStrictEqual([
-      "No summarized chapters available.\n",
-    ]);
+    expect(sdpubMockState.textWrites).toStrictEqual(["No chapters.\n"]);
   });
 
   it("writes only chapter summary text for cat", async () => {
@@ -302,6 +440,25 @@ describe("cli/sdpub", () => {
         "",
       ].join("\n"),
     ]);
+  });
+
+  it("renders book metadata as JSON", async () => {
+    await runSdpubCommand({
+      inputPath: "/tmp/book.sdpub",
+      json: true,
+      subcommand: "meta",
+    });
+
+    expect(JSON.parse(sdpubMockState.textWrites[0]!)).toStrictEqual({
+      authors: ["Ari Lantern", "Bea North"],
+      description: "Fixture description",
+      identifier: "urn:test:sdpub-cli",
+      language: "en",
+      publishedAt: "2026-01-01",
+      publisher: "Open Sample Press",
+      sourceFormat: "epub",
+      title: "Fixture Book",
+    });
   });
 
   it("updates book metadata in place and prints the result", async () => {
@@ -381,6 +538,7 @@ interface MockDigest {
 }
 
 interface MockEditableDocument {
+  listChapters(): Promise<typeof sdpubMockState.listEntries>;
   readBookMeta(): Promise<typeof sdpubMockState.meta>;
   replaceBookMeta(meta: unknown): Promise<void>;
 }

--- a/test/cli/sdpub.test.ts
+++ b/test/cli/sdpub.test.ts
@@ -230,7 +230,7 @@ describe("cli/sdpub", () => {
     ]);
   });
 
-  it("renders serials in toc order", async () => {
+  it("renders chapters in toc order", async () => {
     await runSdpubCommand({
       inputPath: "/tmp/book.sdpub",
       subcommand: "list",
@@ -258,10 +258,10 @@ describe("cli/sdpub", () => {
     ]);
   });
 
-  it("writes only serial summary text for cat", async () => {
+  it("writes only chapter summary text for cat", async () => {
     await runSdpubCommand({
+      chapterId: 2,
       inputPath: "/tmp/book.sdpub",
-      serialId: 2,
       subcommand: "cat",
     });
 

--- a/test/facade/chapter.test.ts
+++ b/test/facade/chapter.test.ts
@@ -255,4 +255,53 @@ describe("facade/chapter", () => {
       }
     });
   });
+
+  it("reports advance progress without making progress callbacks fatal", async () => {
+    await withTempDir("spinedigest-chapter-", async (path) => {
+      const document = await DirectoryDocument.open(path);
+
+      try {
+        const chapter = await addChapter(document, {
+          title: "Draft",
+        });
+        const events: unknown[] = [];
+
+        const skipped = await advanceChapterStages(document, {
+          extractionPrompt: "Keep key beats",
+          llm: {} as never,
+          onProgress: (event) => {
+            events.push(event);
+            throw new Error("progress failed");
+          },
+          targetStage: "summarized",
+        });
+
+        expect(skipped.advanced).toStrictEqual([]);
+        expect(skipped.pending).toMatchObject([
+          {
+            chapterId: chapter.chapterId,
+            stage: "planned",
+          },
+        ]);
+        expect(events).toMatchObject([
+          {
+            targetStage: "summarized",
+            totalChapters: 1,
+            type: "selected",
+          },
+          {
+            chapter: {
+              chapterId: chapter.chapterId,
+              title: "Draft",
+            },
+            reason: "planned",
+            targetStage: "summarized",
+            type: "skipped",
+          },
+        ]);
+      } finally {
+        await document.release();
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- replace legacy serial-facing sdpub cat/help wording with chapter-facing commands
- improve sdpub inspection output for list, graph, and cover workflows
- simplify sdpub graph output by hiding internal scoring fields
- report sdpub stage advance progress and heartbeat messages on stderr

## Tests
- pnpm run lint:fix
- pnpm typecheck
- pnpm lint
- pnpm test:run test/cli/args.test.ts test/cli/main.test.ts test/cli/sdpub.test.ts test/cli/sdpub-stage.test.ts test/cli/sdpub-chapter.test.ts test/cli/sdpub-graph.test.ts test/cli/progress.test.ts test/facade/chapter.test.ts
- pnpm exec prettier --check src/cli/sdpub-graph.ts test/cli/sdpub-graph.test.ts
- git diff --check