### PR TITLE
docs: clarify agent archive exploration guidance

### DIFF
--- a/data/help/commands/archive/index.jinja
+++ b/data/help/commands/archive/index.jinja
@@ -3,6 +3,8 @@ Command: spinedigest index
 
 Purpose:
   Show the archive home/index page and entry points.
+  This is most useful for archive-level readiness and metadata such as title, source format, chapter count, summary count, node count, and edge count.
+  For content exploration after `chapter tree`, choosing chapter ids and using scoped `list --chapter <ids>` usually returns more local context.
 
 Usage:
   spinedigest index <archive.sdpub> [--json]

--- a/data/help/commands/archive/read.jinja
+++ b/data/help/commands/archive/read.jinja
@@ -13,7 +13,7 @@ Contract:
   - Output: plain text only.
   - Reads: chapter source text, fragment source text, summary text, generated node summary, or metadata JSON text.
 
-Use `page` for object details and local navigation. Use `read` when the task is immersive reading rather than object exploration.
+Use `page` for object details and local navigation. For evidence tracing, logic-chain reconstruction, or relationship analysis from source text, `page fragment:<id>` keeps the text with adjacent fragments and related node labels. Use `read` when the task is immersive reading rather than object exploration.
 
 Examples:
   spinedigest read book.sdpub chapter:12

--- a/data/help/topics/ai.jinja
+++ b/data/help/topics/ai.jinja
@@ -5,23 +5,24 @@ AI Agent Guide
 
 Primary contract:
   - Treat `.sdpub` as an LLM Wiki archive managed by SpineDigest.
-  - Use `spinedigest index/list/find/grep/page/read/links/backlinks/export` before unpacking or inspecting ZIP internals.
+  - Use archive commands such as `chapter tree`, `list`, `find`, `grep`, `page`, `read`, `links`, `backlinks`, and `export` before unpacking or inspecting ZIP internals.
   - Choose one of three exploration modes first: search mode (`find`/`grep`), structure mode (`chapter tree`/`list`/`page`), or reading mode (`read`).
   - In search mode, treat untyped `find` as broad candidate discovery. For content understanding, choose a search lens: `--type node`, `--type summary`, or `--type fragment`.
+  - Use `index` when archive-level readiness or metadata matters; after `chapter tree`, scoped `list --chapter <ids>` is usually a lower-context way to expand selected chapters.
   - Prefer `--json` when composing with tools.
   - Do not inspect `database.db` for routine retrieval.
   - Do not launch full-archive LLM-backed builds without estimating first.
 
 Safe first moves:
-  - Existing archive:
-    spinedigest status <archive.sdpub>
-    spinedigest index <archive.sdpub>
   - Broad understanding, synthesis, timeline, relationship, or process tasks:
     spinedigest chapter tree <archive.sdpub> --json
-    spinedigest list <archive.sdpub> --type chapter
+    spinedigest list <archive.sdpub> --type node --chapter <ids>
     spinedigest page <archive.sdpub> chapter:<id>
     # inspect nodeGroups, then:
     spinedigest page <archive.sdpub> node:<id>
+  - Archive readiness, metadata, or build state:
+    spinedigest status <archive.sdpub>
+    spinedigest index <archive.sdpub>
   - Locate candidate chapters or verify missing concepts:
     spinedigest find <archive.sdpub> <query>
     spinedigest find <archive.sdpub> <query> --type node
@@ -69,7 +70,7 @@ Maintenance commands:
   - Prefer archive-first commands unless the user specifically needs metadata mutation, cover extraction, or chapter tree edits.
 
 Discovery rule:
-  If the user question asks for synthesis, a timeline, a process, a relationship map, character development, or conceptual structure, start with `chapter tree --json` for table-of-contents hierarchy, then `list --type chapter`, then `page chapter:<id>` and inspect `nodeGroups`. Do not flatten the archive into raw text first.
+  If the user question asks for synthesis, a timeline, a process, a relationship map, character development, or conceptual structure, start with `chapter tree --json` for a compact table-of-contents map, then select likely chapter ids and use scoped `list --chapter <ids>` or `page chapter:<id>` to expand local context. This usually spends less context than returning to archive-level entry points. Do not flatten the archive into raw text first.
   Use `find` for multi-keyword discovery after the topology pass, or when you need to locate candidate chapters quickly. Whitespace separates keywords, default matching is `--match any`, and stronger matches are ranked first.
   Untyped `find` is broad candidate discovery across metadata, chapter titles, summaries, nodes, and fragments.
   For content understanding, choose a search lens: `--type node` for topology / LLM Wiki structure, `--type summary` for quick overview, or `--type fragment` for original source wording.

