### PR TITLE
Refactor sdpub access and shorten queue write locks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spinedigest",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "CLI-first tool for digesting long-form text and ebooks into compressed text, EPUB, or reusable .sdpub archives.",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/cli/archive-chapter.ts
+++ b/src/cli/archive-chapter.ts
@@ -52,11 +52,9 @@ export async function runArchiveChapterCommand(
       });
       return;
     case "list":
-      await new SpineDigestFile(args.path).openEditableSession(
-        async (document) => {
-          await writeChapterList(await listChapters(document));
-        },
-      );
+      await new SpineDigestFile(args.path).readDocument(async (document) => {
+        await writeChapterList(await listChapters(document));
+      });
       return;
     case "move":
       await runEditableCommand(args.path, async (document) => {
@@ -162,13 +160,11 @@ export async function runArchiveChapterCommand(
       });
       return;
     case "status":
-      await new SpineDigestFile(args.path).openEditableSession(
-        async (document) => {
-          await writeChapterDetails(
-            await getChapterDetails(document, args.chapterId!),
-          );
-        },
-      );
+      await new SpineDigestFile(args.path).readDocument(async (document) => {
+        await writeChapterDetails(
+          await getChapterDetails(document, args.chapterId!),
+        );
+      });
       return;
     case "tree":
       if (args.treeAction === "apply") {
@@ -185,11 +181,9 @@ export async function runArchiveChapterCommand(
         return;
       }
 
-      await new SpineDigestFile(args.path).openEditableSession(
-        async (document) => {
-          await writeChapterTree(await getChapterTree(document));
-        },
-      );
+      await new SpineDigestFile(args.path).readDocument(async (document) => {
+        await writeChapterTree(await getChapterTree(document));
+      });
       return;
   }
 }
