### PR TITLE
fix: prevent graph chunk id collisions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spinedigest",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "CLI-first tool for digesting long-form text and ebooks into compressed text, EPUB, or reusable .sdpub archives.",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/cli/queue.ts
+++ b/src/cli/queue.ts
@@ -180,7 +180,7 @@ async function executeBuildJob(
     async (document) => await readChapterBuildInput(document, job.chapterId),
   );
   let { details } = buildInput;
-  const { nextChunkId, sourceText } = buildInput;
+  const { sourceText } = buildInput;
 
   await reporter.setTotals({
     totalGraphWords: details.stage === "sourced" ? details.words : 0,
@@ -202,7 +202,6 @@ async function executeBuildJob(
     const artifact = await buildChapterGraphArtifact(job.chapterId, {
       extractionPrompt: prompt,
       llm,
-      nextChunkId,
       sourceText,
       workspacePath: job.workspacePath,
       progressTracker: {

--- a/src/document/stores.ts
+++ b/src/document/stores.ts
@@ -6,6 +6,7 @@ import {
   type ChunkImportance,
   type ChunkRecord,
   type ChunkRetention,
+  type CreateChunkRecord,
   type CreateSnakeRecord,
   type FragmentGroupRecord,
   type KnowledgeEdgeRecord,
@@ -218,6 +219,50 @@ export class ChunkStore implements ReadonlyChunkStore {
     this.#database = database;
   }
 
+  public async create(record: CreateChunkRecord): Promise<ChunkRecord> {
+    return await this.#database.transaction(async () => {
+      await this.#database.run(
+        `
+          INSERT INTO chunks (
+            generation,
+            serial_id,
+            fragment_id,
+            sentence_index,
+            label,
+            content,
+            retention,
+            importance,
+            wordsCount,
+            weight
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+        [
+          record.generation,
+          record.sentenceId[0],
+          record.sentenceId[1],
+          record.sentenceId[2],
+          record.label,
+          record.content,
+          record.retention ?? null,
+          record.importance ?? null,
+          record.wordsCount,
+          record.weight,
+        ],
+      );
+
+      const id = await this.#database.getLastInsertRowId();
+      const createdRecord = {
+        ...record,
+        id,
+      };
+
+      await this.#replaceChunkSentences(createdRecord);
+
+      return createdRecord;
+    });
+  }
+
   public async save(record: ChunkRecord): Promise<void> {
     await this.#database.transaction(async () => {
       await this.#database.run(
@@ -252,28 +297,7 @@ export class ChunkStore implements ReadonlyChunkStore {
         ],
       );
 
-      await this.#database.run(
-        `
-          DELETE FROM chunk_sentences
-          WHERE chunk_id = ?
-        `,
-        [record.id],
-      );
-
-      for (const sentenceId of record.sentenceIds) {
-        await this.#database.run(
-          `
-            INSERT INTO chunk_sentences (
-              chunk_id,
-              serial_id,
-              fragment_id,
-              sentence_index
-            )
-            VALUES (?, ?, ?, ?)
-          `,
-          [record.id, sentenceId[0], sentenceId[1], sentenceId[2]],
-        );
-      }
+      await this.#replaceChunkSentences(record);
     });
   }
 
@@ -446,6 +470,31 @@ export class ChunkStore implements ReadonlyChunkStore {
           getNumber(row, "sentence_index"),
         ] as const,
     );
+  }
+
+  async #replaceChunkSentences(record: ChunkRecord): Promise<void> {
+    await this.#database.run(
+      `
+        DELETE FROM chunk_sentences
+        WHERE chunk_id = ?
+      `,
+      [record.id],
+    );
+
+    for (const sentenceId of record.sentenceIds) {
+      await this.#database.run(
+        `
+          INSERT INTO chunk_sentences (
+            chunk_id,
+            serial_id,
+            fragment_id,
+            sentence_index
+          )
+          VALUES (?, ?, ?, ?)
+        `,
+        [record.id, sentenceId[0], sentenceId[1], sentenceId[2]],
+      );
+    }
   }
 
   async #mapChunkRow(row: SqlRow): Promise<ChunkRecord> {

--- a/src/document/types.ts
+++ b/src/document/types.ts
@@ -64,6 +64,8 @@ export interface ChunkRecord {
   readonly weight: number;
 }
 
+export type CreateChunkRecord = Omit<ChunkRecord, "id">;
+
 export interface KnowledgeEdgeRecord {
   readonly fromId: number;
   readonly toId: number;

--- a/src/facade/chapter-build.ts
+++ b/src/facade/chapter-build.ts
@@ -51,7 +51,6 @@ export interface ChapterSummaryInputSnapshot {
 
 export interface BuildChapterGraphArtifactOptions extends GenerateChapterGraphOptions {
   readonly sourceText: readonly string[];
-  readonly nextChunkId: number;
   readonly workspacePath: string;
 }
 
@@ -152,14 +151,12 @@ export async function readChapterBuildInput(
   chapterId: number,
 ): Promise<{
   readonly details: ChapterDetails;
-  readonly nextChunkId: number;
   readonly sourceText: readonly string[];
 }> {
   const details = await getChapterDetails(document, chapterId);
 
   return {
     details,
-    nextChunkId: (await document.chunks.getMaxId()) + 1,
     sourceText: await collectReaderText(readChapterSource(document, chapterId)),
   };
 }
@@ -184,7 +181,6 @@ export async function buildChapterGraphArtifact(
         ...(options.logDirPath === undefined
           ? {}
           : { logDirPath: options.logDirPath }),
-        nextChunkId: options.nextChunkId,
       }).buildTopologyInto(
         chapterId,
         options.sourceText,
@@ -219,22 +215,38 @@ export async function commitChapterGraphArtifact(
         artifact.chapterId,
       );
 
-      for (const chunk of await sourceDocument.chunks.listBySerial(
+      const chunkIdMap = await copyChunks(
+        sourceDocument,
+        openedDocument,
         artifact.chapterId,
-      )) {
-        await openedDocument.chunks.save(chunk);
-      }
+      );
 
       for (const edge of await sourceDocument.knowledgeEdges.listBySerial(
         artifact.chapterId,
       )) {
-        await openedDocument.knowledgeEdges.save(edge);
+        const fromId = chunkIdMap.get(edge.fromId);
+        const toId = chunkIdMap.get(edge.toId);
+
+        if (fromId === undefined || toId === undefined) {
+          continue;
+        }
+
+        await openedDocument.knowledgeEdges.save({
+          ...edge,
+          fromId,
+          toId,
+        });
       }
 
       await openedDocument.fragmentGroups.saveMany(
         await sourceDocument.fragmentGroups.listBySerial(artifact.chapterId),
       );
-      await copySnakes(sourceDocument, openedDocument, artifact.chapterId);
+      await copySnakes(
+        sourceDocument,
+        openedDocument,
+        artifact.chapterId,
+        chunkIdMap,
+      );
       await openedDocument.serials.setTopologyReady(artifact.chapterId);
     });
 
@@ -950,6 +962,7 @@ async function copySnakes(
   sourceDocument: ReadonlyDocument,
   targetDocument: Document,
   serialId: number,
+  chunkIdMap: ReadonlyMap<number, number>,
 ): Promise<void> {
   const sourceSnakes = await sourceDocument.snakes.listBySerial(serialId);
   const snakeIdMap = new Map<number, number>();
@@ -971,8 +984,14 @@ async function copySnakes(
     for (const snakeChunk of await sourceDocument.snakeChunks.listBySnake(
       sourceSnake.id,
     )) {
+      const chunkId = chunkIdMap.get(snakeChunk.chunkId);
+
+      if (chunkId === undefined) {
+        continue;
+      }
+
       await targetDocument.snakeChunks.save({
-        chunkId: snakeChunk.chunkId,
+        chunkId,
         position: snakeChunk.position,
         snakeId: targetSnakeId,
       });
@@ -993,6 +1012,34 @@ async function copySnakes(
       weight: edge.weight,
     });
   }
+}
+
+async function copyChunks(
+  sourceDocument: ReadonlyDocument,
+  targetDocument: Document,
+  serialId: number,
+): Promise<ReadonlyMap<number, number>> {
+  const chunkIdMap = new Map<number, number>();
+
+  for (const chunk of await sourceDocument.chunks.listBySerial(serialId)) {
+    const createdChunk = await targetDocument.chunks.create({
+      content: chunk.content,
+      generation: chunk.generation,
+      label: chunk.label,
+      sentenceId: chunk.sentenceId,
+      sentenceIds: chunk.sentenceIds,
+      weight: chunk.weight,
+      wordsCount: chunk.wordsCount,
+      ...(chunk.importance === undefined
+        ? {}
+        : { importance: chunk.importance }),
+      ...(chunk.retention === undefined ? {} : { retention: chunk.retention }),
+    });
+
+    chunkIdMap.set(chunk.id, createdChunk.id);
+  }
+
+  return chunkIdMap;
 }
 
 async function requireStage(

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -212,7 +212,8 @@ export class LLM<S extends string> {
       input.retryIndex,
       input.retryMax,
     );
-    const useCache = input.useCache ?? true;
+    const useCache =
+      (input.useCache ?? true) && hasVisibleNonSystemContent(input.messages);
     const cacheKey =
       this.#cache !== undefined && useCache
         ? createHash({
@@ -464,6 +465,12 @@ function createCache(cacheDirPath?: string): LLMCache | undefined {
   }
 
   return new LLMCache(resolvedCacheDirPath);
+}
+
+function hasVisibleNonSystemContent(messages: readonly LLMessage[]): boolean {
+  return messages.some(
+    (message) => message.role !== "system" && message.content.trim() !== "",
+  );
 }
 
 function formatRequestParameters(input: {

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -469,7 +469,9 @@ function createCache(cacheDirPath?: string): LLMCache | undefined {
 
 function hasVisibleNonSystemContent(messages: readonly LLMessage[]): boolean {
   return messages.some(
-    (message) => message.role !== "system" && message.content.trim() !== "",
+    (message) =>
+      message.role !== "system" &&
+      (typeof message.content !== "string" || message.content.trim() !== ""),
   );
 }
 

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -8,7 +8,6 @@ import {
 import type { LLM } from "./llm/index.js";
 import type {
   ChunkRecord,
-  ChunkStore,
   Document,
   FragmentGroupRecord,
   FragmentGroupStore,
@@ -141,7 +140,6 @@ export async function writeSerialSource(
 }
 
 export class SerialGeneration {
-  readonly #chunks: ChunkStore;
   readonly #fragmentWordsCount = DEFAULT_FRAGMENT_WORDS_COUNT;
   readonly #fragmentGroups: FragmentGroupStore;
   readonly #idSemaphore = new AsyncSemaphore(1);
@@ -157,7 +155,6 @@ export class SerialGeneration {
   public constructor(options: SerialGenerationOptions) {
     const document = resolveDocument(options);
 
-    this.#chunks = document.chunks;
     this.#fragmentGroups = document.fragmentGroups;
     this.#llm = options.llm;
     this.#logDirPath = options.logDirPath;
@@ -246,7 +243,7 @@ export class SerialGeneration {
   }
 
   async #allocateChunkId(): Promise<number> {
-    return await this.#idSemaphore.use(async () => {
+    return await this.#idSemaphore.use(() => {
       const chunkId = this.#nextChunkId;
       this.#nextChunkId += 1;
       return chunkId;

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -84,7 +84,6 @@ export interface SerialGenerationOptions {
   readonly document?: Document;
   readonly llm: LLM<SpineDigestScope>;
   readonly logDirPath?: string;
-  readonly nextChunkId?: number;
   readonly segmenter?: ReaderSegmenter;
   /** @deprecated Use `document` instead. */
   readonly workspace?: Document;
@@ -153,7 +152,7 @@ export class SerialGeneration {
   readonly #document: Document;
   readonly #writeSemaphore = new AsyncSemaphore(1);
 
-  #nextChunkId: number | undefined;
+  #nextChunkId = 1;
 
   public constructor(options: SerialGenerationOptions) {
     const document = resolveDocument(options);
@@ -162,7 +161,6 @@ export class SerialGeneration {
     this.#fragmentGroups = document.fragmentGroups;
     this.#llm = options.llm;
     this.#logDirPath = options.logDirPath;
-    this.#nextChunkId = options.nextChunkId;
     this.#serials = document.serials;
     this.#segmenter = options.segmenter;
     this.#document = document;
@@ -249,9 +247,6 @@ export class SerialGeneration {
 
   async #allocateChunkId(): Promise<number> {
     return await this.#idSemaphore.use(async () => {
-      if (this.#nextChunkId === undefined) {
-        this.#nextChunkId = (await this.#chunks.getMaxId()) + 1;
-      }
       const chunkId = this.#nextChunkId;
       this.#nextChunkId += 1;
       return chunkId;

--- a/src/topology/topology.ts
+++ b/src/topology/topology.ts
@@ -95,12 +95,41 @@ export class Topology {
 
     await this.#document.serials.ensure(this.#serialId);
 
+    const chunkIdMap = new Map<number, number>();
+
     for (const chunk of weightedChunks) {
-      await this.#document.chunks.save(chunk);
+      const createdChunk = await this.#document.chunks.create({
+        content: chunk.content,
+        generation: chunk.generation,
+        label: chunk.label,
+        sentenceId: chunk.sentenceId,
+        sentenceIds: chunk.sentenceIds,
+        weight: chunk.weight,
+        wordsCount: chunk.wordsCount,
+        ...(chunk.importance === undefined
+          ? {}
+          : { importance: chunk.importance }),
+        ...(chunk.retention === undefined
+          ? {}
+          : { retention: chunk.retention }),
+      });
+
+      chunkIdMap.set(chunk.id, createdChunk.id);
     }
 
     for (const edge of weightedEdges) {
-      await this.#document.knowledgeEdges.save(edge);
+      const fromId = chunkIdMap.get(edge.fromId);
+      const toId = chunkIdMap.get(edge.toId);
+
+      if (fromId === undefined || toId === undefined) {
+        continue;
+      }
+
+      await this.#document.knowledgeEdges.save({
+        ...edge,
+        fromId,
+        toId,
+      });
     }
 
     await this.#document.fragmentGroups.saveMany(fragmentGroups);
@@ -130,7 +159,7 @@ export class Topology {
       }
 
       await this.#document.snakeChunks.save({
-        chunkId: snakeChunk.chunkId,
+        chunkId: chunkIdMap.get(snakeChunk.chunkId) ?? snakeChunk.chunkId,
         position: snakeChunk.position,
         snakeId,
       });

--- a/test/cli/queue.test.ts
+++ b/test/cli/queue.test.ts
@@ -170,7 +170,6 @@ vi.mock("../../src/facade/index.js", () => ({
         stage: queueMockState.buildInputStage,
         words: 4,
       },
-      nextChunkId: 100,
       sourceText: ["Alpha beta."],
     }),
   ),

--- a/test/facade/chapter-graph.test.ts
+++ b/test/facade/chapter-graph.test.ts
@@ -127,7 +127,6 @@ describe("facade/chapter graph", () => {
         const artifact = await buildChapterGraphArtifact(chapter.chapterId, {
           extractionPrompt: "Keep key beats",
           llm: {} as never,
-          nextChunkId: input.nextChunkId,
           sourceText: input.sourceText,
           workspacePath: `${path}/job-workspace`,
         });
@@ -141,7 +140,81 @@ describe("facade/chapter graph", () => {
           stage: "graphed",
           words: 4,
         });
-        await expect(document.chunks.getMaxId()).resolves.toBe(0);
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("remaps staged chunk ids when committing graph artifacts", async () => {
+    await withTempDir("spinedigest-chapter-graph-", async (path) => {
+      const document = await DirectoryDocument.open(`${path}/archive`);
+
+      try {
+        const firstChapter = await addChapter(document, {
+          title: "Chapter 1",
+        });
+        const secondChapter = await addChapter(document, {
+          title: "Chapter 2",
+        });
+
+        await setChapterSource(document, firstChapter.chapterId, [
+          "Alpha beta.",
+        ]);
+        await setChapterSource(document, secondChapter.chapterId, [
+          "Gamma delta.",
+        ]);
+
+        const firstArtifact = await createSingleChunkGraphArtifact({
+          chapterId: firstChapter.chapterId,
+          chunkContent: "Alpha beta.",
+          chunkLabel: "Alpha",
+          documentPath: `${path}/first-artifact`,
+        });
+        const secondArtifact = await createSingleChunkGraphArtifact({
+          chapterId: secondChapter.chapterId,
+          chunkContent: "Gamma delta.",
+          chunkLabel: "Gamma",
+          documentPath: `${path}/second-artifact`,
+        });
+
+        await commitChapterGraphArtifact(document, firstArtifact);
+        await commitChapterGraphArtifact(document, secondArtifact);
+
+        const firstChunks = await document.chunks.listBySerial(
+          firstChapter.chapterId,
+        );
+        const secondChunks = await document.chunks.listBySerial(
+          secondChapter.chapterId,
+        );
+
+        expect(firstChunks).toHaveLength(1);
+        expect(secondChunks).toHaveLength(1);
+        expect(firstChunks[0]?.id).not.toBe(secondChunks[0]?.id);
+        expect(firstChunks[0]).toMatchObject({
+          content: "Alpha beta.",
+          sentenceId: [firstChapter.chapterId, 0, 0],
+        });
+        expect(secondChunks[0]).toMatchObject({
+          content: "Gamma delta.",
+          sentenceId: [secondChapter.chapterId, 0, 0],
+        });
+
+        const firstSnakeIds = await document.snakes.listIdsByGroup(
+          firstChapter.chapterId,
+          0,
+        );
+        const secondSnakeIds = await document.snakes.listIdsByGroup(
+          secondChapter.chapterId,
+          0,
+        );
+
+        expect(
+          await document.snakeChunks.listChunkIds(firstSnakeIds[0]!),
+        ).toStrictEqual([firstChunks[0]!.id]);
+        expect(
+          await document.snakeChunks.listChunkIds(secondSnakeIds[0]!),
+        ).toStrictEqual([secondChunks[0]!.id]);
       } finally {
         await document.release();
       }
@@ -260,6 +333,65 @@ describe("facade/chapter graph", () => {
     });
   });
 });
+
+async function createSingleChunkGraphArtifact(input: {
+  chapterId: number;
+  chunkContent: string;
+  chunkLabel: string;
+  documentPath: string;
+}) {
+  const document = await DirectoryDocument.open(input.documentPath);
+
+  try {
+    await document.openSession(async (openedDocument) => {
+      await openedDocument.serials.createWithId(input.chapterId);
+      const fragments = openedDocument.getSerialFragments(input.chapterId);
+      const draft = await fragments.createDraft();
+
+      draft.addSentence(input.chunkContent, countWords(input.chunkContent));
+      await draft.commit();
+
+      await openedDocument.chunks.save({
+        content: input.chunkContent,
+        generation: 0,
+        id: 1,
+        label: input.chunkLabel,
+        retention: ChunkRetention.Verbatim,
+        sentenceId: [input.chapterId, 0, 0],
+        sentenceIds: [[input.chapterId, 0, 0]],
+        weight: 1,
+        wordsCount: countWords(input.chunkContent),
+      });
+      await openedDocument.fragmentGroups.save({
+        fragmentId: 0,
+        groupId: 0,
+        serialId: input.chapterId,
+      });
+      const snakeId = await openedDocument.snakes.create({
+        firstLabel: input.chunkLabel,
+        groupId: 0,
+        lastLabel: input.chunkLabel,
+        localSnakeId: 0,
+        serialId: input.chapterId,
+        size: 1,
+      });
+
+      await openedDocument.snakeChunks.save({
+        chunkId: 1,
+        position: 0,
+        snakeId,
+      });
+      await openedDocument.serials.setTopologyReady(input.chapterId);
+    });
+  } finally {
+    await document.release();
+  }
+
+  return {
+    chapterId: input.chapterId,
+    documentPath: input.documentPath,
+  };
+}
 
 async function pathExists(path: string): Promise<boolean> {
   try {

--- a/test/llm/client.test.ts
+++ b/test/llm/client.test.ts
@@ -207,6 +207,38 @@ describe("llm/client", () => {
     });
   });
 
+  it("does not use cache for requests without visible non-system content", async () => {
+    await withTempDir("spinedigest-llm-empty-cache-", async (cacheDirPath) => {
+      const llm = new LLM({
+        cacheDirPath,
+        dataDirPath: process.cwd(),
+        model: {
+          modelId: "test-model",
+          provider: "test-provider",
+        } as never,
+      });
+      const messages = [
+        {
+          content: "follow the style guide",
+          role: "system",
+        },
+        {
+          content: "\n\t ",
+          role: "user",
+        },
+      ] as const;
+
+      await expect(llm.request(messages)).resolves.toBe("generated response");
+      aiMockState.generateTextResponse = "second generated response";
+
+      await expect(llm.request(messages)).resolves.toBe(
+        "second generated response",
+      );
+
+      expect(aiMockState.generateTextCalls).toHaveLength(2);
+    });
+  });
+
   it("preserves non-leading system messages in the messages array", async () => {
     const llm = new LLM({
       dataDirPath: process.cwd(),

--- a/test/topology/topology.test.ts
+++ b/test/topology/topology.test.ts
@@ -83,15 +83,16 @@ describe("topology/topology", () => {
 
     await topology.finalize();
 
-    const savedChunks = saveChunk.mock.calls as Array<[ChunkRecord]>;
+    const createdChunks = saveChunk.mock.calls as Array<
+      [Omit<ChunkRecord, "id">]
+    >;
     const savedEdges = saveEdge.mock.calls as Array<[KnowledgeEdgeRecord]>;
 
     expect(ensureSerial).toHaveBeenCalledWith(7);
-    expect(savedChunks.map(([record]) => record)).toStrictEqual([
+    expect(createdChunks.map(([record]) => record)).toStrictEqual([
       {
         content: "Chunk 1",
         generation: 0,
-        id: 1,
         label: "Chunk 1",
         retention: ChunkRetention.Relevant,
         sentenceId: [7, 1, 0],
@@ -102,7 +103,6 @@ describe("topology/topology", () => {
       {
         content: "Chunk 2",
         generation: 0,
-        id: 2,
         importance: ChunkImportance.Critical,
         label: "Chunk 2",
         retention: ChunkRetention.Focused,
@@ -440,7 +440,16 @@ function createDocumentStub(): {
     path: "/tmp/fragments",
     serialId: 7,
   } satisfies ReadonlySerialFragments;
-  const saveChunk = vi.fn(() => Promise.resolve());
+  let nextChunkId = 1;
+  const saveChunk = vi.fn((record: Omit<ChunkRecord, "id">) => {
+    const id = nextChunkId;
+
+    nextChunkId += 1;
+    return Promise.resolve({
+      ...record,
+      id,
+    });
+  });
   const saveEdge = vi.fn(() => Promise.resolve());
   const saveFragmentGroups = vi.fn(() => Promise.resolve());
   let nextSnakeId = 1;
@@ -454,7 +463,7 @@ function createDocumentStub(): {
     createSnake,
     document: {
       chunks: {
-        save: saveChunk,
+        create: saveChunk,
       },
       fragmentGroups: {
         saveMany: saveFragmentGroups,


### PR DESCRIPTION
## Summary
- skip LLM cache for empty non-system prompts to avoid cross-task reviewer reuse
- allocate graph chunk IDs in the target archive commit transaction and remap graph references
- bump package version to 0.2.2

## Tests
- pnpm run lint:fix
- pnpm exec tsc --noEmit
- pnpm test -- test/document/stores.test.ts test/facade/chapter-graph.test.ts test/cli/queue.test.ts test/llm/client.test.ts test/topology/topology.test.ts