--- a/data/help/topics/ai.jinja
+++ b/data/help/topics/ai.jinja
@@ -9,6 +9,7 @@ Primary contract:
   - Choose one of three exploration modes first: search mode (`find`/`grep`), structure mode (`chapter tree`/`list`/`page`), or reading mode (`read`).
   - In search mode, treat untyped `find` as broad candidate discovery. For content understanding, choose a search lens: `--type node`, `--type summary`, or `--type fragment`.
   - Use `index` when archive-level readiness or metadata matters; after `chapter tree`, scoped `list --chapter <ids>` is usually a lower-context way to expand selected chapters.
+  - For evidence tracing, logic-chain reconstruction, or relationship analysis from source text, `page fragment:<id>` keeps source text with adjacent fragments and related node labels.
   - Prefer `--json` when composing with tools.
   - Do not inspect `database.db` for routine retrieval.
   - Do not launch full-archive LLM-backed builds without estimating first.
@@ -28,6 +29,7 @@ Safe first moves:
     spinedigest find <archive.sdpub> <query> --type node
     spinedigest find <archive.sdpub> <query> --type summary
     spinedigest find <archive.sdpub> <query> --type fragment
+    spinedigest page <archive.sdpub> fragment:<serial>:<fragment>
     spinedigest grep <archive.sdpub> <exact phrase>
     spinedigest list <archive.sdpub> --type node --chapter <id>
   - Continuous reading after topology selection:
@@ -77,4 +79,4 @@ Discovery rule:
   Use `find --match all` only when every keyword must appear inside the same returned object.
   Use `grep` only when checking whether an exact continuous phrase exists.
   Use `--chapter`, `--limit`, and returned `nextCursor` to keep retrieval bounded and reproducible.
-  Use `read` when the user wants to understand a chapter or fragment as prose rather than navigate object ids.
+  Use `page fragment:<id>` when source evidence should lead into related nodes or adjacent fragments. Use `read` when the user wants to understand a chapter or fragment as prose rather than navigate object ids.

--- a/data/help/topics/overview.jinja
+++ b/data/help/topics/overview.jinja
@@ -12,13 +12,14 @@ Three exploration modes:
      `find` discovers objects by deterministic keywords; `grep` checks exact text phrases.
      Treat untyped `find` as broad candidate discovery. For content understanding, choose a search lens: `--type node` for topology / LLM Wiki structure, `--type summary` for quick overview, or `--type fragment` for original source wording.
   2. Structure mode:
-     `chapter tree --json` shows table-of-contents hierarchy and chapter ordering; `list` returns bounded collections; `page` opens one detailed object with local navigation such as chapter node groups, node source fragments, and node neighbors.
+     `chapter tree --json` shows a compact table-of-contents map; scoped `list --chapter <ids>` expands selected chapters into bounded collections; `page` opens one detailed object with local navigation such as chapter node groups, node source fragments, and node neighbors.
   3. Reading mode:
      `read` prints continuous plain text for a chapter, summary, fragment, or node.
 
 Priority:
   For synthesis, timelines, relationships, process reconstruction, or concept-structure tasks, use Structure mode first:
-    chapter tree --json -> list --type chapter -> page chapter:<id>
+    chapter tree --json -> list --chapter <ids> -> page chapter:<id>
+  `index` is useful for archive-level readiness and metadata. After a chapter tree, selecting a small set of chapter ids and using scoped list/page usually spends less context for content exploration.
   Treat `find` as candidate discovery and verification, not as the default way to flatten a `.sdpub` into plain text.
 
 Mental model:
@@ -38,9 +39,8 @@ Default workflow:
   spinedigest status book.sdpub
   spinedigest estimate book.sdpub --stage summary
   spinedigest build book.sdpub --stage graph --confirm
-  spinedigest index book.sdpub
   spinedigest chapter tree book.sdpub --json