@@ -198,7 +192,7 @@ async function runEditableCommand(
   path: string,
   operation: (document: DirectoryDocument) => Promise<void> | void,
 ): Promise<void> {
-  await new SpineDigestFile(path).openEditableSession(operation);
+  await new SpineDigestFile(path).write(operation);
 }
 
 function createContentStream(

--- a/src/cli/archive-maintenance.ts
+++ b/src/cli/archive-maintenance.ts
@@ -50,7 +50,7 @@ async function updateArchiveMeta(
   path: string,
   patch: ArchiveMetaPatch,
 ): Promise<void> {
-  await new SpineDigestFile(path).openEditableSession(async (document) => {
+  await new SpineDigestFile(path).write(async (document) => {
     const meta = await document.readBookMeta();
 
     if (meta === undefined) {

--- a/src/cli/archive.ts
+++ b/src/cli/archive.ts
@@ -30,7 +30,7 @@ import {
   type ChapterStage,
 } from "../facade/index.js";
 import { SpineDigestFile } from "../facade/spine-digest-file.js";
-import type { Document } from "../document/index.js";
+import type { ReadonlyDocument } from "../document/index.js";
 
 import type { CLIArchiveArguments } from "./args.js";
 import { runConvertCommand } from "./convert.js";
@@ -59,7 +59,7 @@ export async function runArchiveCommand(
       });
       return;
     case "estimate":
-      await withArchiveDocument(args.archivePath, async (document) => {
+      await readArchiveDocument(args.archivePath, async (document) => {
         await writeEstimate(
           await estimateArchiveBuild(
             document,
@@ -73,7 +73,7 @@ export async function runArchiveCommand(
     case "index": {
       const indexAction = args.action;
 
-      await withArchiveDocument(args.archivePath, async (document) => {
+      await readArchiveDocument(args.archivePath, async (document) => {
         await writeIndex(
           await getArchiveIndex(document),
           indexAction,
@@ -83,7 +83,7 @@ export async function runArchiveCommand(
       return;
     }
     case "list":
-      await withArchiveDocument(args.archivePath, async (document) => {
+      await readArchiveDocument(args.archivePath, async (document) => {
         await writeCollection(
           await listArchiveCollection(document, createCollectionOptions(args)),
           args.json ?? false,
@@ -91,7 +91,7 @@ export async function runArchiveCommand(
       });
       return;
     case "find":
-      await withArchiveDocument(args.archivePath, async (document) => {
+      await readArchiveDocument(args.archivePath, async (document) => {
         await writeFindHits(
           await findArchiveObjects(
             document,
@@ -103,7 +103,7 @@ export async function runArchiveCommand(
       });
       return;
     case "grep":
-      await withArchiveDocument(args.archivePath, async (document) => {
+      await readArchiveDocument(args.archivePath, async (document) => {
         await writeFindHits(
           await grepArchiveObjects(
             document,
@@ -115,7 +115,7 @@ export async function runArchiveCommand(
       });
       return;
     case "page":
-      await withArchiveDocument(args.archivePath, async (document) => {
+      await readArchiveDocument(args.archivePath, async (document) => {
         await writePage(
           await readArchivePage(document, args.objectId!),
           args.json ?? false,
@@ -123,7 +123,7 @@ export async function runArchiveCommand(
       });
       return;
     case "read":
-      await withArchiveDocument(args.archivePath, async (document) => {
+      await readArchiveDocument(args.archivePath, async (document) => {
         await writeTextToStdout(
           `${await readArchiveText(document, args.objectId!)}\n`,
         );
@@ -133,7 +133,7 @@ export async function runArchiveCommand(
     case "backlinks": {
       const linkDirection = args.action;
 
-      await withArchiveDocument(args.archivePath, async (document) => {
+      await readArchiveDocument(args.archivePath, async (document) => {
         await writeLinks(
           await listArchiveLinks(document, args.objectId!, linkDirection),
           linkDirection,
@@ -143,7 +143,7 @@ export async function runArchiveCommand(
       return;
     }
     case "related":
-      await withArchiveDocument(args.archivePath, async (document) => {
+      await readArchiveDocument(args.archivePath, async (document) => {
         await writeList(
           await listRelatedArchiveObjects(document, args.objectId!),
           args.json ?? false,
@@ -151,7 +151,7 @@ export async function runArchiveCommand(
       });
       return;
     case "pack":
-      await withArchiveDocument(args.archivePath, async (document) => {
+      await readArchiveDocument(args.archivePath, async (document) => {
         await writePack(
           await packArchiveContext(
             document,
@@ -163,7 +163,7 @@ export async function runArchiveCommand(
       });
       return;
     case "map":
-      await withArchiveDocument(args.archivePath, async (document) => {
+      await readArchiveDocument(args.archivePath, async (document) => {
         await writeMap(
           await listArchiveObjects(document, "edges"),
           args.json ?? false,
@@ -171,7 +171,7 @@ export async function runArchiveCommand(
       });
       return;
     case "path":
-      await withArchiveDocument(args.archivePath, async (document) => {
+      await readArchiveDocument(args.archivePath, async (document) => {
         await writeTextToStdout(
           formatPath(
             await findGraphPath(
@@ -305,11 +305,11 @@ function createCollectionOptions(
   };
 }
 
-async function withArchiveDocument<T>(
+async function readArchiveDocument<T>(
   path: string,
-  operation: (document: Document) => Promise<T> | T,
+  operation: (document: ReadonlyDocument) => Promise<T> | T,
 ): Promise<void> {
-  await new SpineDigestFile(path).openEditableSession(operation);
+  await new SpineDigestFile(path).readDocument(operation);
 }
 
 async function writeIndex(

--- a/src/cli/queue.ts
+++ b/src/cli/queue.ts
@@ -4,18 +4,21 @@ import {
   addBuildJob,
   assertNoActiveBuildJobs,
   boostBuildJob,
+  buildChapterGraphArtifact,
+  buildChapterSummaryArtifactFromSnapshot,
   cancelBuildJob,
   cleanBuildJobs,
-  generateChapterGraph,
-  generateChapterSummary,
+  commitChapterGraphArtifact,
+  commitChapterSummaryArtifact,
   getBuildJob,
-  getChapterDetails,
   listBuildJobs,
   pauseBuildJob,
+  readChapterBuildInput,
   readBuildJobEvents,
   resumeBuildJob,
   resolveBuildJobId,
   runBuildJobWorker,
+  snapshotChapterSummaryInput,
   updateBuildJobTarget,
   type BuildJob,
   type BuildJobEvent,
@@ -170,68 +173,104 @@ async function executeBuildJob(
   });
   const prompt = resolveExtractionPrompt(job.prompt ?? config.prompt);
 
-  await new SpineDigestFile(job.archivePath).write(async (document) => {
-    let details = await getChapterDetails(document, job.chapterId);
+  const buildInput = await new SpineDigestFile(job.archivePath).readDocument(
+    async (document) => await readChapterBuildInput(document, job.chapterId),
+  );
+  let { details } = buildInput;
+  const { nextChunkId, sourceText } = buildInput;
 
-    await reporter.setTotals({
-      totalGraphWords: details.stage === "sourced" ? details.words : 0,
-      totalSummaryWords:
-        details.stage === "sourced" || details.stage === "graphed"
-          ? details.words
-          : 0,
-    });
-
-    if (details.stage === "planned") {
-      throw new Error(
-        `Chapter ${job.chapterId} is planned. Set source before queueing a build job.`,
-      );
-    }
-    if (details.stage === "sourced") {
-      let graphWords = 0;
-
-      await reporter.stepStarted("graph");
-      details = await generateChapterGraph(document, job.chapterId, {
-        extractionPrompt: prompt,
-        llm,
-        progressTracker: {
-          async advance(wordsCount) {
-            graphWords += wordsCount;
-            await reporter.updateWords({ graphWords });
-          },
-          async complete(finalWordsCount) {
-            await reporter.updateWords({
-              graphWords: finalWordsCount ?? details.words,
-            });
-          },
-        },
-      });
-      await reporter.updateWords({ graphWords: details.words });
-      await reporter.stepCompleted("graph");
-    }
-
-    const latestJob = await getBuildJob(job.jobId);
-
-    assertJobStillRunning(latestJob);
-    if (latestJob.target === "graph" || details.stage === "summarized") {
-      return;
-    }
-    if (details.stage !== "graphed") {
-      details = await getChapterDetails(document, job.chapterId);
-    }
-    if (details.stage !== "graphed") {
-      throw new Error(
-        `Chapter ${job.chapterId} is ${details.stage}. Cannot generate summary.`,
-      );
-    }
-
-    await reporter.stepStarted("summary");
-    details = await generateChapterSummary(document, job.chapterId, {
-      llm,
-    });
-    await reporter.updateWords({ summaryWords: details.words });
-    await reporter.stepCompleted("summary");
-    assertJobStillRunning(await getBuildJob(job.jobId));
+  await reporter.setTotals({
+    totalGraphWords: details.stage === "sourced" ? details.words : 0,
+    totalSummaryWords:
+      details.stage === "sourced" || details.stage === "graphed"
+        ? details.words
+        : 0,
   });
+
+  if (details.stage === "planned") {
+    throw new Error(
+      `Chapter ${job.chapterId} is planned. Set source before queueing a build job.`,
+    );
+  }
+  if (details.stage === "sourced") {
+    let graphWords = 0;
+
+    await reporter.stepStarted("graph");
+    const artifact = await buildChapterGraphArtifact(job.chapterId, {
+      extractionPrompt: prompt,
+      llm,
+      nextChunkId,
+      sourceText,
+      workspacePath: job.workspacePath,
+      progressTracker: {
+        async advance(wordsCount) {
+          graphWords += wordsCount;
+          await reporter.updateWords({ graphWords });
+        },
+        async complete(finalWordsCount) {
+          await reporter.updateWords({
+            graphWords: finalWordsCount ?? details.words,
+          });
+        },
+      },
+    });
+    details = await new SpineDigestFile(job.archivePath).write(
+      async (document) => {
+        assertJobStillRunning(await getBuildJob(job.jobId));
+        return await commitChapterGraphArtifact(document, artifact);
+      },
+    );
+    ({ details } = await new SpineDigestFile(job.archivePath).readDocument(
+      async (document) => await readChapterBuildInput(document, job.chapterId),
+    ));
+    await reporter.updateWords({ graphWords: details.words });
+    await reporter.stepCompleted("graph");
+  }
+
+  const latestJob = await getBuildJob(job.jobId);
+
+  assertJobStillRunning(latestJob);
+  if (latestJob.target === "graph" || details.stage === "summarized") {
+    return;
+  }
+  if (details.stage !== "graphed") {
+    ({ details } = await new SpineDigestFile(job.archivePath).readDocument(
+      async (document) => await readChapterBuildInput(document, job.chapterId),
+    ));
+  }
+  if (details.stage !== "graphed") {
+    throw new Error(
+      `Chapter ${job.chapterId} is ${details.stage}. Cannot generate summary.`,
+    );
+  }
+
+  await reporter.stepStarted("summary");
+  const summaryInput = await new SpineDigestFile(job.archivePath).readDocument(
+    async (document) =>
+      await snapshotChapterSummaryInput(
+        document,
+        job.chapterId,
+        job.workspacePath,
+      ),
+  );
+  const summary = await buildChapterSummaryArtifactFromSnapshot(job.chapterId, {
+    llm,
+    sourceDocumentPath: summaryInput.documentPath,
+    workspacePath: job.workspacePath,
+  });
+  details = await new SpineDigestFile(job.archivePath).write(
+    async (document) => {
+      assertJobStillRunning(await getBuildJob(job.jobId));
+      return await commitChapterSummaryArtifact(
+        document,
+        job.chapterId,
+        summary,
+      );
+    },
+  );
+  await reporter.updateWords({ summaryWords: details.words });
+  await reporter.stepCompleted("summary");
+  assertJobStillRunning(await getBuildJob(job.jobId));
 }
 
 function assertJobStillRunning(job: BuildJob): void {

--- a/src/cli/queue.ts
+++ b/src/cli/queue.ts
@@ -121,7 +121,7 @@ async function resolveQueueJobId(args: CLIQueueArguments): Promise<string> {
 }
 
 async function assertQueueAddReady(args: CLIQueueArguments): Promise<void> {
-  await new SpineDigestFile(args.archivePath!).openSession(async (digest) => {
+  await new SpineDigestFile(args.archivePath!).read(async (digest) => {
     if ((await digest.readChapterStage(args.chapterId!)) === "planned") {
       throw new Error(
         `Chapter ${args.chapterId!} is planned. Set source before queueing a build job.`,
@@ -170,70 +170,68 @@ async function executeBuildJob(
   });
   const prompt = resolveExtractionPrompt(job.prompt ?? config.prompt);
 
-  await new SpineDigestFile(job.archivePath).openEditableSession(
-    async (document) => {
-      let details = await getChapterDetails(document, job.chapterId);
+  await new SpineDigestFile(job.archivePath).write(async (document) => {
+    let details = await getChapterDetails(document, job.chapterId);
 
-      await reporter.setTotals({
-        totalGraphWords: details.stage === "sourced" ? details.words : 0,
-        totalSummaryWords:
-          details.stage === "sourced" || details.stage === "graphed"
-            ? details.words
-            : 0,
-      });
+    await reporter.setTotals({
+      totalGraphWords: details.stage === "sourced" ? details.words : 0,
+      totalSummaryWords:
+        details.stage === "sourced" || details.stage === "graphed"
+          ? details.words
+          : 0,
+    });
 
-      if (details.stage === "planned") {
-        throw new Error(
-          `Chapter ${job.chapterId} is planned. Set source before queueing a build job.`,
-        );
-      }
-      if (details.stage === "sourced") {
-        let graphWords = 0;
+    if (details.stage === "planned") {
+      throw new Error(
+        `Chapter ${job.chapterId} is planned. Set source before queueing a build job.`,
+      );
+    }
+    if (details.stage === "sourced") {
+      let graphWords = 0;
 
-        await reporter.stepStarted("graph");
-        details = await generateChapterGraph(document, job.chapterId, {
-          extractionPrompt: prompt,
-          llm,
-          progressTracker: {
-            async advance(wordsCount) {
-              graphWords += wordsCount;
-              await reporter.updateWords({ graphWords });
-            },
-            async complete(finalWordsCount) {
-              await reporter.updateWords({
-                graphWords: finalWordsCount ?? details.words,
-              });
-            },
-          },
-        });
-        await reporter.updateWords({ graphWords: details.words });
-        await reporter.stepCompleted("graph");
-      }
-
-      const latestJob = await getBuildJob(job.jobId);
-
-      assertJobStillRunning(latestJob);
-      if (latestJob.target === "graph" || details.stage === "summarized") {
-        return;
-      }
-      if (details.stage !== "graphed") {
-        details = await getChapterDetails(document, job.chapterId);
-      }
-      if (details.stage !== "graphed") {
-        throw new Error(
-          `Chapter ${job.chapterId} is ${details.stage}. Cannot generate summary.`,
-        );
-      }
-
-      await reporter.stepStarted("summary");
-      details = await generateChapterSummary(document, job.chapterId, {
+      await reporter.stepStarted("graph");
+      details = await generateChapterGraph(document, job.chapterId, {
+        extractionPrompt: prompt,
         llm,
+        progressTracker: {
+          async advance(wordsCount) {
+            graphWords += wordsCount;
+            await reporter.updateWords({ graphWords });
+          },
+          async complete(finalWordsCount) {
+            await reporter.updateWords({
+              graphWords: finalWordsCount ?? details.words,
+            });
+          },
+        },
       });
-      await reporter.updateWords({ summaryWords: details.words });
-      await reporter.stepCompleted("summary");
-      assertJobStillRunning(await getBuildJob(job.jobId));
-    },
-  );
+      await reporter.updateWords({ graphWords: details.words });
+      await reporter.stepCompleted("graph");
+    }
+
+    const latestJob = await getBuildJob(job.jobId);
+
+    assertJobStillRunning(latestJob);
+    if (latestJob.target === "graph" || details.stage === "summarized") {
+      return;
+    }
+    if (details.stage !== "graphed") {
+      details = await getChapterDetails(document, job.chapterId);
+    }
+    if (details.stage !== "graphed") {
+      throw new Error(
+        `Chapter ${job.chapterId} is ${details.stage}. Cannot generate summary.`,
+      );
+    }
+
+    await reporter.stepStarted("summary");
+    details = await generateChapterSummary(document, job.chapterId, {
+      llm,
+    });
+    await reporter.updateWords({ summaryWords: details.words });
+    await reporter.stepCompleted("summary");
+    assertJobStillRunning(await getBuildJob(job.jobId));
+  });
 }
 
 function assertJobStillRunning(job: BuildJob): void {

--- a/src/facade/app.ts
+++ b/src/facade/app.ts
@@ -185,7 +185,7 @@ export class SpineDigestApp {
     return await this.#withLogging(
       "open-sdpub",
       async () =>
-        await new SpineDigestFile(path).openSession(operation, {
+        await new SpineDigestFile(path).read(operation, {
           ...(options.documentDirPath === undefined
             ? {}
             : { documentDirPath: options.documentDirPath }),

--- a/src/facade/archive-view.ts
+++ b/src/facade/archive-view.ts
@@ -1,6 +1,6 @@
 import type {
   ChunkRecord,
-  Document,
+  ReadonlyDocument,
   KnowledgeEdgeRecord,
   SentenceId,
   SnakeRecord,
@@ -247,7 +247,7 @@ export interface ArchiveNodeSourceFragment {
 }
 
 export async function getArchiveIndex(
-  document: Document,
+  document: ReadonlyDocument,
 ): Promise<ArchiveIndex> {
   const [chapters, meta, nodes, edges] = await Promise.all([
     listChapters(document),
@@ -267,7 +267,7 @@ export async function getArchiveIndex(
 }
 
 export async function listArchiveObjects(
-  document: Document,
+  document: ReadonlyDocument,
   kind: ArchiveListKind,
 ): Promise<readonly ArchiveListItem[]> {
   switch (kind) {
@@ -344,7 +344,7 @@ export async function listArchiveObjects(
 }
 
 export async function listArchiveCollection(
-  document: Document,
+  document: ReadonlyDocument,
   options: ArchiveCollectionOptions = {},
 ): Promise<ArchiveCollectionResult> {
   const items: ArchiveFindHit[] = [];
@@ -448,7 +448,7 @@ export async function listArchiveCollection(
 }
 
 export async function findArchiveObjects(
-  document: Document,
+  document: ReadonlyDocument,
   query: string,
   options: ArchiveFindOptions = {},
 ): Promise<ArchiveFindResult> {
@@ -468,7 +468,7 @@ export async function findArchiveObjects(
 }
 
 export async function grepArchiveObjects(
-  document: Document,
+  document: ReadonlyDocument,
   query: string,
   options: ArchiveFindOptions = {},
 ): Promise<ArchiveFindResult> {
@@ -500,7 +500,7 @@ export async function grepArchiveObjects(
 }
 
 export async function readArchiveText(
-  document: Document,
+  document: ReadonlyDocument,
   id: string,
 ): Promise<string> {
   const reference = parseArchiveReference(id);
@@ -541,7 +541,7 @@ export async function readArchiveText(
 }
 
 export async function readArchivePage(
-  document: Document,
+  document: ReadonlyDocument,
   id: string,
 ): Promise<ArchivePage> {
   const reference = parseArchiveReference(id);
@@ -649,7 +649,7 @@ export async function readArchivePage(
 }
 
 export async function listArchiveLinks(
-  document: Document,
+  document: ReadonlyDocument,
   id: string,
   direction: "backlinks" | "links",
 ): Promise<readonly GraphNeighbor[]> {
@@ -661,7 +661,7 @@ export async function listArchiveLinks(
 }
 
 export async function listAllArchiveLinks(
-  document: Document,
+  document: ReadonlyDocument,
   id: string,
 ): Promise<readonly GraphNeighbor[]> {
   const reference = parseArchiveReference(id);
@@ -675,7 +675,7 @@ export async function listAllArchiveLinks(
 }
 
 export async function listRelatedArchiveObjects(
-  document: Document,
+  document: ReadonlyDocument,
   id: string,
 ): Promise<readonly ArchiveListItem[]> {
   const reference = parseArchiveReference(id);
@@ -697,7 +697,7 @@ export async function listRelatedArchiveObjects(
 }
 
 export async function packArchiveContext(
-  document: Document,
+  document: ReadonlyDocument,
   id: string,
   budget: number,
 ): Promise<ArchivePack> {
@@ -712,7 +712,7 @@ export async function packArchiveContext(
 }
 
 export async function estimateArchiveBuild(
-  document: Document,
+  document: ReadonlyDocument,
   targetStage: string,
 ): Promise<ArchiveEstimate> {
   const chapters = await listChapters(document);
@@ -788,7 +788,7 @@ export function formatFragmentId(serialId: number, fragmentId: number): string {
 }
 
 async function findChapters(
-  document: Document,
+  document: ReadonlyDocument,
   search: ArchiveTextSearch,
 ): Promise<readonly ArchiveFindHit[]> {
   const hits: ArchiveFindHit[] = [];
@@ -862,7 +862,7 @@ async function findChapters(
 }
 
 async function listChapterSourceFragments(
-  document: Document,
+  document: ReadonlyDocument,
   chapterId: number,
 ): Promise<readonly ArchiveSourceFragment[]> {
   const fragments = document.getSerialFragments(chapterId);
@@ -890,7 +890,7 @@ async function listChapterSourceFragments(
 }
 
 async function readSourceFragment(
-  document: Document,
+  document: ReadonlyDocument,
   serialId: number,
   fragmentId: number,
 ): Promise<ArchiveSourceFragment> {
@@ -913,7 +913,7 @@ async function readSourceFragment(
 }
 
 async function listChapterNodeGroups(
-  document: Document,
+  document: ReadonlyDocument,
   chapterId: number,
 ): Promise<readonly ArchiveNodeGroup[]> {
   const snakes = await document.snakes.listBySerial(chapterId);
@@ -935,7 +935,7 @@ async function listChapterNodeGroups(
 }
 
 async function listChapterNodeGroupsByFragment(
-  document: Document,
+  document: ReadonlyDocument,
   chapterId: number,
 ): Promise<readonly ArchiveNodeGroup[]> {
   const nodes = (await document.chunks.listBySerial(chapterId))
@@ -975,7 +975,7 @@ function createArchiveNodeGroup(input: {
 }
 
 async function listSnakeNodeLabels(
-  document: Document,
+  document: ReadonlyDocument,
   snake: SnakeRecord,
 ): Promise<readonly ArchiveNodeLabel[]> {
   return (
@@ -997,7 +997,7 @@ async function listSnakeNodeLabels(
 }
 
 async function listFragmentNodes(
-  document: Document,
+  document: ReadonlyDocument,
   chapterId: number,
   fragmentId: number,
 ): Promise<readonly ArchiveNodeLabel[]> {
@@ -1078,7 +1078,7 @@ function findMeta(
 }
 
 async function findNodes(
-  document: Document,
+  document: ReadonlyDocument,
   search: ArchiveTextSearch,
 ): Promise<readonly ArchiveFindHit[]> {
   const hits: ArchiveFindHit[] = [];
@@ -1119,7 +1119,7 @@ async function findNodes(
 }
 
 async function estimateSourceWords(
-  document: Document,
+  document: ReadonlyDocument,
   chapters: readonly ChapterEntry[],
 ): Promise<number> {
   let words = 0;
@@ -1141,7 +1141,7 @@ async function estimateSourceWords(
 }
 
 async function requireChapter(
-  document: Document,
+  document: ReadonlyDocument,
   chapterId: number,
 ): Promise<ChapterEntry> {
   const chapter = (await listChapters(document)).find(
@@ -1156,7 +1156,7 @@ async function requireChapter(
 }
 
 async function requireNode(
-  document: Document,
+  document: ReadonlyDocument,
   nodeId: number,
 ): Promise<{
   readonly chapterId: number;
@@ -1177,7 +1177,7 @@ async function requireNode(
 }
 
 async function readNodeSourceFragments(
-  document: Document,
+  document: ReadonlyDocument,
   node: GraphNode,
 ): Promise<readonly ArchiveNodeSourceFragment[]> {
   return await Promise.all(

--- a/src/facade/build-queue.ts
+++ b/src/facade/build-queue.ts
@@ -479,7 +479,8 @@ export async function runBuildJobWorker(
   const concurrency = Math.max(1, options.concurrency);
   const idleTimeoutMs = options.idleTimeoutMs ?? 10_000;
   let stopping = false;
-  let lastWorkAt = Date.now();
+  let busySlotCount = 0;
+  let idleSince = Date.now();
 
   const stop = (): void => {
     stopping = true;
@@ -499,46 +500,74 @@ export async function runBuildJobWorker(
       return;
     }
 
-    while (!stopping) {
-      await heartbeatBuildWorker(ownerId, state);
-      await recoverStaleBuildJobs(state);
-      const jobs = await claimQueuedBuildJobs(state, ownerId, concurrency);
+    const runSlot = async (): Promise<void> => {
+      while (!stopping) {
+        await heartbeatBuildWorker(ownerId, state);
+        await recoverStaleBuildJobs(state);
 
-      if (jobs.length === 0) {
-        if (Date.now() - lastWorkAt >= idleTimeoutMs) {
-          break;
-        }
-        await delay(500);
-        continue;
-      }
+        busySlotCount += 1;
+        let job: BuildJob | undefined;
 
-      lastWorkAt = Date.now();
-      await Promise.all(
-        jobs.map(async (job) => {
-          const reporter = new BuildJobProgressAccumulator(job);
-
-          try {
-            await appendBuildJobEvent(job, {
-              at: Date.now(),
-              jobId: job.jobId,
-              seq: 0,
-              state: "running",
-              type: "started",
-            });
-            await options.executeJob(job, reporter);
-            await markBuildJobSucceeded(job.jobId, ownerId);
-          } catch (error) {
-            await markBuildJobFailed(job.jobId, ownerId, error);
+        try {
+          job = await claimQueuedBuildJob(state, ownerId);
+        } finally {
+          if (job === undefined) {
+            busySlotCount -= 1;
           }
-        }),
-      );
-    }
+        }
+
+        if (job === undefined) {
+          if (busySlotCount === 0 && Date.now() - idleSince >= idleTimeoutMs) {
+            break;
+          }
+          await delay(500);
+          continue;
+        }
+
+        idleSince = Date.now();
+
+        try {
+          await executeClaimedBuildJob(job, ownerId, options);
+        } finally {
+          busySlotCount -= 1;
+          if (busySlotCount === 0) {
+            idleSince = Date.now();
+          }
+        }
+      }
+    };
+
+    await Promise.all(
+      Array.from({ length: concurrency }, async () => await runSlot()),
+    );
   } finally {
     clearInterval(heartbeat);
     process.removeListener("SIGINT", stop);
     process.removeListener("SIGTERM", stop);
     await releaseBuildWorkerLease(state, ownerId);
     await state.close();
+  }
+}
+
+async function executeClaimedBuildJob(
+  job: BuildJob,
+  ownerId: string,
+  options: BuildJobWorkerOptions,
+): Promise<void> {
+  const reporter = new BuildJobProgressAccumulator(job);
+
+  try {
+    await appendBuildJobEvent(job, {
+      at: Date.now(),
+      jobId: job.jobId,
+      seq: 0,
+      state: "running",
+      type: "started",
+    });
+    await options.executeJob(job, reporter);
+    await markBuildJobSucceeded(job.jobId, ownerId);
+  } catch (error) {
+    await markBuildJobFailed(job.jobId, ownerId, error);
   }
 }
 
@@ -728,39 +757,38 @@ WHERE job_id = ?
   }
 }
 
-async function claimQueuedBuildJobs(
+async function claimQueuedBuildJob(
   state: Database,
   ownerId: string,
-  limit: number,
-): Promise<BuildJob[]> {
+): Promise<BuildJob | undefined> {
   return await state.transaction(async () => {
-    const jobs = await state.queryAll(
+    const job = await state.queryOne(
       `
 SELECT *
 FROM build_jobs
 WHERE state = 'queued'
 ORDER BY queue_rank ASC, created_at ASC
-LIMIT ?
+LIMIT 1
 `,
-      [limit],
+      undefined,
       mapBuildJob,
     );
-    const now = Date.now();
 
-    for (const job of jobs) {
-      await state.run(
-        `
+    if (job === undefined) {
+      return undefined;
+    }
+
+    const now = Date.now();
+    await state.run(
+      `
 UPDATE build_jobs
 SET state = 'running', owner_id = ?, owner_pid = ?, updated_at = ?
 WHERE job_id = ? AND state = 'queued'
 `,
-        [ownerId, process.pid, now, job.jobId],
-      );
-    }
-
-    return await Promise.all(
-      jobs.map(async (job) => await requireBuildJobById(state, job.jobId)),
+      [ownerId, process.pid, now, job.jobId],
     );
+
+    return await requireBuildJobById(state, job.jobId);
   });
 }
 

--- a/src/facade/chapter-build.ts
+++ b/src/facade/chapter-build.ts
@@ -1,0 +1,423 @@
+import { mkdir, rm } from "fs/promises";
+import { join } from "path";
+
+import type { Document, ReadonlyDocument } from "../document/index.js";
+import { DirectoryDocument } from "../document/index.js";
+import type { ReaderTextStream } from "../reader/index.js";
+import {
+  SerialGeneration,
+  type BuildSerialTopologyOptions,
+} from "../serial.js";
+
+import {
+  getChapterDetails,
+  type ChapterDetails,
+  type GenerateChapterGraphOptions,
+  type GenerateChapterSummaryOptions,
+} from "./chapter.js";
+
+export interface ChapterGraphBuildArtifact {
+  readonly documentPath: string;
+  readonly chapterId: number;
+}
+
+export interface BuildChapterGraphArtifactOptions extends GenerateChapterGraphOptions {
+  readonly sourceText: readonly string[];
+  readonly nextChunkId: number;
+  readonly workspacePath: string;
+}
+
+export interface BuildChapterSummaryArtifactOptions extends GenerateChapterSummaryOptions {
+  readonly sourceDocumentPath?: string;
+  readonly workspacePath: string;
+}
+
+export async function readChapterBuildInput(
+  document: ReadonlyDocument,
+  chapterId: number,
+): Promise<{
+  readonly details: ChapterDetails;
+  readonly nextChunkId: number;
+  readonly sourceText: readonly string[];
+}> {
+  const details = await getChapterDetails(document, chapterId);
+
+  return {
+    details,
+    nextChunkId: (await document.chunks.getMaxId()) + 1,
+    sourceText: await collectReaderText(readChapterSource(document, chapterId)),
+  };
+}
+
+export async function buildChapterGraphArtifact(
+  chapterId: number,
+  options: BuildChapterGraphArtifactOptions,
+): Promise<ChapterGraphBuildArtifact> {
+  const documentPath = join(options.workspacePath, "graph-document");
+
+  await rm(documentPath, { force: true, recursive: true });
+  await mkdir(options.workspacePath, { recursive: true });
+
+  const document = await DirectoryDocument.open(documentPath);
+
+  try {
+    await document.openSession(async (openedDocument) => {
+      await openedDocument.serials.createWithId(chapterId);
+      await new SerialGeneration({
+        document: openedDocument,
+        llm: options.llm,
+        ...(options.logDirPath === undefined
+          ? {}
+          : { logDirPath: options.logDirPath }),
+        nextChunkId: options.nextChunkId,
+      }).buildTopologyInto(
+        chapterId,
+        options.sourceText,
+        createTopologyOptions(options),
+        options.progressTracker,
+      );
+    });
+  } finally {
+    await document.release();
+  }
+
+  return {
+    chapterId,
+    documentPath,
+  };
+}
+
+export async function commitChapterGraphArtifact(
+  document: Document,
+  artifact: ChapterGraphBuildArtifact,
+): Promise<ChapterDetails> {
+  const sourceDocument = await DirectoryDocument.open(artifact.documentPath);
+
+  try {
+    await document.openSession(async (openedDocument) => {
+      await requireStage(openedDocument, artifact.chapterId, "sourced");
+      await openedDocument.clearSerialSource(artifact.chapterId);
+      await openedDocument.serials.ensure(artifact.chapterId);
+      await copySerialFragments(
+        sourceDocument,
+        openedDocument,
+        artifact.chapterId,
+      );
+
+      for (const chunk of await sourceDocument.chunks.listBySerial(
+        artifact.chapterId,
+      )) {
+        await openedDocument.chunks.save(chunk);
+      }
+
+      for (const edge of await sourceDocument.knowledgeEdges.listBySerial(
+        artifact.chapterId,
+      )) {
+        await openedDocument.knowledgeEdges.save(edge);
+      }
+
+      await openedDocument.fragmentGroups.saveMany(
+        await sourceDocument.fragmentGroups.listBySerial(artifact.chapterId),
+      );
+      await copySnakes(sourceDocument, openedDocument, artifact.chapterId);
+      await openedDocument.serials.setTopologyReady(artifact.chapterId);
+    });
+
+    return await getChapterDetails(document, artifact.chapterId);
+  } finally {
+    await sourceDocument.release();
+  }
+}
+
+export async function buildChapterSummaryArtifact(
+  document: ReadonlyDocument,
+  chapterId: number,
+  options: BuildChapterSummaryArtifactOptions,
+): Promise<string> {
+  const sourceDocumentPath = options.sourceDocumentPath;
+
+  if (sourceDocumentPath !== undefined) {
+    return await buildChapterSummaryArtifactFromSnapshot(chapterId, {
+      ...options,
+      sourceDocumentPath,
+    });
+  }
+
+  return await buildChapterSummaryArtifactFromDocument(
+    document,
+    chapterId,
+    options,
+  );
+}
+
+export async function buildChapterSummaryArtifactFromSnapshot(
+  chapterId: number,
+  options: BuildChapterSummaryArtifactOptions & {
+    readonly sourceDocumentPath: string;
+  },
+): Promise<string> {
+  const document = await DirectoryDocument.open(options.sourceDocumentPath);
+
+  try {
+    return await buildChapterSummaryArtifactFromDocument(
+      document,
+      chapterId,
+      options,
+    );
+  } finally {
+    await document.release();
+  }
+}
+
+async function buildChapterSummaryArtifactFromDocument(
+  document: ReadonlyDocument,
+  chapterId: number,
+  options: BuildChapterSummaryArtifactOptions,
+): Promise<string> {
+  const details = await getChapterDetails(document, chapterId);
+
+  if (details.stage !== "graphed") {
+    throw new Error(
+      `Chapter ${chapterId} is ${details.stage}. Generate a summary only for graphed chapters.`,
+    );
+  }
+
+  const summary = await document.readSummary(chapterId);
+
+  if (summary !== undefined) {
+    return summary;
+  }
+
+  return await buildSummaryInTemporaryDocument(document, chapterId, options);
+}
+
+export async function snapshotChapterSummaryInput(
+  document: ReadonlyDocument,
+  chapterId: number,
+  workspacePath: string,
+): Promise<{ readonly documentPath: string }> {
+  const documentPath = join(workspacePath, "summary-input-document");
+
+  await rm(documentPath, { force: true, recursive: true });
+  await mkdir(workspacePath, { recursive: true });
+
+  const targetDocument = await DirectoryDocument.open(documentPath);
+
+  try {
+    await targetDocument.openSession(async (openedDocument) => {
+      await requireStage(document, chapterId, "graphed");
+      await openedDocument.serials.createWithId(chapterId);
+      await copySerialFragments(document, openedDocument, chapterId);
+
+      for (const chunk of await document.chunks.listBySerial(chapterId)) {
+        await openedDocument.chunks.save(chunk);
+      }
+
+      for (const edge of await document.knowledgeEdges.listBySerial(
+        chapterId,
+      )) {
+        await openedDocument.knowledgeEdges.save(edge);
+      }
+
+      await openedDocument.fragmentGroups.saveMany(
+        await document.fragmentGroups.listBySerial(chapterId),
+      );
+      await copySnakes(document, openedDocument, chapterId);
+      await openedDocument.serials.setTopologyReady(chapterId);
+    });
+  } finally {
+    await targetDocument.release();
+  }
+
+  return { documentPath };
+}
+
+export async function commitChapterSummaryArtifact(
+  document: Document,
+  chapterId: number,
+  summary: string,
+): Promise<ChapterDetails> {
+  await document.openSession(async (openedDocument) => {
+    await requireStage(openedDocument, chapterId, "graphed");
+    await openedDocument.writeSummary(chapterId, summary);
+  });
+
+  return await getChapterDetails(document, chapterId);
+}
+
+async function buildSummaryInTemporaryDocument(
+  sourceDocument: ReadonlyDocument,
+  chapterId: number,
+  options: BuildChapterSummaryArtifactOptions,
+): Promise<string> {
+  const documentPath = join(options.workspacePath, "summary-document");
+
+  await rm(documentPath, { force: true, recursive: true });
+  await mkdir(options.workspacePath, { recursive: true });
+
+  const document = await DirectoryDocument.open(documentPath);
+
+  try {
+    await document.openSession(async (openedDocument) => {
+      await openedDocument.serials.createWithId(chapterId);
+      await copySerialFragments(sourceDocument, openedDocument, chapterId);
+
+      for (const chunk of await sourceDocument.chunks.listBySerial(chapterId)) {
+        await openedDocument.chunks.save(chunk);
+      }
+
+      for (const edge of await sourceDocument.knowledgeEdges.listBySerial(
+        chapterId,
+      )) {
+        await openedDocument.knowledgeEdges.save(edge);
+      }
+
+      await openedDocument.fragmentGroups.saveMany(
+        await sourceDocument.fragmentGroups.listBySerial(chapterId),
+      );
+      await copySnakes(sourceDocument, openedDocument, chapterId);
+      await openedDocument.serials.setTopologyReady(chapterId);
+    });
+
+    await new SerialGeneration({
+      document,
+      llm: options.llm,
+      ...(options.logDirPath === undefined
+        ? {}
+        : { logDirPath: options.logDirPath }),
+    }).buildSummary(chapterId, {
+      ...(options.userLanguage === undefined
+        ? {}
+        : { userLanguage: options.userLanguage }),
+    });
+
+    return (await document.readSummary(chapterId)) ?? "";
+  } finally {
+    await document.release();
+    await rm(documentPath, { force: true, recursive: true });
+  }
+}
+
+async function copySerialFragments(
+  sourceDocument: ReadonlyDocument,
+  targetDocument: Document,
+  serialId: number,
+): Promise<void> {
+  const sourceFragments = sourceDocument.getSerialFragments(serialId);
+  const targetFragments = targetDocument.getSerialFragments(serialId);
+
+  for (const fragmentId of await sourceFragments.listFragmentIds()) {
+    const fragment = await sourceFragments.getFragment(fragmentId);
+    const draft = await targetFragments.createDraft();
+
+    for (const sentence of fragment.sentences) {
+      draft.addSentence(sentence.text, sentence.wordsCount);
+    }
+    draft.setSummary(fragment.summary);
+    await draft.commit();
+  }
+}
+
+async function copySnakes(
+  sourceDocument: ReadonlyDocument,
+  targetDocument: Document,
+  serialId: number,
+): Promise<void> {
+  const sourceSnakes = await sourceDocument.snakes.listBySerial(serialId);
+  const snakeIdMap = new Map<number, number>();
+
+  for (const sourceSnake of sourceSnakes) {
+    const targetSnakeId = await targetDocument.snakes.create({
+      firstLabel: sourceSnake.firstLabel,
+      groupId: sourceSnake.groupId,
+      lastLabel: sourceSnake.lastLabel,
+      localSnakeId: sourceSnake.localSnakeId,
+      serialId,
+      size: sourceSnake.size,
+      weight: sourceSnake.weight,
+      wordsCount: sourceSnake.wordsCount,
+    });
+
+    snakeIdMap.set(sourceSnake.id, targetSnakeId);
+
+    for (const snakeChunk of await sourceDocument.snakeChunks.listBySnake(
+      sourceSnake.id,
+    )) {
+      await targetDocument.snakeChunks.save({
+        chunkId: snakeChunk.chunkId,
+        position: snakeChunk.position,
+        snakeId: targetSnakeId,
+      });
+    }
+  }
+
+  for (const edge of await sourceDocument.snakeEdges.listBySerial(serialId)) {
+    const fromSnakeId = snakeIdMap.get(edge.fromSnakeId);
+    const toSnakeId = snakeIdMap.get(edge.toSnakeId);
+
+    if (fromSnakeId === undefined || toSnakeId === undefined) {
+      continue;
+    }
+
+    await targetDocument.snakeEdges.save({
+      fromSnakeId,
+      toSnakeId,
+      weight: edge.weight,
+    });
+  }
+}
+
+async function requireStage(
+  document: ReadonlyDocument,
+  chapterId: number,
+  stage: ChapterDetails["stage"],
+): Promise<void> {
+  const details = await getChapterDetails(document, chapterId);
+
+  if (details.stage !== stage) {
+    throw new Error(
+      `Chapter ${chapterId} is ${details.stage}. Expected ${stage} before committing build output.`,
+    );
+  }
+}
+
+function createTopologyOptions(
+  options: Pick<
+    BuildSerialTopologyOptions,
+    "extractionPrompt" | "userLanguage"
+  >,
+): BuildSerialTopologyOptions {
+  return {
+    extractionPrompt: options.extractionPrompt,
+    ...(options.userLanguage === undefined
+      ? {}
+      : { userLanguage: options.userLanguage }),
+  };
+}
+
+async function* readChapterSource(
+  document: ReadonlyDocument,
+  chapterId: number,
+): ReaderTextStream {
+  const fragments = document.getSerialFragments(chapterId);
+
+  for (const fragmentId of await fragments.listFragmentIds()) {
+    const fragment = await fragments.getFragment(fragmentId);
+
+    for (const sentence of fragment.sentences) {
+      yield sentence.text;
+    }
+  }
+}
+
+async function collectReaderText(
+  stream: ReaderTextStream,
+): Promise<readonly string[]> {
+  const text: string[] = [];
+
+  for await (const chunk of stream) {
+    text.push(chunk);
+  }
+
+  return text;
+}

--- a/src/facade/chapter.ts
+++ b/src/facade/chapter.ts
@@ -1,4 +1,4 @@
-import type { Document } from "../document/index.js";
+import type { Document, ReadonlyDocument } from "../document/index.js";
 import type { Language } from "../common/language.js";
 import type { SpineDigestScope } from "../common/llm-scope.js";
 import type { LLM } from "../llm/index.js";
@@ -345,7 +345,7 @@ export async function generateChapterSummary(
 }
 
 export async function getChapterDetails(
-  document: Document,
+  document: ReadonlyDocument,
   chapterId: number,
 ): Promise<ChapterDetails> {
   const entries = await listChapters(document);
@@ -368,18 +368,20 @@ export async function getChapterDetails(
 }
 
 export async function listChapters(
-  document: Document,
+  document: ReadonlyDocument,
 ): Promise<readonly ChapterEntry[]> {
-  const toc = await normalizeChapterToc(document);
+  const toc = await readChapterToc(document);
 
   return await collectChapterEntries(document, toc.items);
 }
 
-export async function getChapterTree(document: Document): Promise<ChapterTree> {
-  const toc = await normalizeChapterToc(document);
+export async function getChapterTree(
+  document: ReadonlyDocument,
+): Promise<ChapterTree> {
+  const toc = await readChapterToc(document);
 
   return {
-    chapters: toc.items.map(toChapterTreeNode),
+    chapters: toc.items.flatMap(toChapterTreeNodes),
   };
 }
 
@@ -549,13 +551,7 @@ async function normalizeChapterToc(
   document: Document,
 ): Promise<MutableTocFile> {
   const existingToc = await document.readToc();
-  const toc: MutableTocFile =
-    existingToc === undefined
-      ? { items: [], version: TOC_FILE_VERSION }
-      : {
-          items: existingToc.items.map(cloneTocItem),
-          version: existingToc.version,
-        };
+  const toc = await readChapterToc(document);
   let changed = false;
 
   const normalizeItems = async (items: MutableTocItem[]): Promise<void> => {
@@ -580,8 +576,21 @@ async function normalizeChapterToc(
   return toc;
 }
 
+async function readChapterToc(
+  document: ReadonlyDocument,
+): Promise<MutableTocFile> {
+  const toc = await document.readToc();
+
+  return toc === undefined
+    ? { items: [], version: TOC_FILE_VERSION }
+    : {
+        items: toc.items.map(cloneTocItem),
+        version: toc.version,
+      };
+}
+
 async function collectChapterEntries(
-  document: Document,
+  document: ReadonlyDocument,
   items: readonly TocItem[],
   ancestorTitles: readonly string[] = [],
   depth = 0,
@@ -589,12 +598,24 @@ async function collectChapterEntries(
   const entries: ChapterEntry[] = [];
 
   for (const item of items) {
+    const title = normalizeTitle(item.title) ?? null;
+    const tocPath =
+      item.serialId === undefined
+        ? [...ancestorTitles, ...(title === null ? [] : [title])]
+        : [...ancestorTitles, title ?? `Chapter ${item.serialId}`];
+
     if (item.serialId === undefined) {
+      entries.push(
+        ...(await collectChapterEntries(
+          document,
+          item.children,
+          tocPath,
+          depth + 1,
+        )),
+      );
       continue;
     }
 
-    const title = normalizeTitle(item.title) ?? null;
-    const tocPath = [...ancestorTitles, title ?? `Chapter ${item.serialId}`];
     const serialFragments = document.getSerialFragments(item.serialId);
     const fragmentIds = await serialFragments.listFragmentIds();
     const fragmentCount = fragmentIds.length;
@@ -733,7 +754,7 @@ async function advanceEntriesToSummarized(
 }
 
 async function selectChapterEntries(
-  document: Document,
+  document: ReadonlyDocument,
   chapterId: number | undefined,
 ): Promise<readonly ChapterEntry[]> {
   const entries = await listChapters(document);
@@ -794,10 +815,10 @@ function createAdvanceProgressState(
 }
 
 async function collectChapterSubtreeIds(
-  document: Document,
+  document: ReadonlyDocument,
   chapterId: number,
 ): Promise<ReadonlySet<number>> {
-  const toc = await normalizeChapterToc(document);
+  const toc = await readChapterToc(document);
   const selectedIds = new Set<number>();
 
   for (const item of toc.items) {
@@ -865,7 +886,7 @@ async function emitAdvanceProgress(
 }
 
 async function resolveChapterStage(
-  document: Document,
+  document: ReadonlyDocument,
   chapterId: number,
   fragmentCount: number,
 ): Promise<ChapterStage> {
@@ -889,7 +910,7 @@ async function resolveChapterStage(
 }
 
 async function requireChapterDetails(
-  document: Document,
+  document: ReadonlyDocument,
   chapterId: number,
 ): Promise<ChapterDetails> {
   return await getChapterDetails(document, chapterId);
@@ -1278,10 +1299,16 @@ function toChapterTreeNode(item: MutableTocItem): ChapterTreeNode {
   }
 
   return {
-    children: item.children.map(toChapterTreeNode),
+    children: item.children.flatMap(toChapterTreeNodes),
     id: item.serialId,
     title: normalizeTitle(item.title) ?? null,
   };
+}
+
+function toChapterTreeNodes(item: MutableTocItem): ChapterTreeNode[] {
+  return item.serialId === undefined
+    ? item.children.flatMap(toChapterTreeNodes)
+    : [toChapterTreeNode(item)];
 }
 
 function createTopologyOptions(
@@ -1296,7 +1323,7 @@ function createTopologyOptions(
 }
 
 async function* readChapterSource(
-  document: Document,
+  document: ReadonlyDocument,
   chapterId: number,
 ): ReaderTextStream {
   const fragments = document.getSerialFragments(chapterId);

--- a/src/facade/index.ts
+++ b/src/facade/index.ts
@@ -58,6 +58,20 @@ export type {
   BuildJobWorkerOptions,
 } from "./build-queue.js";
 export {
+  buildChapterGraphArtifact,
+  buildChapterSummaryArtifact,
+  buildChapterSummaryArtifactFromSnapshot,
+  commitChapterGraphArtifact,
+  commitChapterSummaryArtifact,
+  readChapterBuildInput,
+  snapshotChapterSummaryInput,
+} from "./chapter-build.js";
+export type {
+  BuildChapterGraphArtifactOptions,
+  BuildChapterSummaryArtifactOptions,
+  ChapterGraphBuildArtifact,
+} from "./chapter-build.js";
+export {
   addChapter,
   advanceChapterStages,
   applyChapterTree,

--- a/src/facade/sdpub-coordinator.ts
+++ b/src/facade/sdpub-coordinator.ts
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS archives (
 const FLUSH_HEARTBEAT_INTERVAL_MS = 5_000;
 
 export class SdpubCoordinator {
-  public async openSession<T>(
+  public async withReadWorkspace<T>(
     archivePath: string,
     operation: (documentDirectoryPath: string) => Promise<T> | T,
     options: {
@@ -57,7 +57,7 @@ export class SdpubCoordinator {
     }
   }
 
-  public async openEditableSession<T>(
+  public async withWriteWorkspace<T>(
     archivePath: string,
     operation: (documentDirectoryPath: string) => Promise<T> | T,
   ): Promise<T> {

--- a/src/facade/spine-digest-file.ts
+++ b/src/facade/spine-digest-file.ts
@@ -13,19 +13,35 @@ export class SpineDigestFile {
     this.#path = resolve(path);
   }
 
-  public async openSession<T>(
+  public async read<T>(
     operation: (digest: SpineDigest) => Promise<T> | T,
     options: {
       readonly documentDirPath?: string;
     } = {},
   ): Promise<T> {
-    return await this.#coordinator.openSession(
+    return await this.readDocument(
+      async (document, directoryPath) =>
+        await operation(new SpineDigest(document, directoryPath)),
+      options,
+    );
+  }
+
+  public async readDocument<T>(
+    operation: (
+      document: DirectoryDocument,
+      directoryPath: string,
+    ) => Promise<T> | T,
+    options: {
+      readonly documentDirPath?: string;
+    } = {},
+  ): Promise<T> {
+    return await this.#coordinator.withReadWorkspace(
       this.#path,
       async (directoryPath) => {
         const document = await DirectoryDocument.open(directoryPath);
 
         try {
-          return await operation(new SpineDigest(document, directoryPath));
+          return await operation(document, directoryPath);
         } finally {
           await document.release();
         }
@@ -34,10 +50,10 @@ export class SpineDigestFile {
     );
   }
 
-  public async openEditableSession<T>(
+  public async write<T>(
     operation: (document: DirectoryDocument) => Promise<T> | T,
   ): Promise<T> {
-    return await this.#coordinator.openEditableSession(
+    return await this.#coordinator.withWriteWorkspace(
       this.#path,
       async (directoryPath) => {
         const document = await DirectoryDocument.open(directoryPath);

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -84,6 +84,7 @@ export interface SerialGenerationOptions {
   readonly document?: Document;
   readonly llm: LLM<SpineDigestScope>;
   readonly logDirPath?: string;
+  readonly nextChunkId?: number;
   readonly segmenter?: ReaderSegmenter;
   /** @deprecated Use `document` instead. */
   readonly workspace?: Document;
@@ -161,6 +162,7 @@ export class SerialGeneration {
     this.#fragmentGroups = document.fragmentGroups;
     this.#llm = options.llm;
     this.#logDirPath = options.logDirPath;
+    this.#nextChunkId = options.nextChunkId;
     this.#serials = document.serials;
     this.#segmenter = options.segmenter;
     this.#document = document;

--- a/test/cli/archive-chapter.test.ts
+++ b/test/cli/archive-chapter.test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const chapterMockState = vi.hoisted(() => ({
   addCalls: [] as unknown[],
-  editableCalls: [] as string[],
+  readCalls: [] as string[],
+  writeCalls: [] as string[],
   inputFileContent: "file content",
   moveCalls: [] as unknown[],
   treeApplyCalls: [] as unknown[],
@@ -74,10 +75,17 @@ vi.mock("../../src/facade/spine-digest-file.js", () => ({
       this.#path = path;
     }
 
-    public async openEditableSession(
+    public async readDocument(
       operation: (document: unknown) => Promise<unknown>,
     ): Promise<unknown> {
-      chapterMockState.editableCalls.push(this.#path);
+      chapterMockState.readCalls.push(this.#path);
+      return await operation({});
+    }
+
+    public async write(
+      operation: (document: unknown) => Promise<unknown>,
+    ): Promise<unknown> {
+      chapterMockState.writeCalls.push(this.#path);
       return await operation({});
     }
   },
@@ -241,7 +249,8 @@ describe("cli/archive-chapter", () => {
 
   beforeEach(() => {
     chapterMockState.addCalls.length = 0;
-    chapterMockState.editableCalls.length = 0;
+    chapterMockState.readCalls.length = 0;
+    chapterMockState.writeCalls.length = 0;
     chapterMockState.moveCalls.length = 0;
     chapterMockState.removeCalls.length = 0;
     chapterMockState.resetCalls.length = 0;
@@ -263,7 +272,8 @@ describe("cli/archive-chapter", () => {
       path: "/tmp/book.sdpub",
     });
 
-    expect(chapterMockState.editableCalls).toStrictEqual(["/tmp/book.sdpub"]);
+    expect(chapterMockState.readCalls).toStrictEqual(["/tmp/book.sdpub"]);
+    expect(chapterMockState.writeCalls).toStrictEqual([]);
     expect(chapterMockState.textWrites).toStrictEqual([
       "[1] planned  Part I\n  [2] source   Chapter 1\n",
     ]);

--- a/test/cli/archive-maintenance.test.ts
+++ b/test/cli/archive-maintenance.test.ts
@@ -15,7 +15,7 @@ const archiveMaintenanceMockState = vi.hoisted(() => ({
         readonly path: string;
       }
     | undefined,
-  editableCalls: [] as string[],
+  writeCalls: [] as string[],
   meta: {
     authors: ["Ari Lantern", "Bea North"],
     description: "Fixture description",
@@ -52,10 +52,10 @@ vi.mock("../../src/facade/spine-digest-file.js", () => ({
       this.#path = path;
     }
 
-    public async openEditableSession(
+    public async write(
       operation: (document: MockEditableDocument) => Promise<unknown>,
     ): Promise<unknown> {
-      archiveMaintenanceMockState.editableCalls.push(this.#path);
+      archiveMaintenanceMockState.writeCalls.push(this.#path);
       return await operation({
         readBookMeta: () => Promise.resolve(archiveMaintenanceMockState.meta),
         replaceBookMeta: (meta: unknown) => {
@@ -95,7 +95,7 @@ describe("cli/archive maintenance", () => {
       mediaType: "image/png",
       path: "images/cover.png",
     };
-    archiveMaintenanceMockState.editableCalls.length = 0;
+    archiveMaintenanceMockState.writeCalls.length = 0;
     archiveMaintenanceMockState.meta = {
       authors: ["Ari Lantern", "Bea North"],
       description: "Fixture description",
@@ -170,7 +170,7 @@ describe("cli/archive maintenance", () => {
       },
     });
 
-    expect(archiveMaintenanceMockState.editableCalls).toStrictEqual([
+    expect(archiveMaintenanceMockState.writeCalls).toStrictEqual([
       "/tmp/book.sdpub",
     ]);
     expect(archiveMaintenanceMockState.replacedMeta).toStrictEqual([

--- a/test/cli/archive.test.ts
+++ b/test/cli/archive.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const archiveMockState = vi.hoisted(() => ({
-  editableCalls: [] as string[],
+  readCalls: [] as string[],
   findHits: [
     {
       chapter: 2,
@@ -166,10 +166,10 @@ vi.mock("../../src/facade/spine-digest-file.js", () => ({
       this.#path = path;
     }
 
-    public async openEditableSession(
+    public async readDocument(
       operation: (document: unknown) => Promise<unknown>,
     ): Promise<unknown> {
-      archiveMockState.editableCalls.push(this.#path);
+      archiveMockState.readCalls.push(this.#path);
       return await operation({});
     }
   },
@@ -290,7 +290,7 @@ import {
 describe("cli/archive", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    archiveMockState.editableCalls.length = 0;
+    archiveMockState.readCalls.length = 0;
     archiveMockState.textWrites.length = 0;
     archiveMockState.links.splice(0, archiveMockState.links.length, {
       direction: "outgoing",
@@ -316,7 +316,7 @@ describe("cli/archive", () => {
       archivePath: "/tmp/book.sdpub",
     });
 
-    expect(archiveMockState.editableCalls).toStrictEqual(["/tmp/book.sdpub"]);
+    expect(archiveMockState.readCalls).toStrictEqual(["/tmp/book.sdpub"]);
     expect(archiveMockState.textWrites[0]).toContain("Archive Type: LLM Wiki");
     expect(archiveMockState.textWrites[0]).toContain("chapter:2");
   });

--- a/test/cli/queue.test.ts
+++ b/test/cli/queue.test.ts
@@ -4,18 +4,40 @@ const queueMockState = vi.hoisted(() => ({
   activeError: undefined as Error | undefined,
   activeJobChecks: [] as unknown[],
   addCalls: [] as unknown[],
+  buildGraphCalls: [] as unknown[],
+  buildSummaryCalls: [] as unknown[],
   chapterStage: "sourced" as "planned" | "sourced" | "graphed" | "summarized",
+  commitGraphCalls: [] as unknown[],
+  commitSummaryCalls: [] as unknown[],
   events: [] as unknown[],
   getJobIds: [] as string[],
+  buildInputStage: "sourced" as
+    | "planned"
+    | "sourced"
+    | "graphed"
+    | "summarized",
   job: {
+    archivePath: "book.sdpub",
+    chapterId: 12,
     eventsPath: "events.ndjson",
     jobId: "job-1",
     state: "succeeded",
+    target: "summary",
+    workspacePath: "/tmp/job-workspace",
   },
+  readDocumentCalls: [] as string[],
   readChapterStageError: undefined as Error | undefined,
   openPaths: [] as string[],
   resolveJobIds: [] as string[],
+  runWorkerOptions: undefined as
+    | {
+        readonly concurrency: number;
+        readonly executeJob: (job: unknown, reporter: unknown) => Promise<void>;
+      }
+    | undefined,
+  stepLog: [] as string[],
   textWrites: [] as string[],
+  writeCalls: [] as string[],
 }));
 
 vi.mock("../../src/facade/spine-digest-file.js", () => ({
@@ -40,6 +62,30 @@ vi.mock("../../src/facade/spine-digest-file.js", () => ({
         },
       });
     }
+
+    public async readDocument(
+      operation: (document: unknown) => Promise<unknown>,
+    ): Promise<unknown> {
+      queueMockState.readDocumentCalls.push(this.#path);
+      queueMockState.stepLog.push("read:start");
+      try {
+        return await operation({});
+      } finally {
+        queueMockState.stepLog.push("read:end");
+      }
+    }
+
+    public async write(
+      operation: (document: unknown) => Promise<unknown>,
+    ): Promise<unknown> {
+      queueMockState.writeCalls.push(this.#path);
+      queueMockState.stepLog.push("write:start");
+      try {
+        return await operation({});
+      } finally {
+        queueMockState.stepLog.push("write:end");
+      }
+    }
   },
 }));
 
@@ -62,10 +108,42 @@ vi.mock("../../src/facade/index.js", () => ({
     return Promise.resolve();
   }),
   boostBuildJob: vi.fn(),
+  buildChapterGraphArtifact: vi.fn((_chapterId: number, options: unknown) => {
+    queueMockState.stepLog.push("build-graph");
+    queueMockState.buildGraphCalls.push(options);
+    return Promise.resolve({
+      chapterId: 12,
+      documentPath: "/tmp/job-workspace/graph-document",
+    });
+  }),
+  buildChapterSummaryArtifactFromSnapshot: vi.fn(
+    (_chapterId: number, options: unknown) => {
+      queueMockState.stepLog.push("build-summary");
+      queueMockState.buildSummaryCalls.push(options);
+      return Promise.resolve("summary text");
+    },
+  ),
   cancelBuildJob: vi.fn(),
   cleanBuildJobs: vi.fn(),
-  generateChapterGraph: vi.fn(),
-  generateChapterSummary: vi.fn(),
+  commitChapterGraphArtifact: vi.fn(() => {
+    queueMockState.stepLog.push("commit-graph");
+    queueMockState.commitGraphCalls.push({});
+    queueMockState.buildInputStage = "graphed";
+    return Promise.resolve({
+      chapterId: 12,
+      stage: "graphed",
+      words: 4,
+    });
+  }),
+  commitChapterSummaryArtifact: vi.fn(() => {
+    queueMockState.stepLog.push("commit-summary");
+    queueMockState.commitSummaryCalls.push({});
+    return Promise.resolve({
+      chapterId: 12,
+      stage: "summarized",
+      words: 4,
+    });
+  }),
   getBuildJob: vi.fn((jobId: string) => {
     queueMockState.getJobIds.push(jobId);
     return Promise.resolve(queueMockState.job);
@@ -78,7 +156,29 @@ vi.mock("../../src/facade/index.js", () => ({
     return Promise.resolve(jobId === "job-1-short" ? "job-1-full" : jobId);
   }),
   resumeBuildJob: vi.fn(),
-  runBuildJobWorker: vi.fn(),
+  runBuildJobWorker: vi.fn(
+    (options: typeof queueMockState.runWorkerOptions) => {
+      queueMockState.runWorkerOptions = options;
+      return Promise.resolve();
+    },
+  ),
+  readChapterBuildInput: vi.fn(() =>
+    Promise.resolve({
+      details: {
+        chapterId: 12,
+        stage: queueMockState.buildInputStage,
+        words: 4,
+      },
+      nextChunkId: 100,
+      sourceText: ["Alpha beta."],
+    }),
+  ),
+  snapshotChapterSummaryInput: vi.fn(() => {
+    queueMockState.stepLog.push("snapshot-summary");
+    return Promise.resolve({
+      documentPath: "/tmp/job-workspace/summary-input-document",
+    });
+  }),
   updateBuildJobTarget: vi.fn(),
 }));
 
@@ -99,18 +199,31 @@ describe("cli/queue", () => {
     queueMockState.activeError = undefined;
     queueMockState.activeJobChecks.length = 0;
     queueMockState.addCalls.length = 0;
+    queueMockState.buildGraphCalls.length = 0;
+    queueMockState.buildSummaryCalls.length = 0;
+    queueMockState.buildInputStage = "sourced";
     queueMockState.chapterStage = "sourced";
+    queueMockState.commitGraphCalls.length = 0;
+    queueMockState.commitSummaryCalls.length = 0;
     queueMockState.events = [];
     queueMockState.getJobIds.length = 0;
     queueMockState.job = {
+      archivePath: "book.sdpub",
+      chapterId: 12,
       eventsPath: "events.ndjson",
       jobId: "job-1",
       state: "succeeded",
+      target: "summary",
+      workspacePath: "/tmp/job-workspace",
     };
     queueMockState.openPaths.length = 0;
+    queueMockState.readDocumentCalls.length = 0;
     queueMockState.readChapterStageError = undefined;
     queueMockState.resolveJobIds.length = 0;
+    queueMockState.runWorkerOptions = undefined;
+    queueMockState.stepLog.length = 0;
     queueMockState.textWrites.length = 0;
+    queueMockState.writeCalls.length = 0;
     process.env.SPINEDIGEST_QUEUE_DISABLE_AUTOSTART = "1";
   });
 
@@ -212,6 +325,54 @@ describe("cli/queue", () => {
       },
     ]);
     expect(queueMockState.textWrites.join("")).toContain("Job job-1 queued");
+  });
+
+  it("runs LLM build work outside archive write scopes", async () => {
+    queueMockState.job = {
+      ...queueMockState.job,
+      state: "running",
+    };
+
+    await runQueueCommand({
+      action: "worker",
+    });
+
+    const reporter = {
+      addOutputCharacters: vi.fn(() => Promise.resolve()),
+      setTotals: vi.fn(() => Promise.resolve()),
+      stepCompleted: vi.fn(() => Promise.resolve()),
+      stepStarted: vi.fn(() => Promise.resolve()),
+      updateWords: vi.fn(() => Promise.resolve()),
+    };
+
+    await queueMockState.runWorkerOptions!.executeJob(
+      queueMockState.job,
+      reporter,
+    );
+
+    expect(queueMockState.stepLog).toStrictEqual([
+      "read:start",
+      "read:end",
+      "build-graph",
+      "write:start",
+      "commit-graph",
+      "write:end",
+      "read:start",
+      "read:end",
+      "read:start",
+      "snapshot-summary",
+      "read:end",
+      "build-summary",
+      "write:start",
+      "commit-summary",
+      "write:end",
+    ]);
+    expect(queueMockState.writeCalls).toStrictEqual([
+      "book.sdpub",
+      "book.sdpub",
+    ]);
+    expect(queueMockState.buildGraphCalls).toHaveLength(1);
+    expect(queueMockState.buildSummaryCalls).toHaveLength(1);
   });
 
   it("writes every watch jsonl event without closing stdout", async () => {

--- a/test/cli/queue.test.ts
+++ b/test/cli/queue.test.ts
@@ -26,7 +26,7 @@ vi.mock("../../src/facade/spine-digest-file.js", () => ({
       this.#path = path;
     }
 
-    public async openSession(
+    public async read(
       operation: (digest: unknown) => Promise<unknown>,
     ): Promise<unknown> {
       queueMockState.openPaths.push(this.#path);

--- a/test/cli/queue.test.ts
+++ b/test/cli/queue.test.ts
@@ -189,6 +189,26 @@ vi.mock("../../src/cli/io.js", () => ({
   }),
 }));
 
+vi.mock("../../src/cli/config.js", () => ({
+  loadCLIConfig: vi.fn(() =>
+    Promise.resolve({
+      request: {
+        concurrent: 2,
+      },
+    }),
+  ),
+}));
+
+vi.mock("../../src/cli/stage-runtime.js", () => ({
+  createStageLLM: vi.fn(() => ({})),
+  loadRequiredStageConfig: vi.fn(() =>
+    Promise.resolve({
+      prompt: "Keep key beats",
+    }),
+  ),
+  resolveExtractionPrompt: vi.fn((prompt: string | undefined) => prompt ?? ""),
+}));
+
 import { runQueueCommand } from "../../src/cli/queue.js";
 
 describe("cli/queue", () => {

--- a/test/facade/build-queue.test.ts
+++ b/test/facade/build-queue.test.ts
@@ -275,6 +275,62 @@ describe("facade/build-queue", () => {
       await worker;
     });
   });
+
+  it("lists multiple running jobs when worker concurrency allows it", async () => {
+    await withTempDir("spinedigest-build-queue-", async (path) => {
+      useStateDir(`${path}/state`);
+      await addBuildJob({
+        archivePath: `${path}/book.sdpub`,
+        chapterId: 1,
+        target: "graph",
+      });
+      await addBuildJob({
+        archivePath: `${path}/book.sdpub`,
+        chapterId: 2,
+        target: "graph",
+      });
+
+      let firstStarted!: () => void;
+      let secondStarted!: () => void;
+      let releaseJobs!: () => void;
+      const firstStartedSignal = new Promise<void>((resolveStarted) => {
+        firstStarted = resolveStarted;
+      });
+      const secondStartedSignal = new Promise<void>((resolveStarted) => {
+        secondStarted = resolveStarted;
+      });
+      const releaseSignal = new Promise<void>((resolveRelease) => {
+        releaseJobs = resolveRelease;
+      });
+
+      const worker = runBuildJobWorker({
+        concurrency: 2,
+        executeJob: async (job) => {
+          if (job.chapterId === 1) {
+            firstStarted();
+          } else if (job.chapterId === 2) {
+            secondStarted();
+          }
+
+          await releaseSignal;
+        },
+        idleTimeoutMs: 0,
+      });
+
+      await withTimeout(
+        Promise.all([firstStartedSignal, secondStartedSignal]),
+        "Timed out waiting for both queue slots to become running.",
+      );
+
+      expect((await listBuildJobs()).map((job) => job.state)).toStrictEqual([
+        "running",
+        "running",
+      ]);
+
+      releaseJobs();
+      await worker;
+    });
+  });
 });
 
 async function forceRunningPid(

--- a/test/facade/build-queue.test.ts
+++ b/test/facade/build-queue.test.ts
@@ -217,6 +217,64 @@ describe("facade/build-queue", () => {
       ).toContain("requeued");
     });
   });
+
+  it("refills idle worker slots while other jobs are still running", async () => {
+    await withTempDir("spinedigest-build-queue-", async (path) => {
+      useStateDir(`${path}/state`);
+      await addBuildJob({
+        archivePath: `${path}/book.sdpub`,
+        chapterId: 1,
+        target: "graph",
+      });
+
+      let firstStarted!: () => void;
+      let secondStarted!: () => void;
+      let releaseFirst!: () => void;
+      let releaseSecond!: () => void;
+      const firstStartedSignal = new Promise<void>((resolveStarted) => {
+        firstStarted = resolveStarted;
+      });
+      const secondStartedSignal = new Promise<void>((resolveStarted) => {
+        secondStarted = resolveStarted;
+      });
+      const firstReleaseSignal = new Promise<void>((resolveRelease) => {
+        releaseFirst = resolveRelease;
+      });
+      const secondReleaseSignal = new Promise<void>((resolveRelease) => {
+        releaseSecond = resolveRelease;
+      });
+
+      const worker = runBuildJobWorker({
+        concurrency: 2,
+        executeJob: async (job) => {
+          if (job.chapterId === 1) {
+            firstStarted();
+            await firstReleaseSignal;
+            return;
+          }
+
+          secondStarted();
+          await secondReleaseSignal;
+        },
+        idleTimeoutMs: 0,
+      });
+
+      await firstStartedSignal;
+      await addBuildJob({
+        archivePath: `${path}/book.sdpub`,
+        chapterId: 2,
+        target: "graph",
+      });
+      await withTimeout(
+        secondStartedSignal,
+        "Timed out waiting for idle queue slot to claim the second job.",
+      );
+
+      releaseFirst();
+      releaseSecond();
+      await worker;
+    });
+  });
 });
 
 async function forceRunningPid(
@@ -254,4 +312,24 @@ function restoreEnv(key: string, value: string | undefined): void {
   }
 
   process.env[key] = value;
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  message: string,
+): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(() => {
+      reject(new Error(message));
+    }, 2_000);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  }
 }

--- a/test/facade/chapter-graph.test.ts
+++ b/test/facade/chapter-graph.test.ts
@@ -54,6 +54,11 @@ import {
   getChapterDetails,
   setChapterSource,
 } from "../../src/facade/chapter.js";
+import {
+  buildChapterGraphArtifact,
+  commitChapterGraphArtifact,
+  readChapterBuildInput,
+} from "../../src/facade/chapter-build.js";
 import { withTempDir } from "../helpers/temp.js";
 
 describe("facade/chapter graph", () => {
@@ -90,6 +95,44 @@ describe("facade/chapter graph", () => {
           stage: "graphed",
           words: 4,
         });
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("commits staged graph output without holding the source document", async () => {
+    await withTempDir("spinedigest-chapter-graph-", async (path) => {
+      const document = await DirectoryDocument.open(`${path}/archive`);
+
+      try {
+        const chapter = await addChapter(document, {
+          title: "Chapter 1",
+        });
+        await setChapterSource(document, chapter.chapterId, [
+          "Alpha beta.",
+          "Gamma delta.",
+        ]);
+
+        const input = await readChapterBuildInput(document, chapter.chapterId);
+        const artifact = await buildChapterGraphArtifact(chapter.chapterId, {
+          extractionPrompt: "Keep key beats",
+          llm: {} as never,
+          nextChunkId: input.nextChunkId,
+          sourceText: input.sourceText,
+          workspacePath: `${path}/job-workspace`,
+        });
+
+        await commitChapterGraphArtifact(document, artifact);
+
+        await expect(
+          getChapterDetails(document, chapter.chapterId),
+        ).resolves.toMatchObject({
+          fragmentCount: 2,
+          stage: "graphed",
+          words: 4,
+        });
+        await expect(document.chunks.getMaxId()).resolves.toBe(0);
       } finally {
         await document.release();
       }

--- a/test/facade/chapter.test.ts
+++ b/test/facade/chapter.test.ts
@@ -69,7 +69,7 @@ describe("facade/chapter", () => {
     });
   });
 
-  it("normalizes serial-less grouping nodes into planned chapters", async () => {
+  it("keeps serial-less grouping nodes read-only when listing chapters", async () => {
     await withTempDir("spinedigest-chapter-", async (path) => {
       const document = await DirectoryDocument.open(path);
 
@@ -95,6 +95,72 @@ describe("facade/chapter", () => {
 
         expect(await listChapters(document)).toMatchObject([
           {
+            chapterId: 1,
+            depth: 1,
+            stage: "planned",
+            title: "Chapter 1",
+            tocPath: ["Part I", "Chapter 1"],
+          },
+        ]);
+        expect(await getChapterTree(document)).toStrictEqual({
+          chapters: [
+            {
+              children: [],
+              id: 1,
+              title: "Chapter 1",
+            },
+          ],
+        });
+        expect(await document.readToc()).toStrictEqual({
+          items: [
+            {
+              children: [
+                {
+                  children: [],
+                  serialId: 1,
+                  title: "Chapter 1",
+                },
+              ],
+              title: "Part I",
+            },
+          ],
+          version: 1,
+        });
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("normalizes serial-less grouping nodes before chapter writes", async () => {
+    await withTempDir("spinedigest-chapter-", async (path) => {
+      const document = await DirectoryDocument.open(path);
+
+      try {
+        await document.openSession(async (openedDocument) => {
+          await openedDocument.createSerial();
+          await openedDocument.writeToc({
+            items: [
+              {
+                children: [
+                  {
+                    children: [],
+                    serialId: 1,
+                    title: "Chapter 1",
+                  },
+                ],
+                title: "Part I",
+              },
+            ],
+            version: 1,
+          });
+        });
+
+        const added = await addChapter(document, { title: "Chapter 2" });
+
+        expect(added.chapterId).toBe(3);
+        expect(await listChapters(document)).toMatchObject([
+          {
             chapterId: 2,
             depth: 0,
             stage: "planned",
@@ -106,12 +172,22 @@ describe("facade/chapter", () => {
             stage: "planned",
             title: "Chapter 1",
           },
+          {
+            chapterId: 3,
+            depth: 0,
+            stage: "planned",
+            title: "Chapter 2",
+          },
         ]);
         expect(await document.readToc()).toMatchObject({
           items: [
             {
               serialId: 2,
               title: "Part I",
+            },
+            {
+              serialId: 3,
+              title: "Chapter 2",
             },
           ],
         });

--- a/test/facade/spine-digest-file.test.ts
+++ b/test/facade/spine-digest-file.test.ts
@@ -17,7 +17,7 @@ describe("facade/spine-digest-file", () => {
     restoreCoordinatorEnv();
   });
 
-  it("opens a saved archive in a temporary session and exposes digest operations", async () => {
+  it("opens a saved archive for reading and exposes digest operations", async () => {
     await withTempDir("spinedigest-facade-file-", async (path) => {
       const document = await DirectoryDocument.open(`${path}/document`);
 
@@ -28,8 +28,8 @@ describe("facade/spine-digest-file", () => {
         await new SpineDigest(document, document.path).saveAs(archivePath);
 
         const digestFile = new SpineDigestFile(archivePath);
-        const exportedText = await digestFile.openSession(async (digest) => {
-          const textPath = `${path}/exports/from-session.txt`;
+        const exportedText = await digestFile.read(async (digest) => {
+          const textPath = `${path}/exports/from-read.txt`;
 
           expect(await digest.readMeta()).toMatchObject({
             title: "Session Fixture",
@@ -62,53 +62,66 @@ describe("facade/spine-digest-file", () => {
         await seedDocument(document);
 
         const archivePath = `${path}/fixture/book.sdpub`;
-        const sessionDir = `${path}/opened-session`;
+        const readDir = `${path}/opened-read`;
 
         await new SpineDigest(document, document.path).saveAs(archivePath);
 
         const digestFile = new SpineDigestFile(archivePath);
-        await digestFile.openSession(
+        await digestFile.read(
           async (digest) => {
             expect(await digest.readMeta()).toMatchObject({
               title: "Session Fixture",
             });
           },
           {
-            documentDirPath: sessionDir,
+            documentDirPath: readDir,
           },
         );
 
         await expect(
-          access(`${sessionDir}/book-meta.json`),
+          access(`${readDir}/book-meta.json`),
         ).resolves.toBeUndefined();
-        expect(
-          await readFile(`${sessionDir}/book-meta.json`, "utf8"),
-        ).toContain("Session Fixture");
+        expect(await readFile(`${readDir}/book-meta.json`, "utf8")).toContain(
+          "Session Fixture",
+        );
       } finally {
         await document.release();
       }
     });
   });
 
-  it("flushes successful editable sessions back to the archive", async () => {
+  it("does not create coordinator state for plain archive reads", async () => {
     await withTempDir("spinedigest-facade-file-", async (path) => {
       useCoordinatorStateDir(`${path}/state`);
       const archivePath = await createSeedArchive(path);
 
-      await new SpineDigestFile(archivePath).openEditableSession(
-        async (document) => {
-          const meta = await document.readBookMeta();
+      await new SpineDigestFile(archivePath).read(async (digest) => {
+        expect(await digest.readMeta()).toMatchObject({
+          title: "Session Fixture",
+        });
+      });
 
-          if (meta === undefined) {
-            throw new Error("Missing test metadata.");
-          }
+      await expect(readCoordinatorArchives(path)).resolves.toStrictEqual([]);
+    });
+  });
 
-          await document.replaceBookMeta({
-            ...meta,
-            title: "Flushed Title",
-          });
-        },
-      );
+  it("flushes successful archive writes back to the archive", async () => {
+    await withTempDir("spinedigest-facade-file-", async (path) => {
+      useCoordinatorStateDir(`${path}/state`);
+      const archivePath = await createSeedArchive(path);
+
+      await new SpineDigestFile(archivePath).write(async (document) => {
+        const meta = await document.readBookMeta();
+
+        if (meta === undefined) {
+          throw new Error("Missing test metadata.");
+        }
+
+        await document.replaceBookMeta({
+          ...meta,
+          title: "Flushed Title",
+        });
+      });
 
       await expect(readCoordinatorArchives(path)).resolves.toStrictEqual([]);
 
@@ -118,27 +131,25 @@ describe("facade/spine-digest-file", () => {
     });
   });
 
-  it("keeps failed editable sessions materialized without flushing", async () => {
+  it("keeps failed archive writes materialized without flushing", async () => {
     await withTempDir("spinedigest-facade-file-", async (path) => {
       useCoordinatorStateDir(`${path}/state`);
       const archivePath = await createSeedArchive(path);
 
       await expect(
-        new SpineDigestFile(archivePath).openEditableSession(
-          async (document) => {
-            const meta = await document.readBookMeta();
+        new SpineDigestFile(archivePath).write(async (document) => {
+          const meta = await document.readBookMeta();
 
-            if (meta === undefined) {
-              throw new Error("Missing test metadata.");
-            }
+          if (meta === undefined) {
+            throw new Error("Missing test metadata.");
+          }
 
-            await document.replaceBookMeta({
-              ...meta,
-              title: "Unflushed Title",
-            });
-            throw new Error("stop before flush");
-          },
-        ),
+          await document.replaceBookMeta({
+            ...meta,
+            title: "Unflushed Title",
+          });
+          throw new Error("stop before flush");
+        }),
       ).rejects.toThrow("stop before flush");
 
       const archives = await readCoordinatorArchives(path);
@@ -163,22 +174,20 @@ describe("facade/spine-digest-file", () => {
       });
       const archivePath = await createSeedArchive(path);
 
-      await new SpineDigestFile(archivePath).openEditableSession(
-        async (document) => {
-          const meta = await document.readBookMeta();
+      await new SpineDigestFile(archivePath).write(async (document) => {
+        const meta = await document.readBookMeta();
 
-          if (meta === undefined) {
-            throw new Error("Missing test metadata.");
-          }
+        if (meta === undefined) {
+          throw new Error("Missing test metadata.");
+        }
 
-          await document.replaceBookMeta({
-            ...meta,
-            title: "Workspace Title",
-          });
-        },
-      );
+        await document.replaceBookMeta({
+          ...meta,
+          title: "Workspace Title",
+        });
+      });
 
-      await new SpineDigestFile(archivePath).openSession(async (digest) => {
+      await new SpineDigestFile(archivePath).read(async (digest) => {
         expect(await digest.readMeta()).toMatchObject({
           title: "Workspace Title",
         });
@@ -189,41 +198,39 @@ describe("facade/spine-digest-file", () => {
     });
   });
 
-  it("rejects concurrent editable sessions for the same archive", async () => {
+  it("rejects concurrent writes for the same archive", async () => {
     await withTempDir("spinedigest-facade-file-", async (path) => {
       useCoordinatorStateDir(`${path}/state`, {
         idleTimeoutMs: 1_000,
         quietPeriodMs: 60_000,
       });
       const archivePath = await createSeedArchive(path);
-      let markFirstSessionEntered!: () => void;
-      let releaseFirstSession!: () => void;
-      const firstSessionEntered = new Promise<void>((resolveEntered) => {
-        markFirstSessionEntered = resolveEntered;
+      let markFirstWriteEntered!: () => void;
+      let releaseFirstWrite!: () => void;
+      const firstWriteEntered = new Promise<void>((resolveEntered) => {
+        markFirstWriteEntered = resolveEntered;
       });
-      const releaseFirstSessionSignal = new Promise<void>((resolveRelease) => {
-        releaseFirstSession = resolveRelease;
+      const releaseFirstWriteSignal = new Promise<void>((resolveRelease) => {
+        releaseFirstWrite = resolveRelease;
       });
 
-      const firstSession = new SpineDigestFile(archivePath).openEditableSession(
-        async () => {
-          markFirstSessionEntered();
-          await releaseFirstSessionSignal;
-        },
-      );
+      const firstWrite = new SpineDigestFile(archivePath).write(async () => {
+        markFirstWriteEntered();
+        await releaseFirstWriteSignal;
+      });
 
-      await firstSessionEntered;
+      await firstWriteEntered;
       await waitForCoordinatorArchive(path);
       await expect(
-        new SpineDigestFile(archivePath).openEditableSession(async () => {}),
+        new SpineDigestFile(archivePath).write(async () => {}),
       ).rejects.toThrow("Archive is already being edited");
 
-      releaseFirstSession();
-      await firstSession;
+      releaseFirstWrite();
+      await firstWrite;
     });
   });
 
-  it("recovers stale editable sessions when the owner process is gone", async () => {
+  it("recovers stale writes when the owner process is gone", async () => {
     await withTempDir("spinedigest-facade-file-", async (path) => {
       useCoordinatorStateDir(`${path}/state`, {
         idleTimeoutMs: 1_000,
@@ -232,33 +239,29 @@ describe("facade/spine-digest-file", () => {
       const archivePath = await createSeedArchive(path);
 
       await expect(
-        new SpineDigestFile(archivePath).openEditableSession(
-          async (document) => {
-            const meta = await document.readBookMeta();
+        new SpineDigestFile(archivePath).write(async (document) => {
+          const meta = await document.readBookMeta();
 
-            if (meta === undefined) {
-              throw new Error("Missing test metadata.");
-            }
+          if (meta === undefined) {
+            throw new Error("Missing test metadata.");
+          }
 
-            await document.replaceBookMeta({
-              ...meta,
-              title: "Interrupted Title",
-            });
-            throw new Error("interrupted");
-          },
-        ),
+          await document.replaceBookMeta({
+            ...meta,
+            title: "Interrupted Title",
+          });
+          throw new Error("interrupted");
+        }),
       ).rejects.toThrow("interrupted");
 
       await setCoordinatorOperationPid(path, -1);
-      await new SpineDigestFile(archivePath).openEditableSession(
-        async (document) => {
-          const meta = await document.readBookMeta();
+      await new SpineDigestFile(archivePath).write(async (document) => {
+        const meta = await document.readBookMeta();
 
-          expect(meta).toMatchObject({
-            title: "Interrupted Title",
-          });
-        },
-      );
+        expect(meta).toMatchObject({
+          title: "Interrupted Title",
+        });
+      });
     });
   });
 });
@@ -328,6 +331,12 @@ async function readCoordinatorArchives(path: string): Promise<
     readonly operationPid: number | null;
   }>
 > {
+  try {
+    await access(`${path}/state/state.sqlite`);
+  } catch {
+    return [];
+  }
+
   const { Database } = await import("../../src/document/index.js");
   const database = await Database.open(
     `${path}/state/state.sqlite`,


### PR DESCRIPTION
## Summary
- split high-level sdpub access into read/readDocument/write paths and move read-only archive commands off write workspaces
- make chapter/archive read helpers accept ReadonlyDocument and prevent read-only TOC queries from writing repairs
- stage queue graph/summary generation in job workspaces so archive write access is held only during final commits
- add coverage for visible queue concurrency through the queue list data source

## Validation
- pnpm verify
- pnpm test:run
- installed local CLI with pnpm run cli:install-local
- verified spinedigest queue list showed 10 running jobs with request.concurrent=10