### PR TITLE
Slim chapter page output

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Search and read through the archive interface:
 
 ```bash
 spinedigest list ./book.sdpub --type chapter
-spinedigest find ./book.sdpub "RAG"
+spinedigest find ./book.sdpub "RAG" --type node
 spinedigest grep ./book.sdpub "exact source phrase"
 spinedigest page ./book.sdpub node:84
 spinedigest read ./book.sdpub chapter:12
@@ -143,7 +143,7 @@ With that archive on hand, agents can search and navigate the knowledge structur
 spinedigest index ./book.sdpub
 spinedigest list ./book.sdpub --type chapter
 spinedigest list ./book.sdpub --type node --chapter 12
-spinedigest find ./book.sdpub "central argument"
+spinedigest find ./book.sdpub "central argument" --type node
 spinedigest page ./book.sdpub chapter:12
 spinedigest read ./book.sdpub chapter:12
 ```

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -82,7 +82,7 @@ spinedigest build ./book.sdpub --stage graph --confirm
 
 ```bash
 spinedigest list ./book.sdpub --type chapter
-spinedigest find ./book.sdpub "RAG"
+spinedigest find ./book.sdpub "RAG" --type node
 spinedigest grep ./book.sdpub "exact source phrase"
 spinedigest page ./book.sdpub node:84
 spinedigest read ./book.sdpub chapter:12
@@ -139,7 +139,7 @@ SpineDigest 用一套分阶段的流程来解决这件事。首先，AI 逐段�
 spinedigest index ./book.sdpub
 spinedigest list ./book.sdpub --type chapter
 spinedigest list ./book.sdpub --type node --chapter 12
-spinedigest find ./book.sdpub "central argument"
+spinedigest find ./book.sdpub "central argument" --type node
 spinedigest page ./book.sdpub chapter:12
 spinedigest read ./book.sdpub chapter:12
 ```

--- a/data/help/commands/archive/find.jinja
+++ b/data/help/commands/archive/find.jinja
@@ -30,4 +30,4 @@ Examples:
   spinedigest find book.sdpub "鄱阳湖" --type summary --json
   spinedigest find book.sdpub "亲自来到洪都" --type fragment --json
   spinedigest find book.sdpub "朱元璋 亲自 来到" --match all --json
-  spinedigest find book.sdpub "张定边" --chapter 12 --type summary,node --limit 10 --json
+  spinedigest find book.sdpub "张定边" --chapter 12 --type node --limit 10 --json

--- a/data/help/commands/archive/page.jinja
+++ b/data/help/commands/archive/page.jinja
@@ -11,7 +11,7 @@ Contract:
   - Mutates: no.
   - LLM: no.
   - JSON: yes.
-  - Chapter pages show summary, topology-derived node groups, and source preview.
+  - Chapter pages show a bounded summary preview and topology-derived node groups.
   - Node pages show generated node summary, source fragment excerpts, and local neighbor previews.
   - Fragment pages show source text, adjacent fragments, and related node labels.
   - Summary and meta pages show only their own content.

--- a/data/help/topics/recipe.jinja
+++ b/data/help/topics/recipe.jinja
@@ -20,13 +20,13 @@ Build one chapter graph:
   spinedigest build book.sdpub --stage graph --chapter 3 --confirm
 
 Find and read source-backed knowledge:
-  spinedigest find book.sdpub "knowledge graph"
+  spinedigest find book.sdpub "knowledge graph" --type node
   spinedigest page book.sdpub node:84
 
 List archive objects as JSON:
   spinedigest list book.sdpub --type node --json
   spinedigest list book.sdpub --type node --chapter 3 --json
-  spinedigest find book.sdpub "RAG" --json
+  spinedigest find book.sdpub "RAG" --type node --json
 
 Read one chapter as continuous text:
   spinedigest read book.sdpub chapter:3

--- a/data/help/topics/task.jinja
+++ b/data/help/topics/task.jinja
@@ -27,7 +27,7 @@ Understand a chapter as wiki topology:
   spinedigest page book.sdpub node:84
 
 Search and read:
-  spinedigest find book.sdpub "RAG"
+  spinedigest find book.sdpub "RAG" --type node
   spinedigest grep book.sdpub "exact source phrase"
   spinedigest page book.sdpub node:84
   spinedigest read book.sdpub chapter:3

--- a/data/help/topics/troubleshoot.jinja
+++ b/data/help/topics/troubleshoot.jinja
@@ -10,7 +10,7 @@ Search returns no matches:
 
 Page shows missing summary:
   Check:
-    For sourced chapters, `page chapter:<id>` should still show source preview and fragment ids.
+    `page chapter:<id>` remains a topology entry page; use `read chapter:<id>` for source text or `find --type fragment` to locate source fragments.
     Build summary only when a summary projection is needed.
 
 Build blocked by confirmation:

--- a/docs/en/ai-agents.md
+++ b/docs/en/ai-agents.md
@@ -18,14 +18,14 @@ Prefer archive-first CLI commands:
 spinedigest status book.sdpub
 spinedigest index book.sdpub
 spinedigest list book.sdpub --type chapter
-spinedigest find book.sdpub "keyword"
+spinedigest find book.sdpub "keyword" --type node
 spinedigest page book.sdpub node:84
 spinedigest read book.sdpub chapter:12
 ```
 
 Use three exploration modes. For synthesis, timelines, relationship analysis, process reconstruction, or concept-structure tasks, start with Structure mode: `list --type chapter`, then `page chapter:<id>` and inspect `nodeGroups`. Search mode uses `find` for candidate discovery and `grep` for exact phrases. `find` defaults to `--match any`; use `--match all` only when every keyword must appear in the same object. Reading mode uses `read` after the relevant chapter, fragment, or node has been selected.
 
-Add `--type summary,node` for concept discovery, `--type fragment` for source wording, and `--chapter`, `--limit`, and `--cursor` to keep retrieval bounded.
+Untyped `find` is broad candidate discovery. For content understanding, choose a search lens: `--type node` for topology / LLM Wiki structure, `--type summary` for quick overview, or `--type fragment` for original source wording. Use `--chapter`, `--limit`, and `--cursor` to keep retrieval bounded.
 
 Use the library API only when the surrounding system explicitly needs in-process integration.
 

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -23,7 +23,10 @@ spinedigest page <archive.sdpub> <id> [--json]
 spinedigest read <archive.sdpub> <id>
 spinedigest links <archive.sdpub> <node:id> [--json]
 spinedigest backlinks <archive.sdpub> <node:id> [--json]
+spinedigest related <archive.sdpub> <node:id> [--json]
 spinedigest path <archive.sdpub> <node:id> <node:id> --chapter <id>
+spinedigest map <archive.sdpub> [--json]
+spinedigest pack <archive.sdpub> <id> [--budget <chars>] [--json]
 spinedigest export <archive.sdpub> --output-format <format> [--output <path>]
 ```
 
@@ -36,10 +39,11 @@ Exploration modes:
 Search and collection behavior:
 
 - `find` is deterministic keyword discovery. It splits the query on whitespace, defaults to `--match any`, and ranks objects that match more terms first.
+- Untyped `find` is broad candidate discovery. For content understanding, choose a search lens: `--type node` for topology / LLM Wiki structure, `--type summary` for quick overview, or `--type fragment` for original source wording.
 - `find --match all` is the strict mode where every keyword must appear in the same object.
 - `grep` is exact text search. It treats the query as one continuous string.
 - `--chapter 12` or `--chapter 11,12` limits results to chapters.
-- `--type chapter,summary,node,fragment,meta` limits `list`; `find` and `grep` search `summary,node,fragment`.
+- `--type chapter,summary,node,fragment,meta` limits `list`; `find` and `grep` accept `--type summary,node,fragment` as search lenses. Untyped search also checks metadata and chapter titles for broad candidate discovery.
 - `--order doc-asc|doc-desc` sorts by stable document position. Default is `doc-asc`.
 - `--limit` defaults to `20`; pass returned `nextCursor` back through `--cursor` for the next page.
 - Neither command does semantic expansion, fuzzy matching, stemming, or vector search.