-  spinedigest list book.sdpub --type chapter
+  spinedigest list book.sdpub --type node --chapter 3,7,12
   spinedigest find book.sdpub "keyword" --type node
   spinedigest page book.sdpub node:84
   spinedigest read book.sdpub chapter:12

--- a/data/help/topics/overview.jinja
+++ b/data/help/topics/overview.jinja
@@ -15,6 +15,7 @@ Three exploration modes:
      `chapter tree --json` shows a compact table-of-contents map; scoped `list --chapter <ids>` expands selected chapters into bounded collections; `page` opens one detailed object with local navigation such as chapter node groups, node source fragments, and node neighbors.
   3. Reading mode:
      `read` prints continuous plain text for a chapter, summary, fragment, or node.
+     When source text is evidence for a logic chain or relationship task, `page fragment:<id>` keeps the text with adjacent fragments and related node labels.
 
 Priority:
   For synthesis, timelines, relationships, process reconstruction, or concept-structure tasks, use Structure mode first:
@@ -41,7 +42,8 @@ Default workflow:
   spinedigest build book.sdpub --stage graph --confirm
   spinedigest chapter tree book.sdpub --json
   spinedigest list book.sdpub --type node --chapter 3,7,12
-  spinedigest find book.sdpub "keyword" --type node
+  spinedigest find book.sdpub "keyword" --type fragment --chapter 3,7,12
+  spinedigest page book.sdpub fragment:3:4
   spinedigest page book.sdpub node:84
   spinedigest read book.sdpub chapter:12
 

--- a/docs/en/ai-agents.md
+++ b/docs/en/ai-agents.md
@@ -15,19 +15,19 @@ Do not treat `.sdpub` as a ZIP payload for routine retrieval. Treat it as a mana
 Prefer archive-first CLI commands:
 
 ```bash
-spinedigest status book.sdpub
-spinedigest index book.sdpub
 spinedigest chapter tree book.sdpub --json
-spinedigest list book.sdpub --type chapter
+spinedigest list book.sdpub --type node --chapter 3,7,12
 spinedigest find book.sdpub "keyword" --type node
 spinedigest page book.sdpub node:84
 spinedigest read book.sdpub chapter:12
 spinedigest pack book.sdpub node:84 --budget 5000
 ```
 
-Use three exploration modes. For synthesis, timelines, relationship analysis, process reconstruction, or concept-structure tasks, start with Structure mode: `chapter tree --json` for table-of-contents hierarchy, then `list --type chapter`, then `page chapter:<id>` and inspect `nodeGroups`. Search mode uses `find` for candidate discovery and `grep` for exact phrases. `find` defaults to `--match any`; use `--match all` only when every keyword must appear in the same object. Reading mode uses `read` after the relevant chapter, fragment, or node has been selected.
+Use three exploration modes. For synthesis, timelines, relationship analysis, process reconstruction, or concept-structure tasks, start with Structure mode: `chapter tree --json` for a compact table-of-contents map, then choose likely chapter ids and expand them with scoped `list --chapter <ids>` or `page chapter:<id>`. Search mode uses `find` for candidate discovery and `grep` for exact phrases. `find` defaults to `--match any`; use `--match all` only when every keyword must appear in the same object. Reading mode uses `read` after the relevant chapter, fragment, or node has been selected.
 
 Untyped `find` is broad candidate discovery. For content understanding, choose a search lens: `--type node` for topology / LLM Wiki structure, `--type summary` for quick overview, or `--type fragment` for original source wording. Use `--chapter`, `--limit`, and `--cursor` to keep retrieval bounded.
+
+`index` is useful when archive-level readiness or metadata matters: title, source format, chapter count, summary count, node count, and edge count. For content exploration after `chapter tree`, selecting a small set of chapter ids and using scoped `list --chapter <ids>` usually spends less context than returning to archive-level entry points.
 
 Use the library API only when the surrounding system explicitly needs in-process integration.
 
@@ -43,15 +43,16 @@ Use the library API only when the surrounding system explicitly needs in-process
 
 ## Recommended Execution Strategy
 
