### PR TITLE
Fix build queue slot refilling

### DIFF
--- a/src/facade/build-queue.ts
+++ b/src/facade/build-queue.ts
@@ -479,7 +479,8 @@ export async function runBuildJobWorker(
   const concurrency = Math.max(1, options.concurrency);
   const idleTimeoutMs = options.idleTimeoutMs ?? 10_000;
   let stopping = false;
-  let lastWorkAt = Date.now();
+  let busySlotCount = 0;
+  let idleSince = Date.now();
 
   const stop = (): void => {
     stopping = true;
@@ -499,46 +500,74 @@ export async function runBuildJobWorker(
       return;
     }
 
-    while (!stopping) {
-      await heartbeatBuildWorker(ownerId, state);
-      await recoverStaleBuildJobs(state);
-      const jobs = await claimQueuedBuildJobs(state, ownerId, concurrency);
+    const runSlot = async (): Promise<void> => {
+      while (!stopping) {
+        await heartbeatBuildWorker(ownerId, state);
+        await recoverStaleBuildJobs(state);
 
-      if (jobs.length === 0) {
-        if (Date.now() - lastWorkAt >= idleTimeoutMs) {
-          break;
-        }
-        await delay(500);
-        continue;
-      }
+        busySlotCount += 1;
+        let job: BuildJob | undefined;
 
-      lastWorkAt = Date.now();
-      await Promise.all(
-        jobs.map(async (job) => {
-          const reporter = new BuildJobProgressAccumulator(job);
-
-          try {
-            await appendBuildJobEvent(job, {
-              at: Date.now(),
-              jobId: job.jobId,
-              seq: 0,
-              state: "running",
-              type: "started",
-            });
-            await options.executeJob(job, reporter);
-            await markBuildJobSucceeded(job.jobId, ownerId);
-          } catch (error) {
-            await markBuildJobFailed(job.jobId, ownerId, error);
+        try {
+          job = await claimQueuedBuildJob(state, ownerId);
+        } finally {
+          if (job === undefined) {
+            busySlotCount -= 1;
           }
-        }),
-      );
-    }
+        }
+
+        if (job === undefined) {
+          if (busySlotCount === 0 && Date.now() - idleSince >= idleTimeoutMs) {
+            break;
+          }
+          await delay(500);
+          continue;
+        }
+
+        idleSince = Date.now();
+
+        try {
+          await executeClaimedBuildJob(job, ownerId, options);
+        } finally {
+          busySlotCount -= 1;
+          if (busySlotCount === 0) {
+            idleSince = Date.now();
+          }
+        }
+      }
+    };
+
+    await Promise.all(
+      Array.from({ length: concurrency }, async () => await runSlot()),
+    );
   } finally {
     clearInterval(heartbeat);
     process.removeListener("SIGINT", stop);
     process.removeListener("SIGTERM", stop);
     await releaseBuildWorkerLease(state, ownerId);
     await state.close();
+  }
+}
+
+async function executeClaimedBuildJob(
+  job: BuildJob,
+  ownerId: string,
+  options: BuildJobWorkerOptions,
+): Promise<void> {
+  const reporter = new BuildJobProgressAccumulator(job);
+
+  try {
+    await appendBuildJobEvent(job, {
+      at: Date.now(),
+      jobId: job.jobId,
+      seq: 0,
+      state: "running",
+      type: "started",
+    });
+    await options.executeJob(job, reporter);
+    await markBuildJobSucceeded(job.jobId, ownerId);
+  } catch (error) {
+    await markBuildJobFailed(job.jobId, ownerId, error);
   }
 }
 
@@ -728,39 +757,38 @@ WHERE job_id = ?
   }
 }
 
-async function claimQueuedBuildJobs(
+async function claimQueuedBuildJob(
   state: Database,
   ownerId: string,
-  limit: number,
-): Promise<BuildJob[]> {
+): Promise<BuildJob | undefined> {
   return await state.transaction(async () => {
-    const jobs = await state.queryAll(
+    const job = await state.queryOne(
       `
 SELECT *
 FROM build_jobs
 WHERE state = 'queued'
 ORDER BY queue_rank ASC, created_at ASC
-LIMIT ?
+LIMIT 1
 `,
-      [limit],
+      undefined,
       mapBuildJob,
     );
-    const now = Date.now();
 
-    for (const job of jobs) {
-      await state.run(
-        `
+    if (job === undefined) {
+      return undefined;
+    }
+
+    const now = Date.now();
+    await state.run(
+      `
 UPDATE build_jobs
 SET state = 'running', owner_id = ?, owner_pid = ?, updated_at = ?
 WHERE job_id = ? AND state = 'queued'
 `,
-        [ownerId, process.pid, now, job.jobId],
-      );
-    }
-
-    return await Promise.all(
-      jobs.map(async (job) => await requireBuildJobById(state, job.jobId)),
+      [ownerId, process.pid, now, job.jobId],
     );
+
+    return await requireBuildJobById(state, job.jobId);
   });
 }
 

--- a/test/facade/build-queue.test.ts
+++ b/test/facade/build-queue.test.ts
@@ -217,6 +217,64 @@ describe("facade/build-queue", () => {
       ).toContain("requeued");
     });
   });
+
+  it("refills idle worker slots while other jobs are still running", async () => {
+    await withTempDir("spinedigest-build-queue-", async (path) => {
+      useStateDir(`${path}/state`);
+      await addBuildJob({
+        archivePath: `${path}/book.sdpub`,
+        chapterId: 1,
+        target: "graph",
+      });
+
+      let firstStarted!: () => void;
+      let secondStarted!: () => void;
+      let releaseFirst!: () => void;
+      let releaseSecond!: () => void;
+      const firstStartedSignal = new Promise<void>((resolveStarted) => {
+        firstStarted = resolveStarted;
+      });
+      const secondStartedSignal = new Promise<void>((resolveStarted) => {
+        secondStarted = resolveStarted;
+      });
+      const firstReleaseSignal = new Promise<void>((resolveRelease) => {
+        releaseFirst = resolveRelease;
+      });
+      const secondReleaseSignal = new Promise<void>((resolveRelease) => {
+        releaseSecond = resolveRelease;
+      });
+
+      const worker = runBuildJobWorker({
+        concurrency: 2,
+        executeJob: async (job) => {
+          if (job.chapterId === 1) {
+            firstStarted();
+            await firstReleaseSignal;
+            return;
+          }
+
+          secondStarted();
+          await secondReleaseSignal;
+        },
+        idleTimeoutMs: 0,
+      });
+
+      await firstStartedSignal;
+      await addBuildJob({
+        archivePath: `${path}/book.sdpub`,
+        chapterId: 2,
+        target: "graph",
+      });
+      await withTimeout(
+        secondStartedSignal,
+        "Timed out waiting for idle queue slot to claim the second job.",
+      );
+
+      releaseFirst();
+      releaseSecond();
+      await worker;
+    });
+  });
 });
 
 async function forceRunningPid(
@@ -254,4 +312,24 @@ function restoreEnv(key: string, value: string | undefined): void {
   }
 
   process.env[key] = value;
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  message: string,
+): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(() => {
+      reject(new Error(message));
+    }, 2_000);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- refactor the build queue worker into independent slot loops that each claim one job at a time
- keep idle slots alive while any job is still running so newly added jobs can be picked up immediately
- add a regression test for adding a second job while the first job is still running

## Tests
- pnpm test:run
- pnpm typecheck
- pnpm lint
- pnpm format:check