@@ -84,8 +88,8 @@ Extension mapping:
 Read/search/navigation commands support `--json` for machine consumption:
 
 ```bash
-spinedigest find book.sdpub "RAG" --json
-spinedigest page book.sdpub node:84 --json
+spinedigest find book.sdpub "RAG" --type node --json
+spinedigest page book.sdpub chapter:3 --json
 ```
 
 Human-readable stdout is Markdown-like text with stable ids and suggested next commands.
@@ -103,7 +107,7 @@ Archive maintenance commands remain available as top-level commands:
 ```bash
 spinedigest meta <archive.sdpub> [metadata options] [--json]
 spinedigest cover <archive.sdpub>
-spinedigest chapter <list|status|add|remove|reset|set-source|set-summary> <path> [options]
+spinedigest chapter <list|status|add|remove|reset|set-source|set-summary|set-title> <path> [options]
 ```
 
 Use archive-first commands for routine exploration. Maintenance commands are for metadata edits, cover extraction, and chapter tree edits.

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -62,10 +62,14 @@ spinedigest build ./book.sdpub --stage graph --chapter 3 --confirm
 ## 6. Search And Read
 
 ```bash
-spinedigest find ./book.sdpub "central argument"
+spinedigest list ./book.sdpub --type chapter
+spinedigest page ./book.sdpub chapter:3
+spinedigest find ./book.sdpub "central argument" --type node
 spinedigest page ./book.sdpub node:84
 spinedigest links ./book.sdpub node:84
 ```
+
+Use untyped `find` for broad candidate discovery. For content understanding, choose a search lens: `--type node` for topology, `--type summary` for quick overview, or `--type fragment` for original source wording.
 
 Use `--json` when another tool will consume the output.
 

--- a/docs/zh-CN/ai-agents.md
+++ b/docs/zh-CN/ai-agents.md
@@ -18,14 +18,14 @@
 spinedigest status book.sdpub
 spinedigest index book.sdpub
 spinedigest list book.sdpub --type chapter
-spinedigest find book.sdpub "keyword"
+spinedigest find book.sdpub "keyword" --type node
 spinedigest page book.sdpub node:84
 spinedigest read book.sdpub chapter:12
 ```
 
 优先先选择三种探索模式之一。对于综合理解、时间线、关系分析、过程梳理或概念结构任务，先走结构模式：`list --type chapter`，再 `page chapter:<id>` 并检查 `nodeGroups`。搜索模式用 `find` 做候选定位，用 `grep` 检查连续精确短语。`find` 默认是 `--match any`；只有必须要求全部关键词出现在同一个对象内时，才使用 `--match all`。阅读模式适合在选定相关 chapter、fragment 或 node 后用 `read` 输出连续文本。
 
-概念发现可加 `--type summary,node`，追原文可加 `--type fragment`，并用 `--chapter`、`--limit`、`--cursor` 控制检索范围。
+无 `--type` 的 `find` 适合广泛发现候选内容。做内容理解时，选择一个 search lens：`--type node` 用于拓扑 / LLM Wiki 结构，`--type summary` 用于快速概览，`--type fragment` 用于原文措辞。使用 `--chapter`、`--limit`、`--cursor` 控制检索范围。
 
 只有外围系统明确需要进程内集成时，才使用 library API。
 

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -23,7 +23,10 @@ spinedigest page <archive.sdpub> <id> [--json]
 spinedigest read <archive.sdpub> <id>
 spinedigest links <archive.sdpub> <node:id> [--json]
 spinedigest backlinks <archive.sdpub> <node:id> [--json]
+spinedigest related <archive.sdpub> <node:id> [--json]
 spinedigest path <archive.sdpub> <node:id> <node:id> --chapter <id>
+spinedigest map <archive.sdpub> [--json]
+spinedigest pack <archive.sdpub> <id> [--budget <chars>] [--json]
 spinedigest export <archive.sdpub> --output-format <format> [--output <path>]
 ```
 