-1. For an unknown archive, run `status` and `index`.
-2. For understanding tasks, use `chapter tree --json`, then `list --type chapter`, then `page chapter:<id>` before keyword search.
+1. For content understanding, use `chapter tree --json` as the compact global map.
+2. Select likely chapter ids from the tree, then use scoped `list --chapter <ids>` or `page chapter:<id>` before keyword search.
 3. Inspect chapter `nodeGroups`, then use `page node:<id>` for relevant knowledge nodes.
 4. Use `find` or `grep` to locate candidate chapters, verify missing concepts, or check exact source wording.
 5. Use `read fragment:<id>` when the user needs original source prose after selecting a relevant node or chapter.
 6. Use `links`, `backlinks`, or `path` to navigate graph context.
 7. Use `pack` when the user needs deterministic context around a known object id.
 8. Use `export` only when the user needs a projection.
-9. Before `build`, run `estimate`; if the estimate is too large for the session, ask the user.
+9. Use `status` or `index` when archive readiness, metadata, or build state is part of the task.
+10. Before `build`, run `estimate`; if the estimate is too large for the session, ask the user.
 
 ## Build Workflow
 

--- a/docs/en/ai-agents.md
+++ b/docs/en/ai-agents.md
@@ -17,7 +17,8 @@ Prefer archive-first CLI commands:
 ```bash
 spinedigest chapter tree book.sdpub --json
 spinedigest list book.sdpub --type node --chapter 3,7,12
-spinedigest find book.sdpub "keyword" --type node
+spinedigest find book.sdpub "keyword" --type fragment --chapter 3,7,12
+spinedigest page book.sdpub fragment:3:4
 spinedigest page book.sdpub node:84
 spinedigest read book.sdpub chapter:12
 spinedigest pack book.sdpub node:84 --budget 5000
@@ -26,6 +27,8 @@ spinedigest pack book.sdpub node:84 --budget 5000
 Use three exploration modes. For synthesis, timelines, relationship analysis, process reconstruction, or concept-structure tasks, start with Structure mode: `chapter tree --json` for a compact table-of-contents map, then choose likely chapter ids and expand them with scoped `list --chapter <ids>` or `page chapter:<id>`. Search mode uses `find` for candidate discovery and `grep` for exact phrases. `find` defaults to `--match any`; use `--match all` only when every keyword must appear in the same object. Reading mode uses `read` after the relevant chapter, fragment, or node has been selected.
 
 Untyped `find` is broad candidate discovery. For content understanding, choose a search lens: `--type node` for topology / LLM Wiki structure, `--type summary` for quick overview, or `--type fragment` for original source wording. Use `--chapter`, `--limit`, and `--cursor` to keep retrieval bounded.
+
+For evidence tracing, logic-chain reconstruction, or relationship analysis that starts from source text, `page fragment:<id>` is often more useful than `read fragment:<id>` because it keeps the source text together with adjacent fragments and related node labels. Use `read chapter:<id>` or `read fragment:<id>` when continuous prose is the goal.
 
 `index` is useful when archive-level readiness or metadata matters: title, source format, chapter count, summary count, node count, and edge count. For content exploration after `chapter tree`, selecting a small set of chapter ids and using scoped `list --chapter <ids>` usually spends less context than returning to archive-level entry points.
 
@@ -47,12 +50,13 @@ Use the library API only when the surrounding system explicitly needs in-process
 2. Select likely chapter ids from the tree, then use scoped `list --chapter <ids>` or `page chapter:<id>` before keyword search.
 3. Inspect chapter `nodeGroups`, then use `page node:<id>` for relevant knowledge nodes.
 4. Use `find` or `grep` to locate candidate chapters, verify missing concepts, or check exact source wording.
-5. Use `read fragment:<id>` when the user needs original source prose after selecting a relevant node or chapter.
-6. Use `links`, `backlinks`, or `path` to navigate graph context.
-7. Use `pack` when the user needs deterministic context around a known object id.
-8. Use `export` only when the user needs a projection.
-9. Use `status` or `index` when archive readiness, metadata, or build state is part of the task.
-10. Before `build`, run `estimate`; if the estimate is too large for the session, ask the user.
+5. Use `page fragment:<id>` when source evidence should lead into related nodes or adjacent fragments.
+6. Use `read` when the user needs prose rather than object navigation.
+7. Use `links`, `backlinks`, or `path` to navigate graph context.
+8. Use `pack` when the user needs deterministic context around a known object id.
+9. Use `export` only when the user needs a projection.
+10. Use `status` or `index` when archive readiness, metadata, or build state is part of the task.
+11. Before `build`, run `estimate`; if the estimate is too large for the session, ask the user.
 
 ## Build Workflow
 

--- a/docs/zh-CN/ai-agents.md
+++ b/docs/zh-CN/ai-agents.md
@@ -15,19 +15,19 @@
 优先使用 archive-first CLI：
 
 ```bash
