### PR TITLE
fix(queue): improve worker resilience

### DIFF
--- a/src/cli/queue.ts
+++ b/src/cli/queue.ts
@@ -176,6 +176,7 @@ async function executeBuildJob(
   });
   const prompt = resolveExtractionPrompt(job.prompt ?? config.prompt);
 
+  await reporter.stepStarted("graph");
   const buildInput = await new SpineDigestFile(job.archivePath).readDocument(
     async (document) => await readChapterBuildInput(document, job.chapterId),
   );
@@ -198,7 +199,6 @@ async function executeBuildJob(
   if (details.stage === "sourced") {
     let graphWords = 0;
 
-    await reporter.stepStarted("graph");
     const artifact = await buildChapterGraphArtifact(job.chapterId, {
       extractionPrompt: prompt,
       llm,

--- a/src/cli/queue.ts
+++ b/src/cli/queue.ts
@@ -258,7 +258,7 @@ async function executeBuildJob(
   );
   const summary = await buildChapterSummaryArtifactFromSnapshot(job.chapterId, {
     llm,
-    sourceDocumentPath: summaryInput.documentPath,
+    snapshotPath: summaryInput.filePath,
     workspacePath: job.workspacePath,
   });
   details = await new SpineDigestFile(job.archivePath).write(

--- a/src/cli/queue.ts
+++ b/src/cli/queue.ts
@@ -176,7 +176,6 @@ async function executeBuildJob(
   });
   const prompt = resolveExtractionPrompt(job.prompt ?? config.prompt);
 
-  await reporter.stepStarted("graph");
   const buildInput = await new SpineDigestFile(job.archivePath).readDocument(
     async (document) => await readChapterBuildInput(document, job.chapterId),
   );
@@ -199,6 +198,7 @@ async function executeBuildJob(
   if (details.stage === "sourced") {
     let graphWords = 0;
 
+    await reporter.stepStarted("graph");
     const artifact = await buildChapterGraphArtifact(job.chapterId, {
       extractionPrompt: prompt,
       llm,

--- a/src/document/database.ts
+++ b/src/document/database.ts
@@ -79,7 +79,7 @@ export class Database {
       const isRootTransaction = this.#transactionDepth === 0;
 
       if (isRootTransaction) {
-        await this.#executeSql("BEGIN");
+        await this.#executeSql("BEGIN IMMEDIATE");
       }
 
       this.#transactionDepth += 1;

--- a/src/document/database.ts
+++ b/src/document/database.ts
@@ -11,6 +11,8 @@ type SqlRowValue = SqlBindValue;
 
 export type SqlRow = Record<string, SqlRowValue>;
 
+const SQLITE_BUSY_TIMEOUT_MS = 15 * 60 * 1000;
+
 export class Database {
   readonly #database: SqliteDatabase;
   readonly #operationScope = new AsyncLocalStorage<boolean>();
@@ -30,6 +32,9 @@ export class Database {
     const database = await openSqliteDatabase(resolvedDatabasePath);
     const openedDatabase = new Database(database);
 
+    await openedDatabase.#executeSql(
+      `PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`,
+    );
     await openedDatabase.#executeSql(schemaSql);
 
     return openedDatabase;

--- a/src/document/database.ts
+++ b/src/document/database.ts
@@ -30,15 +30,18 @@ export class Database {
   public static async open(
     databasePath: string,
     schemaSql: string,
+    options: { readonly readonly?: boolean } = {},
   ): Promise<Database> {
     const resolvedDatabasePath = resolve(databasePath);
-    const database = await openSqliteDatabase(resolvedDatabasePath);
+    const database = await openSqliteDatabase(resolvedDatabasePath, options);
     const openedDatabase = new Database(database);
 
     await openedDatabase.#executeSql(
       `PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`,
     );
-    await openedDatabase.#executeSql(schemaSql);
+    if (options.readonly !== true && schemaSql.trim() !== "") {
+      await openedDatabase.#executeSql(schemaSql);
+    }
 
     return openedDatabase;
   }
@@ -302,11 +305,16 @@ export function getOptionalString(
 
 async function openSqliteDatabase(
   databasePath: string,
+  options: { readonly readonly?: boolean } = {},
 ): Promise<SqliteDatabase> {
   const sqlite3 = await loadSqlite3();
+  const flags =
+    (options.readonly === true
+      ? sqlite3.OPEN_READONLY
+      : sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE) | sqlite3.OPEN_FULLMUTEX;
 
   return await new Promise<SqliteDatabase>((resolveOpen, rejectOpen) => {
-    const database = new sqlite3.Database(databasePath, (error) => {
+    const database = new sqlite3.Database(databasePath, flags, (error) => {
       if (error !== null) {
         rejectOpen(error);
         return;

--- a/src/document/database.ts
+++ b/src/document/database.ts
@@ -13,9 +13,12 @@ export type SqlRow = Record<string, SqlRowValue>;
 
 const SQLITE_BUSY_TIMEOUT_MS = 15 * 60 * 1000;
 
+type DatabaseOperationScope = symbol;
+
 export class Database {
   readonly #database: SqliteDatabase;
-  readonly #operationScope = new AsyncLocalStorage<boolean>();
+  readonly #operationScope = new AsyncLocalStorage<DatabaseOperationScope>();
+  #activeTransactionScope: DatabaseOperationScope | undefined;
   #closed = false;
   #operationChain: Promise<void> = Promise.resolve();
   #transactionDepth = 0;
@@ -77,20 +80,30 @@ export class Database {
     return await this.#runSerialized(async () => {
       this.#assertOpen();
       const isRootTransaction = this.#transactionDepth === 0;
+      const transactionScope =
+        this.#activeTransactionScope ?? Symbol("database transaction scope");
 
       if (isRootTransaction) {
+        this.#activeTransactionScope = transactionScope;
         await this.#executeSql("BEGIN IMMEDIATE");
       }
 
       this.#transactionDepth += 1;
 
       try {
-        const result = await operation();
+        const result = await this.#operationScope.run(
+          transactionScope,
+          operation,
+        );
 
         this.#transactionDepth -= 1;
 
         if (isRootTransaction) {
-          await this.#executeSql("COMMIT");
+          try {
+            await this.#executeSql("COMMIT");
+          } finally {
+            this.#activeTransactionScope = undefined;
+          }
         }
 
         return result;
@@ -98,7 +111,11 @@ export class Database {
         this.#transactionDepth -= 1;
 
         if (isRootTransaction) {
-          await this.#executeSql("ROLLBACK");
+          try {
+            await this.#executeSql("ROLLBACK");
+          } finally {
+            this.#activeTransactionScope = undefined;
+          }
         }
 
         throw error;
@@ -144,13 +161,16 @@ export class Database {
   }
 
   async #runSerialized<T>(operation: () => Promise<T> | T): Promise<T> {
-    if (this.#operationScope.getStore() === true) {
+    const operationScope = this.#operationScope.getStore();
+
+    if (
+      operationScope !== undefined &&
+      operationScope === this.#activeTransactionScope
+    ) {
       return await operation();
     }
 
-    const queuedOperation = this.#operationChain.then(() =>
-      this.#operationScope.run(true, operation),
-    );
+    const queuedOperation = this.#operationChain.then(operation);
 
     this.#operationChain = queuedOperation.then(
       () => undefined,

--- a/src/document/database.ts
+++ b/src/document/database.ts
@@ -87,8 +87,8 @@ export class Database {
         this.#activeTransactionScope ?? Symbol("database transaction scope");
 
       if (isRootTransaction) {
-        this.#activeTransactionScope = transactionScope;
         await this.#executeSql("BEGIN IMMEDIATE");
+        this.#activeTransactionScope = transactionScope;
       }
 
       this.#transactionDepth += 1;
@@ -99,29 +99,22 @@ export class Database {
           operation,
         );
 
-        this.#transactionDepth -= 1;
-
         if (isRootTransaction) {
-          try {
-            await this.#executeSql("COMMIT");
-          } finally {
-            this.#activeTransactionScope = undefined;
-          }
+          await this.#executeSql("COMMIT");
         }
 
         return result;
       } catch (error) {
-        this.#transactionDepth -= 1;
-
         if (isRootTransaction) {
-          try {
-            await this.#executeSql("ROLLBACK");
-          } finally {
-            this.#activeTransactionScope = undefined;
-          }
+          await this.#executeSql("ROLLBACK");
         }
 
         throw error;
+      } finally {
+        this.#transactionDepth -= 1;
+        if (isRootTransaction) {
+          this.#activeTransactionScope = undefined;
+        }
       }
     });
   }

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from "async_hooks";
-import { mkdir, readFile, rm, unlink, writeFile } from "fs/promises";
+import { mkdir, readFile, readdir, rm, unlink, writeFile } from "fs/promises";
 import { join, resolve } from "path";
 import { z } from "zod";
 
@@ -31,6 +31,67 @@ import {
   SnakeStore,
 } from "./stores.js";
 import type { SentenceId } from "./types.js";
+
+export interface DocumentFileStore {
+  close(): Promise<void>;
+  deleteFile(path: string): Promise<void>;
+  deleteTree(path: string): Promise<void>;
+  ensureDirectory(path: string): Promise<void>;
+  initializeDatabaseSchema(): boolean;
+  openDatabaseReadonly(): boolean;
+  listFiles(path: string): Promise<readonly string[]>;
+  readFile(path: string): Promise<Uint8Array | undefined>;
+  resolveDatabasePath(documentPath: string): Promise<string>;
+  writeFile(
+    path: string,
+    content: string | Uint8Array,
+    options: { readonly overwrite?: boolean },
+  ): Promise<void>;
+}
+
+const LOCAL_DOCUMENT_FILE_STORE: DocumentFileStore = {
+  close: () => Promise.resolve(),
+  deleteFile: async (path) => {
+    await unlink(path);
+  },
+  deleteTree: async (path) => {
+    await rm(path, { force: true, recursive: true });
+  },
+  ensureDirectory: async (path) => {
+    await mkdir(path, { recursive: true });
+  },
+  initializeDatabaseSchema: () => true,
+  openDatabaseReadonly: () => false,
+  listFiles: async (path) =>
+    (await readdir(path, { withFileTypes: true }))
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name),
+  readFile: async (path) => {
+    try {
+      return await readFile(path);
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return undefined;
+      }
+
+      throw error;
+    }
+  },
+  resolveDatabasePath: (documentPath) =>
+    Promise.resolve(join(documentPath, "database.db")),
+  writeFile: async (path, content, options) => {
+    if (typeof content === "string") {
+      await writeFile(path, content, {
+        encoding: "utf8",
+        flag: options.overwrite === true ? "w" : "wx",
+      });
+    } else {
+      await writeFile(path, content, {
+        flag: options.overwrite === true ? "w" : "wx",
+      });
+    }
+  },
+};
 
 const coverFileSchema = z.object({
   mediaType: z.string().min(1),
@@ -103,11 +164,18 @@ export class DirectoryDocument implements Document {
   public readonly snakes: SnakeStore;
 
   readonly #database: Database;
+  readonly #fileStore: DocumentFileStore;
   readonly #fragments: Fragments;
   readonly #contextScope = new AsyncLocalStorage<DirectoryDocumentContext>();
 
-  public constructor(database: Database, fragments: Fragments, path: string) {
+  public constructor(
+    database: Database,
+    fragments: Fragments,
+    path: string,
+    fileStore: DocumentFileStore = LOCAL_DOCUMENT_FILE_STORE,
+  ) {
     this.#database = database;
+    this.#fileStore = fileStore;
     this.#fragments = fragments;
     this.chunks = new ChunkStore(database);
     this.fragmentGroups = new FragmentGroupStore(database);
@@ -119,24 +187,40 @@ export class DirectoryDocument implements Document {
     this.snakes = new SnakeStore(database);
   }
 
-  public static async open(documentPath: string): Promise<DirectoryDocument> {
+  public static async open(
+    documentPath: string,
+    options: { readonly fileStore?: DocumentFileStore } = {},
+  ): Promise<DirectoryDocument> {
     const resolvedDocumentPath = resolve(documentPath);
-    const databasePath = join(resolvedDocumentPath, "database.db");
+    const fileStore = options.fileStore ?? LOCAL_DOCUMENT_FILE_STORE;
+    const databasePath =
+      await fileStore.resolveDatabasePath(resolvedDocumentPath);
     const writer = {
       write: async (path: string, content: string): Promise<void> => {
-        await writeFile(path, content, "utf8");
+        await fileStore.writeFile(path, content, { overwrite: false });
       },
     };
-    const fragments = new Fragments(resolvedDocumentPath, writer);
+    const fragments = new Fragments(resolvedDocumentPath, writer, {
+      ensureDirectory: async (path) => {
+        await fileStore.ensureDirectory(path);
+      },
+      listFiles: async (path) => await fileStore.listFiles(path),
+      readFile: async (path) => await fileStore.readFile(path),
+    });
 
-    await mkdir(resolvedDocumentPath, { recursive: true });
+    await fileStore.ensureDirectory(resolvedDocumentPath);
     await fragments.ensureCreated();
 
-    const database = await Database.open(databasePath, SCHEMA_SQL);
+    const database = await Database.open(
+      databasePath,
+      fileStore.initializeDatabaseSchema() ? SCHEMA_SQL : "",
+      { readonly: fileStore.openDatabaseReadonly() },
+    );
     const document = new DirectoryDocument(
       database,
       fragments,
       resolvedDocumentPath,
+      fileStore,
     );
 
     writer.write = async (path: string, content: string): Promise<void> => {
@@ -182,10 +266,7 @@ export class DirectoryDocument implements Document {
 
   public async clearSerialSource(serialId: number): Promise<void> {
     await this.clearSerialGraph(serialId);
-    await rm(this.#fragments.getSerial(serialId).path, {
-      force: true,
-      recursive: true,
-    });
+    await this.#fileStore.deleteTree(this.#fragments.getSerial(serialId).path);
   }
 
   public async deleteSerial(serialId: number): Promise<void> {
@@ -194,7 +275,7 @@ export class DirectoryDocument implements Document {
 
   public async deleteSummary(serialId: number): Promise<void> {
     try {
-      await unlink(this.#getSummaryPath(serialId));
+      await this.#fileStore.deleteFile(this.#getSummaryPath(serialId));
     } catch (error) {
       if (isNodeError(error) && error.code === "ENOENT") {
         return;
@@ -265,15 +346,7 @@ export class DirectoryDocument implements Document {
   }
 
   public async readSummary(serialId: number): Promise<string | undefined> {
-    try {
-      return await readFile(this.#getSummaryPath(serialId), "utf8");
-    } catch (error) {
-      if (isNodeError(error) && error.code === "ENOENT") {
-        return undefined;
-      }
-
-      throw error;
-    }
+    return await this.#readOptionalTextFile(this.#getSummaryPath(serialId));
   }
 
   public async readToc(): Promise<TocFile | undefined> {
@@ -293,7 +366,7 @@ export class DirectoryDocument implements Document {
   }
 
   public async writeCover(cover: SourceAsset): Promise<void> {
-    await mkdir(this.#getCoverDirectoryPath(), { recursive: true });
+    await this.#fileStore.ensureDirectory(this.#getCoverDirectoryPath());
     await this.#writeJsonFile(this.#getCoverInfoPath(), {
       mediaType: cover.mediaType,
       path: cover.path,
@@ -302,7 +375,7 @@ export class DirectoryDocument implements Document {
   }
 
   public async writeSummary(serialId: number, summary: string): Promise<void> {
-    await mkdir(this.#getSummariesPath(), { recursive: true });
+    await this.#fileStore.ensureDirectory(this.#getSummariesPath());
     await this.#writeNewFile(this.#getSummaryPath(serialId), summary);
   }
 
@@ -321,6 +394,7 @@ export class DirectoryDocument implements Document {
   public async release(): Promise<void> {
     await this.flush();
     await this.#database.close();
+    await this.#fileStore.close();
   }
 
   public async close(): Promise<void> {
@@ -373,10 +447,7 @@ export class DirectoryDocument implements Document {
       );
     });
 
-    await rm(this.#fragments.getSerial(serialId).path, {
-      force: true,
-      recursive: true,
-    });
+    await this.#fileStore.deleteTree(this.#fragments.getSerial(serialId).path);
     await this.deleteSummary(serialId);
   }
 
@@ -468,27 +539,15 @@ export class DirectoryDocument implements Document {
   }
 
   async #readOptionalFile(path: string): Promise<Uint8Array | undefined> {
-    try {
-      return await readFile(path);
-    } catch (error) {
-      if (isNodeError(error) && error.code === "ENOENT") {
-        return undefined;
-      }
-
-      throw error;
-    }
+    return await this.#fileStore.readFile(path);
   }
 
   async #readOptionalTextFile(path: string): Promise<string | undefined> {
-    try {
-      return await readFile(path, "utf8");
-    } catch (error) {
-      if (isNodeError(error) && error.code === "ENOENT") {
-        return undefined;
-      }
+    const content = await this.#fileStore.readFile(path);
 
-      throw error;
-    }
+    return content === undefined
+      ? undefined
+      : Buffer.from(content).toString("utf8");
   }
 
   async #writeJsonFile(
@@ -512,16 +571,7 @@ export class DirectoryDocument implements Document {
     options: { readonly overwrite?: boolean },
   ): Promise<void> {
     try {
-      if (typeof content === "string") {
-        await writeFile(path, content, {
-          encoding: "utf8",
-          flag: options.overwrite === true ? "w" : "wx",
-        });
-      } else {
-        await writeFile(path, content, {
-          flag: options.overwrite === true ? "w" : "wx",
-        });
-      }
+      await this.#fileStore.writeFile(path, content, options);
     } catch (error) {
       if (isNodeError(error) && error.code === "EEXIST") {
         throw new Error(`File already exists: ${path}`);

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -193,41 +193,47 @@ export class DirectoryDocument implements Document {
   ): Promise<DirectoryDocument> {
     const resolvedDocumentPath = resolve(documentPath);
     const fileStore = options.fileStore ?? LOCAL_DOCUMENT_FILE_STORE;
-    const databasePath =
-      await fileStore.resolveDatabasePath(resolvedDocumentPath);
-    const writer = {
-      write: async (path: string, content: string): Promise<void> => {
-        await fileStore.writeFile(path, content, { overwrite: false });
-      },
-    };
-    const fragments = new Fragments(resolvedDocumentPath, writer, {
-      ensureDirectory: async (path) => {
-        await fileStore.ensureDirectory(path);
-      },
-      listFiles: async (path) => await fileStore.listFiles(path),
-      readFile: async (path) => await fileStore.readFile(path),
-    });
+    try {
+      const databasePath =
+        await fileStore.resolveDatabasePath(resolvedDocumentPath);
+      const writer = {
+        write: async (path: string, content: string): Promise<void> => {
+          await fileStore.writeFile(path, content, { overwrite: false });
+        },
+      };
+      const fragments = new Fragments(resolvedDocumentPath, writer, {
+        ensureDirectory: async (path) => {
+          await fileStore.ensureDirectory(path);
+        },
+        listFiles: async (path) => await fileStore.listFiles(path),
+        readFile: async (path) => await fileStore.readFile(path),
+      });
 
-    await fileStore.ensureDirectory(resolvedDocumentPath);
-    await fragments.ensureCreated();
+      await fileStore.ensureDirectory(resolvedDocumentPath);
+      await fragments.ensureCreated();
 
-    const database = await Database.open(
-      databasePath,
-      fileStore.initializeDatabaseSchema() ? SCHEMA_SQL : "",
-      { readonly: fileStore.openDatabaseReadonly() },
-    );
-    const document = new DirectoryDocument(
-      database,
-      fragments,
-      resolvedDocumentPath,
-      fileStore,
-    );
+      const database = await Database.open(
+        databasePath,
+        fileStore.initializeDatabaseSchema() ? SCHEMA_SQL : "",
+        { readonly: fileStore.openDatabaseReadonly() },
+      );
 
-    writer.write = async (path: string, content: string): Promise<void> => {
-      await document.#writeNewFile(path, content);
-    };
+      const document = new DirectoryDocument(
+        database,
+        fragments,
+        resolvedDocumentPath,
+        fileStore,
+      );
 
-    return document;
+      writer.write = async (path: string, content: string): Promise<void> => {
+        await document.#writeNewFile(path, content);
+      };
+
+      return document;
+    } catch (error) {
+      await fileStore.close();
+      throw error;
+    }
   }
 
   public static async openSession<T>(
@@ -392,9 +398,12 @@ export class DirectoryDocument implements Document {
   }
 
   public async release(): Promise<void> {
-    await this.flush();
-    await this.#database.close();
-    await this.#fileStore.close();
+    try {
+      await this.flush();
+      await this.#database.close();
+    } finally {
+      await this.#fileStore.close();
+    }
   }
 
   public async close(): Promise<void> {
@@ -411,7 +420,7 @@ export class DirectoryDocument implements Document {
   ): Promise<void> {
     for (const path of [...createdFilePaths].reverse()) {
       try {
-        await unlink(path);
+        await this.#fileStore.deleteFile(path);
       } catch (error) {
         if (isNodeError(error) && error.code === "ENOENT") {
           continue;

--- a/src/document/fragments.ts
+++ b/src/document/fragments.ts
@@ -16,9 +16,36 @@ interface FragmentWriter {
   write(path: string, content: string): Promise<void>;
 }
 
+interface FragmentFileAccess {
+  ensureDirectory(path: string): Promise<void>;
+  listFiles(path: string): Promise<readonly string[]>;
+  readFile(path: string): Promise<Uint8Array | undefined>;
+}
+
 const DEFAULT_FRAGMENT_WRITER: FragmentWriter = {
   write: async (path, content) => {
     await writeFile(path, content, "utf8");
+  },
+};
+
+const DEFAULT_FRAGMENT_FILE_ACCESS: FragmentFileAccess = {
+  ensureDirectory: async (path) => {
+    await mkdir(path, { recursive: true });
+  },
+  listFiles: async (path) =>
+    (await readdir(path, { withFileTypes: true }))
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name),
+  readFile: async (path) => {
+    try {
+      return await readFile(path);
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return undefined;
+      }
+
+      throw error;
+    }
   },
 };
 
@@ -39,19 +66,30 @@ export interface ReadonlySerialFragments {
 
 export class Fragments implements ReadonlyFragments {
   readonly #documentPath: string;
+  readonly #fileAccess: FragmentFileAccess;
   readonly #writer: FragmentWriter;
 
-  public constructor(documentPath: string, writer?: FragmentWriter) {
+  public constructor(
+    documentPath: string,
+    writer?: FragmentWriter,
+    fileAccess?: FragmentFileAccess,
+  ) {
     this.#documentPath = resolve(documentPath);
+    this.#fileAccess = fileAccess ?? DEFAULT_FRAGMENT_FILE_ACCESS;
     this.#writer = writer ?? DEFAULT_FRAGMENT_WRITER;
   }
 
   public async ensureCreated(): Promise<void> {
-    await mkdir(this.path, { recursive: true });
+    await this.#fileAccess.ensureDirectory(this.path);
   }
 
   public getSerial(serialId: number): SerialFragments {
-    return new SerialFragments(this.#documentPath, serialId, this.#writer);
+    return new SerialFragments(
+      this.#documentPath,
+      serialId,
+      this.#writer,
+      this.#fileAccess,
+    );
   }
 
   public async getSentence(sentenceId: SentenceId): Promise<string> {
@@ -94,6 +132,7 @@ export class SerialFragments implements ReadonlySerialFragments {
   readonly #serialId: number;
   #draftOpen = false;
   readonly #documentPath: string;
+  readonly #fileAccess: FragmentFileAccess;
   #nextFragmentId: number | undefined;
   readonly #writer: FragmentWriter;
 
@@ -101,9 +140,11 @@ export class SerialFragments implements ReadonlySerialFragments {
     documentPath: string,
     serialId: number,
     writer?: FragmentWriter,
+    fileAccess?: FragmentFileAccess,
   ) {
     this.#documentPath = resolve(documentPath);
     this.#serialId = serialId;
+    this.#fileAccess = fileAccess ?? DEFAULT_FRAGMENT_FILE_ACCESS;
     this.#writer = writer ?? DEFAULT_FRAGMENT_WRITER;
   }
 
@@ -112,7 +153,7 @@ export class SerialFragments implements ReadonlySerialFragments {
       throw new Error("Only one fragment draft can be open at a time");
     }
 
-    await mkdir(this.path, { recursive: true });
+    await this.#fileAccess.ensureDirectory(this.path);
     this.#draftOpen = true;
 
     return new FragmentDraft(this.#serialId, await this.#peekNextFragmentId(), {
@@ -127,6 +168,7 @@ export class SerialFragments implements ReadonlySerialFragments {
   public async getFragment(fragmentId: number): Promise<FragmentRecord> {
     const fileContent = await readFragmentFile(
       this.#getFragmentPath(fragmentId),
+      this.#fileAccess,
     );
 
     return {
@@ -139,11 +181,10 @@ export class SerialFragments implements ReadonlySerialFragments {
 
   public async listFragmentIds(): Promise<readonly number[]> {
     try {
-      const entries = await readdir(this.path, { withFileTypes: true });
+      const entries = await this.#fileAccess.listFiles(this.path);
 
       return entries
-        .filter((entry) => entry.isFile())
-        .map((entry) => FRAGMENT_FILE_PATTERN.exec(entry.name))
+        .map((entry) => FRAGMENT_FILE_PATTERN.exec(entry))
         .filter((match): match is RegExpExecArray => match !== null)
         .map((match) => Number(match[1]))
         .sort((left, right) => left - right);
@@ -179,7 +220,7 @@ export class SerialFragments implements ReadonlySerialFragments {
       return undefined;
     }
 
-    await mkdir(this.path, { recursive: true });
+    await this.#fileAccess.ensureDirectory(this.path);
     await this.#writer.write(
       this.#getFragmentPath(fragmentId),
       JSON.stringify(
@@ -303,9 +344,16 @@ export class FragmentDraft {
 
 async function readFragmentFile(
   fragmentPath: string,
+  fileAccess: FragmentFileAccess = DEFAULT_FRAGMENT_FILE_ACCESS,
 ): Promise<FragmentFileContent> {
+  const content = await fileAccess.readFile(fragmentPath);
+
+  if (content === undefined) {
+    throw new Error(`Fragment file does not exist: ${fragmentPath}`);
+  }
+
   const rawContent = JSON.parse(
-    await readFile(fragmentPath, "utf8"),
+    Buffer.from(content).toString("utf8"),
   ) as unknown;
 
   if (typeof rawContent !== "object" || rawContent === null) {

--- a/src/facade/archive.ts
+++ b/src/facade/archive.ts
@@ -31,6 +31,17 @@ const sdpubManifestSchema = z.object({
   formatVersion: z.literal(SDPUB_FORMAT_VERSION),
 });
 
+export type SdpubArchiveOverlay =
+  | {
+      readonly entryPath: string;
+      readonly kind: "deleted";
+    }
+  | {
+      readonly entryPath: string;
+      readonly kind: "file";
+      readonly workspacePath: string;
+    };
+
 export async function extractSdpubArchive(
   inputPath: string,
   outputDirectoryPath: string,
@@ -93,6 +104,130 @@ export async function writeSdpubArchive(
   const zipDone = finished(zipFile.outputStream);
 
   zipFile.outputStream.pipe(output);
+  await Promise.all([outputDone, zipDone]);
+}
+
+export async function listSdpubArchiveEntries(
+  inputPath: string,
+): Promise<readonly string[]> {
+  const zipFile = await openArchive(inputPath);
+  const entries = await indexArchiveEntries(zipFile);
+
+  try {
+    await validateArchiveManifest(zipFile, entries);
+    return entries
+      .map((entry) => normalizeArchivePath(entry.fileName))
+      .filter((entryPath) => entryPath !== "")
+      .filter(isSdpubArchivePath)
+      .sort((left, right) => left.localeCompare(right));
+  } finally {
+    zipFile.close();
+  }
+}
+
+export async function readSdpubArchiveEntry(
+  inputPath: string,
+  entryPath: string,
+): Promise<Buffer | undefined> {
+  const normalizedEntryPath = normalizeArchivePath(entryPath);
+  const zipFile = await openArchive(inputPath);
+  const entries = await indexArchiveEntries(zipFile);
+
+  try {
+    await validateArchiveManifest(zipFile, entries);
+    const entry = entries.find(
+      (candidate) =>
+        normalizeArchivePath(candidate.fileName) === normalizedEntryPath,
+    );
+
+    if (entry === undefined) {
+      return undefined;
+    }
+
+    return await readArchiveEntryBuffer(zipFile, entry);
+  } finally {
+    zipFile.close();
+  }
+}
+
+export async function writeSdpubArchiveWithOverlays(
+  inputPath: string,
+  outputPath: string,
+  overlays: readonly SdpubArchiveOverlay[],
+): Promise<void> {
+  await mkdir(dirname(outputPath), { recursive: true });
+
+  const zipFile = await openArchive(inputPath);
+  const sourceEntries = await indexArchiveEntries(zipFile);
+  const overlayByPath = new Map(
+    overlays.map((overlay) => [
+      normalizeArchivePath(overlay.entryPath),
+      overlay,
+    ]),
+  );
+  const entryPaths = new Set<string>();
+
+  for (const entry of sourceEntries) {
+    const archivePath = normalizeArchivePath(entry.fileName);
+
+    if (archivePath !== "" && isSdpubArchivePath(archivePath)) {
+      entryPaths.add(archivePath);
+    }
+  }
+  for (const overlay of overlayByPath.values()) {
+    entryPaths.add(normalizeArchivePath(overlay.entryPath));
+  }
+  entryPaths.add(SDPUB_MANIFEST_PATH);
+
+  const outputZipFile = new YazlZipFile();
+
+  try {
+    await validateArchiveManifest(zipFile, sourceEntries);
+
+    for (const entryPath of [...entryPaths].sort((left, right) =>
+      left.localeCompare(right),
+    )) {
+      const overlay = overlayByPath.get(entryPath);
+
+      if (overlay?.kind === "deleted") {
+        continue;
+      }
+      if (entryPath === SDPUB_MANIFEST_PATH) {
+        outputZipFile.addBuffer(
+          Buffer.from(SDPUB_MANIFEST_CONTENT, "utf8"),
+          entryPath,
+        );
+        continue;
+      }
+      if (overlay?.kind === "file") {
+        outputZipFile.addFile(overlay.workspacePath, entryPath);
+        continue;
+      }
+
+      const sourceEntry = sourceEntries.find(
+        (candidate) => normalizeArchivePath(candidate.fileName) === entryPath,
+      );
+
+      if (sourceEntry === undefined) {
+        continue;
+      }
+
+      outputZipFile.addBuffer(
+        await readArchiveEntryBuffer(zipFile, sourceEntry),
+        entryPath,
+      );
+    }
+  } finally {
+    zipFile.close();
+  }
+
+  outputZipFile.end();
+
+  const output = createWriteStream(outputPath);
+  const outputDone = finished(output);
+  const zipDone = finished(outputZipFile.outputStream);
+
+  outputZipFile.outputStream.pipe(output);
   await Promise.all([outputDone, zipDone]);
 }
 
@@ -275,6 +410,13 @@ async function readArchiveEntryText(
   zipFile: YauzlZipFile,
   entry: Entry,
 ): Promise<string> {
+  return (await readArchiveEntryBuffer(zipFile, entry)).toString("utf8");
+}
+
+async function readArchiveEntryBuffer(
+  zipFile: YauzlZipFile,
+  entry: Entry,
+): Promise<Buffer> {
   const chunks: Buffer[] = [];
   const stream = await openArchiveEntryStream(zipFile, entry);
 
@@ -282,5 +424,5 @@ async function readArchiveEntryText(
     chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
   }
 
-  return Buffer.concat(chunks).toString("utf8");
+  return Buffer.concat(chunks);
 }

--- a/src/facade/archive.ts
+++ b/src/facade/archive.ts
@@ -42,6 +42,56 @@ export type SdpubArchiveOverlay =
       readonly workspacePath: string;
     };
 
+export class SdpubArchiveReader {
+  readonly #entryByPath: Map<string, Entry>;
+  readonly #entries: readonly string[];
+  readonly #zipFile: YauzlZipFile;
+
+  public constructor(zipFile: YauzlZipFile, entries: readonly Entry[]) {
+    this.#zipFile = zipFile;
+    this.#entryByPath = new Map(
+      entries
+        .map((entry) => [normalizeArchivePath(entry.fileName), entry] as const)
+        .filter(([entryPath]) => entryPath !== "")
+        .filter(([entryPath]) => isSdpubArchivePath(entryPath)),
+    );
+    this.#entries = [...this.#entryByPath.keys()].sort((left, right) =>
+      left.localeCompare(right),
+    );
+  }
+
+  public static async open(inputPath: string): Promise<SdpubArchiveReader> {
+    const zipFile = await openArchive(inputPath);
+    const entries = await indexArchiveEntries(zipFile);
+
+    try {
+      await validateArchiveManifest(zipFile, entries);
+      return new SdpubArchiveReader(zipFile, entries);
+    } catch (error) {
+      zipFile.close();
+      throw error;
+    }
+  }
+
+  public close(): void {
+    this.#zipFile.close();
+  }
+
+  public listEntries(): readonly string[] {
+    return this.#entries;
+  }
+
+  public async readEntry(entryPath: string): Promise<Buffer | undefined> {
+    const entry = this.#entryByPath.get(normalizeArchivePath(entryPath));
+
+    if (entry === undefined) {
+      return undefined;
+    }
+
+    return await readArchiveEntryBuffer(this.#zipFile, entry);
+  }
+}
+
 export async function extractSdpubArchive(
   inputPath: string,
   outputDirectoryPath: string,
@@ -110,18 +160,12 @@ export async function writeSdpubArchive(
 export async function listSdpubArchiveEntries(
   inputPath: string,
 ): Promise<readonly string[]> {
-  const zipFile = await openArchive(inputPath);
-  const entries = await indexArchiveEntries(zipFile);
+  const reader = await SdpubArchiveReader.open(inputPath);
 
   try {
-    await validateArchiveManifest(zipFile, entries);
-    return entries
-      .map((entry) => normalizeArchivePath(entry.fileName))
-      .filter((entryPath) => entryPath !== "")
-      .filter(isSdpubArchivePath)
-      .sort((left, right) => left.localeCompare(right));
+    return reader.listEntries();
   } finally {
-    zipFile.close();
+    reader.close();
   }
 }
 
@@ -129,24 +173,12 @@ export async function readSdpubArchiveEntry(
   inputPath: string,
   entryPath: string,
 ): Promise<Buffer | undefined> {
-  const normalizedEntryPath = normalizeArchivePath(entryPath);
-  const zipFile = await openArchive(inputPath);
-  const entries = await indexArchiveEntries(zipFile);
+  const reader = await SdpubArchiveReader.open(inputPath);
 
   try {
-    await validateArchiveManifest(zipFile, entries);
-    const entry = entries.find(
-      (candidate) =>
-        normalizeArchivePath(candidate.fileName) === normalizedEntryPath,
-    );
-
-    if (entry === undefined) {
-      return undefined;
-    }
-
-    return await readArchiveEntryBuffer(zipFile, entry);
+    return await reader.readEntry(entryPath);
   } finally {
-    zipFile.close();
+    reader.close();
   }
 }
 

--- a/src/facade/archive.ts
+++ b/src/facade/archive.ts
@@ -207,7 +207,11 @@ export async function writeSdpubArchiveWithOverlays(
     }
   }
   for (const overlay of overlayByPath.values()) {
-    entryPaths.add(normalizeArchivePath(overlay.entryPath));
+    const archivePath = normalizeArchivePath(overlay.entryPath);
+
+    if (archivePath !== "" && isSdpubArchivePath(archivePath)) {
+      entryPaths.add(archivePath);
+    }
   }
   entryPaths.add(SDPUB_MANIFEST_PATH);
 

--- a/src/facade/build-queue.ts
+++ b/src/facade/build-queue.ts
@@ -767,12 +767,6 @@ async function claimQueuedBuildJob(
 SELECT *
 FROM build_jobs
 WHERE state = 'queued'
-  AND NOT EXISTS (
-    SELECT 1
-    FROM build_jobs AS running_jobs
-    WHERE running_jobs.archive_key = build_jobs.archive_key
-      AND running_jobs.state = 'running'
-  )
 ORDER BY queue_rank ASC, created_at ASC
 LIMIT 1
 `,

--- a/src/facade/build-queue.ts
+++ b/src/facade/build-queue.ts
@@ -1,5 +1,14 @@
 import { createHash, randomUUID } from "crypto";
-import { appendFile, mkdir, mkdtemp, readFile, rm } from "fs/promises";
+import { constants as fsConstants } from "fs";
+import {
+  appendFile,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+} from "fs/promises";
 import { homedir } from "os";
 import { join, resolve } from "path";
 
@@ -1025,12 +1034,11 @@ async function readMinQueueRank(state: Database): Promise<number> {
 
 async function openBuildQueueDatabase(): Promise<Database> {
   const directoryPath = getBuildQueueStateDirectoryPath();
+  const databasePath = join(directoryPath, "build-queue.sqlite");
 
   await mkdir(directoryPath, { recursive: true });
-  return await Database.open(
-    join(directoryPath, "state.sqlite"),
-    BUILD_QUEUE_SCHEMA_SQL,
-  );
+  await copyLegacyStateDatabaseIfNeeded(directoryPath, databasePath);
+  return await Database.open(databasePath, BUILD_QUEUE_SCHEMA_SQL);
 }
 
 async function createJobWorkspacePath(
@@ -1062,6 +1070,51 @@ function getBuildQueueStateDirectoryPath(): string {
   }
 
   return join(homedir(), ".spinedigest", "state");
+}
+
+async function copyLegacyStateDatabaseIfNeeded(
+  directoryPath: string,
+  databasePath: string,
+): Promise<void> {
+  try {
+    if ((await stat(databasePath)).size > 0) {
+      return;
+    }
+    await rm(databasePath, { force: true });
+  } catch {
+    await rm(databasePath, { force: true });
+  }
+
+  try {
+    const legacyDatabasePath = join(directoryPath, "state.sqlite");
+
+    if (!(await legacyDatabaseHasTable(legacyDatabasePath, "build_jobs"))) {
+      return;
+    }
+
+    await copyFile(legacyDatabasePath, databasePath, fsConstants.COPYFILE_EXCL);
+  } catch {
+    return;
+  }
+}
+
+async function legacyDatabaseHasTable(
+  databasePath: string,
+  tableName: string,
+): Promise<boolean> {
+  const database = await Database.open(databasePath, "");
+
+  try {
+    return (
+      (await database.queryOne(
+        "SELECT 1 AS matched FROM sqlite_master WHERE type = 'table' AND name = ?",
+        [tableName],
+        () => true,
+      )) ?? false
+    );
+  } finally {
+    await database.close();
+  }
 }
 
 function mapBuildJob(row: Record<string, unknown>): BuildJob {

--- a/src/facade/build-queue.ts
+++ b/src/facade/build-queue.ts
@@ -501,39 +501,48 @@ export async function runBuildJobWorker(
     }
 
     const runSlot = async (): Promise<void> => {
-      while (!stopping) {
-        await heartbeatBuildWorker(ownerId, state);
-        await recoverStaleBuildJobs(state);
+      const slotState = await openBuildQueueDatabase();
 
-        busySlotCount += 1;
-        let job: BuildJob | undefined;
+      try {
+        while (!stopping) {
+          await heartbeatBuildWorker(ownerId, slotState);
+          await recoverStaleBuildJobs(slotState);
 
-        try {
-          job = await claimQueuedBuildJob(state, ownerId);
-        } finally {
+          busySlotCount += 1;
+          let job: BuildJob | undefined;
+
+          try {
+            job = await claimQueuedBuildJob(slotState, ownerId);
+          } finally {
+            if (job === undefined) {
+              busySlotCount -= 1;
+            }
+          }
+
           if (job === undefined) {
+            if (
+              busySlotCount === 0 &&
+              Date.now() - idleSince >= idleTimeoutMs
+            ) {
+              break;
+            }
+            await delay(500);
+            continue;
+          }
+
+          idleSince = Date.now();
+
+          try {
+            await executeClaimedBuildJob(job, ownerId, options);
+          } finally {
             busySlotCount -= 1;
+            if (busySlotCount === 0) {
+              idleSince = Date.now();
+            }
           }
         }
-
-        if (job === undefined) {
-          if (busySlotCount === 0 && Date.now() - idleSince >= idleTimeoutMs) {
-            break;
-          }
-          await delay(500);
-          continue;
-        }
-
-        idleSince = Date.now();
-
-        try {
-          await executeClaimedBuildJob(job, ownerId, options);
-        } finally {
-          busySlotCount -= 1;
-          if (busySlotCount === 0) {
-            idleSince = Date.now();
-          }
-        }
+      } finally {
+        await slotState.close();
       }
     };
 

--- a/src/facade/build-queue.ts
+++ b/src/facade/build-queue.ts
@@ -501,48 +501,39 @@ export async function runBuildJobWorker(
     }
 
     const runSlot = async (): Promise<void> => {
-      const slotState = await openBuildQueueDatabase();
+      while (!stopping) {
+        await heartbeatBuildWorker(ownerId, state);
+        await recoverStaleBuildJobs(state);
 
-      try {
-        while (!stopping) {
-          await heartbeatBuildWorker(ownerId, slotState);
-          await recoverStaleBuildJobs(slotState);
+        busySlotCount += 1;
+        let job: BuildJob | undefined;
 
-          busySlotCount += 1;
-          let job: BuildJob | undefined;
-
-          try {
-            job = await claimQueuedBuildJob(slotState, ownerId);
-          } finally {
-            if (job === undefined) {
-              busySlotCount -= 1;
-            }
-          }
-
+        try {
+          job = await claimQueuedBuildJob(state, ownerId);
+        } finally {
           if (job === undefined) {
-            if (
-              busySlotCount === 0 &&
-              Date.now() - idleSince >= idleTimeoutMs
-            ) {
-              break;
-            }
-            await delay(500);
-            continue;
-          }
-
-          idleSince = Date.now();
-
-          try {
-            await executeClaimedBuildJob(job, ownerId, options);
-          } finally {
             busySlotCount -= 1;
-            if (busySlotCount === 0) {
-              idleSince = Date.now();
-            }
           }
         }
-      } finally {
-        await slotState.close();
+
+        if (job === undefined) {
+          if (busySlotCount === 0 && Date.now() - idleSince >= idleTimeoutMs) {
+            break;
+          }
+          await delay(500);
+          continue;
+        }
+
+        idleSince = Date.now();
+
+        try {
+          await executeClaimedBuildJob(job, ownerId, options);
+        } finally {
+          busySlotCount -= 1;
+          if (busySlotCount === 0) {
+            idleSince = Date.now();
+          }
+        }
       }
     };
 
@@ -776,6 +767,12 @@ async function claimQueuedBuildJob(
 SELECT *
 FROM build_jobs
 WHERE state = 'queued'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM build_jobs AS running_jobs
+    WHERE running_jobs.archive_key = build_jobs.archive_key
+      AND running_jobs.state = 'running'
+  )
 ORDER BY queue_rank ASC, created_at ASC
 LIMIT 1
 `,

--- a/src/facade/build-queue.ts
+++ b/src/facade/build-queue.ts
@@ -13,6 +13,7 @@ import { homedir } from "os";
 import { join, resolve } from "path";
 
 import { Database } from "../document/index.js";
+import { isNodeError } from "../utils/node-error.js";
 
 export const BUILD_JOB_STATES = [
   "queued",
@@ -1095,8 +1096,15 @@ async function copyLegacyStateDatabaseIfNeeded(
     }
 
     await copyFile(legacyDatabasePath, databasePath, fsConstants.COPYFILE_EXCL);
-  } catch {
-    return;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return;
+    }
+    if (isNodeError(error) && error.code === "EEXIST") {
+      return;
+    }
+
+    throw error;
   }
 }
 

--- a/src/facade/build-queue.ts
+++ b/src/facade/build-queue.ts
@@ -802,40 +802,42 @@ WHERE job_id = ? AND state = 'queued'
 }
 
 async function recoverStaleBuildJobs(state: Database): Promise<void> {
-  const jobs = await state.queryAll(
-    `
+  await state.transaction(async () => {
+    const jobs = await state.queryAll(
+      `
 SELECT *
 FROM build_jobs
 WHERE state = 'running'
   AND owner_pid IS NOT NULL
 `,
-    undefined,
-    mapBuildJob,
-  );
+      undefined,
+      mapBuildJob,
+    );
 
-  for (const job of jobs) {
-    if (job.ownerPid !== undefined && isProcessAlive(job.ownerPid)) {
-      continue;
-    }
+    for (const job of jobs) {
+      if (job.ownerPid !== undefined && isProcessAlive(job.ownerPid)) {
+        continue;
+      }
 
-    const now = Date.now();
-    await state.run(
-      `
+      const now = Date.now();
+      await state.run(
+        `
 UPDATE build_jobs
 SET state = 'queued', owner_id = NULL, owner_pid = NULL,
     current_step = NULL, updated_at = ?
 WHERE job_id = ?
 `,
-      [now, job.jobId],
-    );
-    await appendBuildJobEvent(job, {
-      at: now,
-      jobId: job.jobId,
-      seq: 0,
-      state: "queued",
-      type: "requeued",
-    });
-  }
+        [now, job.jobId],
+      );
+      await appendBuildJobEvent(job, {
+        at: now,
+        jobId: job.jobId,
+        seq: 0,
+        state: "queued",
+        type: "requeued",
+      });
+    }
+  });
 }
 
 async function acquireBuildWorkerLease(

--- a/src/facade/chapter-build.ts
+++ b/src/facade/chapter-build.ts
@@ -1,8 +1,31 @@
-import { mkdir, rm } from "fs/promises";
+import { mkdir, readFile, rm, writeFile } from "fs/promises";
 import { join } from "path";
+import { z } from "zod";
 
-import type { Document, ReadonlyDocument } from "../document/index.js";
+import type {
+  ChunkRecord,
+  Document,
+  FragmentGroupRecord,
+  FragmentRecord,
+  KnowledgeEdgeRecord,
+  ReadonlyChunkStore,
+  ReadonlyDocument,
+  ReadonlyFragmentGroupStore,
+  ReadonlyKnowledgeEdgeStore,
+  ReadonlySerialFragments,
+  ReadonlySerialStore,
+  ReadonlySnakeChunkStore,
+  ReadonlySnakeEdgeStore,
+  ReadonlySnakeStore,
+  SentenceId,
+  SerialRecord,
+  SnakeChunkRecord,
+  SnakeEdgeRecord,
+  SnakeRecord,
+} from "../document/index.js";
 import { DirectoryDocument } from "../document/index.js";
+import { SPINE_DIGEST_EDITOR_SCOPES } from "../common/llm-scope.js";
+import { compressText } from "../editor/index.js";
 import type { ReaderTextStream } from "../reader/index.js";
 import {
   SerialGeneration,
@@ -21,6 +44,10 @@ export interface ChapterGraphBuildArtifact {
   readonly chapterId: number;
 }
 
+export interface ChapterSummaryInputSnapshot {
+  readonly filePath: string;
+}
+
 export interface BuildChapterGraphArtifactOptions extends GenerateChapterGraphOptions {
   readonly sourceText: readonly string[];
   readonly nextChunkId: number;
@@ -28,8 +55,31 @@ export interface BuildChapterGraphArtifactOptions extends GenerateChapterGraphOp
 }
 
 export interface BuildChapterSummaryArtifactOptions extends GenerateChapterSummaryOptions {
+  readonly snapshotPath?: string;
   readonly sourceDocumentPath?: string;
   readonly workspacePath: string;
+}
+
+const summaryInputSnapshotSchema = z.object({
+  chunks: z.array(z.custom<ChunkRecord>()),
+  fragmentGroups: z.array(z.custom<FragmentGroupRecord>()),
+  fragments: z.array(z.custom<FragmentRecord>()),
+  knowledgeEdges: z.array(z.custom<KnowledgeEdgeRecord>()),
+  serial: z.custom<SerialRecord>(),
+  snakeChunks: z.array(z.custom<SnakeChunkRecord>()),
+  snakeEdges: z.array(z.custom<SnakeEdgeRecord>()),
+  snakes: z.array(z.custom<SnakeRecord>()),
+});
+
+interface SummaryInputSnapshotData {
+  readonly chunks: readonly ChunkRecord[];
+  readonly fragmentGroups: readonly FragmentGroupRecord[];
+  readonly fragments: readonly FragmentRecord[];
+  readonly knowledgeEdges: readonly KnowledgeEdgeRecord[];
+  readonly serial: SerialRecord;
+  readonly snakeChunks: readonly SnakeChunkRecord[];
+  readonly snakeEdges: readonly SnakeEdgeRecord[];
+  readonly snakes: readonly SnakeRecord[];
 }
 
 export async function readChapterBuildInput(
@@ -134,10 +184,19 @@ export async function buildChapterSummaryArtifact(
   chapterId: number,
   options: BuildChapterSummaryArtifactOptions,
 ): Promise<string> {
+  const snapshotPath = options.snapshotPath;
+
+  if (snapshotPath !== undefined) {
+    return await buildChapterSummaryArtifactFromSnapshot(chapterId, {
+      ...options,
+      snapshotPath,
+    });
+  }
+
   const sourceDocumentPath = options.sourceDocumentPath;
 
   if (sourceDocumentPath !== undefined) {
-    return await buildChapterSummaryArtifactFromSnapshot(chapterId, {
+    return await buildChapterSummaryArtifactFromDocumentSnapshot(chapterId, {
       ...options,
       sourceDocumentPath,
     });
@@ -151,6 +210,16 @@ export async function buildChapterSummaryArtifact(
 }
 
 export async function buildChapterSummaryArtifactFromSnapshot(
+  chapterId: number,
+  options: BuildChapterSummaryArtifactOptions & {
+    readonly snapshotPath: string;
+  },
+): Promise<string> {
+  const snapshot = await readSummaryInputSnapshot(options.snapshotPath);
+  return await buildSummaryFromSnapshot(snapshot, chapterId, options);
+}
+
+async function buildChapterSummaryArtifactFromDocumentSnapshot(
   chapterId: number,
   options: BuildChapterSummaryArtifactOptions & {
     readonly sourceDocumentPath: string;
@@ -188,48 +257,7 @@ async function buildChapterSummaryArtifactFromDocument(
     return summary;
   }
 
-  return await buildSummaryInTemporaryDocument(document, chapterId, options);
-}
-
-export async function snapshotChapterSummaryInput(
-  document: ReadonlyDocument,
-  chapterId: number,
-  workspacePath: string,
-): Promise<{ readonly documentPath: string }> {
-  const documentPath = join(workspacePath, "summary-input-document");
-
-  await rm(documentPath, { force: true, recursive: true });
-  await mkdir(workspacePath, { recursive: true });
-
-  const targetDocument = await DirectoryDocument.open(documentPath);
-
-  try {
-    await targetDocument.openSession(async (openedDocument) => {
-      await requireStage(document, chapterId, "graphed");
-      await openedDocument.serials.createWithId(chapterId);
-      await copySerialFragments(document, openedDocument, chapterId);
-
-      for (const chunk of await document.chunks.listBySerial(chapterId)) {
-        await openedDocument.chunks.save(chunk);
-      }
-
-      for (const edge of await document.knowledgeEdges.listBySerial(
-        chapterId,
-      )) {
-        await openedDocument.knowledgeEdges.save(edge);
-      }
-
-      await openedDocument.fragmentGroups.saveMany(
-        await document.fragmentGroups.listBySerial(chapterId),
-      );
-      await copySnakes(document, openedDocument, chapterId);
-      await openedDocument.serials.setTopologyReady(chapterId);
-    });
-  } finally {
-    await targetDocument.release();
-  }
-
-  return { documentPath };
+  return await buildSummaryFromDocument(document, chapterId, options);
 }
 
 export async function commitChapterSummaryArtifact(
@@ -245,57 +273,165 @@ export async function commitChapterSummaryArtifact(
   return await getChapterDetails(document, chapterId);
 }
 
-async function buildSummaryInTemporaryDocument(
-  sourceDocument: ReadonlyDocument,
+export async function snapshotChapterSummaryInput(
+  document: ReadonlyDocument,
+  chapterId: number,
+  workspacePath: string,
+): Promise<ChapterSummaryInputSnapshot> {
+  const filePath = join(workspacePath, "summary-input.json");
+
+  await mkdir(workspacePath, { recursive: true });
+  await requireStage(document, chapterId, "graphed");
+
+  const fragments = await readSerialFragments(document, chapterId);
+  const snakes = await document.snakes.listBySerial(chapterId);
+  const snakeChunks = (
+    await Promise.all(
+      snakes.map(
+        async (snake) => await document.snakeChunks.listBySnake(snake.id),
+      ),
+    )
+  ).flat();
+
+  await writeSummaryInputSnapshot(filePath, {
+    chunks: await document.chunks.listBySerial(chapterId),
+    fragmentGroups: await document.fragmentGroups.listBySerial(chapterId),
+    fragments,
+    knowledgeEdges: await document.knowledgeEdges.listBySerial(chapterId),
+    serial: { id: chapterId, topologyReady: true },
+    snakeChunks,
+    snakeEdges: await document.snakeEdges.listBySerial(chapterId),
+    snakes,
+  });
+
+  return { filePath };
+}
+
+async function buildSummaryFromSnapshot(
+  snapshot: SummaryInputSnapshotData,
   chapterId: number,
   options: BuildChapterSummaryArtifactOptions,
 ): Promise<string> {
-  const documentPath = join(options.workspacePath, "summary-document");
+  if (snapshot.serial.id !== chapterId) {
+    throw new Error(
+      `Summary snapshot belongs to chapter ${snapshot.serial.id}, not chapter ${chapterId}.`,
+    );
+  }
+  if (!snapshot.serial.topologyReady) {
+    throw new Error(`Chapter ${chapterId} is not ready for summary.`);
+  }
 
-  await rm(documentPath, { force: true, recursive: true });
-  await mkdir(options.workspacePath, { recursive: true });
+  const document = new SummaryInputSnapshotDocument(snapshot);
+  const fragments = document.getSerialFragments(chapterId);
+  const fragmentIds = await fragments.listFragmentIds();
 
-  const document = await DirectoryDocument.open(documentPath);
+  if (fragmentIds.length <= 1) {
+    return await readPassthroughSummary(fragments, fragmentIds);
+  }
 
-  try {
-    await document.openSession(async (openedDocument) => {
-      await openedDocument.serials.createWithId(chapterId);
-      await copySerialFragments(sourceDocument, openedDocument, chapterId);
+  const summaryParts: string[] = [];
 
-      for (const chunk of await sourceDocument.chunks.listBySerial(chapterId)) {
-        await openedDocument.chunks.save(chunk);
-      }
-
-      for (const edge of await sourceDocument.knowledgeEdges.listBySerial(
-        chapterId,
-      )) {
-        await openedDocument.knowledgeEdges.save(edge);
-      }
-
-      await openedDocument.fragmentGroups.saveMany(
-        await sourceDocument.fragmentGroups.listBySerial(chapterId),
-      );
-      await copySnakes(sourceDocument, openedDocument, chapterId);
-      await openedDocument.serials.setTopologyReady(chapterId);
-    });
-
-    await new SerialGeneration({
+  for (const groupId of await document.fragmentGroups.listGroupIdsForSerial(
+    chapterId,
+  )) {
+    const groupSummary = await compressText({
+      compressionRatio: 0.2,
       document,
+      groupId,
       llm: options.llm,
+      maxClues: 10,
+      maxIterations: 5,
+      scopes: SPINE_DIGEST_EDITOR_SCOPES,
+      serialId: chapterId,
       ...(options.logDirPath === undefined
         ? {}
         : { logDirPath: options.logDirPath }),
-    }).buildSummary(chapterId, {
       ...(options.userLanguage === undefined
         ? {}
         : { userLanguage: options.userLanguage }),
     });
 
-    return (await document.readSummary(chapterId)) ?? "";
-  } finally {
-    await document.release();
-    await rm(documentPath, { force: true, recursive: true });
+    if (groupSummary.trim() === "") {
+      continue;
+    }
+    summaryParts.push(groupSummary);
   }
+
+  return summaryParts.join("\n\n");
+}
+
+async function buildSummaryFromDocument(
+  document: ReadonlyDocument,
+  chapterId: number,
+  options: BuildChapterSummaryArtifactOptions,
+): Promise<string> {
+  const serial = await document.serials.getById(chapterId);
+
+  if (serial === undefined) {
+    throw new Error(
+      `Chapter ${chapterId} does not exist. Use \`spinedigest list <archive.sdpub> --type chapter\` to discover chapter ids.`,
+    );
+  }
+  if (!serial.topologyReady) {
+    throw new Error(`Chapter ${chapterId} is not ready for summary.`);
+  }
+
+  const fragments = document.getSerialFragments(chapterId);
+  const fragmentIds = await fragments.listFragmentIds();
+
+  if (fragmentIds.length <= 1) {
+    return await readPassthroughSummary(fragments, fragmentIds);
+  }
+
+  const summaryParts: string[] = [];
+
+  for (const groupId of await document.fragmentGroups.listGroupIdsForSerial(
+    chapterId,
+  )) {
+    const groupSummary = await compressText({
+      compressionRatio: 0.2,
+      document,
+      groupId,
+      llm: options.llm,
+      maxClues: 10,
+      maxIterations: 5,
+      scopes: SPINE_DIGEST_EDITOR_SCOPES,
+      serialId: chapterId,
+      ...(options.logDirPath === undefined
+        ? {}
+        : { logDirPath: options.logDirPath }),
+      ...(options.userLanguage === undefined
+        ? {}
+        : { userLanguage: options.userLanguage }),
+    });
+
+    if (groupSummary.trim() === "") {
+      continue;
+    }
+    summaryParts.push(groupSummary);
+  }
+
+  return summaryParts.join("\n\n");
+}
+
+async function readPassthroughSummary(
+  fragments: ReadonlySerialFragments,
+  fragmentIds: readonly number[],
+): Promise<string> {
+  if (fragmentIds.length === 0) {
+    return "";
+  }
+
+  const records = await Promise.all(
+    fragmentIds.map(
+      async (fragmentId) => await fragments.getFragment(fragmentId),
+    ),
+  );
+
+  return records
+    .flatMap((fragment) => fragment.sentences.map((sentence) => sentence.text))
+    .join(" ")
+    .trim();
 }
 
 async function copySerialFragments(
@@ -315,6 +451,399 @@ async function copySerialFragments(
     }
     draft.setSummary(fragment.summary);
     await draft.commit();
+  }
+}
+
+async function readSerialFragments(
+  document: ReadonlyDocument,
+  serialId: number,
+): Promise<readonly FragmentRecord[]> {
+  const fragments = document.getSerialFragments(serialId);
+
+  return await Promise.all(
+    (await fragments.listFragmentIds()).map(
+      async (fragmentId) => await fragments.getFragment(fragmentId),
+    ),
+  );
+}
+
+async function readSummaryInputSnapshot(
+  filePath: string,
+): Promise<SummaryInputSnapshotData> {
+  return summaryInputSnapshotSchema.parse(
+    JSON.parse(await readFile(filePath, "utf8")),
+  );
+}
+
+async function writeSummaryInputSnapshot(
+  filePath: string,
+  snapshot: SummaryInputSnapshotData,
+): Promise<void> {
+  await writeFile(filePath, `${JSON.stringify(snapshot)}\n`, "utf8");
+}
+
+class SummaryInputSnapshotDocument implements ReadonlyDocument {
+  public readonly chunks: ReadonlyChunkStore;
+  public readonly fragmentGroups: ReadonlyFragmentGroupStore;
+  public readonly knowledgeEdges: ReadonlyKnowledgeEdgeStore;
+  public readonly serials: ReadonlySerialStore;
+  public readonly snakeChunks: ReadonlySnakeChunkStore;
+  public readonly snakeEdges: ReadonlySnakeEdgeStore;
+  public readonly snakes: ReadonlySnakeStore;
+  readonly #fragments: ReadonlySerialFragments;
+
+  public constructor(snapshot: SummaryInputSnapshotData) {
+    const serialId = snapshot.serial.id;
+
+    this.chunks = new SnapshotChunkStore(snapshot.chunks);
+    this.fragmentGroups = new SnapshotFragmentGroupStore(
+      snapshot.fragmentGroups,
+    );
+    this.knowledgeEdges = new SnapshotKnowledgeEdgeStore(
+      snapshot.knowledgeEdges,
+      snapshot.chunks,
+    );
+    this.serials = new SnapshotSerialStore(snapshot.serial);
+    this.snakeChunks = new SnapshotSnakeChunkStore(snapshot.snakeChunks);
+    this.snakeEdges = new SnapshotSnakeEdgeStore(
+      snapshot.snakeEdges,
+      snapshot.snakes,
+    );
+    this.snakes = new SnapshotSnakeStore(snapshot.snakes);
+    this.#fragments = new SnapshotSerialFragments(serialId, snapshot.fragments);
+  }
+
+  public async getSentence(sentenceId: SentenceId): Promise<string> {
+    const [serialId, fragmentId, sentenceIndex] = sentenceId;
+    const fragment =
+      await this.getSerialFragments(serialId).getFragment(fragmentId);
+    const sentence = fragment.sentences[sentenceIndex];
+
+    if (sentence === undefined) {
+      throw new RangeError(`Sentence ${sentenceIndex} does not exist`);
+    }
+
+    return sentence.text;
+  }
+
+  public getSerialFragments(serialId: number): ReadonlySerialFragments {
+    if (serialId !== this.#fragments.serialId) {
+      return new SnapshotSerialFragments(serialId, []);
+    }
+    return this.#fragments;
+  }
+
+  public async openSession<T>(
+    operation: (document: ReadonlyDocument) => Promise<T> | T,
+  ): Promise<T> {
+    return await operation(this);
+  }
+
+  public readBookMeta(): Promise<undefined> {
+    return Promise.resolve(undefined);
+  }
+
+  public readCover(): Promise<undefined> {
+    return Promise.resolve(undefined);
+  }
+
+  public readSummary(_serialId: number): Promise<undefined> {
+    return Promise.resolve(undefined);
+  }
+
+  public readToc(): Promise<undefined> {
+    return Promise.resolve(undefined);
+  }
+
+  public release(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class SnapshotSerialStore implements ReadonlySerialStore {
+  readonly #serial: SerialRecord;
+
+  public constructor(serial: SerialRecord) {
+    this.#serial = serial;
+  }
+
+  public getById(serialId: number): Promise<SerialRecord | undefined> {
+    return Promise.resolve(
+      serialId === this.#serial.id ? this.#serial : undefined,
+    );
+  }
+
+  public getMaxId(): Promise<number> {
+    return Promise.resolve(this.#serial.id);
+  }
+
+  public listIds(): Promise<number[]> {
+    return Promise.resolve([this.#serial.id]);
+  }
+}
+
+class SnapshotSerialFragments implements ReadonlySerialFragments {
+  public readonly path = "";
+  public readonly serialId: number;
+  readonly #fragmentsById: Map<number, FragmentRecord>;
+
+  public constructor(serialId: number, fragments: readonly FragmentRecord[]) {
+    this.serialId = serialId;
+    this.#fragmentsById = new Map(
+      fragments
+        .filter((fragment) => fragment.serialId === serialId)
+        .map((fragment) => [fragment.fragmentId, fragment]),
+    );
+  }
+
+  public getFragment(fragmentId: number): Promise<FragmentRecord> {
+    const fragment = this.#fragmentsById.get(fragmentId);
+
+    if (fragment === undefined) {
+      throw new Error(`Fragment ${fragmentId} does not exist`);
+    }
+
+    return Promise.resolve(fragment);
+  }
+
+  public listFragmentIds(): Promise<readonly number[]> {
+    return Promise.resolve([...this.#fragmentsById.keys()].sort(compareNumber));
+  }
+}
+
+class SnapshotChunkStore implements ReadonlyChunkStore {
+  readonly #chunks: readonly ChunkRecord[];
+  readonly #chunksById: Map<number, ChunkRecord>;
+
+  public constructor(chunks: readonly ChunkRecord[]) {
+    this.#chunks = [...chunks].sort(compareChunkById);
+    this.#chunksById = new Map(chunks.map((chunk) => [chunk.id, chunk]));
+  }
+
+  public getById(chunkId: number): Promise<ChunkRecord | undefined> {
+    return Promise.resolve(this.#chunksById.get(chunkId));
+  }
+
+  public listAll(): Promise<ChunkRecord[]> {
+    return Promise.resolve([...this.#chunks]);
+  }
+
+  public listByFragments(
+    serialId: number,
+    fragmentIds: readonly number[],
+  ): Promise<ChunkRecord[]> {
+    const fragmentIdSet = new Set(fragmentIds);
+
+    return Promise.resolve(
+      this.#chunks.filter(
+        (chunk) =>
+          chunk.sentenceId[0] === serialId &&
+          fragmentIdSet.has(chunk.sentenceId[1]),
+      ),
+    );
+  }
+
+  public listBySerial(serialId: number): Promise<ChunkRecord[]> {
+    return Promise.resolve(
+      this.#chunks.filter((chunk) => chunk.sentenceId[0] === serialId),
+    );
+  }
+
+  public getMaxId(): Promise<number> {
+    return Promise.resolve(
+      this.#chunks.reduce((maxId, chunk) => Math.max(maxId, chunk.id), 0),
+    );
+  }
+
+  public listFragmentPairs(): Promise<
+    ReadonlyArray<readonly [number, number]>
+  > {
+    const pairs = new Set<string>();
+
+    for (const chunk of this.#chunks) {
+      pairs.add(`${chunk.sentenceId[0]}:${chunk.sentenceId[1]}`);
+    }
+
+    return Promise.resolve(
+      [...pairs]
+        .map((pair) => pair.split(":").map(Number) as [number, number])
+        .sort(comparePair)
+        .map(([serialId, fragmentId]) => [serialId, fragmentId] as const),
+    );
+  }
+}
+
+class SnapshotKnowledgeEdgeStore implements ReadonlyKnowledgeEdgeStore {
+  readonly #edges: readonly KnowledgeEdgeRecord[];
+  readonly #serialIdByChunkId: Map<number, number>;
+
+  public constructor(
+    edges: readonly KnowledgeEdgeRecord[],
+    chunks: readonly ChunkRecord[],
+  ) {
+    this.#edges = [...edges].sort(compareKnowledgeEdge);
+    this.#serialIdByChunkId = new Map(
+      chunks.map((chunk) => [chunk.id, chunk.sentenceId[0]]),
+    );
+  }
+
+  public listAll(): Promise<KnowledgeEdgeRecord[]> {
+    return Promise.resolve([...this.#edges]);
+  }
+
+  public listBySerial(serialId: number): Promise<KnowledgeEdgeRecord[]> {
+    return Promise.resolve(
+      this.#edges.filter(
+        (edge) =>
+          this.#serialIdByChunkId.get(edge.fromId) === serialId &&
+          this.#serialIdByChunkId.get(edge.toId) === serialId,
+      ),
+    );
+  }
+
+  public listIncoming(chunkId: number): Promise<KnowledgeEdgeRecord[]> {
+    return Promise.resolve(this.#edges.filter((edge) => edge.toId === chunkId));
+  }
+
+  public listOutgoing(chunkId: number): Promise<KnowledgeEdgeRecord[]> {
+    return Promise.resolve(
+      this.#edges.filter((edge) => edge.fromId === chunkId),
+    );
+  }
+}
+
+class SnapshotSnakeStore implements ReadonlySnakeStore {
+  readonly #snakes: readonly SnakeRecord[];
+  readonly #snakesById: Map<number, SnakeRecord>;
+
+  public constructor(snakes: readonly SnakeRecord[]) {
+    this.#snakes = [...snakes].sort(compareSnake);
+    this.#snakesById = new Map(snakes.map((snake) => [snake.id, snake]));
+  }
+
+  public getById(snakeId: number): Promise<SnakeRecord | undefined> {
+    return Promise.resolve(this.#snakesById.get(snakeId));
+  }
+
+  public listIdsByGroup(serialId: number, groupId: number): Promise<number[]> {
+    return Promise.resolve(
+      this.#snakes
+        .filter(
+          (snake) => snake.serialId === serialId && snake.groupId === groupId,
+        )
+        .map((snake) => snake.id)
+        .sort(compareNumber),
+    );
+  }
+
+  public listBySerial(serialId: number): Promise<SnakeRecord[]> {
+    return Promise.resolve(
+      this.#snakes.filter((snake) => snake.serialId === serialId),
+    );
+  }
+}
+
+class SnapshotSnakeChunkStore implements ReadonlySnakeChunkStore {
+  readonly #snakeChunks: readonly SnakeChunkRecord[];
+
+  public constructor(snakeChunks: readonly SnakeChunkRecord[]) {
+    this.#snakeChunks = [...snakeChunks].sort(compareSnakeChunk);
+  }
+
+  public listChunkIds(snakeId: number): Promise<number[]> {
+    return Promise.resolve(
+      this.#snakeChunks
+        .filter((snakeChunk) => snakeChunk.snakeId === snakeId)
+        .map((snakeChunk) => snakeChunk.chunkId),
+    );
+  }
+
+  public listBySnake(snakeId: number): Promise<SnakeChunkRecord[]> {
+    return Promise.resolve(
+      this.#snakeChunks.filter((snakeChunk) => snakeChunk.snakeId === snakeId),
+    );
+  }
+}
+
+class SnapshotSnakeEdgeStore implements ReadonlySnakeEdgeStore {
+  readonly #edges: readonly SnakeEdgeRecord[];
+  readonly #serialIdBySnakeId: Map<number, number>;
+
+  public constructor(
+    edges: readonly SnakeEdgeRecord[],
+    snakes: readonly SnakeRecord[],
+  ) {
+    this.#edges = [...edges].sort(compareSnakeEdge);
+    this.#serialIdBySnakeId = new Map(
+      snakes.map((snake) => [snake.id, snake.serialId]),
+    );
+  }
+
+  public listIncoming(snakeId: number): Promise<SnakeEdgeRecord[]> {
+    return Promise.resolve(
+      this.#edges.filter((edge) => edge.toSnakeId === snakeId),
+    );
+  }
+
+  public listOutgoing(snakeId: number): Promise<SnakeEdgeRecord[]> {
+    return Promise.resolve(
+      this.#edges.filter((edge) => edge.fromSnakeId === snakeId),
+    );
+  }
+
+  public listWithin(snakeIds: readonly number[]): Promise<SnakeEdgeRecord[]> {
+    const snakeIdSet = new Set(snakeIds);
+
+    return Promise.resolve(
+      this.#edges.filter(
+        (edge) =>
+          snakeIdSet.has(edge.fromSnakeId) && snakeIdSet.has(edge.toSnakeId),
+      ),
+    );
+  }
+
+  public listBySerial(serialId: number): Promise<SnakeEdgeRecord[]> {
+    return Promise.resolve(
+      this.#edges.filter(
+        (edge) =>
+          this.#serialIdBySnakeId.get(edge.fromSnakeId) === serialId &&
+          this.#serialIdBySnakeId.get(edge.toSnakeId) === serialId,
+      ),
+    );
+  }
+}
+
+class SnapshotFragmentGroupStore implements ReadonlyFragmentGroupStore {
+  readonly #groups: readonly FragmentGroupRecord[];
+
+  public constructor(groups: readonly FragmentGroupRecord[]) {
+    this.#groups = [...groups].sort(compareFragmentGroup);
+  }
+
+  public listBySerial(serialId: number): Promise<FragmentGroupRecord[]> {
+    return Promise.resolve(
+      this.#groups.filter((group) => group.serialId === serialId),
+    );
+  }
+
+  public listSerialIds(): Promise<number[]> {
+    return Promise.resolve(
+      [...new Set(this.#groups.map((group) => group.serialId))].sort(
+        compareNumber,
+      ),
+    );
+  }
+
+  public listGroupIdsForSerial(serialId: number): Promise<number[]> {
+    return Promise.resolve(
+      [
+        ...new Set(
+          this.#groups
+            .filter((group) => group.serialId === serialId)
+            .map((group) => group.groupId),
+        ),
+      ].sort(compareNumber),
+    );
   }
 }
 
@@ -420,4 +949,57 @@ async function collectReaderText(
   }
 
   return text;
+}
+
+function compareNumber(left: number, right: number): number {
+  return left - right;
+}
+
+function compareChunkById(left: ChunkRecord, right: ChunkRecord): number {
+  return left.id - right.id;
+}
+
+function compareFragmentGroup(
+  left: FragmentGroupRecord,
+  right: FragmentGroupRecord,
+): number {
+  return (
+    left.serialId - right.serialId ||
+    left.groupId - right.groupId ||
+    left.fragmentId - right.fragmentId
+  );
+}
+
+function compareKnowledgeEdge(
+  left: KnowledgeEdgeRecord,
+  right: KnowledgeEdgeRecord,
+): number {
+  return left.fromId - right.fromId || left.toId - right.toId;
+}
+
+function comparePair(
+  left: readonly [number, number],
+  right: readonly [number, number],
+): number {
+  return left[0] - right[0] || left[1] - right[1];
+}
+
+function compareSnake(left: SnakeRecord, right: SnakeRecord): number {
+  return left.groupId - right.groupId || left.id - right.id;
+}
+
+function compareSnakeChunk(
+  left: SnakeChunkRecord,
+  right: SnakeChunkRecord,
+): number {
+  return left.snakeId - right.snakeId || left.position - right.position;
+}
+
+function compareSnakeEdge(
+  left: SnakeEdgeRecord,
+  right: SnakeEdgeRecord,
+): number {
+  return (
+    left.fromSnakeId - right.fromSnakeId || left.toSnakeId - right.toSnakeId
+  );
 }

--- a/src/facade/chapter-build.ts
+++ b/src/facade/chapter-build.ts
@@ -31,6 +31,7 @@ import {
   SerialGeneration,
   type BuildSerialTopologyOptions,
 } from "../serial.js";
+import { ChunkImportance, ChunkRetention } from "../document/types.js";
 
 import {
   getChapterDetails,
@@ -60,15 +61,79 @@ export interface BuildChapterSummaryArtifactOptions extends GenerateChapterSumma
   readonly workspacePath: string;
 }
 
+const sentenceIdSchema = z.tuple([
+  z.number(),
+  z.number(),
+  z.number(),
+]) satisfies z.ZodType<SentenceId>;
+const sentenceRecordSchema = z.object({
+  text: z.string(),
+  wordsCount: z.number(),
+});
+const fragmentRecordSchema = z.object({
+  serialId: z.number(),
+  fragmentId: z.number(),
+  summary: z.string(),
+  sentences: z.array(sentenceRecordSchema),
+}) satisfies z.ZodType<FragmentRecord>;
+const serialRecordSchema = z.object({
+  id: z.number(),
+  topologyReady: z.boolean(),
+}) satisfies z.ZodType<SerialRecord>;
+const chunkRecordSchema = z.object({
+  id: z.number(),
+  generation: z.number(),
+  sentenceId: sentenceIdSchema,
+  label: z.string(),
+  content: z.string(),
+  sentenceIds: z.array(sentenceIdSchema),
+  retention: z.enum(ChunkRetention).optional(),
+  importance: z.enum(ChunkImportance).optional(),
+  wordsCount: z.number(),
+  weight: z.number(),
+});
+const knowledgeEdgeRecordSchema = z.object({
+  fromId: z.number(),
+  toId: z.number(),
+  strength: z.string().optional(),
+  weight: z.number(),
+});
+const snakeRecordSchema = z.object({
+  id: z.number(),
+  serialId: z.number(),
+  groupId: z.number(),
+  localSnakeId: z.number(),
+  size: z.number(),
+  firstLabel: z.string(),
+  lastLabel: z.string(),
+  wordsCount: z.number(),
+  weight: z.number(),
+}) satisfies z.ZodType<SnakeRecord>;
+const snakeChunkRecordSchema = z.object({
+  snakeId: z.number(),
+  chunkId: z.number(),
+  position: z.number(),
+}) satisfies z.ZodType<SnakeChunkRecord>;
+const snakeEdgeRecordSchema = z.object({
+  fromSnakeId: z.number(),
+  toSnakeId: z.number(),
+  weight: z.number(),
+}) satisfies z.ZodType<SnakeEdgeRecord>;
+const fragmentGroupRecordSchema = z.object({
+  serialId: z.number(),
+  groupId: z.number(),
+  fragmentId: z.number(),
+}) satisfies z.ZodType<FragmentGroupRecord>;
+
 const summaryInputSnapshotSchema = z.object({
-  chunks: z.array(z.custom<ChunkRecord>()),
-  fragmentGroups: z.array(z.custom<FragmentGroupRecord>()),
-  fragments: z.array(z.custom<FragmentRecord>()),
-  knowledgeEdges: z.array(z.custom<KnowledgeEdgeRecord>()),
-  serial: z.custom<SerialRecord>(),
-  snakeChunks: z.array(z.custom<SnakeChunkRecord>()),
-  snakeEdges: z.array(z.custom<SnakeEdgeRecord>()),
-  snakes: z.array(z.custom<SnakeRecord>()),
+  chunks: z.array(chunkRecordSchema),
+  fragmentGroups: z.array(fragmentGroupRecordSchema),
+  fragments: z.array(fragmentRecordSchema),
+  knowledgeEdges: z.array(knowledgeEdgeRecordSchema),
+  serial: serialRecordSchema,
+  snakeChunks: z.array(snakeChunkRecordSchema),
+  snakeEdges: z.array(snakeEdgeRecordSchema),
+  snakes: z.array(snakeRecordSchema),
 });
 
 interface SummaryInputSnapshotData {
@@ -470,9 +535,43 @@ async function readSerialFragments(
 async function readSummaryInputSnapshot(
   filePath: string,
 ): Promise<SummaryInputSnapshotData> {
-  return summaryInputSnapshotSchema.parse(
+  const snapshot = summaryInputSnapshotSchema.parse(
     JSON.parse(await readFile(filePath, "utf8")),
   );
+
+  return {
+    ...snapshot,
+    chunks: snapshot.chunks.map(toChunkRecord),
+    knowledgeEdges: snapshot.knowledgeEdges.map(toKnowledgeEdgeRecord),
+  };
+}
+
+function toChunkRecord(record: z.infer<typeof chunkRecordSchema>): ChunkRecord {
+  return {
+    id: record.id,
+    generation: record.generation,
+    sentenceId: record.sentenceId,
+    label: record.label,
+    content: record.content,
+    sentenceIds: record.sentenceIds,
+    ...(record.retention === undefined ? {} : { retention: record.retention }),
+    ...(record.importance === undefined
+      ? {}
+      : { importance: record.importance }),
+    wordsCount: record.wordsCount,
+    weight: record.weight,
+  };
+}
+
+function toKnowledgeEdgeRecord(
+  record: z.infer<typeof knowledgeEdgeRecordSchema>,
+): KnowledgeEdgeRecord {
+  return {
+    fromId: record.fromId,
+    toId: record.toId,
+    ...(record.strength === undefined ? {} : { strength: record.strength }),
+    weight: record.weight,
+  };
 }
 
 async function writeSummaryInputSnapshot(

--- a/src/facade/chapter.ts
+++ b/src/facade/chapter.ts
@@ -348,8 +348,8 @@ export async function getChapterDetails(
   document: ReadonlyDocument,
   chapterId: number,
 ): Promise<ChapterDetails> {
-  const entries = await listChapters(document);
-  const entry = entries.find((item) => item.chapterId === chapterId);
+  const toc = await readChapterToc(document);
+  const entry = await findChapterEntry(document, toc.items, chapterId);
 
   if (entry === undefined) {
     throw new Error(
@@ -589,6 +589,44 @@ async function readChapterToc(
       };
 }
 
+async function findChapterEntry(
+  document: ReadonlyDocument,
+  items: readonly TocItem[],
+  chapterId: number,
+  ancestorTitles: readonly string[] = [],
+  depth = 0,
+): Promise<ChapterEntry | undefined> {
+  for (const item of items) {
+    const title = normalizeTitle(item.title) ?? null;
+    const tocPath =
+      item.serialId === undefined
+        ? [...ancestorTitles, ...(title === null ? [] : [title])]
+        : [...ancestorTitles, title ?? `Chapter ${item.serialId}`];
+
+    if (item.serialId === chapterId) {
+      return await createChapterEntry(document, item, item.serialId, {
+        depth,
+        title,
+        tocPath,
+      });
+    }
+
+    const childEntry = await findChapterEntry(
+      document,
+      item.children,
+      chapterId,
+      tocPath,
+      depth + 1,
+    );
+
+    if (childEntry !== undefined) {
+      return childEntry;
+    }
+  }
+
+  return undefined;
+}
+
 async function collectChapterEntries(
   document: ReadonlyDocument,
   items: readonly TocItem[],
@@ -616,30 +654,13 @@ async function collectChapterEntries(
       continue;
     }
 
-    const serialFragments = document.getSerialFragments(item.serialId);
-    const fragmentIds = await serialFragments.listFragmentIds();
-    const fragmentCount = fragmentIds.length;
-    let words = 0;
-
-    for (const fragmentId of fragmentIds) {
-      const fragment = await serialFragments.getFragment(fragmentId);
-
-      words += fragment.sentences.reduce(
-        (total, sentence) => total + sentence.wordsCount,
-        0,
-      );
-    }
-
-    entries.push({
-      chapterId: item.serialId,
-      childCount: item.children.length,
-      depth,
-      fragmentCount,
-      stage: await resolveChapterStage(document, item.serialId, fragmentCount),
-      title,
-      tocPath,
-      words,
-    });
+    entries.push(
+      await createChapterEntry(document, item, item.serialId, {
+        depth,
+        title,
+        tocPath,
+      }),
+    );
     entries.push(
       ...(await collectChapterEntries(
         document,
@@ -651,6 +672,42 @@ async function collectChapterEntries(
   }
 
   return entries;
+}
+
+async function createChapterEntry(
+  document: ReadonlyDocument,
+  item: TocItem,
+  serialId: number,
+  input: {
+    readonly depth: number;
+    readonly title: string | null;
+    readonly tocPath: readonly string[];
+  },
+): Promise<ChapterEntry> {
+  const serialFragments = document.getSerialFragments(serialId);
+  const fragmentIds = await serialFragments.listFragmentIds();
+  const fragmentCount = fragmentIds.length;
+  let words = 0;
+
+  for (const fragmentId of fragmentIds) {
+    const fragment = await serialFragments.getFragment(fragmentId);
+
+    words += fragment.sentences.reduce(
+      (total, sentence) => total + sentence.wordsCount,
+      0,
+    );
+  }
+
+  return {
+    chapterId: serialId,
+    childCount: item.children.length,
+    depth: input.depth,
+    fragmentCount,
+    stage: await resolveChapterStage(document, serialId, fragmentCount),
+    title: input.title,
+    tocPath: input.tocPath,
+    words,
+  };
 }
 
 async function advanceEntriesToGraphed(

--- a/src/facade/sdpub-coordinator.ts
+++ b/src/facade/sdpub-coordinator.ts
@@ -1,5 +1,15 @@
 import { createHash, randomUUID } from "crypto";
-import { mkdir, mkdtemp, readFile, rename, rm, writeFile } from "fs/promises";
+import { constants as fsConstants } from "fs";
+import {
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "fs/promises";
 import { homedir, tmpdir } from "os";
 import { basename, dirname, join, posix, resolve } from "path";
 
@@ -835,12 +845,57 @@ async function withStateDatabase<T>(
 
 async function openStateDatabase(): Promise<Database> {
   const directoryPath = getCoordinatorStateDirectoryPath();
+  const databasePath = join(directoryPath, "sdpub-coordinator.sqlite");
 
   await mkdir(directoryPath, { recursive: true });
-  return await Database.open(
-    join(directoryPath, "state.sqlite"),
-    STATE_SCHEMA_SQL,
-  );
+  await copyLegacyStateDatabaseIfNeeded(directoryPath, databasePath);
+  return await Database.open(databasePath, STATE_SCHEMA_SQL);
+}
+
+async function copyLegacyStateDatabaseIfNeeded(
+  directoryPath: string,
+  databasePath: string,
+): Promise<void> {
+  try {
+    if ((await stat(databasePath)).size > 0) {
+      return;
+    }
+
+    await rm(databasePath, { force: true });
+  } catch {
+    await rm(databasePath, { force: true });
+  }
+
+  try {
+    const legacyDatabasePath = join(directoryPath, "state.sqlite");
+
+    if (!(await legacyDatabaseHasTable(legacyDatabasePath, "entry_overlays"))) {
+      return;
+    }
+
+    await copyFile(legacyDatabasePath, databasePath, fsConstants.COPYFILE_EXCL);
+  } catch {
+    return;
+  }
+}
+
+async function legacyDatabaseHasTable(
+  databasePath: string,
+  tableName: string,
+): Promise<boolean> {
+  const database = await Database.open(databasePath, "");
+
+  try {
+    return (
+      (await database.queryOne(
+        "SELECT 1 AS matched FROM sqlite_master WHERE type = 'table' AND name = ?",
+        [tableName],
+        () => true,
+      )) ?? false
+    );
+  } finally {
+    await database.close();
+  }
 }
 
 async function createWorkspaceFilePath(

--- a/src/facade/sdpub-coordinator.ts
+++ b/src/facade/sdpub-coordinator.ts
@@ -222,7 +222,7 @@ class SdpubDocumentFileStore implements DocumentFileStore {
           entryPath,
           "state",
           async () =>
-            await resolveEntrySource(this.#archivePath, {
+            await resolveEntrySource({
               archiveKey: this.#archiveKey,
               entryPath,
             }),
@@ -292,16 +292,29 @@ class SdpubDocumentFileStore implements DocumentFileStore {
     const entryPath = this.#toEntryPath(path);
 
     await withEntryLock(this.#archiveKey, entryPath, "write", async () => {
+      const source = await withEntryLock(
+        this.#archiveKey,
+        entryPath,
+        "state",
+        async () =>
+          await resolveEntrySource({
+            archiveKey: this.#archiveKey,
+            entryPath,
+          }),
+      );
+      const archiveEntryExists =
+        source.kind === "archive" &&
+        (await readSdpubArchiveEntry(this.#archivePath, entryPath)) !==
+          undefined;
+
+      if (
+        options.overwrite !== true &&
+        (source.kind === "workspace" || archiveEntryExists)
+      ) {
+        throw new Error(`File already exists: ${path}`);
+      }
+
       await withEntryLock(this.#archiveKey, entryPath, "state", async () => {
-        const source = await resolveEntrySource(this.#archivePath, {
-          archiveKey: this.#archiveKey,
-          entryPath,
-        });
-
-        if (options.overwrite !== true && source.kind !== "deleted") {
-          throw new Error(`File already exists: ${path}`);
-        }
-
         const workspacePath =
           source.kind === "workspace"
             ? source.path
@@ -658,10 +671,10 @@ async function listArchiveEntryPathsByPrefix(
   );
 }
 
-async function resolveEntrySource(
-  archivePath: string,
-  input: { readonly archiveKey: string; readonly entryPath: string },
-): Promise<
+async function resolveEntrySource(input: {
+  readonly archiveKey: string;
+  readonly entryPath: string;
+}): Promise<
   | { readonly kind: "archive" }
   | { readonly kind: "deleted" }
   | { readonly kind: "workspace"; readonly path: string }
@@ -674,12 +687,6 @@ async function resolveEntrySource(
   if (overlay?.workspacePath !== undefined) {
     return { kind: "workspace", path: overlay.workspacePath };
   }
-  if (
-    (await readSdpubArchiveEntry(archivePath, input.entryPath)) === undefined
-  ) {
-    return { kind: "deleted" };
-  }
-
   return { kind: "archive" };
 }
 

--- a/src/facade/sdpub-coordinator.ts
+++ b/src/facade/sdpub-coordinator.ts
@@ -1,32 +1,75 @@
 import { createHash, randomUUID } from "crypto";
-import { mkdir, mkdtemp, rename, rm } from "fs/promises";
+import { mkdir, mkdtemp, readFile, rename, rm, writeFile } from "fs/promises";
 import { homedir, tmpdir } from "os";
-import { basename, dirname, join, resolve } from "path";
+import { basename, dirname, join, posix, resolve } from "path";
 
 import { Database } from "../document/index.js";
+import type { DocumentFileStore } from "../document/document.js";
+import { AsyncSemaphore } from "../utils/async-semaphore.js";
 
-import { extractSdpubArchive, writeSdpubArchive } from "./archive.js";
+import {
+  extractSdpubArchive,
+  readSdpubArchiveEntry,
+  writeSdpubArchiveWithOverlays,
+  type SdpubArchiveOverlay,
+} from "./archive.js";
 
 const STATE_SCHEMA_SQL = `
-CREATE TABLE IF NOT EXISTS archives (
-  archive_key TEXT PRIMARY KEY,
+CREATE TABLE IF NOT EXISTS entry_overlays (
+  archive_key TEXT NOT NULL,
   archive_path TEXT NOT NULL,
-  workspace_path TEXT NOT NULL,
-  dirty INTEGER NOT NULL DEFAULT 0,
-  flushable INTEGER NOT NULL DEFAULT 0,
-  operation_owner TEXT,
-  operation_pid INTEGER,
-  operation_heartbeat_at INTEGER,
-  flusher_owner TEXT,
-  flusher_pid INTEGER,
-  flusher_heartbeat_at INTEGER,
-  updated_at INTEGER NOT NULL
+  entry_path TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  workspace_path TEXT,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (archive_key, entry_path)
+);
+
+CREATE TABLE IF NOT EXISTS entry_locks (
+  archive_key TEXT NOT NULL,
+  entry_path TEXT NOT NULL,
+  mode TEXT NOT NULL,
+  owner_id TEXT NOT NULL,
+  owner_pid INTEGER NOT NULL,
+  heartbeat_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (archive_key, entry_path, owner_id)
+);
+
+CREATE TABLE IF NOT EXISTS entry_sqlite_leases (
+  archive_key TEXT NOT NULL,
+  entry_path TEXT NOT NULL,
+  owner_id TEXT NOT NULL,
+  owner_pid INTEGER NOT NULL,
+  heartbeat_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (archive_key, entry_path, owner_id)
+);
+
+CREATE TABLE IF NOT EXISTS archive_commit_locks (
+  archive_key TEXT PRIMARY KEY,
+  owner_id TEXT NOT NULL,
+  owner_pid INTEGER NOT NULL,
+  heartbeat_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL
 );
 `;
 
-const FLUSH_HEARTBEAT_INTERVAL_MS = 5_000;
+const DATABASE_ENTRY_PATH = "database.db";
+const LOCK_POLL_INTERVAL_MS = 100;
+const LOCK_STALE_TIMEOUT_MS = 60_000;
+const STATE_DATABASE_SEMAPHORE = new AsyncSemaphore(1);
+
+type EntryLockMode = "read" | "state" | "write";
 
 export class SdpubCoordinator {
+  public createFileStore(
+    archivePath: string,
+    options: { readonly readonlyDatabase?: boolean } = {},
+  ): DocumentFileStore {
+    return new SdpubDocumentFileStore(resolve(archivePath), options);
+  }
+
   public async withReadWorkspace<T>(
     archivePath: string,
     operation: (documentDirectoryPath: string) => Promise<T> | T,
@@ -34,20 +77,26 @@ export class SdpubCoordinator {
       readonly documentDirPath?: string;
     } = {},
   ): Promise<T> {
-    if (options.documentDirPath !== undefined) {
-      const directoryPath = resolve(options.documentDirPath);
+    const directoryPath =
+      options.documentDirPath === undefined
+        ? await mkdtemp(join(tmpdir(), "spinedigest-open-"))
+        : resolve(options.documentDirPath);
 
+    try {
       await extractSdpubArchive(resolve(archivePath), directoryPath);
       return await operation(directoryPath);
+    } finally {
+      if (options.documentDirPath === undefined) {
+        await rm(directoryPath, { force: true, recursive: true });
+      }
     }
+  }
 
-    const entry = await this.#getArchiveEntry(resolve(archivePath));
-
-    if (entry !== undefined) {
-      return await operation(entry.workspacePath);
-    }
-
-    const directoryPath = await mkdtemp(join(tmpdir(), "spinedigest-open-"));
+  public async withWriteWorkspace<T>(
+    archivePath: string,
+    operation: (documentDirectoryPath: string) => Promise<T> | T,
+  ): Promise<T> {
+    const directoryPath = await mkdtemp(join(tmpdir(), "spinedigest-write-"));
 
     try {
       await extractSdpubArchive(resolve(archivePath), directoryPath);
@@ -56,393 +105,713 @@ export class SdpubCoordinator {
       await rm(directoryPath, { force: true, recursive: true });
     }
   }
-
-  public async withWriteWorkspace<T>(
-    archivePath: string,
-    operation: (documentDirectoryPath: string) => Promise<T> | T,
-  ): Promise<T> {
-    const resolvedArchivePath = resolve(archivePath);
-    const ownerId = createOwnerId();
-    const archiveKey = createArchiveKey(resolvedArchivePath);
-    const workspacePath = await this.#prepareWorkspace({
-      archiveKey,
-      archivePath: resolvedArchivePath,
-      ownerId,
-    });
-
-    let completed = false;
-
-    try {
-      const result = await operation(workspacePath);
-
-      await this.#markFlushable(archiveKey);
-      completed = true;
-      return result;
-    } finally {
-      await this.#releaseOperation(archiveKey, ownerId, completed);
-      if (completed) {
-        await tryStartSdpubFlusher();
-      }
-    }
-  }
-
-  async #prepareWorkspace(input: {
-    readonly archiveKey: string;
-    readonly archivePath: string;
-    readonly ownerId: string;
-  }): Promise<string> {
-    const state = await openStateDatabase();
-
-    try {
-      await cleanupStaleState(state);
-
-      return await state.transaction(async () => {
-        const now = Date.now();
-        const existing = await readArchiveState(state, input.archiveKey);
-
-        if (
-          existing?.operationOwner !== undefined &&
-          existing.operationPid !== undefined &&
-          isProcessAlive(existing.operationPid)
-        ) {
-          throw new Error(
-            `Archive is already being edited by process ${existing.operationPid}: ${input.archivePath}`,
-          );
-        }
-
-        if (existing !== undefined) {
-          await state.run(
-            `
-UPDATE archives
-SET operation_owner = ?, operation_pid = ?, operation_heartbeat_at = ?,
-    dirty = 1, flushable = 0, archive_path = ?, updated_at = ?
-WHERE archive_key = ?
-`,
-            [
-              input.ownerId,
-              process.pid,
-              now,
-              input.archivePath,
-              now,
-              input.archiveKey,
-            ],
-          );
-          return existing.workspacePath;
-        }
-
-        const workspacePath = await createWorkspacePath(input.archiveKey);
-
-        await extractSdpubArchive(input.archivePath, workspacePath);
-        await state.run(
-          `
-INSERT INTO archives (
-  archive_key, archive_path, workspace_path, dirty, flushable,
-  operation_owner, operation_pid, operation_heartbeat_at, updated_at
-) VALUES (?, ?, ?, 1, 0, ?, ?, ?, ?)
-`,
-          [
-            input.archiveKey,
-            input.archivePath,
-            workspacePath,
-            input.ownerId,
-            process.pid,
-            now,
-            now,
-          ],
-        );
-        return workspacePath;
-      });
-    } finally {
-      await state.close();
-    }
-  }
-
-  async #markFlushable(archiveKey: string): Promise<void> {
-    const state = await openStateDatabase();
-
-    try {
-      await state.run(
-        `
-UPDATE archives
-SET flushable = 1, updated_at = ?
-WHERE archive_key = ? AND dirty = 1
-`,
-        [Date.now(), archiveKey],
-      );
-    } finally {
-      await state.close();
-    }
-  }
-
-  async #releaseOperation(
-    archiveKey: string,
-    ownerId: string,
-    completed: boolean,
-  ): Promise<void> {
-    const state = await openStateDatabase();
-
-    try {
-      await state.run(
-        `
-UPDATE archives
-SET operation_owner = NULL, operation_pid = NULL, operation_heartbeat_at = NULL,
-    flushable = CASE WHEN ? = 1 THEN flushable ELSE 0 END,
-    updated_at = ?
-WHERE archive_key = ? AND operation_owner = ?
-`,
-        [completed ? 1 : 0, Date.now(), archiveKey, ownerId],
-      );
-    } finally {
-      await state.close();
-    }
-  }
-
-  async #getArchiveEntry(
-    archivePath: string,
-  ): Promise<{ readonly workspacePath: string } | undefined> {
-    const state = await openStateDatabase();
-
-    try {
-      await cleanupStaleState(state);
-      const archiveKey = createArchiveKey(archivePath);
-      const entry = await readArchiveState(state, archiveKey);
-
-      if (entry === undefined) {
-        return undefined;
-      }
-
-      return { workspacePath: entry.workspacePath };
-    } finally {
-      await state.close();
-    }
-  }
 }
 
 export async function tryStartSdpubFlusher(): Promise<void> {
-  const state = await openStateDatabase();
-  const ownerId = createOwnerId();
-
-  try {
+  const archiveKeys = await withStateDatabase(async (state) => {
     await cleanupStaleState(state);
-
-    const acquired = await state.transaction(async () => {
-      const running = await state.queryOne(
-        `
-SELECT flusher_pid
-FROM archives
-WHERE flusher_pid IS NOT NULL
-LIMIT 1
+    return await state.queryAll(
+      `
+SELECT DISTINCT archive_key
+FROM entry_overlays
+ORDER BY archive_key
 `,
-        undefined,
-        (row) => getNumber(row, "flusher_pid"),
-      );
+      undefined,
+      (row) => getString(row, "archive_key"),
+    );
+  });
 
-      if (running !== undefined && isProcessAlive(running)) {
-        return false;
-      }
+  for (const archiveKey of archiveKeys) {
+    await flushArchiveOverlays(archiveKey);
+  }
+}
 
-      const now = Date.now();
+class SdpubDocumentFileStore implements DocumentFileStore {
+  readonly #archiveKey: string;
+  readonly #archivePath: string;
+  readonly #readonlyDatabase: boolean;
+  readonly #sqliteLeaseOwnerId = createOwnerId();
 
-      await state.run(
-        `
-UPDATE archives
-SET flusher_owner = ?, flusher_pid = ?, flusher_heartbeat_at = ?
-WHERE dirty = 1 AND flushable = 1
-`,
-        [ownerId, process.pid, now],
-      );
-      return true;
+  public constructor(
+    archivePath: string,
+    options: { readonly readonlyDatabase?: boolean },
+  ) {
+    this.#archivePath = resolve(archivePath);
+    this.#archiveKey = createArchiveKey(this.#archivePath);
+    this.#readonlyDatabase = options.readonlyDatabase === true;
+  }
+
+  public async close(): Promise<void> {
+    await releaseSqliteLease({
+      archiveKey: this.#archiveKey,
+      entryPath: DATABASE_ENTRY_PATH,
+      ownerId: this.#sqliteLeaseOwnerId,
+    });
+  }
+
+  public async deleteFile(path: string): Promise<void> {
+    const entryPath = this.#toEntryPath(path);
+
+    await withEntryLock(this.#archiveKey, entryPath, "write", async () => {
+      await withEntryLock(this.#archiveKey, entryPath, "state", async () => {
+        const overlay = await readOverlay(this.#archiveKey, entryPath);
+
+        if (overlay?.workspacePath !== undefined) {
+          await rm(overlay.workspacePath, { force: true });
+        }
+
+        await upsertOverlay({
+          archiveKey: this.#archiveKey,
+          archivePath: this.#archivePath,
+          entryPath,
+          kind: "deleted",
+        });
+      });
+    });
+  }
+
+  public async deleteTree(path: string): Promise<void> {
+    const rootEntryPath = this.#toEntryPath(path);
+    const entries = await listVisibleEntryPaths(this.#archivePath, {
+      archiveKey: this.#archiveKey,
+      prefix: `${rootEntryPath}/`,
     });
 
-    if (!acquired) {
-      return;
+    for (const entryPath of entries) {
+      await this.deleteFile(entryPath);
     }
-
-    await runSdpubFlusher({ ownerId });
-  } finally {
-    await state.close();
   }
-}
 
-async function runSdpubFlusher(input: { readonly ownerId: string }) {
-  let stopping = false;
-  const stop = (): void => {
-    stopping = true;
-  };
+  public ensureDirectory(): Promise<void> {
+    return Promise.resolve();
+  }
 
-  process.once("SIGINT", stop);
-  process.once("SIGTERM", stop);
+  public initializeDatabaseSchema(): boolean {
+    return false;
+  }
 
-  const state = await openStateDatabase();
-  const heartbeat = setInterval(() => {
-    void heartbeatFlusher(input.ownerId).catch(() => undefined);
-  }, FLUSH_HEARTBEAT_INTERVAL_MS);
-  let lastWorkAt = Date.now();
+  public openDatabaseReadonly(): boolean {
+    return this.#readonlyDatabase;
+  }
 
-  try {
-    while (!stopping) {
-      await heartbeatFlusher(input.ownerId, state);
-      const candidate = await selectFlushCandidate(state, input.ownerId);
+  public async listFiles(path: string): Promise<readonly string[]> {
+    const directoryEntryPath = this.#toEntryPath(path);
+    const prefix = directoryEntryPath === "" ? "" : `${directoryEntryPath}/`;
+    const entries = await listVisibleEntryPaths(this.#archivePath, {
+      archiveKey: this.#archiveKey,
+      prefix,
+    });
 
-      if (candidate === undefined) {
-        if (Date.now() - lastWorkAt >= getFlushIdleTimeoutMs()) {
-          break;
+    return entries
+      .map((entryPath) => entryPath.slice(prefix.length))
+      .filter((entryPath) => !entryPath.includes("/"))
+      .map((entryPath) => posix.basename(entryPath))
+      .sort((left, right) => left.localeCompare(right));
+  }
+
+  public async readFile(path: string): Promise<Uint8Array | undefined> {
+    const entryPath = this.#toEntryPath(path);
+
+    return await withEntryLock(
+      this.#archiveKey,
+      entryPath,
+      "read",
+      async () => {
+        const source = await withEntryLock(
+          this.#archiveKey,
+          entryPath,
+          "state",
+          async () =>
+            await resolveEntrySource(this.#archivePath, {
+              archiveKey: this.#archiveKey,
+              entryPath,
+            }),
+        );
+
+        if (source.kind === "deleted") {
+          return undefined;
         }
-        await delay(500);
-        continue;
-      }
+        if (source.kind === "workspace") {
+          return await readFile(source.path);
+        }
 
-      lastWorkAt = Date.now();
-      await flushArchive(candidate);
-      await markFlushed(state, candidate.archiveKey);
+        return await readSdpubArchiveEntry(this.#archivePath, entryPath);
+      },
+    );
+  }
+
+  public async resolveDatabasePath(): Promise<string> {
+    return await withEntryLock(
+      this.#archiveKey,
+      DATABASE_ENTRY_PATH,
+      "state",
+      async () => {
+        let overlay = await readOverlay(this.#archiveKey, DATABASE_ENTRY_PATH);
+
+        if (overlay?.kind !== "file") {
+          const workspacePath = await createWorkspaceFilePath(
+            this.#archiveKey,
+            DATABASE_ENTRY_PATH,
+          );
+          const content = await readSdpubArchiveEntry(
+            this.#archivePath,
+            DATABASE_ENTRY_PATH,
+          );
+
+          await mkdir(dirname(workspacePath), { recursive: true });
+          await writeFile(workspacePath, content ?? new Uint8Array());
+          await upsertOverlay({
+            archiveKey: this.#archiveKey,
+            archivePath: this.#archivePath,
+            entryPath: DATABASE_ENTRY_PATH,
+            kind: "file",
+            workspacePath,
+          });
+          overlay = await readOverlay(this.#archiveKey, DATABASE_ENTRY_PATH);
+        }
+
+        if (overlay?.workspacePath === undefined) {
+          throw new Error("Could not materialize SQLite database.");
+        }
+
+        await acquireSqliteLease({
+          archiveKey: this.#archiveKey,
+          entryPath: DATABASE_ENTRY_PATH,
+          ownerId: this.#sqliteLeaseOwnerId,
+        });
+        return overlay.workspacePath;
+      },
+    );
+  }
+
+  public async writeFile(
+    path: string,
+    content: string | Uint8Array,
+    options: { readonly overwrite?: boolean },
+  ): Promise<void> {
+    const entryPath = this.#toEntryPath(path);
+
+    await withEntryLock(this.#archiveKey, entryPath, "write", async () => {
+      await withEntryLock(this.#archiveKey, entryPath, "state", async () => {
+        const source = await resolveEntrySource(this.#archivePath, {
+          archiveKey: this.#archiveKey,
+          entryPath,
+        });
+
+        if (options.overwrite !== true && source.kind !== "deleted") {
+          throw new Error(`File already exists: ${path}`);
+        }
+
+        const workspacePath =
+          source.kind === "workspace"
+            ? source.path
+            : await createWorkspaceFilePath(this.#archiveKey, entryPath);
+
+        await mkdir(dirname(workspacePath), { recursive: true });
+        await writeFile(workspacePath, content);
+        await upsertOverlay({
+          archiveKey: this.#archiveKey,
+          archivePath: this.#archivePath,
+          entryPath,
+          kind: "file",
+          workspacePath,
+        });
+      });
+    });
+  }
+
+  #toEntryPath(path: string): string {
+    const resolvedPath = resolve(path);
+    const rootPrefix = this.#archivePath.endsWith("/")
+      ? this.#archivePath
+      : `${this.#archivePath}/`;
+
+    if (resolvedPath.startsWith(rootPrefix)) {
+      return normalizeEntryPath(resolvedPath.slice(rootPrefix.length));
     }
-  } finally {
-    clearInterval(heartbeat);
-    process.removeListener("SIGINT", stop);
-    process.removeListener("SIGTERM", stop);
-    await releaseFlusher(input.ownerId, state);
-    await state.close();
+
+    return normalizeEntryPath(path);
   }
 }
 
-async function selectFlushCandidate(
-  state: Database,
-  ownerId: string,
-): Promise<ArchiveState | undefined> {
-  return await state.queryOne(
-    `
-SELECT *
-FROM archives
-WHERE dirty = 1
-  AND flushable = 1
-  AND operation_owner IS NULL
-  AND flusher_owner = ?
-  AND updated_at <= ?
-ORDER BY updated_at ASC
-LIMIT 1
-`,
-    [ownerId, Date.now() - getFlushQuietPeriodMs()],
-    mapArchiveState,
-  );
-}
+async function flushArchiveOverlays(archiveKey: string): Promise<void> {
+  const overlays = await listOverlays(archiveKey);
+  const archivePath = await resolveArchivePathFromKey(archiveKey);
 
-async function flushArchive(archive: ArchiveState): Promise<void> {
-  const temporaryDirectoryPath = await mkdtemp(
-    join(tmpdir(), "spinedigest-flush-"),
-  );
-  const temporaryArchivePath = join(
-    temporaryDirectoryPath,
-    basename(archive.archivePath),
-  );
-
-  try {
-    await writeSdpubArchive(archive.workspacePath, temporaryArchivePath);
-    await mkdir(dirname(archive.archivePath), { recursive: true });
-    await rename(temporaryArchivePath, archive.archivePath);
-  } finally {
-    await rm(temporaryDirectoryPath, { force: true, recursive: true });
-  }
-}
-
-async function markFlushed(state: Database, archiveKey: string): Promise<void> {
-  const archive = await readArchiveState(state, archiveKey);
-
-  if (archive === undefined) {
+  if (overlays.length === 0 || archivePath === undefined) {
     return;
   }
 
-  await state.run(
-    `
-UPDATE archives
-SET dirty = 0, flushable = 0, updated_at = ?
+  const entryPaths = overlays
+    .map((overlay) => overlay.entryPath)
+    .sort((left, right) => left.localeCompare(right));
+  const releaseLocks: Array<() => Promise<void>> = [];
+
+  try {
+    for (const entryPath of entryPaths) {
+      releaseLocks.push(await acquireEntryLock(archiveKey, entryPath, "write"));
+    }
+    for (const entryPath of entryPaths) {
+      releaseLocks.push(await acquireEntryLock(archiveKey, entryPath, "state"));
+    }
+
+    if (entryPaths.includes(DATABASE_ENTRY_PATH)) {
+      await waitForSqliteLeasesToDrain(archiveKey, DATABASE_ENTRY_PATH);
+    }
+
+    const currentOverlays = await listOverlays(archiveKey);
+
+    if (currentOverlays.length === 0) {
+      return;
+    }
+
+    const releaseCommit = await acquireArchiveCommitLock(archiveKey);
+
+    try {
+      const temporaryDirectoryPath = await mkdtemp(
+        join(tmpdir(), "spinedigest-flush-"),
+      );
+      const temporaryArchivePath = join(
+        temporaryDirectoryPath,
+        basename(archivePath),
+      );
+
+      try {
+        await writeSdpubArchiveWithOverlays(
+          archivePath,
+          temporaryArchivePath,
+          currentOverlays.map(toArchiveOverlay),
+        );
+        await mkdir(dirname(archivePath), { recursive: true });
+        await rename(temporaryArchivePath, archivePath);
+      } finally {
+        await rm(temporaryDirectoryPath, { force: true, recursive: true });
+      }
+    } finally {
+      await releaseCommit();
+    }
+
+    for (const overlay of currentOverlays) {
+      if (overlay.workspacePath !== undefined) {
+        await rm(overlay.workspacePath, { force: true });
+      }
+      await deleteOverlay(archiveKey, overlay.entryPath);
+    }
+  } finally {
+    for (const release of releaseLocks.reverse()) {
+      await release();
+    }
+  }
+}
+
+async function acquireArchiveCommitLock(
+  archiveKey: string,
+): Promise<() => Promise<void>> {
+  const ownerId = createOwnerId();
+
+  while (true) {
+    const acquired = await withStateDatabase(async (state) => {
+      await cleanupStaleState(state);
+      return await state.transaction(async () => {
+        const existing = await state.queryOne(
+          "SELECT * FROM archive_commit_locks WHERE archive_key = ?",
+          [archiveKey],
+          mapArchiveCommitLock,
+        );
+
+        if (existing !== undefined) {
+          return false;
+        }
+
+        await state.run(
+          `
+INSERT INTO archive_commit_locks (
+  archive_key, owner_id, owner_pid, heartbeat_at, created_at
+) VALUES (?, ?, ?, ?, ?)
+`,
+          [archiveKey, ownerId, process.pid, Date.now(), Date.now()],
+        );
+        return true;
+      });
+    });
+
+    if (acquired) {
+      return async () => {
+        await withStateDatabase(async (releaseState) => {
+          await releaseState.run(
+            "DELETE FROM archive_commit_locks WHERE archive_key = ? AND owner_id = ?",
+            [archiveKey, ownerId],
+          );
+        });
+      };
+    }
+
+    await delay(LOCK_POLL_INTERVAL_MS);
+  }
+}
+
+async function acquireEntryLock(
+  archiveKey: string,
+  entryPath: string,
+  mode: EntryLockMode,
+): Promise<() => Promise<void>> {
+  const ownerId = createOwnerId();
+
+  while (true) {
+    const acquired = await withStateDatabase(async (state) => {
+      await cleanupStaleState(state);
+      return await state.transaction(async () => {
+        const conflicts = await state.queryAll(
+          `
+SELECT *
+FROM entry_locks
+WHERE archive_key = ? AND entry_path = ?
+`,
+          [archiveKey, entryPath],
+          mapEntryLock,
+        );
+
+        if (
+          conflicts.some(
+            (lock) =>
+              lock.ownerId !== ownerId && locksConflict(mode, lock.mode),
+          )
+        ) {
+          return false;
+        }
+
+        await state.run(
+          `
+INSERT INTO entry_locks (
+  archive_key, entry_path, mode, owner_id, owner_pid, heartbeat_at, created_at
+) VALUES (?, ?, ?, ?, ?, ?, ?)
+`,
+          [
+            archiveKey,
+            entryPath,
+            mode,
+            ownerId,
+            process.pid,
+            Date.now(),
+            Date.now(),
+          ],
+        );
+        return true;
+      });
+    });
+
+    if (acquired) {
+      return async () => {
+        await withStateDatabase(async (releaseState) => {
+          await releaseState.run(
+            `
+DELETE FROM entry_locks
+WHERE archive_key = ? AND entry_path = ? AND owner_id = ?
+`,
+            [archiveKey, entryPath, ownerId],
+          );
+        });
+      };
+    }
+
+    await delay(LOCK_POLL_INTERVAL_MS);
+  }
+}
+
+async function withEntryLock<T>(
+  archiveKey: string,
+  entryPath: string,
+  mode: EntryLockMode,
+  operation: () => Promise<T> | T,
+): Promise<T> {
+  const release = await acquireEntryLock(archiveKey, entryPath, mode);
+
+  try {
+    return await operation();
+  } finally {
+    await release();
+  }
+}
+
+function locksConflict(requested: EntryLockMode, existing: EntryLockMode) {
+  if (requested === "state" || existing === "state") {
+    return requested === "state" && existing === "state";
+  }
+  if (requested === "read" && existing === "read") {
+    return false;
+  }
+
+  return true;
+}
+
+async function acquireSqliteLease(input: {
+  readonly archiveKey: string;
+  readonly entryPath: string;
+  readonly ownerId: string;
+}): Promise<void> {
+  await withStateDatabase(async (state) => {
+    await cleanupStaleState(state);
+    await state.run(
+      `
+INSERT OR REPLACE INTO entry_sqlite_leases (
+  archive_key, entry_path, owner_id, owner_pid, heartbeat_at, created_at
+) VALUES (?, ?, ?, ?, ?, ?)
+`,
+      [
+        input.archiveKey,
+        input.entryPath,
+        input.ownerId,
+        process.pid,
+        Date.now(),
+        Date.now(),
+      ],
+    );
+  });
+}
+
+async function releaseSqliteLease(input: {
+  readonly archiveKey: string;
+  readonly entryPath: string;
+  readonly ownerId: string;
+}): Promise<void> {
+  await withStateDatabase(async (state) => {
+    await state.run(
+      `
+DELETE FROM entry_sqlite_leases
+WHERE archive_key = ? AND entry_path = ? AND owner_id = ?
+`,
+      [input.archiveKey, input.entryPath, input.ownerId],
+    );
+  });
+}
+
+async function waitForSqliteLeasesToDrain(
+  archiveKey: string,
+  entryPath: string,
+): Promise<void> {
+  while (true) {
+    const count = await withStateDatabase(async (state) => {
+      await cleanupStaleState(state);
+      return await state.queryOne(
+        `
+SELECT COUNT(*) AS count
+FROM entry_sqlite_leases
+WHERE archive_key = ? AND entry_path = ?
+`,
+        [archiveKey, entryPath],
+        (row) => getNumber(row, "count"),
+      );
+    });
+
+    if (count === 0) {
+      return;
+    }
+
+    await delay(LOCK_POLL_INTERVAL_MS);
+  }
+}
+
+async function listVisibleEntryPaths(
+  archivePath: string,
+  input: { readonly archiveKey: string; readonly prefix: string },
+): Promise<readonly string[]> {
+  const archiveEntries = await listArchiveEntryPathsByPrefix(
+    archivePath,
+    input.prefix,
+  );
+  const overlays = await withStateDatabase(
+    async (state) =>
+      await state.queryAll(
+        `
+SELECT *
+FROM entry_overlays
 WHERE archive_key = ?
 `,
-    [Date.now(), archiveKey],
+        [input.archiveKey],
+        mapEntryOverlay,
+      ),
   );
+  const entries = new Set(archiveEntries);
 
-  await rm(archive.workspacePath, { force: true, recursive: true });
-  await state.run("DELETE FROM archives WHERE archive_key = ?", [archiveKey]);
-}
-
-async function heartbeatFlusher(
-  ownerId: string,
-  existingState?: Database,
-): Promise<void> {
-  const state = existingState ?? (await openStateDatabase());
-
-  try {
-    await state.run(
-      `
-UPDATE archives
-SET flusher_heartbeat_at = ?
-WHERE flusher_owner = ?
-`,
-      [Date.now(), ownerId],
-    );
-  } finally {
-    if (existingState === undefined) {
-      await state.close();
+  for (const overlay of overlays) {
+    if (!overlay.entryPath.startsWith(input.prefix)) {
+      continue;
+    }
+    if (overlay.kind === "deleted") {
+      entries.delete(overlay.entryPath);
+    } else {
+      entries.add(overlay.entryPath);
     }
   }
+
+  return [...entries].sort((left, right) => left.localeCompare(right));
 }
 
-async function releaseFlusher(
-  ownerId: string,
-  existingState?: Database,
-): Promise<void> {
-  const state = existingState ?? (await openStateDatabase());
+async function listArchiveEntryPathsByPrefix(
+  archivePath: string,
+  prefix: string,
+): Promise<readonly string[]> {
+  const { listSdpubArchiveEntries } = await import("./archive.js");
 
-  try {
+  return (await listSdpubArchiveEntries(archivePath)).filter((entryPath) =>
+    entryPath.startsWith(prefix),
+  );
+}
+
+async function resolveEntrySource(
+  archivePath: string,
+  input: { readonly archiveKey: string; readonly entryPath: string },
+): Promise<
+  | { readonly kind: "archive" }
+  | { readonly kind: "deleted" }
+  | { readonly kind: "workspace"; readonly path: string }
+> {
+  const overlay = await readOverlay(input.archiveKey, input.entryPath);
+
+  if (overlay?.kind === "deleted") {
+    return { kind: "deleted" };
+  }
+  if (overlay?.workspacePath !== undefined) {
+    return { kind: "workspace", path: overlay.workspacePath };
+  }
+  if (
+    (await readSdpubArchiveEntry(archivePath, input.entryPath)) === undefined
+  ) {
+    return { kind: "deleted" };
+  }
+
+  return { kind: "archive" };
+}
+
+async function readOverlay(
+  archiveKey: string,
+  entryPath: string,
+): Promise<EntryOverlay | undefined> {
+  return await withStateDatabase(
+    async (state) =>
+      await state.queryOne(
+        "SELECT * FROM entry_overlays WHERE archive_key = ? AND entry_path = ?",
+        [archiveKey, entryPath],
+        mapEntryOverlay,
+      ),
+  );
+}
+
+async function listOverlays(
+  archiveKey: string,
+): Promise<readonly EntryOverlay[]> {
+  return await withStateDatabase(
+    async (state) =>
+      await state.queryAll(
+        `
+SELECT *
+FROM entry_overlays
+WHERE archive_key = ?
+ORDER BY entry_path ASC
+`,
+        [archiveKey],
+        mapEntryOverlay,
+      ),
+  );
+}
+
+async function upsertOverlay(input: {
+  readonly archiveKey: string;
+  readonly archivePath: string;
+  readonly entryPath: string;
+  readonly kind: "deleted" | "file";
+  readonly workspacePath?: string;
+}): Promise<void> {
+  await withStateDatabase(async (state) => {
     await state.run(
       `
-UPDATE archives
-SET flusher_owner = NULL, flusher_pid = NULL, flusher_heartbeat_at = NULL
-WHERE flusher_owner = ?
+INSERT INTO entry_overlays (
+  archive_key, archive_path, entry_path, kind, workspace_path, updated_at
+) VALUES (?, ?, ?, ?, ?, ?)
+ON CONFLICT(archive_key, entry_path)
+DO UPDATE SET kind = excluded.kind,
+              archive_path = excluded.archive_path,
+              workspace_path = excluded.workspace_path,
+              updated_at = excluded.updated_at
 `,
-      [ownerId],
+      [
+        input.archiveKey,
+        input.archivePath,
+        input.entryPath,
+        input.kind,
+        input.workspacePath ?? null,
+        Date.now(),
+      ],
     );
-  } finally {
-    if (existingState === undefined) {
-      await state.close();
-    }
-  }
+  });
+}
+
+async function deleteOverlay(
+  archiveKey: string,
+  entryPath: string,
+): Promise<void> {
+  await withStateDatabase(async (state) => {
+    await state.run(
+      "DELETE FROM entry_overlays WHERE archive_key = ? AND entry_path = ?",
+      [archiveKey, entryPath],
+    );
+  });
+}
+
+async function resolveArchivePathFromKey(
+  archiveKey: string,
+): Promise<string | undefined> {
+  return await withStateDatabase(
+    async (state) =>
+      await state.queryOne(
+        "SELECT archive_path FROM entry_overlays WHERE archive_key = ? LIMIT 1",
+        [archiveKey],
+        (row) => getString(row, "archive_path"),
+      ),
+  );
 }
 
 async function cleanupStaleState(state: Database): Promise<void> {
-  const rows = await state.queryAll(
-    "SELECT * FROM archives",
-    undefined,
-    mapArchiveState,
-  );
+  const now = Date.now();
 
-  for (const row of rows) {
-    if (row.operationPid !== undefined && !isProcessAlive(row.operationPid)) {
-      await state.run(
-        `
-UPDATE archives
-SET operation_owner = NULL, operation_pid = NULL,
-    operation_heartbeat_at = NULL, flushable = 0, updated_at = ?
-WHERE archive_key = ?
+  await state.run(
+    `
+DELETE FROM entry_locks
+WHERE owner_pid IS NOT NULL
+  AND heartbeat_at <= ?
 `,
-        [Date.now(), row.archiveKey],
-      );
-    }
-
-    if (row.flusherPid !== undefined && !isProcessAlive(row.flusherPid)) {
-      await releaseFlusher(row.flusherOwner ?? "", state);
-    }
-  }
+    [now - LOCK_STALE_TIMEOUT_MS],
+  );
+  await state.run(
+    `
+DELETE FROM entry_sqlite_leases
+WHERE owner_pid IS NOT NULL
+  AND heartbeat_at <= ?
+`,
+    [now - LOCK_STALE_TIMEOUT_MS],
+  );
+  await state.run(
+    `
+DELETE FROM archive_commit_locks
+WHERE owner_pid IS NOT NULL
+  AND heartbeat_at <= ?
+`,
+    [now - LOCK_STALE_TIMEOUT_MS],
+  );
 }
 
-async function readArchiveState(
-  state: Database,
-  archiveKey: string,
-): Promise<ArchiveState | undefined> {
-  return await state.queryOne(
-    "SELECT * FROM archives WHERE archive_key = ?",
-    [archiveKey],
-    mapArchiveState,
-  );
+async function withStateDatabase<T>(
+  operation: (state: Database) => Promise<T> | T,
+): Promise<T> {
+  return await STATE_DATABASE_SEMAPHORE.use(async () => {
+    const state = await openStateDatabase();
+
+    try {
+      return await operation(state);
+    } finally {
+      await state.close();
+    }
+  });
 }
 
 async function openStateDatabase(): Promise<Database> {
@@ -455,15 +824,41 @@ async function openStateDatabase(): Promise<Database> {
   );
 }
 
-async function createWorkspacePath(archiveKey: string): Promise<string> {
-  const rootPath = join(
+async function createWorkspaceFilePath(
+  archiveKey: string,
+  entryPath: string,
+): Promise<string> {
+  const directoryPath = join(
     getCoordinatorStateDirectoryPath(),
     "workspaces",
     archiveKey,
+    dirname(entryPath),
   );
 
-  await mkdir(rootPath, { recursive: true });
-  return await mkdtemp(join(rootPath, "materialized-"));
+  await mkdir(directoryPath, { recursive: true });
+  return join(directoryPath, `${basename(entryPath)}.${randomUUID()}`);
+}
+
+function toArchiveOverlay(overlay: EntryOverlay): SdpubArchiveOverlay {
+  if (overlay.kind === "deleted") {
+    return {
+      entryPath: overlay.entryPath,
+      kind: "deleted",
+    };
+  }
+  if (overlay.workspacePath === undefined) {
+    throw new Error(`Missing workspace path for ${overlay.entryPath}.`);
+  }
+
+  return {
+    entryPath: overlay.entryPath,
+    kind: "file",
+    workspacePath: overlay.workspacePath,
+  };
+}
+
+function normalizeEntryPath(path: string): string {
+  return path.replaceAll("\\", "/").replace(/^\/+/u, "");
 }
 
 function getCoordinatorStateDirectoryPath(): string {
@@ -476,37 +871,6 @@ function getCoordinatorStateDirectoryPath(): string {
   return join(homedir(), ".spinedigest", "state");
 }
 
-function getFlushQuietPeriodMs(): number {
-  return parseNonNegativeIntegerEnv(
-    process.env.SPINEDIGEST_FLUSH_QUIET_PERIOD_MS,
-    10_000,
-  );
-}
-
-function getFlushIdleTimeoutMs(): number {
-  return parseNonNegativeIntegerEnv(
-    process.env.SPINEDIGEST_FLUSH_IDLE_TIMEOUT_MS,
-    10_000,
-  );
-}
-
-function parseNonNegativeIntegerEnv(
-  value: string | undefined,
-  fallback: number,
-): number {
-  if (value === undefined || value.trim() === "") {
-    return fallback;
-  }
-
-  const parsed = Number(value);
-
-  if (!Number.isInteger(parsed) || parsed < 0) {
-    return fallback;
-  }
-
-  return parsed;
-}
-
 function createArchiveKey(archivePath: string): string {
   return createHash("sha256").update(resolve(archivePath)).digest("hex");
 }
@@ -515,46 +879,72 @@ function createOwnerId(): string {
   return `${process.pid}-${randomUUID()}`;
 }
 
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 async function delay(ms: number): Promise<void> {
   await new Promise<void>((resolveDelay) => {
     setTimeout(resolveDelay, ms);
   });
 }
 
-interface ArchiveState {
+interface EntryOverlay {
   readonly archiveKey: string;
   readonly archivePath: string;
-  readonly workspacePath: string;
-  readonly operationOwner?: string;
-  readonly operationPid?: number;
-  readonly flusherOwner?: string;
-  readonly flusherPid?: number;
+  readonly entryPath: string;
+  readonly kind: "deleted" | "file";
+  readonly workspacePath?: string;
 }
 
-function mapArchiveState(row: Record<string, unknown>): ArchiveState {
-  const operationOwner = getOptionalString(row, "operation_owner");
-  const operationPid = getOptionalNumber(row, "operation_pid");
-  const flusherOwner = getOptionalString(row, "flusher_owner");
-  const flusherPid = getOptionalNumber(row, "flusher_pid");
+interface EntryLock {
+  readonly mode: EntryLockMode;
+  readonly ownerId: string;
+}
+
+interface ArchiveCommitLock {
+  readonly ownerId: string;
+}
+
+function mapEntryOverlay(row: Record<string, unknown>): EntryOverlay {
+  const workspacePath = getOptionalString(row, "workspace_path");
 
   return {
     archiveKey: getString(row, "archive_key"),
     archivePath: getString(row, "archive_path"),
-    workspacePath: getString(row, "workspace_path"),
-    ...(operationOwner === undefined ? {} : { operationOwner }),
-    ...(operationPid === undefined ? {} : { operationPid }),
-    ...(flusherOwner === undefined ? {} : { flusherOwner }),
-    ...(flusherPid === undefined ? {} : { flusherPid }),
+    entryPath: getString(row, "entry_path"),
+    kind: getOverlayKind(row),
+    ...(workspacePath === undefined ? {} : { workspacePath }),
   };
+}
+
+function mapEntryLock(row: Record<string, unknown>): EntryLock {
+  return {
+    mode: getEntryLockMode(row),
+    ownerId: getString(row, "owner_id"),
+  };
+}
+
+function mapArchiveCommitLock(row: Record<string, unknown>): ArchiveCommitLock {
+  return {
+    ownerId: getString(row, "owner_id"),
+  };
+}
+
+function getEntryLockMode(row: Record<string, unknown>): EntryLockMode {
+  const mode = getString(row, "mode");
+
+  if (mode === "read" || mode === "state" || mode === "write") {
+    return mode;
+  }
+
+  throw new Error(`Unsupported entry lock mode: ${mode}.`);
+}
+
+function getOverlayKind(row: Record<string, unknown>): "deleted" | "file" {
+  const kind = getString(row, "kind");
+
+  if (kind === "deleted" || kind === "file") {
+    return kind;
+  }
+
+  throw new Error(`Unsupported entry overlay kind: ${kind}.`);
 }
 
 function getString(row: Record<string, unknown>, key: string): string {
@@ -589,23 +979,6 @@ function getOptionalString(
 
   if (typeof value !== "string") {
     throw new TypeError(`Expected ${key} to be a string`);
-  }
-
-  return value;
-}
-
-function getOptionalNumber(
-  row: Record<string, unknown>,
-  key: string,
-): number | undefined {
-  const value = row[key];
-
-  if (value === null || value === undefined) {
-    return undefined;
-  }
-
-  if (typeof value !== "number") {
-    throw new TypeError(`Expected ${key} to be a number`);
   }
 
   return value;

--- a/src/facade/sdpub-coordinator.ts
+++ b/src/facade/sdpub-coordinator.ts
@@ -118,7 +118,14 @@ export class SdpubCoordinator {
   }
 }
 
-export async function tryStartSdpubFlusher(): Promise<void> {
+export async function tryStartSdpubFlusher(
+  archivePath?: string,
+): Promise<void> {
+  if (archivePath !== undefined) {
+    await flushArchiveOverlays(createArchiveKey(resolve(archivePath)));
+    return;
+  }
+
   const archiveKeys = await withStateDatabase(async (state) => {
     await cleanupStaleState(state);
     return await state.queryAll(

--- a/src/facade/sdpub-coordinator.ts
+++ b/src/facade/sdpub-coordinator.ts
@@ -10,6 +10,7 @@ import { AsyncSemaphore } from "../utils/async-semaphore.js";
 import {
   extractSdpubArchive,
   readSdpubArchiveEntry,
+  SdpubArchiveReader,
   writeSdpubArchiveWithOverlays,
   type SdpubArchiveOverlay,
 } from "./archive.js";
@@ -129,6 +130,7 @@ ORDER BY archive_key
 class SdpubDocumentFileStore implements DocumentFileStore {
   readonly #archiveKey: string;
   readonly #archivePath: string;
+  #archiveReader: Promise<SdpubArchiveReader> | undefined;
   readonly #readonlyDatabase: boolean;
   readonly #sqliteLeaseOwnerId = createOwnerId();
 
@@ -142,6 +144,10 @@ class SdpubDocumentFileStore implements DocumentFileStore {
   }
 
   public async close(): Promise<void> {
+    if (this.#archiveReader !== undefined) {
+      (await this.#archiveReader).close();
+      this.#archiveReader = undefined;
+    }
     await releaseSqliteLease({
       archiveKey: this.#archiveKey,
       entryPath: DATABASE_ENTRY_PATH,
@@ -172,10 +178,13 @@ class SdpubDocumentFileStore implements DocumentFileStore {
 
   public async deleteTree(path: string): Promise<void> {
     const rootEntryPath = this.#toEntryPath(path);
-    const entries = await listVisibleEntryPaths(this.#archivePath, {
-      archiveKey: this.#archiveKey,
-      prefix: `${rootEntryPath}/`,
-    });
+    const entries = await listVisibleEntryPaths(
+      await this.#listArchiveEntries(),
+      {
+        archiveKey: this.#archiveKey,
+        prefix: `${rootEntryPath}/`,
+      },
+    );
 
     for (const entryPath of entries) {
       await this.deleteFile(entryPath);
@@ -197,10 +206,13 @@ class SdpubDocumentFileStore implements DocumentFileStore {
   public async listFiles(path: string): Promise<readonly string[]> {
     const directoryEntryPath = this.#toEntryPath(path);
     const prefix = directoryEntryPath === "" ? "" : `${directoryEntryPath}/`;
-    const entries = await listVisibleEntryPaths(this.#archivePath, {
-      archiveKey: this.#archiveKey,
-      prefix,
-    });
+    const entries = await listVisibleEntryPaths(
+      await this.#listArchiveEntries(),
+      {
+        archiveKey: this.#archiveKey,
+        prefix,
+      },
+    );
 
     return entries
       .map((entryPath) => entryPath.slice(prefix.length))
@@ -235,7 +247,7 @@ class SdpubDocumentFileStore implements DocumentFileStore {
           return await readFile(source.path);
         }
 
-        return await readSdpubArchiveEntry(this.#archivePath, entryPath);
+        return await this.#readArchiveEntry(entryPath);
       },
     );
   }
@@ -304,8 +316,7 @@ class SdpubDocumentFileStore implements DocumentFileStore {
       );
       const archiveEntryExists =
         source.kind === "archive" &&
-        (await readSdpubArchiveEntry(this.#archivePath, entryPath)) !==
-          undefined;
+        (await this.#readArchiveEntry(entryPath)) !== undefined;
 
       if (
         options.overwrite !== true &&
@@ -344,6 +355,19 @@ class SdpubDocumentFileStore implements DocumentFileStore {
     }
 
     return normalizeEntryPath(path);
+  }
+
+  async #listArchiveEntries(): Promise<readonly string[]> {
+    return (await this.#getArchiveReader()).listEntries();
+  }
+
+  async #readArchiveEntry(entryPath: string): Promise<Buffer | undefined> {
+    return await (await this.#getArchiveReader()).readEntry(entryPath);
+  }
+
+  async #getArchiveReader(): Promise<SdpubArchiveReader> {
+    this.#archiveReader ??= SdpubArchiveReader.open(this.#archivePath);
+    return await this.#archiveReader;
   }
 }
 
@@ -625,12 +649,11 @@ WHERE archive_key = ? AND entry_path = ?
 }
 
 async function listVisibleEntryPaths(
-  archivePath: string,
+  archiveEntries: readonly string[],
   input: { readonly archiveKey: string; readonly prefix: string },
 ): Promise<readonly string[]> {
-  const archiveEntries = await listArchiveEntryPathsByPrefix(
-    archivePath,
-    input.prefix,
+  const matchingArchiveEntries = archiveEntries.filter((entryPath) =>
+    entryPath.startsWith(input.prefix),
   );
   const overlays = await withStateDatabase(
     async (state) =>
@@ -644,7 +667,7 @@ WHERE archive_key = ?
         mapEntryOverlay,
       ),
   );
-  const entries = new Set(archiveEntries);
+  const entries = new Set(matchingArchiveEntries);
 
   for (const overlay of overlays) {
     if (!overlay.entryPath.startsWith(input.prefix)) {
@@ -658,17 +681,6 @@ WHERE archive_key = ?
   }
 
   return [...entries].sort((left, right) => left.localeCompare(right));
-}
-
-async function listArchiveEntryPathsByPrefix(
-  archivePath: string,
-  prefix: string,
-): Promise<readonly string[]> {
-  const { listSdpubArchiveEntries } = await import("./archive.js");
-
-  return (await listSdpubArchiveEntries(archivePath)).filter((entryPath) =>
-    entryPath.startsWith(prefix),
-  );
 }
 
 async function resolveEntrySource(input: {

--- a/src/facade/sdpub-coordinator.ts
+++ b/src/facade/sdpub-coordinator.ts
@@ -399,6 +399,7 @@ async function flushArchiveOverlays(archiveKey: string): Promise<void> {
   const entryPaths = overlays
     .map((overlay) => overlay.entryPath)
     .sort((left, right) => left.localeCompare(right));
+  const lockedEntryPaths = new Set(entryPaths);
   const releaseLocks: Array<() => Promise<void>> = [];
 
   try {
@@ -413,7 +414,9 @@ async function flushArchiveOverlays(archiveKey: string): Promise<void> {
       await waitForSqliteLeasesToDrain(archiveKey, DATABASE_ENTRY_PATH);
     }
 
-    const currentOverlays = await listOverlays(archiveKey);
+    const currentOverlays = (await listOverlays(archiveKey)).filter((overlay) =>
+      lockedEntryPaths.has(overlay.entryPath),
+    );
 
     if (currentOverlays.length === 0) {
       return;
@@ -809,31 +812,73 @@ async function resolveArchivePathFromKey(
 
 async function cleanupStaleState(state: Database): Promise<void> {
   const now = Date.now();
+  const staleOwnerPids = new Set<number>();
+
+  for (const tableName of [
+    "entry_locks",
+    "entry_sqlite_leases",
+    "archive_commit_locks",
+  ]) {
+    const rows = await state.queryAll(
+      `
+SELECT DISTINCT owner_pid
+FROM ${tableName}
+WHERE owner_pid IS NOT NULL
+  AND heartbeat_at <= ?
+`,
+      [now - LOCK_STALE_TIMEOUT_MS],
+      (row) => getNumber(row, "owner_pid"),
+    );
+
+    for (const ownerPid of rows) {
+      if (!isProcessAlive(ownerPid)) {
+        staleOwnerPids.add(ownerPid);
+      }
+    }
+  }
+
+  if (staleOwnerPids.size === 0) {
+    return;
+  }
 
   await state.run(
     `
 DELETE FROM entry_locks
-WHERE owner_pid IS NOT NULL
-  AND heartbeat_at <= ?
+WHERE owner_pid IN (${createPlaceholders(staleOwnerPids.size)})
 `,
-    [now - LOCK_STALE_TIMEOUT_MS],
+    [...staleOwnerPids],
   );
   await state.run(
     `
 DELETE FROM entry_sqlite_leases
-WHERE owner_pid IS NOT NULL
-  AND heartbeat_at <= ?
+WHERE owner_pid IN (${createPlaceholders(staleOwnerPids.size)})
 `,
-    [now - LOCK_STALE_TIMEOUT_MS],
+    [...staleOwnerPids],
   );
   await state.run(
     `
 DELETE FROM archive_commit_locks
-WHERE owner_pid IS NOT NULL
-  AND heartbeat_at <= ?
+WHERE owner_pid IN (${createPlaceholders(staleOwnerPids.size)})
 `,
-    [now - LOCK_STALE_TIMEOUT_MS],
+    [...staleOwnerPids],
   );
+}
+
+function createPlaceholders(count: number): string {
+  return Array.from({ length: count }, () => "?").join(", ");
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ESRCH") {
+      return false;
+    }
+
+    return true;
+  }
 }
 
 async function withStateDatabase<T>(

--- a/src/facade/spine-digest-file.ts
+++ b/src/facade/spine-digest-file.ts
@@ -2,7 +2,7 @@ import { resolve } from "path";
 
 import { DirectoryDocument } from "../document/index.js";
 
-import { SdpubCoordinator } from "./sdpub-coordinator.js";
+import { SdpubCoordinator, tryStartSdpubFlusher } from "./sdpub-coordinator.js";
 import { SpineDigest } from "./spine-digest.js";
 
 export class SpineDigestFile {
@@ -35,6 +35,20 @@ export class SpineDigestFile {
       readonly documentDirPath?: string;
     } = {},
   ): Promise<T> {
+    if (options.documentDirPath === undefined) {
+      const document = await DirectoryDocument.open(this.#path, {
+        fileStore: this.#coordinator.createFileStore(this.#path, {
+          readonlyDatabase: true,
+        }),
+      });
+
+      try {
+        return await operation(document, this.#path);
+      } finally {
+        await document.release();
+      }
+    }
+
     return await this.#coordinator.withReadWorkspace(
       this.#path,
       async (directoryPath) => {
@@ -53,18 +67,22 @@ export class SpineDigestFile {
   public async write<T>(
     operation: (document: DirectoryDocument) => Promise<T> | T,
   ): Promise<T> {
-    return await this.#coordinator.withWriteWorkspace(
-      this.#path,
-      async (directoryPath) => {
-        const document = await DirectoryDocument.open(directoryPath);
+    const document = await DirectoryDocument.open(this.#path, {
+      fileStore: this.#coordinator.createFileStore(this.#path),
+    });
+    let completed = false;
 
-        try {
-          return await operation(document);
-        } finally {
-          await document.flush();
-          await document.release();
-        }
-      },
-    );
+    try {
+      const result = await operation(document);
+
+      completed = true;
+      return result;
+    } finally {
+      await document.flush();
+      await document.release();
+      if (completed) {
+        await tryStartSdpubFlusher();
+      }
+    }
   }
 }

--- a/src/facade/spine-digest-file.ts
+++ b/src/facade/spine-digest-file.ts
@@ -81,7 +81,7 @@ export class SpineDigestFile {
       await document.flush();
       await document.release();
       if (completed) {
-        await tryStartSdpubFlusher();
+        await tryStartSdpubFlusher(this.#path);
       }
     }
   }

--- a/test/cli/queue.test.ts
+++ b/test/cli/queue.test.ts
@@ -177,7 +177,7 @@ vi.mock("../../src/facade/index.js", () => ({
   snapshotChapterSummaryInput: vi.fn(() => {
     queueMockState.stepLog.push("snapshot-summary");
     return Promise.resolve({
-      documentPath: "/tmp/job-workspace/summary-input-document",
+      filePath: "/tmp/job-workspace/summary-input.json",
     });
   }),
   updateBuildJobTarget: vi.fn(),
@@ -482,6 +482,13 @@ describe("cli/queue", () => {
     ]);
     expect(queueMockState.buildGraphCalls).toHaveLength(1);
     expect(queueMockState.buildSummaryCalls).toHaveLength(1);
+    expect(queueMockState.buildSummaryCalls[0]).toMatchObject({
+      snapshotPath: "/tmp/job-workspace/summary-input.json",
+      workspacePath: "/tmp/job-workspace",
+    });
+    expect(queueMockState.buildSummaryCalls[0]).not.toHaveProperty(
+      "sourceDocumentPath",
+    );
   });
 
   it("writes every watch jsonl event without closing stdout", async () => {

--- a/test/facade/app.test.ts
+++ b/test/facade/app.test.ts
@@ -221,6 +221,9 @@ describe("facade/app", () => {
 
   it("opens saved digest archives without requiring llm configuration", async () => {
     await withTempDir("spinedigest-app-", async (path) => {
+      const originalStateDir = process.env.SPINEDIGEST_STATE_DIR;
+
+      process.env.SPINEDIGEST_STATE_DIR = `${path}/state`;
       const document = await DirectoryDocument.open(`${path}/document`);
 
       try {
@@ -261,6 +264,11 @@ describe("facade/app", () => {
         expect(title).toBe("App Open Fixture");
       } finally {
         await document.release();
+        if (originalStateDir === undefined) {
+          delete process.env.SPINEDIGEST_STATE_DIR;
+        } else {
+          process.env.SPINEDIGEST_STATE_DIR = originalStateDir;
+        }
       }
     });
   });

--- a/test/facade/build-queue.test.ts
+++ b/test/facade/build-queue.test.ts
@@ -246,7 +246,7 @@ describe("facade/build-queue", () => {
         concurrency: 1,
         executeJob: async () => {
           const lock = await lockSqliteDatabaseBriefly(
-            `${path}/state/state.sqlite`,
+            `${path}/state/build-queue.sqlite`,
           );
           releaseLockPromise = lock.released;
           throw new Error("planned failure");
@@ -270,7 +270,11 @@ describe("facade/build-queue", () => {
         target: "graph",
       });
 
-      await forceRunningPid(`${path}/state/state.sqlite`, job.jobId, 99999999);
+      await forceRunningPid(
+        `${path}/state/build-queue.sqlite`,
+        job.jobId,
+        99999999,
+      );
 
       const jobs = await listBuildJobs();
       const updated = jobs.find((item) => item.jobId === job.jobId);

--- a/test/facade/build-queue.test.ts
+++ b/test/facade/build-queue.test.ts
@@ -340,7 +340,7 @@ describe("facade/build-queue", () => {
     });
   });
 
-  it("does not run multiple jobs for the same archive at the same time", async () => {
+  it("runs multiple jobs for the same archive when worker concurrency allows it", async () => {
     await withTempDir("spinedigest-build-queue-", async (path) => {
       useStateDir(`${path}/state`);
       await addBuildJob({
@@ -355,10 +355,14 @@ describe("facade/build-queue", () => {
       });
 
       let firstStarted!: () => void;
+      let secondStarted!: () => void;
       let releaseFirst!: () => void;
       let releaseSecond!: () => void;
       const firstStartedSignal = new Promise<void>((resolveStarted) => {
         firstStarted = resolveStarted;
+      });
+      const secondStartedSignal = new Promise<void>((resolveStarted) => {
+        secondStarted = resolveStarted;
       });
       const firstReleaseSignal = new Promise<void>((resolveRelease) => {
         releaseFirst = resolveRelease;
@@ -378,23 +382,21 @@ describe("facade/build-queue", () => {
             return;
           }
 
+          secondStarted();
           await secondReleaseSignal;
         },
         idleTimeoutMs: 0,
       });
 
       await firstStartedSignal;
+      await secondStartedSignal;
 
       expect((await listBuildJobs()).map((job) => job.state)).toStrictEqual([
         "running",
-        "queued",
+        "running",
       ]);
 
       releaseFirst();
-      await withTimeout(
-        waitForRunningJobCount(1),
-        "Timed out waiting for the second same-archive job to start.",
-      );
       releaseSecond();
       await worker;
     });

--- a/test/facade/build-queue.test.ts
+++ b/test/facade/build-queue.test.ts
@@ -197,6 +197,70 @@ describe("facade/build-queue", () => {
     });
   });
 
+  it("continues claiming queued jobs after one job fails", async () => {
+    await withTempDir("spinedigest-build-queue-", async (path) => {
+      useStateDir(`${path}/state`);
+      const failedJob = await addBuildJob({
+        archivePath: `${path}/book.sdpub`,
+        chapterId: 1,
+        target: "summary",
+      });
+      const succeededJob = await addBuildJob({
+        archivePath: `${path}/book.sdpub`,
+        chapterId: 2,
+        target: "summary",
+      });
+
+      await runBuildJobWorker({
+        concurrency: 1,
+        executeJob: (job) => {
+          if (job.jobId === failedJob.jobId) {
+            throw new Error("planned failure");
+          }
+
+          return Promise.resolve();
+        },
+        idleTimeoutMs: 0,
+      });
+
+      expect(await getBuildJob(failedJob.jobId)).toMatchObject({
+        state: "failed",
+      });
+      expect(await getBuildJob(succeededJob.jobId)).toMatchObject({
+        state: "succeeded",
+      });
+    });
+  });
+
+  it("waits for transient sqlite locks while marking failed jobs", async () => {
+    await withTempDir("spinedigest-build-queue-", async (path) => {
+      useStateDir(`${path}/state`);
+      const job = await addBuildJob({
+        archivePath: `${path}/book.sdpub`,
+        chapterId: 1,
+        target: "summary",
+      });
+      let releaseLockPromise: Promise<void> | undefined;
+
+      await runBuildJobWorker({
+        concurrency: 1,
+        executeJob: async () => {
+          const lock = await lockSqliteDatabaseBriefly(
+            `${path}/state/state.sqlite`,
+          );
+          releaseLockPromise = lock.released;
+          throw new Error("planned failure");
+        },
+        idleTimeoutMs: 0,
+      });
+
+      await requirePromise(releaseLockPromise);
+      expect(await getBuildJob(job.jobId)).toMatchObject({
+        state: "failed",
+      });
+    });
+  });
+
   it("recovers stale running jobs back to queued", async () => {
     await withTempDir("spinedigest-build-queue-", async (path) => {
       useStateDir(`${path}/state`);
@@ -355,6 +419,43 @@ WHERE job_id = ?
   } finally {
     await database.close();
   }
+}
+
+async function lockSqliteDatabaseBriefly(
+  databasePath: string,
+): Promise<{ readonly released: Promise<void> }> {
+  const database = await Database.open(
+    databasePath,
+    "CREATE TABLE IF NOT EXISTS build_jobs (job_id TEXT PRIMARY KEY);",
+  );
+
+  await database.run("BEGIN EXCLUSIVE");
+
+  return {
+    released: new Promise<void>((resolveRelease, rejectRelease) => {
+      setTimeout(() => {
+        void (async () => {
+          try {
+            await database.run("COMMIT");
+            await database.close();
+            resolveRelease();
+          } catch (error) {
+            rejectRelease(
+              error instanceof Error ? error : new Error(String(error)),
+            );
+          }
+        })();
+      }, 100);
+    }),
+  };
+}
+
+function requirePromise<T>(promise: Promise<T> | undefined): Promise<T> {
+  if (promise === undefined) {
+    throw new Error("Expected promise to be assigned.");
+  }
+
+  return promise;
 }
 
 function useStateDir(path: string): void {

--- a/test/facade/build-queue.test.ts
+++ b/test/facade/build-queue.test.ts
@@ -281,8 +281,10 @@ describe("facade/build-queue", () => {
 
       expect(updated?.state).toBe("queued");
       expect(
-        (await readBuildJobEvents(job)).map((event) => event.type),
-      ).toContain("requeued");
+        (await readBuildJobEvents(job)).filter(
+          (event) => event.type === "requeued",
+        ),
+      ).toHaveLength(1);
     });
   });
 

--- a/test/facade/build-queue.test.ts
+++ b/test/facade/build-queue.test.ts
@@ -430,8 +430,7 @@ describe("facade/build-queue", () => {
         idleTimeoutMs: 2_000,
       });
 
-      await withTimeout(
-        waitForRunningJob(),
+      await waitForRunningJob(
         "Timed out waiting for the first queue slot to become running.",
       );
 
@@ -447,12 +446,17 @@ describe("facade/build-queue", () => {
     });
   });
 
-  async function waitForRunningJob(): Promise<void> {
-    await waitForRunningJobCount(1);
+  async function waitForRunningJob(message: string): Promise<void> {
+    await waitForRunningJobCount(1, message);
   }
 
-  async function waitForRunningJobCount(count: number): Promise<void> {
-    while (true) {
+  async function waitForRunningJobCount(
+    count: number,
+    message: string,
+  ): Promise<void> {
+    const deadline = Date.now() + 2_000;
+
+    while (Date.now() < deadline) {
       if (
         (await listBuildJobs()).filter((job) => job.state === "running")
           .length >= count
@@ -461,6 +465,8 @@ describe("facade/build-queue", () => {
       }
       await delay(50);
     }
+
+    throw new Error(message);
   }
 
   it("lists multiple running jobs when worker concurrency allows it", async () => {

--- a/test/facade/build-queue.test.ts
+++ b/test/facade/build-queue.test.ts
@@ -325,7 +325,7 @@ describe("facade/build-queue", () => {
 
       await firstStartedSignal;
       await addBuildJob({
-        archivePath: `${path}/book.sdpub`,
+        archivePath: `${path}/other-book.sdpub`,
         chapterId: 2,
         target: "graph",
       });
@@ -340,7 +340,7 @@ describe("facade/build-queue", () => {
     });
   });
 
-  it("lists multiple running jobs when worker concurrency allows it", async () => {
+  it("does not run multiple jobs for the same archive at the same time", async () => {
     await withTempDir("spinedigest-build-queue-", async (path) => {
       useStateDir(`${path}/state`);
       await addBuildJob({
@@ -350,6 +350,121 @@ describe("facade/build-queue", () => {
       });
       await addBuildJob({
         archivePath: `${path}/book.sdpub`,
+        chapterId: 2,
+        target: "graph",
+      });
+
+      let firstStarted!: () => void;
+      let releaseFirst!: () => void;
+      let releaseSecond!: () => void;
+      const firstStartedSignal = new Promise<void>((resolveStarted) => {
+        firstStarted = resolveStarted;
+      });
+      const firstReleaseSignal = new Promise<void>((resolveRelease) => {
+        releaseFirst = resolveRelease;
+      });
+      const secondReleaseSignal = new Promise<void>((resolveRelease) => {
+        releaseSecond = resolveRelease;
+      });
+      let startedCount = 0;
+
+      const worker = runBuildJobWorker({
+        concurrency: 2,
+        executeJob: async () => {
+          startedCount += 1;
+          if (startedCount === 1) {
+            firstStarted();
+            await firstReleaseSignal;
+            return;
+          }
+
+          await secondReleaseSignal;
+        },
+        idleTimeoutMs: 0,
+      });
+
+      await firstStartedSignal;
+
+      expect((await listBuildJobs()).map((job) => job.state)).toStrictEqual([
+        "running",
+        "queued",
+      ]);
+
+      releaseFirst();
+      await withTimeout(
+        waitForRunningJobCount(1),
+        "Timed out waiting for the second same-archive job to start.",
+      );
+      releaseSecond();
+      await worker;
+    });
+  });
+
+  it("keeps queue reads responsive while idle slots wait for work", async () => {
+    await withTempDir("spinedigest-build-queue-", async (path) => {
+      useStateDir(`${path}/state`);
+      await addBuildJob({
+        archivePath: `${path}/book.sdpub`,
+        chapterId: 1,
+        target: "graph",
+      });
+
+      let releaseJob!: () => void;
+      const releaseSignal = new Promise<void>((resolveRelease) => {
+        releaseJob = resolveRelease;
+      });
+
+      const worker = runBuildJobWorker({
+        concurrency: 4,
+        executeJob: async () => {
+          await releaseSignal;
+        },
+        idleTimeoutMs: 2_000,
+      });
+
+      await withTimeout(
+        waitForRunningJob(),
+        "Timed out waiting for the first queue slot to become running.",
+      );
+
+      await expect(
+        withTimeout(
+          listBuildJobs({ all: true }),
+          "Timed out waiting for queue list while worker slots were idle.",
+        ),
+      ).resolves.toHaveLength(1);
+
+      releaseJob();
+      await worker;
+    });
+  });
+
+  async function waitForRunningJob(): Promise<void> {
+    await waitForRunningJobCount(1);
+  }
+
+  async function waitForRunningJobCount(count: number): Promise<void> {
+    while (true) {
+      if (
+        (await listBuildJobs()).filter((job) => job.state === "running")
+          .length >= count
+      ) {
+        return;
+      }
+      await delay(50);
+    }
+  }
+
+  it("lists multiple running jobs when worker concurrency allows it", async () => {
+    await withTempDir("spinedigest-build-queue-", async (path) => {
+      useStateDir(`${path}/state`);
+      await addBuildJob({
+        archivePath: `${path}/book.sdpub`,
+        chapterId: 1,
+        target: "graph",
+      });
+      await addBuildJob({
+        archivePath: `${path}/other-book.sdpub`,
         chapterId: 2,
         target: "graph",
       });
@@ -489,4 +604,10 @@ async function withTimeout<T>(
       clearTimeout(timeout);
     }
   }
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise<void>((resolveDelay) => {
+    setTimeout(resolveDelay, ms);
+  });
 }

--- a/test/facade/chapter-graph.test.ts
+++ b/test/facade/chapter-graph.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
+import { access } from "fs/promises";
 
-import { DirectoryDocument } from "../../src/document/index.js";
+import { DirectoryDocument, ChunkRetention } from "../../src/document/index.js";
+
+vi.mock("../../src/editor/index.js", () => ({
+  compressText: vi.fn((options: { readonly groupId: number }) =>
+    Promise.resolve(`summary group ${options.groupId}`),
+  ),
+}));
 
 vi.mock("../../src/serial.js", () => ({
   SerialGeneration: class {
@@ -56,8 +63,10 @@ import {
 } from "../../src/facade/chapter.js";
 import {
   buildChapterGraphArtifact,
+  buildChapterSummaryArtifactFromSnapshot,
   commitChapterGraphArtifact,
   readChapterBuildInput,
+  snapshotChapterSummaryInput,
 } from "../../src/facade/chapter-build.js";
 import { withTempDir } from "../helpers/temp.js";
 
@@ -138,7 +147,128 @@ describe("facade/chapter graph", () => {
       }
     });
   });
+
+  it("builds summary from a snapshot file without sdpub-shaped temp documents", async () => {
+    await withTempDir("spinedigest-chapter-summary-", async (path) => {
+      const document = await DirectoryDocument.open(`${path}/archive`);
+
+      try {
+        const chapter = await addChapter(document, {
+          title: "Chapter 1",
+        });
+        await setChapterSource(document, chapter.chapterId, [
+          "Alpha beta.",
+          "Gamma delta.",
+        ]);
+        const fragments = document.getSerialFragments(chapter.chapterId);
+
+        await document.openSession(async (openedDocument) => {
+          await openedDocument.chunks.save({
+            content: "Alpha beta.",
+            generation: 0,
+            id: 1,
+            label: "Alpha",
+            retention: ChunkRetention.Verbatim,
+            sentenceId: [chapter.chapterId, 0, 0],
+            sentenceIds: [[chapter.chapterId, 0, 0]],
+            weight: 1,
+            wordsCount: 2,
+          });
+          await openedDocument.chunks.save({
+            content: "Gamma delta.",
+            generation: 0,
+            id: 2,
+            label: "Gamma",
+            sentenceId: [chapter.chapterId, 1, 0],
+            sentenceIds: [[chapter.chapterId, 1, 0]],
+            weight: 1,
+            wordsCount: 2,
+          });
+          await openedDocument.fragmentGroups.saveMany([
+            {
+              fragmentId: 0,
+              groupId: 1,
+              serialId: chapter.chapterId,
+            },
+            {
+              fragmentId: 1,
+              groupId: 2,
+              serialId: chapter.chapterId,
+            },
+          ]);
+          await openedDocument.snakes.create({
+            firstLabel: "Alpha",
+            groupId: 1,
+            lastLabel: "Alpha",
+            localSnakeId: 1,
+            serialId: chapter.chapterId,
+            size: 1,
+          });
+          await openedDocument.snakes.create({
+            firstLabel: "Gamma",
+            groupId: 2,
+            lastLabel: "Gamma",
+            localSnakeId: 1,
+            serialId: chapter.chapterId,
+            size: 1,
+          });
+          await openedDocument.snakeChunks.save({
+            chunkId: 1,
+            position: 0,
+            snakeId: 1,
+          });
+          await openedDocument.snakeChunks.save({
+            chunkId: 2,
+            position: 0,
+            snakeId: 2,
+          });
+          await openedDocument.serials.setTopologyReady(chapter.chapterId);
+        });
+
+        await expect(fragments.listFragmentIds()).resolves.toStrictEqual([
+          0, 1,
+        ]);
+
+        const snapshot = await snapshotChapterSummaryInput(
+          document,
+          chapter.chapterId,
+          `${path}/job-workspace`,
+        );
+        const summary = await buildChapterSummaryArtifactFromSnapshot(
+          chapter.chapterId,
+          {
+            llm: {} as never,
+            snapshotPath: snapshot.filePath,
+            workspacePath: `${path}/job-workspace`,
+          },
+        );
+
+        expect(snapshot.filePath).toBe(
+          `${path}/job-workspace/summary-input.json`,
+        );
+        await expect(pathExists(snapshot.filePath)).resolves.toBe(true);
+        await expect(
+          pathExists(`${path}/job-workspace/summary-input-document`),
+        ).resolves.toBe(false);
+        await expect(
+          pathExists(`${path}/job-workspace/summary-document`),
+        ).resolves.toBe(false);
+        expect(summary).toBe("summary group 1\n\nsummary group 2");
+      } finally {
+        await document.release();
+      }
+    });
+  });
 });
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 function countWords(text: string): number {
   return text

--- a/test/facade/chapter.test.ts
+++ b/test/facade/chapter.test.ts
@@ -1,3 +1,5 @@
+import { rm } from "fs/promises";
+
 import { describe, expect, it } from "vitest";
 
 import { DirectoryDocument } from "../../src/document/index.js";
@@ -249,6 +251,38 @@ describe("facade/chapter", () => {
         );
 
         expect(resetToPlanned.stage).toBe("planned");
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("reads one chapter details without scanning unrelated chapter fragments", async () => {
+    await withTempDir("spinedigest-chapter-", async (path) => {
+      const document = await DirectoryDocument.open(path);
+
+      try {
+        const first = await addChapter(document, {
+          title: "Chapter 1",
+        });
+        const second = await addChapter(document, {
+          title: "Chapter 2",
+        });
+
+        await setChapterSource(document, first.chapterId, ["Alpha beta."]);
+        await setChapterSource(document, second.chapterId, ["Gamma delta."]);
+        await rm(document.getSerialFragments(second.chapterId).path, {
+          force: true,
+          recursive: true,
+        });
+
+        await expect(
+          getChapterDetails(document, first.chapterId),
+        ).resolves.toMatchObject({
+          chapterId: first.chapterId,
+          stage: "sourced",
+          words: 2,
+        });
       } finally {
         await document.release();
       }

--- a/test/facade/spine-digest-file.test.ts
+++ b/test/facade/spine-digest-file.test.ts
@@ -364,14 +364,14 @@ async function readCoordinatorOverlays(path: string): Promise<
   }>
 > {
   try {
-    await access(`${path}/state/state.sqlite`);
+    await access(`${path}/state/sdpub-coordinator.sqlite`);
   } catch {
     return [];
   }
 
   const { Database } = await import("../../src/document/index.js");
   const database = await Database.open(
-    `${path}/state/state.sqlite`,
+    `${path}/state/sdpub-coordinator.sqlite`,
     "CREATE TABLE IF NOT EXISTS entry_overlays (archive_key TEXT, archive_path TEXT, entry_path TEXT, kind TEXT, workspace_path TEXT, updated_at INTEGER);",
   );
 

--- a/test/facade/spine-digest-file.test.ts
+++ b/test/facade/spine-digest-file.test.ts
@@ -19,6 +19,7 @@ describe("facade/spine-digest-file", () => {
 
   it("opens a saved archive for reading and exposes digest operations", async () => {
     await withTempDir("spinedigest-facade-file-", async (path) => {
+      useCoordinatorStateDir(`${path}/state`);
       const document = await DirectoryDocument.open(`${path}/document`);
 
       try {
@@ -90,7 +91,7 @@ describe("facade/spine-digest-file", () => {
     });
   });
 
-  it("does not create coordinator state for plain archive reads", async () => {
+  it("materializes sqlite state for plain archive reads", async () => {
     await withTempDir("spinedigest-facade-file-", async (path) => {
       useCoordinatorStateDir(`${path}/state`);
       const archivePath = await createSeedArchive(path);
@@ -101,7 +102,31 @@ describe("facade/spine-digest-file", () => {
         });
       });
 
-      await expect(readCoordinatorArchives(path)).resolves.toStrictEqual([]);
+      await expect(readCoordinatorOverlays(path)).resolves.toMatchObject([
+        {
+          entryPath: "database.db",
+          kind: "file",
+        },
+      ]);
+    });
+  });
+
+  it("opens the same archive concurrently without reinitializing sqlite schema", async () => {
+    await withTempDir("spinedigest-facade-file-", async (path) => {
+      useCoordinatorStateDir(`${path}/state`);
+      const archivePath = await createSeedArchive(path);
+
+      await Promise.all(
+        Array.from(
+          { length: 6 },
+          async () =>
+            await new SpineDigestFile(archivePath).read(async (digest) => {
+              expect(await digest.readMeta()).toMatchObject({
+                title: "Session Fixture",
+              });
+            }),
+        ),
+      );
     });
   });
 
@@ -123,7 +148,7 @@ describe("facade/spine-digest-file", () => {
         });
       });
 
-      await expect(readCoordinatorArchives(path)).resolves.toStrictEqual([]);
+      await expect(readCoordinatorOverlays(path)).resolves.toStrictEqual([]);
 
       await expect(readArchivedTitle(path, archivePath)).resolves.toBe(
         "Flushed Title",
@@ -152,14 +177,11 @@ describe("facade/spine-digest-file", () => {
         }),
       ).rejects.toThrow("stop before flush");
 
-      const archives = await readCoordinatorArchives(path);
+      const overlays = await readCoordinatorOverlays(path);
 
-      expect(archives).toHaveLength(1);
-      expect(archives[0]).toMatchObject({
-        dirty: 1,
-        flushable: 0,
-        operationPid: null,
-      });
+      expect(overlays.map((overlay) => overlay.entryPath).sort()).toStrictEqual(
+        ["book-meta.json", "database.db"],
+      );
       await expect(readArchivedTitle(path, archivePath)).resolves.toBe(
         "Session Fixture",
       );
@@ -193,49 +215,63 @@ describe("facade/spine-digest-file", () => {
         });
       });
       await expect(readArchivedTitle(path, archivePath)).resolves.toBe(
-        "Session Fixture",
+        "Workspace Title",
       );
     });
   });
 
-  it("rejects concurrent writes for the same archive", async () => {
+  it("runs concurrent writes to different archive entries", async () => {
     await withTempDir("spinedigest-facade-file-", async (path) => {
       useCoordinatorStateDir(`${path}/state`, {
         idleTimeoutMs: 1_000,
         quietPeriodMs: 60_000,
       });
       const archivePath = await createSeedArchive(path);
-      let markFirstWriteEntered!: () => void;
-      let releaseFirstWrite!: () => void;
-      const firstWriteEntered = new Promise<void>((resolveEntered) => {
-        markFirstWriteEntered = resolveEntered;
-      });
-      const releaseFirstWriteSignal = new Promise<void>((resolveRelease) => {
-        releaseFirstWrite = resolveRelease;
-      });
+      await Promise.all([
+        new SpineDigestFile(archivePath).write(async (document) => {
+          const meta = await document.readBookMeta();
 
-      const firstWrite = new SpineDigestFile(archivePath).write(async () => {
-        markFirstWriteEntered();
-        await releaseFirstWriteSignal;
+          if (meta === undefined) {
+            throw new Error("Missing test metadata.");
+          }
+
+          await document.replaceBookMeta({
+            ...meta,
+            title: "Concurrent Title",
+          });
+        }),
+        new SpineDigestFile(archivePath).write(async (document) => {
+          await document.replaceToc({
+            items: [
+              {
+                children: [],
+                serialId: 1,
+                title: "Concurrent Chapter",
+              },
+            ],
+            version: 1,
+          });
+        }),
+      ]);
+
+      await new SpineDigestFile(archivePath).read(async (digest) => {
+        expect(await digest.readMeta()).toMatchObject({
+          title: "Concurrent Title",
+        });
+        expect(await digest.readToc()).toMatchObject({
+          items: [
+            {
+              title: "Concurrent Chapter",
+            },
+          ],
+        });
       });
-
-      await firstWriteEntered;
-      await waitForCoordinatorArchive(path);
-      await expect(
-        new SpineDigestFile(archivePath).write(async () => {}),
-      ).rejects.toThrow("Archive is already being edited");
-
-      releaseFirstWrite();
-      await firstWrite;
     });
   });
 
-  it("recovers stale writes when the owner process is gone", async () => {
+  it("preserves a failed write overlay for later reads", async () => {
     await withTempDir("spinedigest-facade-file-", async (path) => {
-      useCoordinatorStateDir(`${path}/state`, {
-        idleTimeoutMs: 1_000,
-        quietPeriodMs: 60_000,
-      });
+      useCoordinatorStateDir(`${path}/state`);
       const archivePath = await createSeedArchive(path);
 
       await expect(
@@ -248,18 +284,15 @@ describe("facade/spine-digest-file", () => {
 
           await document.replaceBookMeta({
             ...meta,
-            title: "Interrupted Title",
+            title: "Failed Overlay Title",
           });
-          throw new Error("interrupted");
+          throw new Error("keep overlay");
         }),
-      ).rejects.toThrow("interrupted");
+      ).rejects.toThrow("keep overlay");
 
-      await setCoordinatorOperationPid(path, -1);
-      await new SpineDigestFile(archivePath).write(async (document) => {
-        const meta = await document.readBookMeta();
-
-        expect(meta).toMatchObject({
-          title: "Interrupted Title",
+      await new SpineDigestFile(archivePath).read(async (digest) => {
+        expect(await digest.readMeta()).toMatchObject({
+          title: "Failed Overlay Title",
         });
       });
     });
@@ -323,12 +356,11 @@ async function readArchivedTitle(
   return meta.title;
 }
 
-async function readCoordinatorArchives(path: string): Promise<
+async function readCoordinatorOverlays(path: string): Promise<
   Array<{
     readonly archivePath: string;
-    readonly dirty: number;
-    readonly flushable: number;
-    readonly operationPid: number | null;
+    readonly entryPath: string;
+    readonly kind: string;
   }>
 > {
   try {
@@ -340,56 +372,23 @@ async function readCoordinatorArchives(path: string): Promise<
   const { Database } = await import("../../src/document/index.js");
   const database = await Database.open(
     `${path}/state/state.sqlite`,
-    "CREATE TABLE IF NOT EXISTS archives (archive_key TEXT);",
+    "CREATE TABLE IF NOT EXISTS entry_overlays (archive_key TEXT, archive_path TEXT, entry_path TEXT, kind TEXT, workspace_path TEXT, updated_at INTEGER);",
   );
 
   try {
     return await database.queryAll(
       `
-SELECT archive_path, dirty, flushable, operation_pid
-FROM archives
-ORDER BY archive_path
+SELECT archive_path, entry_path, kind
+FROM entry_overlays
+ORDER BY archive_path, entry_path
 `,
       undefined,
       (row) => ({
         archivePath: expectString(row.archive_path),
-        dirty: expectNumber(row.dirty),
-        flushable: expectNumber(row.flushable),
-        operationPid:
-          row.operation_pid === null ? null : expectNumber(row.operation_pid),
+        entryPath: expectString(row.entry_path),
+        kind: expectString(row.kind),
       }),
     );
-  } finally {
-    await database.close();
-  }
-}
-
-async function waitForCoordinatorArchive(path: string): Promise<void> {
-  for (let attempt = 0; attempt < 50; attempt += 1) {
-    if ((await readCoordinatorArchives(path)).length > 0) {
-      return;
-    }
-
-    await new Promise<void>((resolveDelay) => {
-      setTimeout(resolveDelay, 10);
-    });
-  }
-
-  throw new Error("Timed out waiting for coordinator archive state.");
-}
-
-async function setCoordinatorOperationPid(
-  path: string,
-  pid: number,
-): Promise<void> {
-  const { Database } = await import("../../src/document/index.js");
-  const database = await Database.open(
-    `${path}/state/state.sqlite`,
-    "CREATE TABLE IF NOT EXISTS archives (archive_key TEXT);",
-  );
-
-  try {
-    await database.run("UPDATE archives SET operation_pid = ?", [pid]);
   } finally {
     await database.close();
   }
@@ -429,14 +428,6 @@ function restoreEnv(key: string, value: string | undefined): void {
 function expectString(value: unknown): string {
   if (typeof value !== "string") {
     throw new TypeError("Expected string.");
-  }
-
-  return value;
-}
-
-function expectNumber(value: unknown): number {
-  if (typeof value !== "number") {
-    throw new TypeError("Expected number.");
   }
 
   return value;

--- a/test/facade/spine-digest-file.test.ts
+++ b/test/facade/spine-digest-file.test.ts
@@ -1,4 +1,4 @@
-import { access, readFile } from "fs/promises";
+import { access, mkdir, readFile } from "fs/promises";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -152,6 +152,38 @@ describe("facade/spine-digest-file", () => {
 
       await expect(readArchivedTitle(path, archivePath)).resolves.toBe(
         "Flushed Title",
+      );
+    });
+  });
+
+  it("does not let unrelated stale overlays fail archive writes", async () => {
+    await withTempDir("spinedigest-facade-file-", async (path) => {
+      useCoordinatorStateDir(`${path}/state`);
+      const archivePath = await createSeedArchive(path);
+      await createStaleOverlay(path);
+
+      await new SpineDigestFile(archivePath).write(async (document) => {
+        const meta = await document.readBookMeta();
+
+        if (meta === undefined) {
+          throw new Error("Missing test metadata.");
+        }
+
+        await document.replaceBookMeta({
+          ...meta,
+          title: "Fresh Title",
+        });
+      });
+
+      await expect(readArchivedTitle(path, archivePath)).resolves.toBe(
+        "Fresh Title",
+      );
+      await expect(readCoordinatorOverlays(path)).resolves.toContainEqual(
+        expect.objectContaining({
+          archivePath: `${path}/missing/book.sdpub`,
+          entryPath: "database.db",
+          kind: "file",
+        }),
       );
     });
   });
@@ -388,6 +420,46 @@ ORDER BY archive_path, entry_path
         entryPath: expectString(row.entry_path),
         kind: expectString(row.kind),
       }),
+    );
+  } finally {
+    await database.close();
+  }
+}
+
+async function createStaleOverlay(path: string): Promise<void> {
+  const { Database } = await import("../../src/document/index.js");
+
+  await mkdir(`${path}/state`, { recursive: true });
+  const database = await Database.open(
+    `${path}/state/sdpub-coordinator.sqlite`,
+    `
+CREATE TABLE IF NOT EXISTS entry_overlays (
+  archive_key TEXT NOT NULL,
+  archive_path TEXT NOT NULL,
+  entry_path TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  workspace_path TEXT,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (archive_key, entry_path)
+);
+`,
+  );
+
+  try {
+    await database.run(
+      `
+INSERT INTO entry_overlays (
+  archive_key, archive_path, entry_path, kind, workspace_path, updated_at
+) VALUES (?, ?, ?, ?, ?, ?)
+`,
+      [
+        "missing-archive-key",
+        `${path}/missing/book.sdpub`,
+        "database.db",
+        "file",
+        `${path}/missing/database.db`,
+        Date.now(),
+      ],
     );
   } finally {
     await database.close();

--- a/test/facade/spine-digest-file.test.ts
+++ b/test/facade/spine-digest-file.test.ts
@@ -404,7 +404,8 @@ async function readCoordinatorOverlays(path: string): Promise<
   const { Database } = await import("../../src/document/index.js");
   const database = await Database.open(
     `${path}/state/sdpub-coordinator.sqlite`,
-    "CREATE TABLE IF NOT EXISTS entry_overlays (archive_key TEXT, archive_path TEXT, entry_path TEXT, kind TEXT, workspace_path TEXT, updated_at INTEGER);",
+    "",
+    { readonly: true },
   );
 
   try {


### PR DESCRIPTION
## Summary
- make queue jobs fail and release slots when worker tasks throw
- split queue and sdpub coordinator state to avoid cross-database lock contention
- coordinate sdpub entry overlays and flush only the current archive
- recover stale queue jobs atomically and expose preparation step state

## Validation
- pnpm verify
- pnpm test:run
- large local sdpub queue run: 114 succeeded, 0 failed, coordinator locks/overlays cleared