@@ -36,10 +39,11 @@ spinedigest export <archive.sdpub> --output-format <format> [--output <path>]
 搜索与集合行为：
 
 - `find` 是确定性的关键词发现。它按空白拆分 query，默认 `--match any`，并优先返回命中更多关键词的对象。
+- 无 `--type` 的 `find` 适合广泛发现候选内容。做内容理解时，选择一个 search lens：`--type node` 用于拓扑 / LLM Wiki 结构，`--type summary` 用于快速概览，`--type fragment` 用于原文措辞。
 - `find --match all` 是严格模式，要求同一个对象内包含全部关键词。
 - `grep` 是精确文本搜索。它把 query 当作一个连续字符串。
 - `--chapter 12` 或 `--chapter 11,12` 用于限定章节。
-- `--type chapter,summary,node,fragment,meta` 用于限定 `list`；`find` 和 `grep` 搜索 `summary,node,fragment`。
+- `--type chapter,summary,node,fragment,meta` 用于限定 `list`；`find` 和 `grep` 接受 `--type summary,node,fragment` 作为 search lens。无 `--type` 的搜索也会检查 metadata 和 chapter title，用于广泛发现候选内容。
 - `--order doc-asc|doc-desc` 按稳定文档位置排序，默认 `doc-asc`。
 - `--limit` 默认 `20`；下一页把返回的 `nextCursor` 传给 `--cursor`。
 - 两个命令都不做语义扩展、模糊匹配、词干匹配或向量搜索。
@@ -84,8 +88,8 @@ spinedigest export <archive.sdpub> --output-format <format> [--output <path>]
 读取、搜索和导航命令支持 `--json`：
 
 ```bash
-spinedigest find book.sdpub "RAG" --json
-spinedigest page book.sdpub node:84 --json
+spinedigest find book.sdpub "RAG" --type node --json
+spinedigest page book.sdpub chapter:3 --json
 ```
 
 默认 stdout 是适合人和 Agent 阅读的 Markdown-like 文本，包含稳定 ID 和下一步命令提示。
@@ -103,7 +107,7 @@ spinedigest transform [--input <path>] [--output <path>] [--input-format <format
 ```bash
 spinedigest meta <archive.sdpub> [metadata options] [--json]
 spinedigest cover <archive.sdpub>
-spinedigest chapter <list|status|add|remove|reset|set-source|set-summary> <path> [options]
+spinedigest chapter <list|status|add|remove|reset|set-source|set-summary|set-title> <path> [options]
 ```
 
 常规探索请使用 archive-first commands。维护命令用于 metadata 编辑、cover 提取和 chapter tree 编辑。

--- a/docs/zh-CN/quickstart.md
+++ b/docs/zh-CN/quickstart.md
@@ -62,10 +62,14 @@ spinedigest build ./book.sdpub --stage graph --chapter 3 --confirm
 ## 6. 搜索和阅读
 
 ```bash
-spinedigest find ./book.sdpub "central argument"
+spinedigest list ./book.sdpub --type chapter
+spinedigest page ./book.sdpub chapter:3
+spinedigest find ./book.sdpub "central argument" --type node
 spinedigest page ./book.sdpub node:84
 spinedigest links ./book.sdpub node:84
 ```
+
+无 `--type` 的 `find` 适合广泛发现候选内容。做内容理解时，选择一个 search lens：`--type node` 用于拓扑结构，`--type summary` 用于快速概览，`--type fragment` 用于原文措辞。
 
 输出要交给其他工具消费时，使用 `--json`。
 

--- a/src/cli/archive.ts
+++ b/src/cli/archive.ts
@@ -619,9 +619,9 @@ async function writePage(page: ArchivePage, json: boolean): Promise<void> {
           ...formatNodeGroups(page.nodeGroups),
           "",
           "Summary:",
-          formatLongPageText(page.content ?? "[summary missing]"),
+          `${page.summary ?? "[summary missing]"}${page.summaryTruncated ? "\n[summary truncated]" : ""}`,
           "",
-          formatChapterSourcePreview(page),
+          formatChapterNextSteps(page),
         ].join("\n") + "\n",
       );
       return;