-spinedigest status book.sdpub
-spinedigest index book.sdpub
 spinedigest chapter tree book.sdpub --json
-spinedigest list book.sdpub --type chapter
+spinedigest list book.sdpub --type node --chapter 3,7,12
 spinedigest find book.sdpub "keyword" --type node
 spinedigest page book.sdpub node:84
 spinedigest read book.sdpub chapter:12
 spinedigest pack book.sdpub node:84 --budget 5000
 ```
 
-优先先选择三种探索模式之一。对于综合理解、时间线、关系分析、过程梳理或概念结构任务，先走结构模式：用 `chapter tree --json` 查看目录层级，再用 `list --type chapter`，再 `page chapter:<id>` 并检查 `nodeGroups`。搜索模式用 `find` 做候选定位，用 `grep` 检查连续精确短语。`find` 默认是 `--match any`；只有必须要求全部关键词出现在同一个对象内时，才使用 `--match all`。阅读模式适合在选定相关 chapter、fragment 或 node 后用 `read` 输出连续文本。
+优先先选择三种探索模式之一。对于综合理解、时间线、关系分析、过程梳理或概念结构任务，先走结构模式：用 `chapter tree --json` 查看压缩后的目录地图，再选择可能相关的 chapter id，并用带范围的 `list --chapter <ids>` 或 `page chapter:<id>` 展开局部。搜索模式用 `find` 做候选定位，用 `grep` 检查连续精确短语。`find` 默认是 `--match any`；只有必须要求全部关键词出现在同一个对象内时，才使用 `--match all`。阅读模式适合在选定相关 chapter、fragment 或 node 后用 `read` 输出连续文本。
 
 无 `--type` 的 `find` 适合广泛发现候选内容。做内容理解时，选择一个 search lens：`--type node` 用于拓扑 / LLM Wiki 结构，`--type summary` 用于快速概览，`--type fragment` 用于原文措辞。使用 `--chapter`、`--limit`、`--cursor` 控制检索范围。
+
+`index` 适合在需要归档级 readiness 或元信息时使用，例如标题、source format、章节数、summary 数、node 数和 edge 数。对于 `chapter tree` 之后的内容探索，先选择少量 chapter id，再用带范围的 `list --chapter <ids>` 展开局部，通常比回到归档级入口更节省上下文。
 
 只有外围系统明确需要进程内集成时，才使用 library API。
 
@@ -43,15 +43,16 @@ spinedigest pack book.sdpub node:84 --budget 5000
 
 ## 推荐执行策略
 
-1. 面对未知归档，先运行 `status` 和 `index`。
-2. 对理解型任务，先用 `chapter tree --json`，再用 `list --type chapter`，再在关键词搜索前使用 `page chapter:<id>`。
+1. 对内容理解任务，先用 `chapter tree --json` 作为压缩后的全局地图。
+2. 从 tree 中选择可能相关的 chapter id，再用带范围的 `list --chapter <ids>` 或 `page chapter:<id>`，然后再做关键词搜索。
 3. 检查 chapter 的 `nodeGroups`，再对相关知识节点使用 `page node:<id>`。
 4. 用 `find` 或 `grep` 定位候选章节、验证缺失概念，或检查精确原文。
 5. 选定相关 node 或 chapter 后，当用户需要原文 prose 时，用 `read fragment:<id>`。
 6. 用 `links`、`backlinks` 或 `path` 导航图上下文。
 7. 用户需要围绕已知 object id 打包确定性上下文时，使用 `pack`。
 8. 只有用户需要 projection 时才 `export`。
-9. `build` 前先 `estimate`；如果估算超出当前交互预算，先询问用户。
+9. 当任务涉及归档 readiness、元信息或构建状态时，再使用 `status` 或 `index`。
+10. `build` 前先 `estimate`；如果估算超出当前交互预算，先询问用户。
 
 ## 构建流程
 

--- a/docs/zh-CN/ai-agents.md
+++ b/docs/zh-CN/ai-agents.md
@@ -17,7 +17,8 @@
 ```bash
 spinedigest chapter tree book.sdpub --json
 spinedigest list book.sdpub --type node --chapter 3,7,12