@@ -828,12 +828,12 @@ function formatNodeGroups(
   }
 
   const visibleGroups = groups.slice(0, 12);
-  const lines = visibleGroups.flatMap((group, index) => {
+  const lines = visibleGroups.flatMap((group) => {
     const visibleNodes = group.nodes.slice(0, 10);
     const moreNodes = group.nodeCount - visibleNodes.length;
 
     return [
-      `  Group ${index + 1}  ${group.nodeCount} nodes  ${formatSpan(group.span)}`,
+      `  Group ${group.groupId}  ${group.nodeCount} nodes`,
       ...formatNodeLabels(visibleNodes).map((line) => `  ${line}`),
       ...(moreNodes > 0 ? [`    ... ${moreNodes} more nodes`] : []),
     ];
@@ -889,23 +889,6 @@ function formatPosition(
   ]
     .filter((part): part is string => part !== undefined)
     .join(", ");
-}
-
-function formatSpan(span: {
-  readonly end?: {
-    readonly chapter: number;
-    readonly fragment?: number;
-  };
-  readonly start?: {
-    readonly chapter: number;
-    readonly fragment?: number;
-  };
-}): string {
-  if (span.start === undefined && span.end === undefined) {
-    return "span [unknown]";
-  }
-
-  return `span ${formatPosition(span.start)} -> ${formatPosition(span.end)}`;
 }
 
 function formatDuration(seconds: number): string {
@@ -983,7 +966,7 @@ function formatProgressStep(step: "graph" | "summary"): string {
 function formatPackAnchor(anchor: ArchivePage): string {
   switch (anchor.type) {
     case "chapter":
-      return `${anchor.id} ${anchor.title}\n${anchor.content ?? "[summary missing]"}`;
+      return `${anchor.id} ${anchor.title}\n${anchor.summary ?? "[summary missing]"}`;
     case "fragment":
       return `${anchor.id}\n${anchor.fragment.text}`;
     case "meta":
@@ -1003,28 +986,15 @@ function formatPackAnchor(anchor: ArchivePage): string {
   }
 }
 
-function formatChapterSourcePreview(
+function formatChapterNextSteps(
   page: Extract<ArchivePage, { readonly type: "chapter" }>,
 ): string {
-  const lines: string[] = [];
-
-  if (page.sourcePreview !== undefined) {
-    lines.push("Source Preview:", page.sourcePreview);
-  }
-
-  lines.push(
-    "",
+  return [
     "Next:",
     `  spinedigest list <archive.sdpub> --type node --chapter ${page.chapter.chapterId}`,
     `  spinedigest find <archive.sdpub> <keyword> --chapter ${page.chapter.chapterId}`,
     `  spinedigest read <archive.sdpub> ${page.id}`,
-  );
-
-  return lines.join("\n");
-}
-
-function formatLongPageText(text: string): string {
-  return text.length > 1200 ? `${text.slice(0, 1197)}...` : text;
+  ].join("\n");
 }
 
 function truncateToBudget(text: string, budget: number): string {

--- a/src/facade/archive-view.ts
+++ b/src/facade/archive-view.ts
@@ -148,12 +148,11 @@ export interface ArchiveListItem {
 export type ArchivePage =
   | {
       readonly chapter: ChapterEntry;
-      readonly content: string | undefined;
-      readonly fragments: readonly ArchiveSourceFragment[];
       readonly id: string;
       readonly nodeGroups: readonly ArchiveNodeGroup[];
       readonly nodeCount: number;
-      readonly sourcePreview: string | undefined;
+      readonly summary: string | undefined;
+      readonly summaryTruncated: boolean;
       readonly title: string;
       readonly type: "chapter";
     }
@@ -218,21 +217,18 @@ export interface ArchivePack {
 
 export interface ArchiveNodeGroup {
   readonly groupId: number;
-  readonly id: string;
   readonly nodeCount: number;
   readonly nodes: readonly ArchiveNodeLabel[];
-  readonly span: {
-    readonly end?: ArchiveFindPosition;
-    readonly start?: ArchiveFindPosition;
-  };
-  readonly weight: number;
-  readonly wordsCount: number;
 }
 
 export interface ArchiveNodeLabel {
   readonly id: string;
-  readonly position: ArchiveFindPosition | undefined;
   readonly title: string;
+}
+
+interface PositionedNodeLabel {
+  readonly label: ArchiveNodeLabel;
+  readonly position: ArchiveFindPosition | undefined;
 }
 
 export interface ArchiveSourceFragment {
@@ -553,20 +549,21 @@ export async function readArchivePage(
   switch (reference.type) {
     case "chapter": {
       const chapter = await requireChapter(document, reference.id);
-      const [fragments, nodeGroups, nodes] = await Promise.all([
-        listChapterSourceFragments(document, reference.id),
+      const [nodeGroups, nodes, summary] = await Promise.all([
         listChapterNodeGroups(document, reference.id),
         document.chunks.listBySerial(reference.id),
+        document.readSummary(reference.id),
       ]);
+      const summaryPreview =
+        summary === undefined ? undefined : truncatePageSummary(summary);
 
       return {
         chapter,
-        content: await document.readSummary(reference.id),
-        fragments,
         id: formatChapterId(reference.id),
         nodeCount: nodes.length,
         nodeGroups,
-        sourcePreview: createSourcePreview(fragments),
+        summary: summaryPreview?.text,
+        summaryTruncated: summaryPreview?.truncated ?? false,
         title: chapter.title ?? `[chapter ${reference.id}]`,
         type: "chapter",
       };
@@ -930,10 +927,7 @@ async function listChapterNodeGroups(
       snakes.map(async (snake) =>
         createArchiveNodeGroup({
           groupId: snake.localSnakeId,
-          id: `node-group:${chapterId}:${snake.localSnakeId}`,
           nodes: await listSnakeNodeLabels(document, snake),
-          weight: snake.weight,
-          wordsCount: snake.wordsCount,
         }),
       ),
     )
@@ -945,15 +939,15 @@ async function listChapterNodeGroupsByFragment(
   chapterId: number,
 ): Promise<readonly ArchiveNodeGroup[]> {
   const nodes = (await document.chunks.listBySerial(chapterId))
-    .map(createNodeLabel)
-    .sort(compareNodeLabels);
+    .map(createPositionedNodeLabel)
+    .sort(comparePositionedNodeLabels);
   const nodesByFragment = new Map<number, ArchiveNodeLabel[]>();
 
   for (const node of nodes) {
     const fragmentId = node.position?.fragment ?? -1;
     const groupNodes = nodesByFragment.get(fragmentId) ?? [];
 
-    groupNodes.push(node);
+    groupNodes.push(node.label);
     nodesByFragment.set(fragmentId, groupNodes);
   }
 
@@ -961,45 +955,22 @@ async function listChapterNodeGroupsByFragment(
     .sort(([leftFragment], [rightFragment]) =>
       compareNumbers(leftFragment, rightFragment),
     )
-    .map(([fragmentId, groupNodes], index) =>
+    .map(([, groupNodes], index) =>
       createArchiveNodeGroup({
         groupId: index,
-        id:
-          fragmentId < 0
-            ? `node-group:${chapterId}:unknown`
-            : `node-group:${chapterId}:fragment:${fragmentId}`,
         nodes: groupNodes,
-        weight: groupNodes.length,
-        wordsCount: 0,
       }),
     );
 }
 
 function createArchiveNodeGroup(input: {
   readonly groupId: number;
-  readonly id: string;
   readonly nodes: readonly ArchiveNodeLabel[];
-  readonly weight: number;
-  readonly wordsCount: number;
 }): ArchiveNodeGroup {
-  const positions = input.nodes
-    .map((node) => node.position)
-    .filter(isDefined)
-    .sort(compareArchivePositions);
-
   return {
     groupId: input.groupId,
-    id: input.id,
     nodeCount: input.nodes.length,
     nodes: input.nodes,
-    span: {
-      ...(positions[positions.length - 1] === undefined
-        ? {}
-        : { end: positions[positions.length - 1] }),
-      ...(positions[0] === undefined ? {} : { start: positions[0] }),
-    },
-    weight: input.weight,
-    wordsCount: input.wordsCount,
   };
 }
 
@@ -1013,13 +984,16 @@ async function listSnakeNodeLabels(
         async (chunkId) => {
           const chunk = await document.chunks.getById(chunkId);
 
-          return chunk === undefined ? undefined : createNodeLabel(chunk);
+          return chunk === undefined
+            ? undefined
+            : createPositionedNodeLabel(chunk);
         },
       ),
     )
   )
     .filter(isDefined)
-    .sort(compareNodeLabels);
+    .sort(comparePositionedNodeLabels)
+    .map(({ label }) => label);
 }
 
 async function listFragmentNodes(
@@ -1028,21 +1002,28 @@ async function listFragmentNodes(
   fragmentId: number,
 ): Promise<readonly ArchiveNodeLabel[]> {
   return (await document.chunks.listByFragments(chapterId, [fragmentId]))
-    .map(createNodeLabel)
-    .sort(compareNodeLabels);
+    .map(createPositionedNodeLabel)
+    .sort(comparePositionedNodeLabels)
+    .map(({ label }) => label);
 }
 
 function createNodeLabel(node: ChunkRecord): ArchiveNodeLabel {
   return {
     id: formatNodeId(node.id),
-    position: createNodePosition(node.sentenceIds),
     title: node.label,
   };
 }
 
-function compareNodeLabels(
-  left: ArchiveNodeLabel,
-  right: ArchiveNodeLabel,
+function createPositionedNodeLabel(node: ChunkRecord): PositionedNodeLabel {
+  return {
+    label: createNodeLabel(node),
+    position: createNodePosition(node.sentenceIds),
+  };
+}
+
+function comparePositionedNodeLabels(
+  left: PositionedNodeLabel,
+  right: PositionedNodeLabel,
 ): number {
   if (left.position !== undefined && right.position !== undefined) {
     return compareArchivePositions(left.position, right.position);
@@ -1056,18 +1037,7 @@ function compareNodeLabels(
     return 1;
   }
 
-  return left.id.localeCompare(right.id);
-}
-
-function createSourcePreview(
-  fragments: readonly ArchiveSourceFragment[],
-): string | undefined {
-  const text = fragments
-    .map((fragment) => fragment.text)
-    .join("\n")
-    .trim();
-
-  return text === "" ? undefined : createSnippet(text);
+  return left.label.id.localeCompare(right.label.id);
 }
 
 function findMeta(
@@ -1338,6 +1308,7 @@ interface ArchiveTextMatch {
 }
 
 const DEFAULT_FIND_LIMIT = 20;
+const PAGE_SUMMARY_LIMIT = 1600;
 
 const BROAD_FIND_LENS_HINT = {
   lenses: {
@@ -1562,6 +1533,20 @@ function createSearchTerms(query: string): readonly string[] {
     .toLowerCase()
     .split(/\s+/u)
     .filter((term) => term !== "");
+}
+
+function truncatePageSummary(text: string): {
+  readonly text: string;
+  readonly truncated: boolean;
+} {
+  if (text.length <= PAGE_SUMMARY_LIMIT) {
+    return { text, truncated: false };
+  }
+
+  return {
+    text: `${text.slice(0, PAGE_SUMMARY_LIMIT - 3)}...`,
+    truncated: true,
+  };
 }
 
 function getPositionChapter(hit: ArchiveFindHit): number {

--- a/test/cli/archive.test.ts
+++ b/test/cli/archive.test.ts
@@ -131,36 +131,26 @@ const archiveMockState = vi.hoisted(() => ({
       title: "Chapter 2",
       tocPath: ["Chapter 2"],
     },
-    content: `Long summary ${"summary ".repeat(220)}`,
-    fragments: [],
     id: "chapter:2",
     nodeCount: 2,
     nodeGroups: [
       {
         groupId: 0,
-        id: "node-group:2:0",
         nodeCount: 2,
         nodes: [
           {
             id: "node:9",
-            position: { chapter: 2, fragment: 0 },
             title: "Retrieval design",
           },
           {
             id: "node:11",
-            position: { chapter: 2, fragment: 0 },
             title: "Related",
           },
         ],
-        span: {
-          end: { chapter: 2, fragment: 0 },
-          start: { chapter: 2, fragment: 0 },
-        },
-        weight: 1,
-        wordsCount: 7,
       },
     ],
-    sourcePreview: "Chapter source preview.",
+    summary: `Long summary ${"summary ".repeat(120)}`,
+    summaryTruncated: true,
     title: "Chapter 2",
     type: "chapter",
   },
@@ -481,7 +471,8 @@ describe("cli/archive", () => {
       output.indexOf("Summary:"),
     );
     expect(output).toContain("node:9  Retrieval design");
-    expect(output).toContain("Source Preview:");
+    expect(output).not.toContain("Source Preview:");
+    expect(output).toContain("[summary truncated]");
     expect(output.length).toBeLessThan(1800);
   });
 

--- a/test/facade/archive-view.test.ts
+++ b/test/facade/archive-view.test.ts
@@ -211,7 +211,7 @@ describe("facade/archive-view", () => {
     });
   });
 
-  it("shows source previews on sourced chapter pages", async () => {
+  it("keeps chapter pages compact for topology exploration", async () => {
     await withTempDir("spinedigest-archive-view-", async (path) => {
       const document = await DirectoryDocument.open(`${path}/document`);
 
@@ -225,7 +225,14 @@ describe("facade/archive-view", () => {
         if (page.type !== "chapter") {
           throw new Error("Expected chapter page");
         }
-        expect(page.sourcePreview).toContain("LLM Wiki");
+        expect(page.summary).toContain("Summary");
+        expect(page.summaryTruncated).toBe(true);
+        expect(JSON.stringify(page)).not.toContain("sourcePreview");
+        expect(JSON.stringify(page)).not.toContain("fragments");
+        expect(JSON.stringify(page)).not.toContain("position");
+        expect(JSON.stringify(page)).not.toContain("span");
+        expect(JSON.stringify(page)).not.toContain("weight");
+        expect(JSON.stringify(page)).not.toContain("wordsCount");
       } finally {
         await document.release();
       }
@@ -268,6 +275,7 @@ describe("facade/archive-view", () => {
           nodeCount: 2,
           nodeGroups: [
             expect.objectContaining({
+              groupId: 0,
               nodeCount: 2,
               nodes: [
                 expect.objectContaining({
@@ -338,7 +346,7 @@ describe("facade/archive-view", () => {
           nodeCount: 2,
           nodeGroups: [
             expect.objectContaining({
-              id: "node-group:1:fragment:0",
+              groupId: 0,
               nodeCount: 2,
               nodes: [
                 expect.objectContaining({
@@ -459,6 +467,7 @@ async function seedSourcedDocument(
         snakeId,
       });
     }
+    await openedDocument.writeSummary(1, `Summary ${"detail ".repeat(400)}`);
     await openedDocument.writeBookMeta({
       authors: [],
       description: null,


### PR DESCRIPTION
## Summary
- Slim `page chapter:<id>` so it stays a topology entry page instead of expanding source fragments.
- Replace chapter page `content` with bounded `summary` / `summaryTruncated` output.
- Remove internal node group fields from chapter page JSON, keeping only `groupId`, `nodeCount`, and node labels.
- Align README, public docs, and help recipes with typed `find` search lenses and the new chapter page behavior.

## Verification
- `pnpm verify`
- `pnpm test:run`
- Smoke tested `page ../martials/明朝那些事儿.sdpub chapter:12 --json` and confirmed removed fields are absent.