-spinedigest find book.sdpub "keyword" --type node
+spinedigest find book.sdpub "keyword" --type fragment --chapter 3,7,12
+spinedigest page book.sdpub fragment:3:4
 spinedigest page book.sdpub node:84
 spinedigest read book.sdpub chapter:12
 spinedigest pack book.sdpub node:84 --budget 5000
@@ -26,6 +27,8 @@ spinedigest pack book.sdpub node:84 --budget 5000
 优先先选择三种探索模式之一。对于综合理解、时间线、关系分析、过程梳理或概念结构任务，先走结构模式：用 `chapter tree --json` 查看压缩后的目录地图，再选择可能相关的 chapter id，并用带范围的 `list --chapter <ids>` 或 `page chapter:<id>` 展开局部。搜索模式用 `find` 做候选定位，用 `grep` 检查连续精确短语。`find` 默认是 `--match any`；只有必须要求全部关键词出现在同一个对象内时，才使用 `--match all`。阅读模式适合在选定相关 chapter、fragment 或 node 后用 `read` 输出连续文本。
 
 无 `--type` 的 `find` 适合广泛发现候选内容。做内容理解时，选择一个 search lens：`--type node` 用于拓扑 / LLM Wiki 结构，`--type summary` 用于快速概览，`--type fragment` 用于原文措辞。使用 `--chapter`、`--limit`、`--cursor` 控制检索范围。
+
+当任务从原文出发追踪证据、逻辑链或关系时，`page fragment:<id>` 往往比 `read fragment:<id>` 更有用，因为它把 source text、相邻 fragments 和相关 node labels 放在一起。目标是连续阅读 prose 时，再使用 `read chapter:<id>` 或 `read fragment:<id>`。
 
 `index` 适合在需要归档级 readiness 或元信息时使用，例如标题、source format、章节数、summary 数、node 数和 edge 数。对于 `chapter tree` 之后的内容探索，先选择少量 chapter id，再用带范围的 `list --chapter <ids>` 展开局部，通常比回到归档级入口更节省上下文。
 
@@ -47,12 +50,13 @@ spinedigest pack book.sdpub node:84 --budget 5000
 2. 从 tree 中选择可能相关的 chapter id，再用带范围的 `list --chapter <ids>` 或 `page chapter:<id>`，然后再做关键词搜索。
 3. 检查 chapter 的 `nodeGroups`，再对相关知识节点使用 `page node:<id>`。
 4. 用 `find` 或 `grep` 定位候选章节、验证缺失概念，或检查精确原文。
-5. 选定相关 node 或 chapter 后，当用户需要原文 prose 时，用 `read fragment:<id>`。
-6. 用 `links`、`backlinks` 或 `path` 导航图上下文。
-7. 用户需要围绕已知 object id 打包确定性上下文时，使用 `pack`。
-8. 只有用户需要 projection 时才 `export`。
-9. 当任务涉及归档 readiness、元信息或构建状态时，再使用 `status` 或 `index`。
-10. `build` 前先 `estimate`；如果估算超出当前交互预算，先询问用户。
+5. 当原文证据需要继续进入相关 node 或相邻 fragment 时，使用 `page fragment:<id>`。
+6. 当用户需要 prose 而不是对象导航时，使用 `read`。
+7. 用 `links`、`backlinks` 或 `path` 导航图上下文。
+8. 用户需要围绕已知 object id 打包确定性上下文时，使用 `pack`。
+9. 只有用户需要 projection 时才 `export`。
+10. 当任务涉及归档 readiness、元信息或构建状态时，再使用 `status` 或 `index`。
+11. `build` 前先 `estimate`；如果估算超出当前交互预算，先询问用户。
 
 ## 构建流程
 


### PR DESCRIPTION
## Summary
- clarify that agent content exploration should start from chapter tree and then use scoped list/page calls
- describe when index is useful for archive-level readiness and metadata
- document page fragment:<id> as the better source-evidence entry point for logic-chain and relationship analysis

## Checks
- pnpm run lint:fix