### PR TITLE
feat(cli): improve pagination and URI ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,19 +86,19 @@ Search, browse, and read through the knowledge-base interface:
 
 ```bash
 wikigraph chapter tree ./book.sdpub --json
-wikigraph search wikigraph://book.sdpub "RAG" --type chunk
-wikigraph search wikigraph://book.sdpub/chapter/12 "exact source phrase" --type source
-wikigraph get wikigraph://book.sdpub/chapter/12
-wikigraph get wikigraph://book.sdpub/chunk/84
-wikigraph related wikigraph://book.sdpub/chunk/84
-wikigraph evidence wikigraph://book.sdpub/chunk/84
-wikigraph pack wikigraph://book.sdpub/chunk/84 --budget 5000
+wikigraph wkg://book.sdpub search "RAG" --type chunk
+wikigraph wkg://book.sdpub/chapter/12 search "exact source phrase" --type source
+wikigraph wkg://book.sdpub/chapter/12 get
+wikigraph wkg://book.sdpub/chunk/84 get
+wikigraph wkg://book.sdpub/chunk/84 related
+wikigraph wkg://book.sdpub/chunk/84 evidence
+wikigraph wkg://book.sdpub/chunk/84 pack --budget 5000
 ```
 
 Output a projection only when you need a portable view. For example, read one chapter into Markdown text, or export the full archive as an EPUB:
 
 ```bash
-wikigraph get wikigraph://book.sdpub/chapter/12/source/ > ./chapter-12.md
+wikigraph wkg://book.sdpub/chapter/12/source/ get > ./chapter-12.md
 wikigraph export ./book.sdpub --output-format epub --output ./digest.epub
 ```
 
@@ -148,10 +148,10 @@ With that archive on hand, you can search and navigate the knowledge structure d
 ```bash
 wikigraph index ./book.sdpub
 wikigraph chapter tree ./book.sdpub --json
-wikigraph list wikigraph://book.sdpub/chapter/12 --type chunk
-wikigraph search wikigraph://book.sdpub "central argument" --type chunk
-wikigraph get wikigraph://book.sdpub/chapter/12
-wikigraph get wikigraph://book.sdpub/chapter/12/source/
+wikigraph wkg://book.sdpub/chapter/12 list --type chunk
+wikigraph wkg://book.sdpub search "central argument" --type chunk
+wikigraph wkg://book.sdpub/chapter/12 get
+wikigraph wkg://book.sdpub/chapter/12/source/ get
 ```
 
 Markdown, EPUB, txt, and JSON-style outputs are projections of the archive. They are useful for portability and reading, but they do not replace the `.sdpub` object when graph links and source fragments matter.

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -86,19 +86,19 @@ wikigraph queue watch <job-id> --jsonl
 
 ```bash
 wikigraph chapter tree ./book.sdpub --json
-wikigraph search wikigraph://book.sdpub "RAG" --type chunk
-wikigraph search wikigraph://book.sdpub/chapter/12 "exact source phrase" --type source
-wikigraph get wikigraph://book.sdpub/chapter/12
-wikigraph get wikigraph://book.sdpub/chunk/84
-wikigraph related wikigraph://book.sdpub/chunk/84
-wikigraph evidence wikigraph://book.sdpub/chunk/84
-wikigraph pack wikigraph://book.sdpub/chunk/84 --budget 5000
+wikigraph wkg://book.sdpub search "RAG" --type chunk
+wikigraph wkg://book.sdpub/chapter/12 search "exact source phrase" --type source
+wikigraph wkg://book.sdpub/chapter/12 get
+wikigraph wkg://book.sdpub/chunk/84 get
+wikigraph wkg://book.sdpub/chunk/84 related
+wikigraph wkg://book.sdpub/chunk/84 evidence
+wikigraph wkg://book.sdpub/chunk/84 pack --budget 5000
 ```
 
 只有需要便携视图时再输出 projection。比如只需要某一章的 `.md` 文本，可以读取该章；需要完整电子书视图时再导出 EPUB：
 
 ```bash
-wikigraph get wikigraph://book.sdpub/chapter/12/source/ > ./chapter-12.md
+wikigraph wkg://book.sdpub/chapter/12/source/ get > ./chapter-12.md
 wikigraph export ./book.sdpub --output-format epub --output ./digest.epub
 ```
 
@@ -148,10 +148,10 @@ SpineDigest 的目标，是把长文档变成外部工作记忆。
 ```bash
 wikigraph index ./book.sdpub
 wikigraph chapter tree ./book.sdpub --json
-wikigraph list wikigraph://book.sdpub/chapter/12 --type chunk
-wikigraph search wikigraph://book.sdpub "central argument" --type chunk
-wikigraph get wikigraph://book.sdpub/chapter/12
-wikigraph get wikigraph://book.sdpub/chapter/12/source/
+wikigraph wkg://book.sdpub/chapter/12 list --type chunk
+wikigraph wkg://book.sdpub search "central argument" --type chunk
+wikigraph wkg://book.sdpub/chapter/12 get
+wikigraph wkg://book.sdpub/chapter/12/source/ get
 ```
 
 Markdown、EPUB、txt 和 JSON 风格输出都是归档的 projection。它们适合携带和阅读，但当你需要图链接和证据追溯时，不能替代 `.sdpub` 本身。

--- a/data/help/commands/archive/evidence.jinja
+++ b/data/help/commands/archive/evidence.jinja
@@ -11,7 +11,7 @@ Use when:
   - You need support before quoting, verifying, or answering from a claim.
 
 Usage:
-  wikigraph evidence <object-uri> [--limit <n>] [--cursor <token>] [--json|--jsonl] [--help|-h]
+  wikigraph <object-uri> evidence [--limit <n>] [--cursor <token>] [--json|--jsonl] [--help|-h]
 
 Returns:
   - Evidence items anchored to source text.
@@ -27,5 +27,5 @@ Next steps:
   - Use `pack` when evidence confirms the object is a useful answer anchor.
 
 Examples:
-  wikigraph evidence wikigraph:///books/book.sdpub/entity/Q162593
-  wikigraph evidence wikigraph:///books/book.sdpub/chapter/3/triple/Q162593/discusses/Q9476
+  wikigraph wkg:///books/book.sdpub/entity/Q162593 evidence
+  wikigraph wkg:///books/book.sdpub/chapter/3/triple/Q162593/discusses/Q9476 evidence

--- a/data/help/commands/archive/get.jinja
+++ b/data/help/commands/archive/get.jinja
@@ -7,10 +7,10 @@ Purpose:
   Read one readable Wiki Graph object by URI.
 
 Use when:
-  - You already have a `wikigraph://...` URI and need to inspect its object payload.
+  - You already have a `wkg://...` URI and need to inspect its object payload.
 
 Usage:
-  wikigraph get <object-uri> [--evidence [n]] [--json|--jsonl] [--help|-h]
+  wikigraph <object-uri> get [--evidence [n]] [--json|--jsonl] [--help|-h]
 
 Returns:
   - The selected object in human-readable text, JSON, or JSONL.
@@ -26,5 +26,5 @@ Next steps:
   - Use `pack` to assemble bounded context around the object.
 
 Examples:
-  wikigraph get wikigraph:///books/book.sdpub/chunk/123
-  wikigraph get wikigraph:///books/book.sdpub/chapter/1/source/0#42..60
+  wikigraph wkg:///books/book.sdpub/chunk/123 get
+  wikigraph wkg:///books/book.sdpub/chapter/1/source/0#42..60 get

--- a/data/help/commands/archive/index.jinja
+++ b/data/help/commands/archive/index.jinja
@@ -4,7 +4,7 @@ Command: wikigraph index
 Purpose:
   Show the archive home/index page and entry points.
   This is most useful for archive-level readiness and metadata such as title, source format, chapter count, summary count, node count, and edge count.
-  For content exploration after `chapter tree`, use scoped URIs such as `wikigraph:///book.sdpub/chapter/3`.
+  For content exploration after `chapter tree`, use scoped URIs such as `wkg:///book.sdpub/chapter/3`.
 
 Usage:
   wikigraph index <archive.sdpub> [--json]

--- a/data/help/commands/archive/list.jinja
+++ b/data/help/commands/archive/list.jinja
@@ -10,7 +10,7 @@ Use when:
   - You need objects of a kind without a text query, such as all chapters or all entities.
 
 Usage:
-  wikigraph list <wikigraph-uri-with-sdpub-locator> [--type <meta|chapter|entity|triple|source|summary|chunk[,kind...]>] [--limit <n>] [--evidence [n]] [--cursor <token>] [--json|--jsonl] [--help|-h]
+  wikigraph <wikigraph-uri-with-sdpub-locator> list [--type <meta|chapter|entity|triple|source|summary|chunk[,kind...]>] [--limit <n>] [--evidence [n]] [--cursor <token>] [--json|--jsonl] [--help|-h]
 
 Returns:
   - URI-addressable objects in document order.
@@ -22,5 +22,5 @@ Notes:
   - Use `wikigraph help uri` before constructing Wiki Graph URIs; bare filesystem paths are not valid object command inputs.
 
 Examples:
-  wikigraph list wikigraph:///books/book.sdpub --type chapter
-  wikigraph list wikigraph:///books/book.sdpub/chapter/3 --type entity --json
+  wikigraph wkg:///books/book.sdpub list --type chapter
+  wikigraph wkg:///books/book.sdpub/chapter/3 list --type entity --json

--- a/data/help/commands/archive/next.jinja
+++ b/data/help/commands/archive/next.jinja
@@ -24,4 +24,4 @@ Notes:
 
 Examples:
   wikigraph next c_7Kp9x2aQ
-  wikigraph next wikigraph:///books/book.sdpub c_7Kp9x2aQ --json
+  wikigraph next wkg:///books/book.sdpub c_7Kp9x2aQ --json

--- a/data/help/commands/archive/pack.jinja
+++ b/data/help/commands/archive/pack.jinja
@@ -10,7 +10,7 @@ Use when:
   - You already selected a useful readable URI and need compact context for an answer.
 
 Usage:
-  wikigraph pack <object-uri> [--budget <chars>] [--json|--jsonl] [--help|-h]
+  wikigraph <object-uri> pack [--budget <chars>] [--json|--jsonl] [--help|-h]
 
 Returns:
   - A context package constrained by `--budget`.
@@ -25,5 +25,5 @@ Next steps:
   - Use the packed context to answer, or continue with `related` if context is too narrow.
 
 Examples:
-  wikigraph pack wikigraph:///books/book.sdpub/chapter/1/summary/ --budget 5000
-  wikigraph pack wikigraph:///books/book.sdpub/chunk/123
+  wikigraph wkg:///books/book.sdpub/chapter/1/summary/ pack --budget 5000
+  wikigraph wkg:///books/book.sdpub/chunk/123 pack

--- a/data/help/commands/archive/related.jinja
+++ b/data/help/commands/archive/related.jinja
@@ -10,10 +10,10 @@ Use when:
   - You have a selected readable object and need adjacent graph context.
 
 Usage:
-  wikigraph related <object-uri> [--evidence [n]] [--json|--jsonl] [--help|-h]
+  wikigraph <object-uri> related [--evidence [n]] [--json|--jsonl] [--help|-h]
 
 Returns:
-  - Related full `wikigraph://...` URIs with labels or summaries.
+  - Related full `wkg://...` URIs with labels or summaries.
 
 Notes:
   - `related` starts from a known URI; `search` starts from query text.
@@ -27,4 +27,4 @@ Next steps:
   - Use `pack` when one related object becomes the answer anchor.
 
 Examples:
-  wikigraph related wikigraph:///books/book.sdpub/chunk/123
+  wikigraph wkg:///books/book.sdpub/chunk/123 related

--- a/data/help/commands/archive/search.jinja
+++ b/data/help/commands/archive/search.jinja
@@ -10,10 +10,10 @@ Use when:
   - You have words, names, phrases, or concepts and need candidate object URIs.
 
 Usage:
-  wikigraph search <wikigraph-uri-with-sdpub-locator> <query> [--type <meta|chapter|entity|triple|source|summary|chunk[,kind...]>] [--limit <n>] [--evidence [n]] [--cursor <token>] [--json|--jsonl] [--help|-h]
+  wikigraph <wikigraph-uri-with-sdpub-locator> search <query> [--type <meta|chapter|entity|triple|source|summary|chunk[,kind...]>] [--limit <n>] [--evidence [n]] [--cursor <token>] [--json|--jsonl] [--help|-h]
 
 Returns:
-  - In text output, a ranked list of full `wikigraph://...` URIs.
+  - In text output, a ranked list of full `wkg://...` URIs.
   - With `--json` or `--jsonl`, machine-readable search result items.
 
 Notes:
@@ -31,5 +31,5 @@ Next steps:
   - Use `pack` after selecting a useful readable URI.
 
 Examples:
-  wikigraph search wikigraph:///books/book.sdpub "恩典 婴儿洗礼"
-  wikigraph search wikigraph:///books/book.sdpub/chapter/3 "infant baptism" --type entity --json
+  wikigraph wkg:///books/book.sdpub search "恩典 婴儿洗礼"
+  wikigraph wkg:///books/book.sdpub/chapter/3 search "infant baptism" --type entity --json

--- a/data/help/commands/root.jinja
+++ b/data/help/commands/root.jinja
@@ -20,14 +20,14 @@ Object workflow:
   - `pack` builds bounded Agent-readable context around one readable URI.
 
 Object commands:
-  wikigraph search <wikigraph-uri-with-sdpub-locator> <query> [--type <meta|chapter|entity|triple|source|summary|chunk[,kind...]>] [--limit <n>] [--cursor <token>] [--evidence [n]] [--json|--jsonl]
-  wikigraph list <wikigraph-uri-with-sdpub-locator> [--type <meta|chapter|entity|triple|source|summary|chunk[,kind...]>] [--limit <n>] [--cursor <token>] [--evidence [n]] [--json|--jsonl]
-  wikigraph get <object-uri> [--evidence [n]] [--json|--jsonl]
-  wikigraph related <object-uri> [--evidence [n]] [--json|--jsonl]
-  wikigraph evidence <entity|triple|summary|chunk-uri> [--limit <n>] [--cursor <token>] [--json|--jsonl]
+  wikigraph <wikigraph-uri-with-sdpub-locator> search <query> [--type <meta|chapter|entity|triple|source|summary|chunk[,kind...]>] [--limit <n>] [--cursor <token>] [--evidence [n]] [--json|--jsonl]
+  wikigraph <wikigraph-uri-with-sdpub-locator> list [--type <meta|chapter|entity|triple|source|summary|chunk[,kind...]>] [--limit <n>] [--cursor <token>] [--evidence [n]] [--json|--jsonl]
+  wikigraph <object-uri> get [--evidence [n]] [--json|--jsonl]
+  wikigraph <object-uri> related [--evidence [n]] [--json|--jsonl]
+  wikigraph <entity|triple|summary|chunk-uri> evidence [--limit <n>] [--cursor <token>] [--json|--jsonl]
   wikigraph next <cursor> [--limit <n>] [--json|--jsonl]
   wikigraph next <wikigraph-uri-with-sdpub-locator> <cursor> [--limit <n>] [--json|--jsonl]
-  wikigraph pack <object-uri> [--budget <chars>] [--json|--jsonl]
+  wikigraph <object-uri> pack [--budget <chars>] [--json|--jsonl]
 
 URI requirement:
   `search`, `list`, `get`, `related`, `evidence`, and `pack` use Wiki Graph URIs, not bare filesystem paths.

--- a/data/help/topics/ai.jinja
+++ b/data/help/topics/ai.jinja
@@ -13,14 +13,16 @@ Object command inputs:
     ./book.sdpub -> wkg://book.sdpub
 
 Treat every search result as a Wiki Graph URI.
+Search results may use short object URIs such as `wkg://entity/Q8018`; prepend the archive locator before passing them back to object commands:
+  wkg:///absolute/path/book.sdpub/entity/Q8018
 
 Default exploration loop:
   1. `wikigraph help uri`
   2. `wikigraph wkg:///absolute/path/book.sdpub search <query>`
-  3. `wikigraph <object-uri> get`
-  4. `wikigraph <object-uri> related`
-  5. `wikigraph <object-uri> evidence`
-  6. `wikigraph <object-uri> pack --budget <chars>`
+  3. `wikigraph <located-object-uri> get`
+  4. `wikigraph <located-object-uri> related`
+  5. `wikigraph <located-object-uri> evidence`
+  6. `wikigraph <located-object-uri> pack --budget <chars>`
 
 Example:
   wikigraph wkg:///Users/me/book.sdpub search "朱元璋" --type entity,triple --limit 20 --json

--- a/data/help/topics/ai.jinja
+++ b/data/help/topics/ai.jinja
@@ -9,21 +9,21 @@ Primary contract:
 Object command inputs:
   Never pass a bare filesystem path to `search`, `list`, `get`, `related`, `evidence`, or `pack`.
   Convert archive paths into Wiki Graph URIs first:
-    /Users/me/book.sdpub -> wikigraph:///Users/me/book.sdpub
-    ./book.sdpub -> wikigraph://book.sdpub
+    /Users/me/book.sdpub -> wkg:///Users/me/book.sdpub
+    ./book.sdpub -> wkg://book.sdpub
 
 Treat every search result as a Wiki Graph URI.
 
 Default exploration loop:
   1. `wikigraph help uri`
-  2. `wikigraph search wikigraph:///absolute/path/book.sdpub <query>`
-  3. `wikigraph get <object-uri>`
-  4. `wikigraph related <object-uri>`
-  5. `wikigraph evidence <object-uri>`
-  6. `wikigraph pack <object-uri> --budget <chars>`
+  2. `wikigraph wkg:///absolute/path/book.sdpub search <query>`
+  3. `wikigraph <object-uri> get`
+  4. `wikigraph <object-uri> related`
+  5. `wikigraph <object-uri> evidence`
+  6. `wikigraph <object-uri> pack --budget <chars>`
 
 Example:
-  wikigraph search wikigraph:///Users/me/book.sdpub "朱元璋" --type entity,triple --limit 20 --json
+  wikigraph wkg:///Users/me/book.sdpub search "朱元璋" --type entity,triple --limit 20 --json
 
 Use `--type` on search to filter currently searchable object kinds:
   meta, chapter, source, summary, chunk, entity, triple

--- a/data/help/topics/command.jinja
+++ b/data/help/topics/command.jinja
@@ -8,7 +8,7 @@ Object commands:
   wikigraph <wikigraph-uri-with-sdpub-locator> list
   wikigraph <object-uri> get
   wikigraph <object-uri> related
-  wikigraph <object-uri> evidence
+  wikigraph <entity|triple|summary|chunk-uri> evidence
   wikigraph next <cursor>
   wikigraph <object-uri> pack
 

--- a/data/help/topics/command.jinja
+++ b/data/help/topics/command.jinja
@@ -4,13 +4,13 @@ Topic: command
 Command Overview
 
 Object commands:
-  wikigraph search <wikigraph-uri-with-sdpub-locator> <query>
-  wikigraph list <wikigraph-uri-with-sdpub-locator>
-  wikigraph get <object-uri>
-  wikigraph related <object-uri>
-  wikigraph evidence <object-uri>
+  wikigraph <wikigraph-uri-with-sdpub-locator> search <query>
+  wikigraph <wikigraph-uri-with-sdpub-locator> list
+  wikigraph <object-uri> get
+  wikigraph <object-uri> related
+  wikigraph <object-uri> evidence
   wikigraph next <cursor>
-  wikigraph pack <object-uri>
+  wikigraph <object-uri> pack
 
 URI routing:
   `search`, `list`, `get`, `related`, `evidence`, and `pack` use Wiki Graph URIs, not bare filesystem paths.

--- a/data/help/topics/recipe.jinja
+++ b/data/help/topics/recipe.jinja
@@ -12,12 +12,12 @@ Queue derived data:
   wikigraph queue add book.sdpub --chapter 3 --task reading-summary --accept-cost
 
 Search and open objects:
-  wikigraph search wikigraph:///Users/me/book.sdpub "恩典 婴儿洗礼"
-  wikigraph list wikigraph:///Users/me/book.sdpub/chapter/3 --type entity
-  wikigraph get wikigraph:///Users/me/book.sdpub/chunk/123
-  wikigraph related wikigraph:///Users/me/book.sdpub/chunk/123
-  wikigraph evidence wikigraph:///Users/me/book.sdpub/triple/Q162593/discusses/Q9476
-  wikigraph pack wikigraph:///Users/me/book.sdpub/entity/Q162593 --budget 5000
+  wikigraph wkg:///Users/me/book.sdpub search "恩典 婴儿洗礼"
+  wikigraph wkg:///Users/me/book.sdpub/chapter/3 list --type entity
+  wikigraph wkg:///Users/me/book.sdpub/chunk/123 get
+  wikigraph wkg:///Users/me/book.sdpub/chunk/123 related
+  wikigraph wkg:///Users/me/book.sdpub/triple/Q162593/discusses/Q9476 evidence
+  wikigraph wkg:///Users/me/book.sdpub/entity/Q162593 pack --budget 5000
 
 Export:
   wikigraph export book.sdpub --output-format markdown --output out.md

--- a/data/help/topics/task.jinja
+++ b/data/help/topics/task.jinja
@@ -12,9 +12,9 @@ Generate:
   wikigraph queue add book.sdpub --chapter 3 --task knowledge-graph --accept-cost
 
 Explore:
-  wikigraph search wikigraph:///Users/me/book.sdpub "keyword"
-  wikigraph list wikigraph:///Users/me/book.sdpub/chapter/3 --type entity
-  wikigraph get wikigraph:///Users/me/book.sdpub/<object-path>
-  wikigraph related wikigraph:///Users/me/book.sdpub/<object-path>
-  wikigraph evidence wikigraph:///Users/me/book.sdpub/<object-path>
-  wikigraph pack wikigraph:///Users/me/book.sdpub/<object-path> --budget 5000
+  wikigraph wkg:///Users/me/book.sdpub search "keyword"
+  wikigraph wkg:///Users/me/book.sdpub/chapter/3 list --type entity
+  wikigraph wkg:///Users/me/book.sdpub/<object-path> get
+  wikigraph wkg:///Users/me/book.sdpub/<object-path> related
+  wikigraph wkg:///Users/me/book.sdpub/<object-path> evidence
+  wikigraph wkg:///Users/me/book.sdpub/<object-path> pack --budget 5000

--- a/data/help/topics/uri.jinja
+++ b/data/help/topics/uri.jinja
@@ -10,41 +10,41 @@ Archive locator:
   - A command URI must contain a `.sdpub` locator.
   - Do not pass a bare filesystem path to object commands.
     Use a Wiki Graph URI instead:
-    /Users/me/book.sdpub -> wikigraph:///Users/me/book.sdpub
-    ./book.sdpub -> wikigraph://book.sdpub
-  - Absolute archive locators use `wikigraph:///`:
-    wikigraph:///books/book.sdpub
-  - Relative archive locators use `wikigraph://`:
-    wikigraph://book.sdpub
-    wikigraph://books/book.sdpub
+    /Users/me/book.sdpub -> wkg:///Users/me/book.sdpub
+    ./book.sdpub -> wkg://book.sdpub
+  - Absolute archive locators use `wkg:///`:
+    wkg:///books/book.sdpub
+  - Relative archive locators use `wkg://`:
+    wkg://book.sdpub
+    wkg://books/book.sdpub
   - The first path segment ending in `.sdpub` is the archive/object boundary.
 
 Short object URIs:
   Commands return short object URIs without local file paths:
-    wikigraph://chapter/3
-    wikigraph://chapter/3/source/
-    wikigraph://chapter/3/source/0#4..8
-    wikigraph://chapter/3/summary/
-    wikigraph://chunk/12
-    wikigraph://entity/Q8018
-    wikigraph://triple/Q8018/discusses/Q123
+    wkg://chapter/3
+    wkg://chapter/3/source/
+    wkg://chapter/3/source/0#4..8
+    wkg://chapter/3/summary/
+    wkg://chunk/12
+    wkg://entity/Q8018
+    wkg://triple/Q8018/discusses/Q123
 
 Located object URIs:
   Add an archive locator before the object path when passing a URI to a command:
-    wikigraph:///books/book.sdpub/chapter/3
-    wikigraph:///books/book.sdpub/chapter/3/source/0#4..8
-    wikigraph://book.sdpub/entity/Q8018
+    wkg:///books/book.sdpub/chapter/3
+    wkg:///books/book.sdpub/chapter/3/source/0#4..8
+    wkg://book.sdpub/entity/Q8018
 
 Object command examples:
   Search an absolute local archive:
-    wikigraph search wikigraph:///Users/me/book.sdpub "keyword" --type entity,triple --limit 20 --json
+    wikigraph wkg:///Users/me/book.sdpub search "keyword" --type entity,triple --limit 20 --json
   Open an object inside an absolute local archive:
-    wikigraph get wikigraph:///Users/me/book.sdpub/entity/Q8018
+    wikigraph wkg:///Users/me/book.sdpub/entity/Q8018 get
 
 Scopes:
-  - `wikigraph:///book.sdpub` addresses the whole archive.
-  - `wikigraph:///book.sdpub/chapter/3` scopes search and list to chapter 3.
-  - `wikigraph://chapter/3/entity/Q8018` is the entity view whose evidence must appear in chapter 3.
+  - `wkg:///book.sdpub` addresses the whole archive.
+  - `wkg:///book.sdpub/chapter/3` scopes search and list to chapter 3.
+  - `wkg://chapter/3/entity/Q8018` is the entity view whose evidence must appear in chapter 3.
 
 Object boundaries:
   - `chapter` is a structural object; searching it uses chapter title and structure, not child source or summary text.

--- a/docs/en/ai-agents.md
+++ b/docs/en/ai-agents.md
@@ -25,6 +25,7 @@ wikigraph index book.sdpub --json
 ```
 
 Use three exploration modes. For synthesis, timelines, relationship analysis, process reconstruction, or concept-structure tasks, start with Structure mode: `chapter tree --json` for a compact table-of-contents map, then choose likely chapter ids and expand them with scoped URI search or `wkg://... get`. Search mode uses `wkg://... search --type <kind>` for candidate discovery and falls back to source/summary/chunk text when structured objects do not match. Reading mode uses `wkg://... get` after the relevant source URI has been selected.
+Search results may display short object URIs such as `wkg://entity/Q9957`; prepend the archive locator before reusing them in object commands, for example `wkg://book.sdpub/entity/Q9957`.
 
 Choose a search lens explicitly: `--type chunk` for Reading Graph structure, `--type summary` for quick overview, `--type source` for original wording, or `--type entity,triple` for Knowledge Graph objects. Use scoped chapter URIs, `--limit`, and `--cursor` to keep retrieval bounded.
 

--- a/docs/en/ai-agents.md
+++ b/docs/en/ai-agents.md
@@ -12,25 +12,25 @@ Do not treat `.sdpub` as a ZIP payload for routine retrieval. Treat it as a mana
 
 ## Preferred Interface
 
-Prefer archive-first CLI commands:
+Prefer archive commands for archive state and URI-first object commands for exploration:
 
 ```bash
 wikigraph chapter tree book.sdpub --json
-wikigraph search book.sdpub "keyword" --type source,summary,chunk,entity,triple --chapter 3,7,12
-wikigraph get book.sdpub wikigraph://source/chapter/3#0..8
-wikigraph related book.sdpub <uri>
-wikigraph evidence book.sdpub <uri>
-wikigraph pack book.sdpub <uri> --budget 5000
+wikigraph wkg://book.sdpub search "keyword" --type source,summary,chunk,entity,triple
+wikigraph wkg://book.sdpub/chapter/3/source/0#0..8 get
+wikigraph <uri> related
+wikigraph <uri> evidence
+wikigraph <uri> pack --budget 5000
 wikigraph index book.sdpub --json
 ```
 
-Use three exploration modes. For synthesis, timelines, relationship analysis, process reconstruction, or concept-structure tasks, start with Structure mode: `chapter tree --json` for a compact table-of-contents map, then choose likely chapter ids and expand them with scoped `search --chapter <ids>` or `get <uri>`. Search mode uses `search --type <kind>` for candidate discovery and falls back to source/summary/chunk text when structured objects do not match. Reading mode uses `get wikigraph://source/...` after the relevant source URI has been selected.
+Use three exploration modes. For synthesis, timelines, relationship analysis, process reconstruction, or concept-structure tasks, start with Structure mode: `chapter tree --json` for a compact table-of-contents map, then choose likely chapter ids and expand them with scoped URI search or `wkg://... get`. Search mode uses `wkg://... search --type <kind>` for candidate discovery and falls back to source/summary/chunk text when structured objects do not match. Reading mode uses `wkg://... get` after the relevant source URI has been selected.
 
-Choose a search lens explicitly: `--type chunk` for Reading Graph structure, `--type summary` for quick overview, `--type source` for original wording, or `--type entity,triple` for Knowledge Graph objects. Use `--chapter`, `--limit`, and `--cursor` to keep retrieval bounded.
+Choose a search lens explicitly: `--type chunk` for Reading Graph structure, `--type summary` for quick overview, `--type source` for original wording, or `--type entity,triple` for Knowledge Graph objects. Use scoped chapter URIs, `--limit`, and `--cursor` to keep retrieval bounded.
 
-For evidence tracing, logic-chain reconstruction, or relationship analysis that starts from source text, use `evidence <uri>` to return source ranges for a known object, then use `related <uri>` or `pack <uri>` to move back into nearby objects. Use source URIs when continuous prose is the goal.
+For evidence tracing, logic-chain reconstruction, or relationship analysis that starts from source text, use `wikigraph <uri> evidence` to return source ranges for a known object, then use `wikigraph <uri> related` or `wikigraph <uri> pack` to move back into nearby objects. Use source URIs when continuous prose is the goal.
 
-`index` is useful when archive-level readiness or metadata matters: title, source format, chapter count, summary count, node count, and edge count. For content exploration after `chapter tree`, selecting a small set of chapter ids and using scoped `search --chapter <ids>` usually spends less context than returning to archive-level entry points.
+`index` is useful when archive-level readiness or metadata matters: title, source format, chapter count, summary count, node count, and edge count. For content exploration after `chapter tree`, selecting a small set of chapter ids and using scoped chapter URIs usually spends less context than returning to archive-level entry points.
 
 Use the library API only when the surrounding system explicitly needs in-process integration.
 
@@ -38,7 +38,7 @@ Use the library API only when the surrounding system explicitly needs in-process
 
 - Primary object: `.sdpub`
 - Creation sources: EPUB, Markdown, TXT, and text pipelines
-- Read objects: Wiki Graph URIs such as `wikigraph://source/chapter/1#0..3`, `wikigraph://chunk/42`, `wikigraph://entity/Q9957`, and `wikigraph://triple/...`
+- Read objects: Wiki Graph URIs such as `wkg://source/chapter/1#0..3`, `wkg://chunk/42`, `wkg://entity/Q9957`, and `wkg://triple/...`
 - Cheap operations: `index`, `search`, `get`, `related`, `evidence`, `pack`, `export`
 - Expensive operations: Reading Graph, Reading Summary, or Knowledge Graph `queue add`
 - Estimate first: `wikigraph estimate <archive.sdpub> --stage reading-summary`
@@ -47,12 +47,12 @@ Use the library API only when the surrounding system explicitly needs in-process
 ## Recommended Execution Strategy
 
 1. For content understanding, use `chapter tree --json` as the compact global map.
-2. Select likely chapter ids from the tree, then use scoped `search --chapter <ids>` before broad search.
-3. Use `search` to locate source, summary, chunk, entity, or triple objects.
-4. Use `get <uri>` to inspect one object.
-5. Use `evidence <uri>` when an object should be grounded back to source text.
-6. Use `related <uri>` to move to nearby peer objects.
-7. Use `pack <uri>` when the user needs deterministic context around a known object.
+2. Select likely chapter ids from the tree, then search scoped chapter URIs before broad archive search.
+3. Use `wikigraph <uri> search` to locate source, summary, chunk, entity, or triple objects.
+4. Use `wikigraph <uri> get` to inspect one object.
+5. Use `wikigraph <uri> evidence` when an object should be grounded back to source text.
+6. Use `wikigraph <uri> related` to move to nearby peer objects.
+7. Use `wikigraph <uri> pack` when the user needs deterministic context around a known object.
 8. Use `export` only when the user needs a projection.
 9. Use `index` when archive readiness, metadata, or build state is part of the task.
 10. Before `queue add`, run `estimate`; if the estimate is too large for the session, ask the user.

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -19,8 +19,8 @@ wikigraph index <archive.sdpub> [--json]
 wikigraph <archive-or-scope-uri> search <query> [--type <chapter|entity|triple|source|summary|chunk[,kind...]>] [--limit <n>] [--cursor <token>] [--json|--jsonl]
 wikigraph <archive-or-scope-uri> list [--type <chapter|entity|triple|source|summary|chunk[,kind...]>] [--limit <n>] [--cursor <token>] [--json|--jsonl]
 wikigraph <object-uri> get [--json|--jsonl]
-wikigraph <object-uri> related [--json|--jsonl]
-wikigraph <object-uri> evidence [--limit <n>] [--cursor <token>] [--json|--jsonl]
+wikigraph <object-uri> related [--evidence [n]] [--json|--jsonl]
+wikigraph <entity|triple|summary|chunk-uri> evidence [--limit <n>] [--cursor <token>] [--json|--jsonl]
 wikigraph <object-uri> pack [--budget <chars>] [--json|--jsonl]
 wikigraph export <archive.sdpub> --output-format <format> [--output <path>]
 wikigraph queue add <archive.sdpub> --chapter <id> [--task reading-graph|reading-summary|knowledge-graph] --accept-cost [--boost] [--llm <json>] [--prompt <text>]
@@ -42,7 +42,7 @@ Search and collection behavior:
 
 - `search` finds URI-addressable objects from query text. Search results are leads, not source evidence.
 - `list` enumerates URI-addressable objects without query text.
-- Object commands use Wiki Graph URIs. Convert archive paths to archive URIs such as `wkg:///Users/me/book.sdpub` before using `search`, `list`, `get`, `related`, `evidence`, or `pack`.
+- Object commands use Wiki Graph URIs. Use an archive or scope URI such as `wkg:///Users/me/book.sdpub` for `search` and `list`; use a concrete object URI such as `wkg:///Users/me/book.sdpub/chapter/12` for `get`, `related`, `evidence`, or `pack`.
 - For content understanding, choose a search lens: `--type chunk` for Reading Graph structure, `--type summary` for quick overview, `--type source` for original source wording, or `--type entity,triple` for Knowledge Graph objects.
 - Use a chapter scope URI such as `wkg:///Users/me/book.sdpub/chapter/12` to keep search or list local to one chapter.
 - `--limit` defaults to `20`; pass returned `nextCursor` back through `--cursor` for the next page.

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -2,10 +2,11 @@
 
 # CLI Reference
 
-SpineDigest is archive-first. The primary object is a `.sdpub` knowledge-base archive, and the primary command shape is:
+SpineDigest is archive-first. The primary object is a `.sdpub` knowledge-base archive. Archive maintenance commands start with an action; object exploration commands start with a Wiki Graph URI:
 
 ```bash
 wikigraph <action> <archive.sdpub> ...
+wikigraph <wkg-uri> <action> ...
 ```
 
 ## Archive Commands
@@ -15,12 +16,12 @@ wikigraph create <archive.sdpub> [source] [--input-format <format>] [--llm <json
 wikigraph estimate <archive.sdpub> [--stage <source|reading-graph|reading-summary>] [--json]
 wikigraph status <archive.sdpub> [--json]
 wikigraph index <archive.sdpub> [--json]
-wikigraph search <archive-or-scope-uri> <query> [--type <chapter|entity|triple|source|summary|chunk[,kind...]>] [--limit <n>] [--cursor <token>] [--json|--jsonl]
-wikigraph list <archive-or-scope-uri> [--type <chapter|entity|triple|source|summary|chunk[,kind...]>] [--limit <n>] [--cursor <token>] [--json|--jsonl]
-wikigraph get <object-uri> [--json|--jsonl]
-wikigraph related <object-uri> [--json|--jsonl]
-wikigraph evidence <object-uri> [--limit <n>] [--cursor <token>] [--json|--jsonl]
-wikigraph pack <object-uri> [--budget <chars>] [--json|--jsonl]
+wikigraph <archive-or-scope-uri> search <query> [--type <chapter|entity|triple|source|summary|chunk[,kind...]>] [--limit <n>] [--cursor <token>] [--json|--jsonl]
+wikigraph <archive-or-scope-uri> list [--type <chapter|entity|triple|source|summary|chunk[,kind...]>] [--limit <n>] [--cursor <token>] [--json|--jsonl]
+wikigraph <object-uri> get [--json|--jsonl]
+wikigraph <object-uri> related [--json|--jsonl]
+wikigraph <object-uri> evidence [--limit <n>] [--cursor <token>] [--json|--jsonl]
+wikigraph <object-uri> pack [--budget <chars>] [--json|--jsonl]
 wikigraph export <archive.sdpub> --output-format <format> [--output <path>]
 wikigraph queue add <archive.sdpub> --chapter <id> [--task reading-graph|reading-summary|knowledge-graph] --accept-cost [--boost] [--llm <json>] [--prompt <text>]
 wikigraph queue list [--all] [--active] [--input <archive.sdpub>] [--json]
@@ -41,9 +42,9 @@ Search and collection behavior:
 
 - `search` finds URI-addressable objects from query text. Search results are leads, not source evidence.
 - `list` enumerates URI-addressable objects without query text.
-- Object commands use Wiki Graph URIs. Convert archive paths to archive URIs such as `wikigraph:///Users/me/book.sdpub` before using `search`, `list`, `get`, `related`, `evidence`, or `pack`.
+- Object commands use Wiki Graph URIs. Convert archive paths to archive URIs such as `wkg:///Users/me/book.sdpub` before using `search`, `list`, `get`, `related`, `evidence`, or `pack`.
 - For content understanding, choose a search lens: `--type chunk` for Reading Graph structure, `--type summary` for quick overview, `--type source` for original source wording, or `--type entity,triple` for Knowledge Graph objects.
-- Use a chapter scope URI such as `wikigraph:///Users/me/book.sdpub/chapter/12` to keep search or list local to one chapter.
+- Use a chapter scope URI such as `wkg:///Users/me/book.sdpub/chapter/12` to keep search or list local to one chapter.
 - `--limit` defaults to `20`; pass returned `nextCursor` back through `--cursor` for the next page.
 - Search does not do semantic expansion, stemming, or vector search.
 - Read `wikigraph help uri` for the URI grammar and object boundary rules.
@@ -86,8 +87,8 @@ Extension mapping:
 Read/search/navigation commands support `--json` for machine consumption:
 
 ```bash
-wikigraph search wikigraph:///Users/me/book.sdpub "RAG" --type chunk --json
-wikigraph get wikigraph:///Users/me/book.sdpub/chapter/3 --json
+wikigraph wkg:///Users/me/book.sdpub search "RAG" --type chunk --json
+wikigraph wkg:///Users/me/book.sdpub/chapter/3 get --json
 ```
 
 Human-readable stdout is Markdown-like text with stable ids and suggested next commands.

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -65,12 +65,12 @@ wikigraph queue list --input ./book.sdpub
 
 ```bash
 wikigraph chapter tree ./book.sdpub --json
-wikigraph search wikigraph://book.sdpub "central argument" --type chunk
-wikigraph get wikigraph://book.sdpub/chapter/3
-wikigraph get wikigraph://book.sdpub/chunk/84
-wikigraph related wikigraph://book.sdpub/chunk/84
-wikigraph evidence wikigraph://book.sdpub/chunk/84
-wikigraph pack wikigraph://book.sdpub/chunk/84 --budget 5000
+wikigraph wkg://book.sdpub search "central argument" --type chunk
+wikigraph wkg://book.sdpub/chapter/3 get
+wikigraph wkg://book.sdpub/chunk/84 get
+wikigraph wkg://book.sdpub/chunk/84 related
+wikigraph wkg://book.sdpub/chunk/84 evidence
+wikigraph wkg://book.sdpub/chunk/84 pack --budget 5000
 ```
 
 Use `--type` to choose a search lens: `--type chunk` for Reading Graph structure, `--type summary` for quick overview, `--type source` for original source wording, or `--type entity,triple` for Knowledge Graph objects.
@@ -84,7 +84,7 @@ Use `--json` when another tool will consume the output.
 Use projections when you need a portable view. For example, read one chapter into Markdown text, or export the full archive as an EPUB:
 
 ```bash
-wikigraph get wikigraph://book.sdpub/chapter/3/source/ > ./chapter-3.md
+wikigraph wkg://book.sdpub/chapter/3/source/ get > ./chapter-3.md
 wikigraph export ./book.sdpub --output-format epub --output ./digest.epub
 ```
 

--- a/docs/zh-CN/ai-agents.md
+++ b/docs/zh-CN/ai-agents.md
@@ -25,6 +25,7 @@ wikigraph index book.sdpub --json
 ```
 
 优先先选择三种探索模式之一。对于综合理解、时间线、关系分析、过程梳理或概念结构任务，先走结构模式：用 `chapter tree --json` 查看压缩后的目录地图，再选择可能相关的 chapter id，并用 scoped URI search 或 `wkg://... get` 展开局部。搜索模式用 `wkg://... search --type <kind>` 做候选定位；结构化对象没有命中时，会退回 source / summary / chunk 文本。阅读模式适合在选定 source URI 后用 `wkg://... get` 输出连续文本。
+Search result 可能显示短 object URI，例如 `wkg://entity/Q9957`；把它继续传给 object command 前，需要补上 archive locator，例如 `wkg://book.sdpub/entity/Q9957`。
 
 显式选择 search lens：`--type chunk` 用于 Reading Graph 结构，`--type summary` 用于快速概览，`--type source` 用于原文措辞，`--type entity,triple` 用于 Knowledge Graph 对象。使用 scoped chapter URI、`--limit`、`--cursor` 控制检索范围。
 

--- a/docs/zh-CN/ai-agents.md
+++ b/docs/zh-CN/ai-agents.md
@@ -12,25 +12,25 @@
 
 ## 优先接口
 
-优先使用 archive-first CLI：
+归档状态使用 archive command，内容探索优先使用 URI-first object command：
 
 ```bash
 wikigraph chapter tree book.sdpub --json
-wikigraph search book.sdpub "keyword" --type source,summary,chunk,entity,triple --chapter 3,7,12
-wikigraph get book.sdpub wikigraph://source/chapter/3#0..8
-wikigraph related book.sdpub <uri>
-wikigraph evidence book.sdpub <uri>
-wikigraph pack book.sdpub <uri> --budget 5000
+wikigraph wkg://book.sdpub search "keyword" --type source,summary,chunk,entity,triple
+wikigraph wkg://book.sdpub/chapter/3/source/0#0..8 get
+wikigraph <uri> related
+wikigraph <uri> evidence
+wikigraph <uri> pack --budget 5000
 wikigraph index book.sdpub --json
 ```
 
-优先先选择三种探索模式之一。对于综合理解、时间线、关系分析、过程梳理或概念结构任务，先走结构模式：用 `chapter tree --json` 查看压缩后的目录地图，再选择可能相关的 chapter id，并用带范围的 `search --chapter <ids>` 或 `get <uri>` 展开局部。搜索模式用 `search --type <kind>` 做候选定位；结构化对象没有命中时，会退回 source / summary / chunk 文本。阅读模式适合在选定 source URI 后用 `get wikigraph://source/...` 输出连续文本。
+优先先选择三种探索模式之一。对于综合理解、时间线、关系分析、过程梳理或概念结构任务，先走结构模式：用 `chapter tree --json` 查看压缩后的目录地图，再选择可能相关的 chapter id，并用 scoped URI search 或 `wkg://... get` 展开局部。搜索模式用 `wkg://... search --type <kind>` 做候选定位；结构化对象没有命中时，会退回 source / summary / chunk 文本。阅读模式适合在选定 source URI 后用 `wkg://... get` 输出连续文本。
 
-显式选择 search lens：`--type chunk` 用于 Reading Graph 结构，`--type summary` 用于快速概览，`--type source` 用于原文措辞，`--type entity,triple` 用于 Knowledge Graph 对象。使用 `--chapter`、`--limit`、`--cursor` 控制检索范围。
+显式选择 search lens：`--type chunk` 用于 Reading Graph 结构，`--type summary` 用于快速概览，`--type source` 用于原文措辞，`--type entity,triple` 用于 Knowledge Graph 对象。使用 scoped chapter URI、`--limit`、`--cursor` 控制检索范围。
 
-当任务从原文出发追踪证据、逻辑链或关系时，用 `evidence <uri>` 把已知对象带回 source range，再用 `related <uri>` 或 `pack <uri>` 回到附近对象。目标是连续阅读 prose 时，使用 source URI。
+当任务从原文出发追踪证据、逻辑链或关系时，用 `wikigraph <uri> evidence` 把已知对象带回 source range，再用 `wikigraph <uri> related` 或 `wikigraph <uri> pack` 回到附近对象。目标是连续阅读 prose 时，使用 source URI。
 
-`index` 适合在需要归档级 readiness 或元信息时使用，例如标题、source format、章节数、summary 数、node 数和 edge 数。对于 `chapter tree` 之后的内容探索，先选择少量 chapter id，再用带范围的 `search --chapter <ids>` 展开局部，通常比回到归档级入口更节省上下文。
+`index` 适合在需要归档级 readiness 或元信息时使用，例如标题、source format、章节数、summary 数、node 数和 edge 数。对于 `chapter tree` 之后的内容探索，先选择少量 chapter id，再用 scoped chapter URI 展开局部，通常比回到归档级入口更节省上下文。
 
 只有外围系统明确需要进程内集成时，才使用 library API。
 
@@ -38,7 +38,7 @@ wikigraph index book.sdpub --json
 
 - 主对象：`.sdpub`
 - 创建源：EPUB、Markdown、TXT 和文本管道
-- 可读对象：Wiki Graph URI，例如 `wikigraph://source/chapter/1#0..3`、`wikigraph://chunk/42`、`wikigraph://entity/Q9957` 和 `wikigraph://triple/...`
+- 可读对象：Wiki Graph URI，例如 `wkg://source/chapter/1#0..3`、`wkg://chunk/42`、`wkg://entity/Q9957` 和 `wkg://triple/...`
 - 便宜操作：`index`、`search`、`get`、`related`、`evidence`、`pack`、`export`
 - 昂贵操作：Reading Graph、Reading Summary 或 Knowledge Graph `queue add`
 - 先估算：`wikigraph estimate <archive.sdpub> --stage reading-summary`
@@ -47,12 +47,12 @@ wikigraph index book.sdpub --json
 ## 推荐执行策略
 
 1. 对内容理解任务，先用 `chapter tree --json` 作为压缩后的全局地图。
-2. 从 tree 中选择可能相关的 chapter id，再用带范围的 `search --chapter <ids>`，然后再做宽泛搜索。
-3. 用 `search` 定位 source、summary、chunk、entity 或 triple 对象。
-4. 用 `get <uri>` 检查单个对象。
-5. 当对象需要回到原文证据时，使用 `evidence <uri>`。
-6. 用 `related <uri>` 移动到附近同级对象。
-7. 用户需要围绕已知 object 打包确定性上下文时，使用 `pack <uri>`。
+2. 从 tree 中选择可能相关的 chapter id，先搜索 scoped chapter URI，然后再做宽泛搜索。
+3. 用 `wikigraph <uri> search` 定位 source、summary、chunk、entity 或 triple 对象。
+4. 用 `wikigraph <uri> get` 检查单个对象。
+5. 当对象需要回到原文证据时，使用 `wikigraph <uri> evidence`。
+6. 用 `wikigraph <uri> related` 移动到附近同级对象。
+7. 用户需要围绕已知 object 打包确定性上下文时，使用 `wikigraph <uri> pack`。
 8. 只有用户需要 projection 时才 `export`。
 9. 当任务涉及归档 readiness、元信息或构建状态时，再使用 `index`。
 10. `queue add` 前先 `estimate`；如果估算超出当前交互预算，先询问用户。

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -19,8 +19,8 @@ wikigraph index <archive.sdpub> [--json]
 wikigraph <archive-or-scope-uri> search <query> [--type <chapter|entity|triple|source|summary|chunk[,kind...]>] [--limit <n>] [--cursor <token>] [--json|--jsonl]
 wikigraph <archive-or-scope-uri> list [--type <chapter|entity|triple|source|summary|chunk[,kind...]>] [--limit <n>] [--cursor <token>] [--json|--jsonl]
 wikigraph <object-uri> get [--json|--jsonl]
-wikigraph <object-uri> related [--json|--jsonl]
-wikigraph <object-uri> evidence [--limit <n>] [--cursor <token>] [--json|--jsonl]
+wikigraph <object-uri> related [--evidence [n]] [--json|--jsonl]
+wikigraph <entity|triple|summary|chunk-uri> evidence [--limit <n>] [--cursor <token>] [--json|--jsonl]
 wikigraph <object-uri> pack [--budget <chars>] [--json|--jsonl]
 wikigraph export <archive.sdpub> --output-format <format> [--output <path>]
 wikigraph queue add <archive.sdpub> --chapter <id> [--task reading-graph|reading-summary|knowledge-graph] --accept-cost [--boost] [--llm <json>] [--prompt <text>]
@@ -42,7 +42,7 @@ wikigraph queue clean
 
 - `search` 根据 query text 查找可 URI 寻址的对象。Search result 是线索，不等于 source evidence。
 - `list` 在没有 query text 时枚举可 URI 寻址的对象。
-- Object command 使用 Wiki Graph URI。使用 `search`、`list`、`get`、`related`、`evidence` 或 `pack` 前，先把 archive path 转为 archive URI，例如 `wkg:///Users/me/book.sdpub`。
+- Object command 使用 Wiki Graph URI。`search` 和 `list` 使用 archive 或 scope URI，例如 `wkg:///Users/me/book.sdpub`；`get`、`related`、`evidence` 和 `pack` 使用具体 object URI，例如 `wkg:///Users/me/book.sdpub/chapter/12`。
 - 做内容理解时，选择一个 search lens：`--type chunk` 用于 Reading Graph 结构，`--type summary` 用于快速概览，`--type source` 用于原文措辞，`--type entity,triple` 用于 Knowledge Graph 对象。
 - 使用 chapter scope URI，例如 `wkg:///Users/me/book.sdpub/chapter/12`，把 search 或 list 限定在一个章节内。
 - `--limit` 默认 `20`；下一页把返回的 `nextCursor` 传给 `--cursor`。

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -2,10 +2,11 @@
 
 # CLI Reference
 
-SpineDigest 采用 archive-first CLI。主对象是 `.sdpub` 知识库归档，主命令形态是：
+SpineDigest 采用 archive-first CLI。主对象是 `.sdpub` 知识库归档。归档维护命令以 action 开头；对象探索命令以 Wiki Graph URI 开头：
 
 ```bash
 wikigraph <action> <archive.sdpub> ...
+wikigraph <wkg-uri> <action> ...
 ```
 
 ## 归档命令
@@ -15,12 +16,12 @@ wikigraph create <archive.sdpub> [source] [--input-format <format>] [--llm <json
 wikigraph estimate <archive.sdpub> [--stage <source|reading-graph|reading-summary>] [--json]
 wikigraph status <archive.sdpub> [--json]
 wikigraph index <archive.sdpub> [--json]
-wikigraph search <archive-or-scope-uri> <query> [--type <chapter|entity|triple|source|summary|chunk[,kind...]>] [--limit <n>] [--cursor <token>] [--json|--jsonl]
-wikigraph list <archive-or-scope-uri> [--type <chapter|entity|triple|source|summary|chunk[,kind...]>] [--limit <n>] [--cursor <token>] [--json|--jsonl]
-wikigraph get <object-uri> [--json|--jsonl]
-wikigraph related <object-uri> [--json|--jsonl]
-wikigraph evidence <object-uri> [--limit <n>] [--cursor <token>] [--json|--jsonl]
-wikigraph pack <object-uri> [--budget <chars>] [--json|--jsonl]
+wikigraph <archive-or-scope-uri> search <query> [--type <chapter|entity|triple|source|summary|chunk[,kind...]>] [--limit <n>] [--cursor <token>] [--json|--jsonl]
+wikigraph <archive-or-scope-uri> list [--type <chapter|entity|triple|source|summary|chunk[,kind...]>] [--limit <n>] [--cursor <token>] [--json|--jsonl]
+wikigraph <object-uri> get [--json|--jsonl]
+wikigraph <object-uri> related [--json|--jsonl]
+wikigraph <object-uri> evidence [--limit <n>] [--cursor <token>] [--json|--jsonl]
+wikigraph <object-uri> pack [--budget <chars>] [--json|--jsonl]
 wikigraph export <archive.sdpub> --output-format <format> [--output <path>]
 wikigraph queue add <archive.sdpub> --chapter <id> [--task reading-graph|reading-summary|knowledge-graph] --accept-cost [--boost] [--llm <json>] [--prompt <text>]
 wikigraph queue list [--all] [--active] [--input <archive.sdpub>] [--json]
@@ -41,9 +42,9 @@ wikigraph queue clean
 
 - `search` 根据 query text 查找可 URI 寻址的对象。Search result 是线索，不等于 source evidence。
 - `list` 在没有 query text 时枚举可 URI 寻址的对象。
-- Object command 使用 Wiki Graph URI。使用 `search`、`list`、`get`、`related`、`evidence` 或 `pack` 前，先把 archive path 转为 archive URI，例如 `wikigraph:///Users/me/book.sdpub`。
+- Object command 使用 Wiki Graph URI。使用 `search`、`list`、`get`、`related`、`evidence` 或 `pack` 前，先把 archive path 转为 archive URI，例如 `wkg:///Users/me/book.sdpub`。
 - 做内容理解时，选择一个 search lens：`--type chunk` 用于 Reading Graph 结构，`--type summary` 用于快速概览，`--type source` 用于原文措辞，`--type entity,triple` 用于 Knowledge Graph 对象。
-- 使用 chapter scope URI，例如 `wikigraph:///Users/me/book.sdpub/chapter/12`，把 search 或 list 限定在一个章节内。
+- 使用 chapter scope URI，例如 `wkg:///Users/me/book.sdpub/chapter/12`，把 search 或 list 限定在一个章节内。
 - `--limit` 默认 `20`；下一页把返回的 `nextCursor` 传给 `--cursor`。
 - Search 不做语义扩展、词干匹配或向量搜索。
 - URI 语法和 object boundary 规则见 `wikigraph help uri`。
@@ -86,8 +87,8 @@ Queue 行为：
 读取、搜索和导航命令支持 `--json`：
 
 ```bash
-wikigraph search wikigraph:///Users/me/book.sdpub "RAG" --type chunk --json
-wikigraph get wikigraph:///Users/me/book.sdpub/chapter/3 --json
+wikigraph wkg:///Users/me/book.sdpub search "RAG" --type chunk --json
+wikigraph wkg:///Users/me/book.sdpub/chapter/3 get --json
 ```
 
 默认 stdout 是适合人和 Agent 阅读的 Markdown-like 文本，包含稳定 ID 和下一步命令提示。

--- a/docs/zh-CN/quickstart.md
+++ b/docs/zh-CN/quickstart.md
@@ -65,12 +65,12 @@ wikigraph queue list --input ./book.sdpub
 
 ```bash
 wikigraph chapter tree ./book.sdpub --json
-wikigraph search wikigraph://book.sdpub "central argument" --type chunk
-wikigraph get wikigraph://book.sdpub/chapter/3
-wikigraph get wikigraph://book.sdpub/chunk/84
-wikigraph related wikigraph://book.sdpub/chunk/84
-wikigraph evidence wikigraph://book.sdpub/chunk/84
-wikigraph pack wikigraph://book.sdpub/chunk/84 --budget 5000
+wikigraph wkg://book.sdpub search "central argument" --type chunk
+wikigraph wkg://book.sdpub/chapter/3 get
+wikigraph wkg://book.sdpub/chunk/84 get
+wikigraph wkg://book.sdpub/chunk/84 related
+wikigraph wkg://book.sdpub/chunk/84 evidence
+wikigraph wkg://book.sdpub/chunk/84 pack --budget 5000
 ```
 
 使用 `--type` 选择 search lens：`--type chunk` 用于 Reading Graph 结构，`--type summary` 用于快速概览，`--type source` 用于原文措辞，`--type entity,triple` 用于 Knowledge Graph 对象。
@@ -84,7 +84,7 @@ Object command 使用 Wiki Graph URI。手动构造 URI 时，先读 `wikigraph 
 只有需要便携视图时再输出 projection。比如只需要某一章的 `.md` 文本，可以读取该章；需要完整电子书视图时再导出 EPUB：
 
 ```bash
-wikigraph get wikigraph://book.sdpub/chapter/3/source/ > ./chapter-3.md
+wikigraph wkg://book.sdpub/chapter/3/source/ get > ./chapter-3.md
 wikigraph export ./book.sdpub --output-format epub --output ./digest.epub
 ```
 

--- a/src/cli/archive.ts
+++ b/src/cli/archive.ts
@@ -522,13 +522,17 @@ async function createOutputContinuationCursor(
   let input: ContinuationCursor;
 
   if (context.continuationKind === "evidence") {
+    if (context.targetUri === undefined) {
+      throw new Error("Evidence continuation cursors require a target URI.");
+    }
+
     input = {
       archiveKey: context.archiveKey,
       archivePath: context.archivePath,
       cursor,
       format: context.format,
       kind: "evidence",
-      targetUri: context.targetUri ?? "",
+      targetUri: context.targetUri,
     };
   } else if (context.continuationKind === "collection") {
     input = {

--- a/src/cli/archive.ts
+++ b/src/cli/archive.ts
@@ -320,7 +320,7 @@ async function runNextArchivePage(args: CLIArchiveArguments): Promise<void> {
 
   await readArchiveDocument(cursor.archivePath, async (document) => {
     const format = args.format ?? cursor.format;
-    const limit = args.limit ?? cursor.limit;
+    const limit = args.limit ?? DEFAULT_OUTPUT_LIMIT;
 
     switch (cursor.kind) {
       case "collection": {
@@ -528,7 +528,6 @@ async function createOutputContinuationCursor(
       cursor,
       format: context.format,
       kind: "evidence",
-      limit: context.evidenceLimit ?? context.limit,
       targetUri: context.targetUri ?? "",
     };
   } else if (context.continuationKind === "collection") {
@@ -543,7 +542,6 @@ async function createOutputContinuationCursor(
       format: context.format,
       ids: context.ids ?? null,
       kind: "collection",
-      limit: context.limit,
       order: context.order ?? "doc-asc",
       types: context.types,
     };
@@ -557,7 +555,6 @@ async function createOutputContinuationCursor(
         : { evidenceLimit: context.evidenceLimit }),
       format: context.format,
       kind: "search",
-      limit: context.limit,
       types: context.types,
     };
   }

--- a/src/cli/archive.ts
+++ b/src/cli/archive.ts
@@ -981,7 +981,13 @@ async function writePage(
           `Mentions: ${page.mentionCount}`,
           "",
           "Evidence:",
-          ...formatEvidencePreviewBlocks(page.evidence),
+          ...formatEvidencePreviewBlocks(
+            await createEvidencePreviewObject(page.evidence, {
+              ...context,
+              continuationKind: "evidence",
+              targetUri: page.id,
+            }),
+          ),
         ].join("\n") + "\n",
       );
       return;
@@ -992,7 +998,13 @@ async function writePage(
           page.label,
           "",
           "Evidence:",
-          ...formatEvidencePreviewBlocks(page.evidence),
+          ...formatEvidencePreviewBlocks(
+            await createEvidencePreviewObject(page.evidence, {
+              ...context,
+              continuationKind: "evidence",
+              targetUri: page.id,
+            }),
+          ),
         ].join("\n") + "\n",
       );
       return;
@@ -1253,6 +1265,7 @@ function formatFindObject(object: ArchiveOutputObject): string {
     if (hiddenEvidenceCount > 0) {
       lines.push("", `${hiddenEvidenceCount} evidence more...`);
     }
+    lines.push(...formatEvidencePreviewContinuation(object.evidence));
   }
 
   return lines.join("\n");
@@ -1376,7 +1389,7 @@ function formatSourceFragmentLines(
 }
 
 function formatEvidencePreviewBlocks(
-  evidence: ArchiveFindEvidencePreview,
+  evidence: ArchiveOutputEvidencePreview,
 ): string[] {
   if (evidence.sources.length === 0) {
     return ["[none]"];
@@ -1385,7 +1398,7 @@ function formatEvidencePreviewBlocks(
   const lines = evidence.sources.flatMap((item, index) => [
     ...(index === 0 ? [] : [""]),
     `-- evidence ${index + 1}/${evidence.shown}`,
-    formatEvidenceItem(item),
+    formatSourceObject(item),
   ]);
   const hiddenEvidenceCount = evidence.total - evidence.shown;
 
@@ -1393,7 +1406,16 @@ function formatEvidencePreviewBlocks(
     lines.push(`${hiddenEvidenceCount} evidence more...`);
   }
 
+  lines.push(...formatEvidencePreviewContinuation(evidence));
   return lines;
+}
+
+function formatEvidencePreviewContinuation(
+  evidence: ArchiveOutputEvidencePreview,
+): string[] {
+  return evidence.nextCursor === null
+    ? []
+    : ["", `More evidence: wikigraph next ${evidence.nextCursor}`];
 }
 
 function normalizeSourceText(text: string): string {
@@ -1493,7 +1515,13 @@ async function formatPackAnchor(
         `Mentions: ${anchor.mentionCount}`,
         "",
         "Evidence:",
-        ...formatEvidencePreviewBlocks(anchor.evidence),
+        ...formatEvidencePreviewBlocks(
+          await createEvidencePreviewObject(anchor.evidence, {
+            ...context,
+            continuationKind: "evidence",
+            targetUri: anchor.id,
+          }),
+        ),
       ].join("\n");
     case "triple":
       return [
@@ -1501,7 +1529,13 @@ async function formatPackAnchor(
         anchor.label,
         "",
         "Evidence:",
-        ...formatEvidencePreviewBlocks(anchor.evidence),
+        ...formatEvidencePreviewBlocks(
+          await createEvidencePreviewObject(anchor.evidence, {
+            ...context,
+            continuationKind: "evidence",
+            targetUri: anchor.id,
+          }),
+        ),
       ].join("\n");
   }
 }

--- a/src/cli/archive.ts
+++ b/src/cli/archive.ts
@@ -1262,10 +1262,12 @@ function formatFindObject(object: ArchiveOutputObject): string {
 
     const hiddenEvidenceCount = object.evidence.total - object.evidence.shown;
 
-    if (hiddenEvidenceCount > 0) {
-      lines.push("", `${hiddenEvidenceCount} evidence more...`);
-    }
-    lines.push(...formatEvidencePreviewContinuation(object.evidence));
+    lines.push(
+      ...formatEvidencePreviewContinuation(
+        object.evidence,
+        hiddenEvidenceCount,
+      ),
+    );
   }
 
   return lines.join("\n");
@@ -1402,20 +1404,26 @@ function formatEvidencePreviewBlocks(
   ]);
   const hiddenEvidenceCount = evidence.total - evidence.shown;
 
-  if (hiddenEvidenceCount > 0) {
-    lines.push(`${hiddenEvidenceCount} evidence more...`);
-  }
-
-  lines.push(...formatEvidencePreviewContinuation(evidence));
+  lines.push(
+    ...formatEvidencePreviewContinuation(evidence, hiddenEvidenceCount),
+  );
   return lines;
 }
 
 function formatEvidencePreviewContinuation(
   evidence: ArchiveOutputEvidencePreview,
+  hiddenEvidenceCount: number,
 ): string[] {
-  return evidence.nextCursor === null
-    ? []
-    : ["", `More evidence: wikigraph next ${evidence.nextCursor}`];
+  if (evidence.nextCursor !== null) {
+    return [
+      "",
+      `${hiddenEvidenceCount} more evidence: wikigraph next ${evidence.nextCursor}`,
+    ];
+  }
+
+  return hiddenEvidenceCount > 0
+    ? ["", `${hiddenEvidenceCount} evidence more...`]
+    : [];
 }
 
 function normalizeSourceText(text: string): string {

--- a/src/cli/archive.ts
+++ b/src/cli/archive.ts
@@ -635,7 +635,7 @@ function requireLocatedObjectOrArchiveUri(uri: string): {
     throw new Error(
       [
         `Expected a Wiki Graph URI with a .sdpub archive locator: ${uri}`,
-        `Example: ${uri.endsWith(".sdpub") && uri.startsWith("/") ? `wikigraph://${uri}` : "wikigraph:///absolute/path/book.sdpub"}`,
+        `Example: ${uri.endsWith(".sdpub") && uri.startsWith("/") ? `wkg://${uri}` : "wkg:///absolute/path/book.sdpub"}`,
         "See: wikigraph help uri",
       ].join("\n"),
     );
@@ -645,7 +645,7 @@ function requireLocatedObjectOrArchiveUri(uri: string): {
 }
 
 function parseChapterScope(uri: string): number | undefined {
-  const match = /^wikigraph:\/\/chapter\/([1-9][0-9]*)(?:\/|$)/u.exec(uri);
+  const match = /^wkg:\/\/chapter\/([1-9][0-9]*)(?:\/|$)/u.exec(uri);
 
   return match?.[1] === undefined ? undefined : Number(match[1]);
 }
@@ -682,14 +682,14 @@ async function writeIndex(
       "",
       "Reading Graph:",
       "  No reading chunks are currently available. If a reading-graph queue task already ran, the source may be too short or sparse.",
-      "  Next: inspect source with `wikigraph get wikigraph://<archive.sdpub>/chapter/<id>/source/` or queue `--task reading-graph`.",
+      "  Next: inspect source with `wikigraph wkg://<archive.sdpub>/chapter/<id>/source/ get` or queue `--task reading-graph`.",
     );
   } else if (index.edgeCount === 0) {
     lines.push(
       "",
       "Reading Graph:",
       "  Reading chunks exist, but no chunk edges are currently available. This can be valid when extracted chunks have no stable relationships.",
-      "  Next: inspect chunks with `wikigraph search wikigraph://<archive.sdpub> <query> --type chunk`.",
+      "  Next: inspect chunks with `wikigraph wkg://<archive.sdpub> search <query> --type chunk`.",
     );
   }
 
@@ -703,9 +703,9 @@ async function writeIndex(
     lines.push(
       "",
       "Next:",
-      "  wikigraph search wikigraph://<archive.sdpub> <term>",
-      "  wikigraph get wikigraph://<archive.sdpub>/chapter/<id>/source/",
-      "  wikigraph related <object-uri>",
+      "  wikigraph wkg://<archive.sdpub> search <term>",
+      "  wikigraph wkg://<archive.sdpub>/chapter/<id>/source/ get",
+      "  wikigraph <object-uri> related",
     );
   }
 
@@ -1052,7 +1052,7 @@ function formatNextCursor(nextCursor: string | null): string {
 
 function formatNoMatches(result: ArchiveFindResult): string {
   if (result.match === "all" && result.terms.length > 1) {
-    return `No matches. Try: wikigraph search <archive-uri> "${result.query}" --type ${formatFindTypes(result)}${formatFindLensHint(result)}\n`;
+    return `No matches. Try: wikigraph <archive-uri> search "${result.query}" --type ${formatFindTypes(result)}${formatFindLensHint(result)}\n`;
   }
 
   const lines = [
@@ -1568,15 +1568,15 @@ function toWikiGraphUri(id: string): string {
 
   switch (type) {
     case "chapter":
-      return `wikigraph://chapter/${first ?? ""}`;
+      return `wkg://chapter/${first ?? ""}`;
     case "fragment":
-      return `wikigraph://chapter/${first ?? ""}/source/${second ?? "0"}`;
+      return `wkg://chapter/${first ?? ""}/source/${second ?? "0"}`;
     case "meta":
-      return "wikigraph://";
+      return "wkg://";
     case "node":
-      return `wikigraph://chunk/${first ?? ""}`;
+      return `wkg://chunk/${first ?? ""}`;
     case "summary":
-      return `wikigraph://chapter/${first ?? ""}/summary/`;
+      return `wkg://chapter/${first ?? ""}/summary/`;
     default:
       return id;
   }

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -520,6 +520,10 @@ export function parseCLIArguments(
     );
   }
 
+  if (isWikiGraphUri(positionals[0])) {
+    return parseArchiveUriFirstArguments(positionals, values);
+  }
+
   if (isArchiveAction(positionals[0])) {
     return parseArchiveArguments(positionals[0], positionals.slice(1), values);
   }
@@ -531,6 +535,36 @@ export function parseCLIArguments(
         : `Unknown command: ${positionals[0]}.`,
       CLI_HELP_ROUTES.command,
     ),
+  );
+}
+
+function parseArchiveUriFirstArguments(
+  positionals: readonly string[],
+  values: ArchiveArgumentValues,
+): ParsedCLIArguments {
+  const uri = positionals[0];
+  const action = positionals[1];
+
+  if (uri === undefined) {
+    throw new Error("Internal error: missing URI-first archive URI.");
+  }
+
+  if (!isUriFirstArchiveAction(action)) {
+    throw new Error(
+      withHelpRoute(
+        action === undefined
+          ? `Missing action after ${uri}.`
+          : `The URI-first form does not support \`${action}\`.`,
+        CLI_HELP_ROUTES.command,
+      ),
+    );
+  }
+
+  return parseArchiveArguments(
+    action,
+    [uri, ...positionals.slice(2)],
+    values,
+    `wikigraph ${uri} ${action} --help`,
   );
 }
 
@@ -1054,6 +1088,7 @@ function parseArchiveArguments(
   action: CLIArchiveAction,
   positionals: readonly string[],
   values: ArchiveArgumentValues,
+  helpRoute = `wikigraph ${action} --help`,
 ): ParsedCLIArguments {
   const normalized = normalizeArchiveInlineOptions(positionals, values);
 
@@ -1061,7 +1096,6 @@ function parseArchiveArguments(
   values = normalized.values;
 
   const archivePath = positionals[0];
-  const helpRoute = `wikigraph ${action} --help`;
 
   if (values.help === true) {
     return {
@@ -1433,14 +1467,14 @@ function formatMissingArchiveInputMessage(action: CLIArchiveAction): string {
     case "index":
       return "Missing archive path. Use `wikigraph index <archive.sdpub>`.";
     case "search":
-      return "Missing Wiki Graph URI with .sdpub locator. Use `wikigraph search wikigraph://<archive.sdpub> <query>`.";
+      return "Missing Wiki Graph URI with .sdpub locator. Use `wikigraph wkg://<archive.sdpub> search <query>`.";
     case "list":
-      return "Missing Wiki Graph URI with .sdpub locator. Use `wikigraph list wikigraph://<archive.sdpub>`.";
+      return "Missing Wiki Graph URI with .sdpub locator. Use `wikigraph wkg://<archive.sdpub> list`.";
     case "get":
     case "related":
     case "evidence":
     case "pack":
-      return `Missing object URI. Use \`wikigraph ${action} wikigraph://<archive.sdpub>/<object>\`.`;
+      return `Missing object URI. Use \`wikigraph wkg://<archive.sdpub>/<object> ${action}\`.`;
     case "next":
       return "Missing continuation cursor. Use `wikigraph next <cursor>`.";
   }
@@ -2732,6 +2766,23 @@ function isArchiveAction(value: string | undefined): value is CLIArchiveAction {
     value === "related" ||
     value === "search"
   );
+}
+
+function isUriFirstArchiveAction(
+  value: string | undefined,
+): value is "evidence" | "get" | "list" | "pack" | "related" | "search" {
+  return (
+    value === "evidence" ||
+    value === "get" ||
+    value === "list" ||
+    value === "pack" ||
+    value === "related" ||
+    value === "search"
+  );
+}
+
+function isWikiGraphUri(value: string | undefined): boolean {
+  return value?.startsWith("wkg://") === true;
 }
 
 function isQueueAction(value: string | undefined): value is CLIQueueAction {

--- a/src/facade/archive-uri.ts
+++ b/src/facade/archive-uri.ts
@@ -6,7 +6,7 @@ export interface LocatedWikiGraphUri {
 }
 
 export function parseLocatedWikiGraphUri(uri: string): LocatedWikiGraphUri {
-  const prefix = "wikigraph://";
+  const prefix = "wkg://";
 
   if (!uri.startsWith(prefix)) {
     throw new Error(formatWikiGraphUriExpectedError(uri));
@@ -35,7 +35,7 @@ export function parseLocatedWikiGraphUri(uri: string): LocatedWikiGraphUri {
     ...(objectPath === "" && !path.endsWith("/")
       ? {}
       : {
-          objectUri: `wikigraph://${objectPath}${hash === "" ? "" : `#${hash}`}`,
+          objectUri: `wkg://${objectPath}${hash === "" ? "" : `#${hash}`}`,
         }),
   };
 }
@@ -73,8 +73,8 @@ export function requireLocatedObjectUri(uri: string): {
 function formatWikiGraphUriExpectedError(value: string): string {
   const example =
     value.endsWith(".sdpub") && value.startsWith("/")
-      ? `wikigraph://${value}`
-      : "wikigraph:///absolute/path/book.sdpub";
+      ? `wkg://${value}`
+      : "wkg:///absolute/path/book.sdpub";
 
   return [
     `Expected a Wiki Graph URI with a .sdpub archive locator: ${value}`,

--- a/src/facade/archive-view.ts
+++ b/src/facade/archive-view.ts
@@ -955,7 +955,7 @@ export async function readArchivePage(
   id: string,
   options: ArchivePageOptions = {},
 ): Promise<ArchivePage> {
-  if (id.startsWith("wikigraph://")) {
+  if (id.startsWith("wkg://")) {
     return await readWikiGraphPage(document, id, options);
   }
 
@@ -1190,7 +1190,7 @@ export async function listRelatedArchiveObjects(
   document: ReadonlyDocument,
   id: string,
 ): Promise<readonly ArchiveListItem[]> {
-  if (id.startsWith("wikigraph://")) {
+  if (id.startsWith("wkg://")) {
     return await listRelatedWikiGraphObjects(document, id);
   }
 
@@ -1569,7 +1569,7 @@ function findEntities(
       hit: {
         chapter: mention.chapterId,
         field: "title" as const,
-        id: `wikigraph://entity/${mention.qid}`,
+        id: `wkg://entity/${mention.qid}`,
         ...createFindMatchFields(match),
         position: {
           chapter: mention.chapterId,
@@ -1740,7 +1740,7 @@ function listEntityCollection(
         createUnscoredEntityEvidenceMention(mention),
       ),
       field: "title",
-      id: `wikigraph://entity/${qid}`,
+      id: `wkg://entity/${qid}`,
       position: {
         chapter: first.chapterId,
         fragment: first.fragmentId,
@@ -1999,11 +1999,11 @@ function formatTripleUri(
   predicate: string,
   objectQid: string,
 ): string {
-  return `wikigraph://triple/${subjectQid}/${encodeURIComponent(predicate)}/${objectQid}`;
+  return `wkg://triple/${subjectQid}/${encodeURIComponent(predicate)}/${objectQid}`;
 }
 
 function formatEntityUri(qid: string): string {
-  return `wikigraph://entity/${qid}`;
+  return `wkg://entity/${qid}`;
 }
 
 function isEntityOnlySearch(options: ArchiveFindOptions): boolean {
@@ -2083,7 +2083,7 @@ function toMentionRecord(hit: EntitySearchMentionHit): MentionRecord {
 }
 
 function parseEntityQid(id: string): string | undefined {
-  const prefix = "wikigraph://entity/";
+  const prefix = "wkg://entity/";
 
   return id.startsWith(prefix) ? id.slice(prefix.length) : undefined;
 }
@@ -3075,7 +3075,7 @@ function formatSourceRangeUri(
   startSentenceIndex: number,
   endSentenceIndex: number,
 ): string {
-  return `wikigraph://chapter/${chapterId}/source/${fragmentId}#${startSentenceIndex}..${endSentenceIndex}`;
+  return `wkg://chapter/${chapterId}/source/${fragmentId}#${startSentenceIndex}..${endSentenceIndex}`;
 }
 
 function mergeEvidenceRanges(
@@ -3163,7 +3163,7 @@ type WikiGraphReference =
     };
 
 function parseWikiGraphReference(uri: string): WikiGraphReference {
-  if (!uri.startsWith("wikigraph://")) {
+  if (!uri.startsWith("wkg://")) {
     const archiveReference = parseArchiveReference(uri);
 
     switch (archiveReference.type) {
@@ -3184,14 +3184,12 @@ function parseWikiGraphReference(uri: string): WikiGraphReference {
     }
   }
 
-  if (uri === "wikigraph://") {
+  if (uri === "wkg://") {
     return { type: "meta" };
   }
 
-  const parsed = new URL(uri);
-  const pathParts = [parsed.hostname, ...parsed.pathname.split("/")].filter(
-    (part) => part !== "",
-  );
+  const [rawPath = "", hash = ""] = uri.slice("wkg://".length).split("#", 2);
+  const pathParts = rawPath.split("/").filter((part) => part !== "");
 
   if (pathParts.length === 0) {
     return { type: "meta" };
@@ -3233,7 +3231,7 @@ function parseWikiGraphReference(uri: string): WikiGraphReference {
             break;
           case "source":
             if (pathParts.length === 3 || pathParts.length === 4) {
-              const [start, end] = parseSentenceRange(parsed.hash);
+              const [start, end] = parseSentenceRange(hash);
               const fragmentId =
                 pathParts[3] === undefined
                   ? undefined

--- a/src/facade/continuation-cursor.ts
+++ b/src/facade/continuation-cursor.ts
@@ -2,11 +2,7 @@ import { randomBytes } from "crypto";
 import { join, resolve } from "path";
 
 import { resolveWikiGraphStateDirectoryPath } from "../common/wiki-graph-dir.js";
-import {
-  getNumber,
-  getOptionalString,
-  getString,
-} from "../document/database.js";
+import { getOptionalString, getString } from "../document/database.js";
 import { openSharedStateDatabase } from "../document/index.js";
 import type { Database } from "../document/index.js";
 
@@ -20,7 +16,6 @@ export type ContinuationCursor =
       readonly format: "json" | "jsonl" | "text";
       readonly ids: readonly string[] | null;
       readonly kind: "collection";
-      readonly limit: number;
       readonly order: "doc-asc" | "doc-desc";
       readonly types: readonly string[] | null;
     }
@@ -31,7 +26,6 @@ export type ContinuationCursor =
       readonly evidenceLimit?: number;
       readonly format: "json" | "jsonl" | "text";
       readonly kind: "search";
-      readonly limit: number;
       readonly types: readonly string[] | null;
     }
   | {
@@ -40,7 +34,6 @@ export type ContinuationCursor =
       readonly cursor: string;
       readonly format: "json" | "jsonl" | "text";
       readonly kind: "evidence";
-      readonly limit: number;
       readonly targetUri: string;
     };
 
@@ -90,7 +83,7 @@ export async function createContinuationCursor(
         input.kind,
         JSON.stringify(createCursorPayload(input)),
         input.format,
-        input.limit,
+        1,
         now,
         now + CURSOR_TTL_MS,
         now,
@@ -113,7 +106,7 @@ export async function readContinuationCursor(
 
     const record = await database.queryOne(
       `
-        SELECT archive_key, archive_path, kind, payload_json, format, limit_value
+        SELECT archive_key, archive_path, kind, payload_json, format
         FROM continuation_cursors
         WHERE cursor_id = ?
       `,
@@ -123,7 +116,6 @@ export async function readContinuationCursor(
         archivePath: getString(row, "archive_path"),
         format: parseCursorFormat(getString(row, "format")),
         kind: getString(row, "kind"),
-        limit: getNumber(row, "limit_value"),
         payloadJSON: getString(row, "payload_json"),
       }),
     );
@@ -179,7 +171,6 @@ function parseContinuationCursorRecord(record: {
   readonly archivePath: string;
   readonly format: "json" | "jsonl" | "text";
   readonly kind: string;
-  readonly limit: number;
   readonly payloadJSON: string;
 }): ContinuationCursor {
   const payload = parsePayload(record.payloadJSON);
@@ -194,7 +185,6 @@ function parseContinuationCursorRecord(record: {
       format: record.format,
       ids: getPayloadStringArrayOrNull(payload, "ids"),
       kind: "collection",
-      limit: record.limit,
       order: getPayloadOrder(payload),
       types: getPayloadStringArrayOrNull(payload, "types"),
     };
@@ -208,7 +198,6 @@ function parseContinuationCursorRecord(record: {
       ...getPayloadOptionalPositiveInteger(payload, "evidenceLimit"),
       format: record.format,
       kind: "search",
-      limit: record.limit,
       types: getPayloadStringArrayOrNull(payload, "types"),
     };
   }
@@ -220,7 +209,6 @@ function parseContinuationCursorRecord(record: {
       cursor: getPayloadString(payload, "cursor"),
       format: record.format,
       kind: "evidence",
-      limit: record.limit,
       targetUri: getPayloadString(payload, "targetUri"),
     };
   }

--- a/src/facade/search-cache.ts
+++ b/src/facade/search-cache.ts
@@ -884,7 +884,7 @@ function mapEntitySearchObjectRow(
       total: getNumber(row, "evidence_count"),
     },
     field: "title",
-    id: `wikigraph://entity/${qid}`,
+    id: `wkg://entity/${qid}`,
     matchCount: getNumber(row, "match_count"),
     matchedTerms,
     missingTerms,

--- a/src/facade/spine-digest.ts
+++ b/src/facade/spine-digest.ts
@@ -106,7 +106,7 @@ export class SpineDigest {
 
       if (record === undefined) {
         throw new Error(
-          `No completed summary exists for id ${serialId}. Use \`wikigraph list wikigraph://<archive.sdpub> --type chapter\` to discover chapter ids, then \`wikigraph get wikigraph://<archive.sdpub>/chapter/${serialId}/summary/\` after summary is ready.`,
+          `No completed summary exists for id ${serialId}. Use \`wikigraph wkg://<archive.sdpub> list --type chapter\` to discover chapter ids, then \`wikigraph wkg://<archive.sdpub>/chapter/${serialId}/summary/ get\` after summary is ready.`,
         );
       }
 

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -579,7 +579,7 @@ export async function readSerial(
 
   if (summary === undefined) {
     throw new Error(
-      `Chapter ${serialId} summary is missing. Run \`wikigraph queue add <archive.sdpub> --chapter ${serialId} --task reading-summary --accept-cost\` before export, or inspect the chapter with \`wikigraph get wikigraph://<archive.sdpub>/chapter/${serialId}/source/\`.`,
+      `Chapter ${serialId} summary is missing. Run \`wikigraph queue add <archive.sdpub> --chapter ${serialId} --task reading-summary --accept-cost\` before export, or inspect the chapter with \`wikigraph wkg://<archive.sdpub>/chapter/${serialId}/source/ get\`.`,
     );
   }
 

--- a/src/wikipage/wikimedia-client.ts
+++ b/src/wikipage/wikimedia-client.ts
@@ -274,7 +274,7 @@ export function replaceTitleUriWithQidUri(
       const title = decodeURIComponent(encodedTitle);
       const qid = titleToQid.get(title);
 
-      return qid === undefined ? label : `[[${label}|wikigraph://qid=${qid}]]`;
+      return qid === undefined ? label : `[[${label}|wkg://qid=${qid}]]`;
     },
   );
 }

--- a/test/cli/archive.test.ts
+++ b/test/cli/archive.test.ts
@@ -363,7 +363,6 @@ vi.mock("../../src/facade/index.js", () => ({
       cursor: "raw-search-cursor",
       format: "json",
       kind: "search",
-      limit: 20,
       types: ["entity"],
     }),
   ),
@@ -504,7 +503,6 @@ describe("cli/archive", () => {
       format: "json",
       ids: null,
       kind: "collection",
-      limit: 20,
       order: "doc-asc",
       types: ["entity"],
     });
@@ -519,7 +517,6 @@ describe("cli/archive", () => {
       format: "json",
       ids: null,
       kind: "collection",
-      limit: 20,
       order: "doc-asc",
       types: ["entity"],
     });
@@ -783,6 +780,22 @@ describe("cli/archive", () => {
     });
   });
 
+  it("uses the next command limit instead of cursor state", async () => {
+    await runArchiveCommand({
+      action: "next",
+      archivePath: "c_next",
+      format: "json",
+      limit: 7,
+    });
+
+    expect(findArchiveObjects).toHaveBeenCalledWith({}, "", {
+      archiveKey: "/tmp/book.sdpub",
+      cursor: "raw-search-cursor",
+      limit: 7,
+      types: ["entity"],
+    });
+  });
+
   it("preserves evidence preview limits on search continuation cursors", async () => {
     vi.mocked(findArchiveObjects).mockResolvedValueOnce({
       chapters: null,
@@ -814,7 +827,6 @@ describe("cli/archive", () => {
       evidenceLimit: 4,
       format: "json",
       kind: "search",
-      limit: 20,
       types: ["entity"],
     });
   });
@@ -863,7 +875,6 @@ describe("cli/archive", () => {
       cursor: "raw-next-evidence-cursor",
       format: "json",
       kind: "evidence",
-      limit: 4,
       targetUri: "wikigraph://entity/Q1",
     });
   });

--- a/test/cli/archive.test.ts
+++ b/test/cli/archive.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   ArchiveCollectionResult,
+  ArchiveEvidence,
   ArchiveFindHit,
   ArchivePage,
 } from "../../src/facade/archive-view.js";
@@ -135,7 +136,7 @@ const archiveMockState = vi.hoisted(() => ({
     ],
     limit: 20,
     nextCursor: null,
-  },
+  } satisfies ArchiveEvidence,
   listItems: [
     {
       id: "node:11",
@@ -1226,6 +1227,29 @@ describe("cli/archive", () => {
     expect(listArchiveEvidence).toHaveBeenCalledWith({}, "wkg://entity/Q1", {
       cursor: "cursor-1",
       limit: 3,
+    });
+  });
+
+  it("creates evidence continuation cursors with the target URI", async () => {
+    vi.mocked(listArchiveEvidence).mockResolvedValueOnce({
+      ...archiveMockState.evidence,
+      nextCursor: "raw-next-evidence-cursor",
+    });
+
+    await runArchiveCommand({
+      action: "evidence",
+      archivePath: "wkg:///tmp/book.sdpub",
+      format: "json",
+      objectId: "wkg:///tmp/book.sdpub/entity/Q1",
+    });
+
+    expect(createContinuationCursor).toHaveBeenCalledWith({
+      archiveKey: "/tmp/book.sdpub",
+      archivePath: "/tmp/book.sdpub",
+      cursor: "raw-next-evidence-cursor",
+      format: "json",
+      kind: "evidence",
+      targetUri: "wkg://entity/Q1",
     });
   });
 

--- a/test/cli/archive.test.ts
+++ b/test/cli/archive.test.ts
@@ -506,7 +506,7 @@ describe("cli/archive", () => {
     });
 
     expect(archiveMockState.textWrites[0]).toContain(
-      "More evidence: wikigraph next c_more_evidence",
+      "2 more evidence: wikigraph next c_more_evidence",
     );
     expect(archiveMockState.textWrites[0]).toContain(
       "Next page: wikigraph next c_more_results",
@@ -1048,9 +1048,8 @@ describe("cli/archive", () => {
       objectId: "wikigraph:///tmp/book.sdpub/entity/Q1",
     });
 
-    expect(archiveMockState.textWrites[0]).toContain("2 evidence more...");
     expect(archiveMockState.textWrites[0]).toContain(
-      "More evidence: wikigraph next c_more_evidence",
+      "2 more evidence: wikigraph next c_more_evidence",
     );
     expect(archiveMockState.textWrites[0]).not.toContain("Next page:");
   });

--- a/test/cli/archive.test.ts
+++ b/test/cli/archive.test.ts
@@ -17,7 +17,7 @@ const archiveMockState = vi.hoisted(() => ({
             chapterId: 2,
             endSentenceIndex: 1,
             fragmentId: 0,
-            id: "wikigraph://chapter/2/source/0#0..1",
+            id: "wkg://chapter/2/source/0#0..1",
             source: "RAG original source fragment.",
             startSentenceIndex: 0,
             title: "Chapter 2",
@@ -27,7 +27,7 @@ const archiveMockState = vi.hoisted(() => ({
         total: 3,
       },
       field: "title",
-      id: "wikigraph://entity/Q1",
+      id: "wkg://entity/Q1",
       matchedTerms: ["rag"],
       position: { chapter: 2, fragment: 0 },
       score: 1,
@@ -47,7 +47,7 @@ const archiveMockState = vi.hoisted(() => ({
             chapterId: 2,
             endSentenceIndex: 1,
             fragmentId: 0,
-            id: "wikigraph://chapter/2/source/0#0..1",
+            id: "wkg://chapter/2/source/0#0..1",
             source: "RAG original source fragment.",
             startSentenceIndex: 0,
             title: "Chapter 2",
@@ -57,7 +57,7 @@ const archiveMockState = vi.hoisted(() => ({
         total: 1,
       },
       field: "title",
-      id: "wikigraph://triple/Q1/mentions/Q2",
+      id: "wkg://triple/Q1/mentions/Q2",
       position: { chapter: 2, fragment: 0 },
       snippet: "RAG mentions agent",
       title: "Q1 mentions Q2",
@@ -115,7 +115,7 @@ const archiveMockState = vi.hoisted(() => ({
         chapterId: 2,
         endSentenceIndex: 1,
         fragmentId: 0,
-        id: "wikigraph://chapter/2/source/0#0..1",
+        id: "wkg://chapter/2/source/0#0..1",
         source:
           "\n\t\nRAG original source fragment.\n   \n\t\nSecond paragraph.\n\n",
         startSentenceIndex: 0,
@@ -126,7 +126,7 @@ const archiveMockState = vi.hoisted(() => ({
         chapterId: 2,
         endSentenceIndex: 3,
         fragmentId: 0,
-        id: "wikigraph://chapter/2/source/0#3..3",
+        id: "wkg://chapter/2/source/0#3..3",
         source: "Follow-up source fragment.",
         startSentenceIndex: 3,
         title: "Chapter 2",
@@ -144,7 +144,7 @@ const archiveMockState = vi.hoisted(() => ({
       type: "node",
     },
     {
-      id: "wikigraph://triple/Q1/mentions/Q2",
+      id: "wkg://triple/Q1/mentions/Q2",
       label: "RAG mentions agent",
       objectLabel: "agent",
       objectQid: "Q2",
@@ -162,7 +162,7 @@ const archiveMockState = vi.hoisted(() => ({
       {
         chapter: 2,
         field: "title",
-        id: "wikigraph://entity/Q1",
+        id: "wkg://entity/Q1",
         position: { chapter: 2, fragment: 0 },
         snippet: "1 mentions",
         title: "RAG",
@@ -214,7 +214,7 @@ const archiveMockState = vi.hoisted(() => ({
           chapterId: 2,
           endSentenceIndex: 1,
           fragmentId: 0,
-          id: "wikigraph://chapter/2/source/0#0..1",
+          id: "wkg://chapter/2/source/0#0..1",
           source: "RAG original source fragment.",
           startSentenceIndex: 0,
           title: "Chapter 2",
@@ -223,7 +223,7 @@ const archiveMockState = vi.hoisted(() => ({
       ],
       total: 1,
     },
-    id: "wikigraph://entity/Q1",
+    id: "wkg://entity/Q1",
     label: "RAG",
     labels: [
       "RAG",
@@ -248,7 +248,7 @@ const archiveMockState = vi.hoisted(() => ({
           chapterId: 2,
           endSentenceIndex: 1,
           fragmentId: 0,
-          id: "wikigraph://chapter/2/source/0#0..1",
+          id: "wkg://chapter/2/source/0#0..1",
           source:
             "\n\t\nRAG original source fragment.\n   \n\t\nSecond paragraph.\n\n",
           startSentenceIndex: 0,
@@ -259,7 +259,7 @@ const archiveMockState = vi.hoisted(() => ({
           chapterId: 2,
           endSentenceIndex: 3,
           fragmentId: 0,
-          id: "wikigraph://chapter/2/source/0#3..3",
+          id: "wkg://chapter/2/source/0#3..3",
           source: "Follow-up source fragment.",
           startSentenceIndex: 3,
           title: "Chapter 2",
@@ -268,7 +268,7 @@ const archiveMockState = vi.hoisted(() => ({
       ],
       total: 2,
     },
-    id: "wikigraph://triple/Q1/mentions/Q2",
+    id: "wkg://triple/Q1/mentions/Q2",
     label: "RAG(Q1) mentions agent(Q2)",
     objectQid: "Q2",
     predicate: "mentions",
@@ -371,13 +371,13 @@ vi.mock("../../src/facade/index.js", () => ({
   ),
   readArchivePage: vi.fn((_document: unknown, id: string) =>
     Promise.resolve(
-      id === "wikigraph://entity/Q1"
+      id === "wkg://entity/Q1"
         ? archiveMockState.entityPage
-        : id === "wikigraph://triple/Q1/mentions/Q2"
+        : id === "wkg://triple/Q1/mentions/Q2"
           ? archiveMockState.triplePage
-          : id === "wikigraph://chapter/2"
+          : id === "wkg://chapter/2"
             ? archiveMockState.chapterPage
-            : id === "wikigraph://"
+            : id === "wkg://"
               ? archiveMockState.metaPage
               : archiveMockState.page,
     ),
@@ -427,13 +427,13 @@ describe("cli/archive", () => {
   it("prints search hits as Wiki Graph URI objects", async () => {
     await runArchiveCommand({
       action: "search",
-      archivePath: "wikigraph:///tmp/book.sdpub",
+      archivePath: "wkg:///tmp/book.sdpub",
       format: "text",
       kinds: ["chunk"],
       query: "RAG",
     });
 
-    expect(archiveMockState.textWrites[0]).toContain("wikigraph://chunk/9");
+    expect(archiveMockState.textWrites[0]).toContain("wkg://chunk/9");
     expect(archiveMockState.textWrites[0]).toContain("Retrieval design");
     expect(findArchiveObjects).toHaveBeenCalledWith({}, "RAG", {
       archiveKey: "/tmp/book.sdpub",
@@ -444,7 +444,7 @@ describe("cli/archive", () => {
   it("passes entity search kinds to archive search", async () => {
     await runArchiveCommand({
       action: "search",
-      archivePath: "wikigraph:///tmp/book.sdpub",
+      archivePath: "wkg:///tmp/book.sdpub",
       evidenceLimit: 3,
       format: "text",
       kinds: ["entity"],
@@ -456,10 +456,10 @@ describe("cli/archive", () => {
       evidenceLimit: 3,
       types: ["entity"],
     });
-    expect(archiveMockState.textWrites[0]).toContain("1 wikigraph://entity/Q1");
+    expect(archiveMockState.textWrites[0]).toContain("1 wkg://entity/Q1");
     expect(archiveMockState.textWrites[0]).toContain("-- evidence 1/1");
     expect(archiveMockState.textWrites[0]).toContain(
-      "@@ wikigraph://chapter/2/source/0#0..1 @@",
+      "@@ wkg://chapter/2/source/0#0..1 @@",
     );
     expect(archiveMockState.textWrites[0]).toContain("2 evidence more...");
   });
@@ -498,7 +498,7 @@ describe("cli/archive", () => {
 
     await runArchiveCommand({
       action: "search",
-      archivePath: "wikigraph:///tmp/book.sdpub",
+      archivePath: "wkg:///tmp/book.sdpub",
       evidenceLimit: 1,
       format: "text",
       kinds: ["entity"],
@@ -516,7 +516,7 @@ describe("cli/archive", () => {
   it("prints listed archive objects as Wiki Graph URI objects", async () => {
     await runArchiveCommand({
       action: "list",
-      archivePath: "wikigraph:///tmp/book.sdpub/chapter/2",
+      archivePath: "wkg:///tmp/book.sdpub/chapter/2",
       format: "text",
       kinds: ["entity"],
     });
@@ -528,7 +528,7 @@ describe("cli/archive", () => {
         types: ["entity"],
       },
     );
-    expect(archiveMockState.textWrites[0]).toContain("wikigraph://entity/Q1");
+    expect(archiveMockState.textWrites[0]).toContain("wkg://entity/Q1");
     expect(archiveMockState.textWrites[0]).toContain("RAG");
   });
 
@@ -540,7 +540,7 @@ describe("cli/archive", () => {
 
     await runArchiveCommand({
       action: "list",
-      archivePath: "wikigraph:///tmp/book.sdpub/chapter/2",
+      archivePath: "wkg:///tmp/book.sdpub/chapter/2",
       evidenceLimit: 3,
       format: "json",
       kinds: ["entity"],
@@ -595,7 +595,7 @@ describe("cli/archive", () => {
       nextCursor: null,
       objects: [
         {
-          uri: "wikigraph://entity/Q1",
+          uri: "wkg://entity/Q1",
         },
       ],
     });
@@ -609,7 +609,7 @@ describe("cli/archive", () => {
 
     await runArchiveCommand({
       action: "list",
-      archivePath: "wikigraph:///tmp/book.sdpub/chapter/2",
+      archivePath: "wkg:///tmp/book.sdpub/chapter/2",
       evidenceLimit: 3,
       format: "json",
       kinds: ["entity"],
@@ -634,7 +634,7 @@ describe("cli/archive", () => {
             sources: [
               {
                 text: "RAG original source fragment.",
-                uri: "wikigraph://chapter/2/source/0#0..1",
+                uri: "wkg://chapter/2/source/0#0..1",
               },
             ],
             total: 3,
@@ -642,7 +642,7 @@ describe("cli/archive", () => {
           label: "RAG",
           score: 1,
           type: "entity",
-          uri: "wikigraph://entity/Q1",
+          uri: "wkg://entity/Q1",
         },
       ],
     });
@@ -670,7 +670,7 @@ describe("cli/archive", () => {
 
     await runArchiveCommand({
       action: "list",
-      archivePath: "wikigraph:///tmp/book.sdpub/chapter/2",
+      archivePath: "wkg:///tmp/book.sdpub/chapter/2",
       evidenceLimit: 1,
       format: "json",
       kinds: ["entity"],
@@ -681,7 +681,7 @@ describe("cli/archive", () => {
       expect.objectContaining({
         cursor: "raw-evidence-cursor",
         kind: "evidence",
-        targetUri: "wikigraph://entity/Q1",
+        targetUri: "wkg://entity/Q1",
       }),
     );
     expect(createContinuationCursor).toHaveBeenNthCalledWith(
@@ -712,7 +712,7 @@ describe("cli/archive", () => {
 
     await runArchiveCommand({
       action: "list",
-      archivePath: "wikigraph:///tmp/book.sdpub/chapter/2",
+      archivePath: "wkg:///tmp/book.sdpub/chapter/2",
       evidenceLimit: 3,
       format: "json",
       kinds: ["triple"],
@@ -737,7 +737,7 @@ describe("cli/archive", () => {
             sources: [
               {
                 text: "RAG original source fragment.",
-                uri: "wikigraph://chapter/2/source/0#0..1",
+                uri: "wkg://chapter/2/source/0#0..1",
               },
             ],
             total: 1,
@@ -745,7 +745,7 @@ describe("cli/archive", () => {
           objectLabel: "agent",
           predicate: "mentions",
           subjectLabel: "RAG",
-          uri: "wikigraph://triple/Q1/mentions/Q2",
+          uri: "wkg://triple/Q1/mentions/Q2",
         },
       ],
     });
@@ -757,7 +757,7 @@ describe("cli/archive", () => {
   it("prints search objects as JSON", async () => {
     await runArchiveCommand({
       action: "search",
-      archivePath: "wikigraph:///tmp/book.sdpub",
+      archivePath: "wkg:///tmp/book.sdpub",
       format: "json",
       kinds: ["entity"],
       query: "RAG",
@@ -772,13 +772,13 @@ describe("cli/archive", () => {
           score: 1,
           summary: "RAG original source fragment.",
           type: "entity",
-          uri: "wikigraph://entity/Q1",
+          uri: "wkg://entity/Q1",
         },
       ],
     });
     expect(archiveMockState.textWrites[0]).toContain(
       [
-        '      "uri": "wikigraph://entity/Q1"',
+        '      "uri": "wkg://entity/Q1"',
         '      "type": "entity"',
         '      "label": "RAG"',
         '      "score": 1',
@@ -791,15 +791,13 @@ describe("cli/archive", () => {
   it("prints search cursor metadata as JSONL", async () => {
     await runArchiveCommand({
       action: "search",
-      archivePath: "wikigraph:///tmp/book.sdpub",
+      archivePath: "wkg:///tmp/book.sdpub",
       format: "jsonl",
       kinds: ["entity"],
       query: "RAG",
     });
 
-    expect(archiveMockState.textWrites[0]).toContain(
-      '"uri":"wikigraph://entity/Q1"',
-    );
+    expect(archiveMockState.textWrites[0]).toContain('"uri":"wkg://entity/Q1"');
     expect(parseJSONLLastLine(archiveMockState.textWrites[0])).toStrictEqual({
       nextCursor: null,
       type: "page",
@@ -826,7 +824,7 @@ describe("cli/archive", () => {
       nextCursor: null,
       objects: [
         {
-          uri: "wikigraph://entity/Q1",
+          uri: "wkg://entity/Q1",
         },
       ],
     });
@@ -865,7 +863,7 @@ describe("cli/archive", () => {
 
     await runArchiveCommand({
       action: "search",
-      archivePath: "wikigraph:///tmp/book.sdpub",
+      archivePath: "wkg:///tmp/book.sdpub",
       evidenceLimit: 4,
       format: "json",
       kinds: ["entity"],
@@ -914,7 +912,7 @@ describe("cli/archive", () => {
 
     await runArchiveCommand({
       action: "search",
-      archivePath: "wikigraph:///tmp/book.sdpub",
+      archivePath: "wkg:///tmp/book.sdpub",
       evidenceLimit: 4,
       format: "json",
       kinds: ["entity"],
@@ -927,19 +925,19 @@ describe("cli/archive", () => {
       cursor: "raw-next-evidence-cursor",
       format: "json",
       kind: "evidence",
-      targetUri: "wikigraph://entity/Q1",
+      targetUri: "wkg://entity/Q1",
     });
   });
 
   it("gets an object by Wiki Graph URI", async () => {
     await runArchiveCommand({
       action: "get",
-      archivePath: "wikigraph:///tmp/book.sdpub",
+      archivePath: "wkg:///tmp/book.sdpub",
       format: "text",
-      objectId: "wikigraph:///tmp/book.sdpub/chunk/9",
+      objectId: "wkg:///tmp/book.sdpub/chunk/9",
     });
 
-    expect(readArchivePage).toHaveBeenCalledWith({}, "wikigraph://chunk/9", {});
+    expect(readArchivePage).toHaveBeenCalledWith({}, "wkg://chunk/9", {});
     expect(archiveMockState.textWrites[0]).toContain("node:9");
     expect(archiveMockState.textWrites[0]).toContain("Source Fragments:");
   });
@@ -947,18 +945,14 @@ describe("cli/archive", () => {
   it("gets a chapter as a minimal object", async () => {
     await runArchiveCommand({
       action: "get",
-      archivePath: "wikigraph:///tmp/book.sdpub",
+      archivePath: "wkg:///tmp/book.sdpub",
       format: "json",
-      objectId: "wikigraph:///tmp/book.sdpub/chapter/2",
+      objectId: "wkg:///tmp/book.sdpub/chapter/2",
     });
 
-    expect(readArchivePage).toHaveBeenCalledWith(
-      {},
-      "wikigraph://chapter/2",
-      {},
-    );
+    expect(readArchivePage).toHaveBeenCalledWith({}, "wkg://chapter/2", {});
     expect(JSON.parse(archiveMockState.textWrites[0] ?? "")).toStrictEqual({
-      uri: "wikigraph://chapter/2",
+      uri: "wkg://chapter/2",
       title: "Chapter 2",
       stage: "reading-graph",
     });
@@ -967,15 +961,15 @@ describe("cli/archive", () => {
   it("gets archive metadata from a root object URI", async () => {
     await runArchiveCommand({
       action: "get",
-      archivePath: "wikigraph:///tmp/book.sdpub",
+      archivePath: "wkg:///tmp/book.sdpub",
       format: "text",
-      objectId: "wikigraph:///tmp/book.sdpub/",
+      objectId: "wkg:///tmp/book.sdpub/",
     });
 
-    expect(readArchivePage).toHaveBeenCalledWith({}, "wikigraph://", {});
+    expect(readArchivePage).toHaveBeenCalledWith({}, "wkg://", {});
     expect(archiveMockState.textWrites[0]).toBe(
       [
-        "uri: wikigraph://",
+        "uri: wkg://",
         "title: Archive Fixture",
         "authors: Archive Author",
         "publisher: Archive Press",
@@ -988,17 +982,17 @@ describe("cli/archive", () => {
   it("gets an entity by Wiki Graph URI", async () => {
     await runArchiveCommand({
       action: "get",
-      archivePath: "wikigraph:///tmp/book.sdpub",
+      archivePath: "wkg:///tmp/book.sdpub",
       evidenceLimit: 3,
       format: "json",
-      objectId: "wikigraph:///tmp/book.sdpub/entity/Q1",
+      objectId: "wkg:///tmp/book.sdpub/entity/Q1",
     });
 
-    expect(readArchivePage).toHaveBeenCalledWith({}, "wikigraph://entity/Q1", {
+    expect(readArchivePage).toHaveBeenCalledWith({}, "wkg://entity/Q1", {
       evidenceLimit: 3,
     });
     expect(JSON.parse(archiveMockState.textWrites[0] ?? "")).toStrictEqual({
-      uri: "wikigraph://entity/Q1",
+      uri: "wkg://entity/Q1",
       labels: [
         "RAG",
         "retrieval-augmented generation",
@@ -1014,7 +1008,7 @@ describe("cli/archive", () => {
         shown: 1,
         sources: [
           {
-            uri: "wikigraph://chapter/2/source/0#0..1",
+            uri: "wkg://chapter/2/source/0#0..1",
             text: "RAG original source fragment.",
           },
         ],
@@ -1022,9 +1016,7 @@ describe("cli/archive", () => {
       },
     });
     expect(archiveMockState.textWrites[0]).toContain(
-      ['  "uri": "wikigraph://entity/Q1",', '  "labels": [', '    "RAG",'].join(
-        "\n",
-      ),
+      ['  "uri": "wkg://entity/Q1",', '  "labels": [', '    "RAG",'].join("\n"),
     );
   });
 
@@ -1042,10 +1034,10 @@ describe("cli/archive", () => {
 
     await runArchiveCommand({
       action: "get",
-      archivePath: "wikigraph:///tmp/book.sdpub",
+      archivePath: "wkg:///tmp/book.sdpub",
       evidenceLimit: 1,
       format: "text",
-      objectId: "wikigraph:///tmp/book.sdpub/entity/Q1",
+      objectId: "wkg:///tmp/book.sdpub/entity/Q1",
     });
 
     expect(archiveMockState.textWrites[0]).toContain(
@@ -1057,10 +1049,10 @@ describe("cli/archive", () => {
   it("gets a triple as concise JSON", async () => {
     await runArchiveCommand({
       action: "get",
-      archivePath: "wikigraph:///tmp/book.sdpub",
+      archivePath: "wkg:///tmp/book.sdpub",
       evidenceLimit: 3,
       format: "json",
-      objectId: "wikigraph:///tmp/book.sdpub/triple/Q1/mentions/Q2",
+      objectId: "wkg:///tmp/book.sdpub/triple/Q1/mentions/Q2",
     });
 
     const output = JSON.parse(archiveMockState.textWrites[0] ?? "") as Record<
@@ -1070,7 +1062,7 @@ describe("cli/archive", () => {
 
     expect(readArchivePage).toHaveBeenCalledWith(
       {},
-      "wikigraph://triple/Q1/mentions/Q2",
+      "wkg://triple/Q1/mentions/Q2",
       { evidenceLimit: 3 },
     );
     expect(output).toStrictEqual({
@@ -1080,17 +1072,17 @@ describe("cli/archive", () => {
         sources: [
           {
             text: "\n\t\nRAG original source fragment.\n   \n\t\nSecond paragraph.\n\n",
-            uri: "wikigraph://chapter/2/source/0#0..1",
+            uri: "wkg://chapter/2/source/0#0..1",
           },
           {
             text: "Follow-up source fragment.",
-            uri: "wikigraph://chapter/2/source/0#3..3",
+            uri: "wkg://chapter/2/source/0#3..3",
           },
         ],
         total: 2,
       },
       label: "RAG(Q1) mentions agent(Q2)",
-      uri: "wikigraph://triple/Q1/mentions/Q2",
+      uri: "wkg://triple/Q1/mentions/Q2",
     });
     expect(output).not.toHaveProperty("id");
     expect(output).not.toHaveProperty("subjectQid");
@@ -1101,24 +1093,21 @@ describe("cli/archive", () => {
   it("prints related objects", async () => {
     await runArchiveCommand({
       action: "related",
-      archivePath: "wikigraph:///tmp/book.sdpub",
+      archivePath: "wkg:///tmp/book.sdpub",
       format: "text",
-      objectId: "wikigraph:///tmp/book.sdpub/chunk/9",
+      objectId: "wkg:///tmp/book.sdpub/chunk/9",
     });
 
-    expect(listRelatedArchiveObjects).toHaveBeenCalledWith(
-      {},
-      "wikigraph://chunk/9",
-    );
-    expect(archiveMockState.textWrites[0]).toContain("wikigraph://chunk/11");
+    expect(listRelatedArchiveObjects).toHaveBeenCalledWith({}, "wkg://chunk/9");
+    expect(archiveMockState.textWrites[0]).toContain("wkg://chunk/11");
     expect(archiveMockState.textWrites[0]).toContain("Related");
     expect(archiveMockState.textWrites[0]).toContain(
       [
-        "wikigraph://chunk/11",
+        "wkg://chunk/11",
         "Related",
         "Related chunk",
         "",
-        "wikigraph://triple/Q1/mentions/Q2",
+        "wkg://triple/Q1/mentions/Q2",
         "RAG(Q1) mentions agent(Q2)",
       ].join("\n"),
     );
@@ -1128,9 +1117,9 @@ describe("cli/archive", () => {
   it("prints related triples as structured JSON", async () => {
     await runArchiveCommand({
       action: "related",
-      archivePath: "wikigraph:///tmp/book.sdpub",
+      archivePath: "wkg:///tmp/book.sdpub",
       format: "json",
-      objectId: "wikigraph:///tmp/book.sdpub/entity/Q1",
+      objectId: "wkg:///tmp/book.sdpub/entity/Q1",
     });
 
     expect(JSON.parse(archiveMockState.textWrites[0] ?? "")).toStrictEqual({
@@ -1141,10 +1130,10 @@ describe("cli/archive", () => {
           label: "Related",
           summary: "Related chunk",
           type: "node",
-          uri: "wikigraph://chunk/11",
+          uri: "wkg://chunk/11",
         },
         {
-          uri: "wikigraph://triple/Q1/mentions/Q2",
+          uri: "wkg://triple/Q1/mentions/Q2",
           predicate: "mentions",
           subjectLabel: "RAG",
           objectLabel: "agent",
@@ -1153,7 +1142,7 @@ describe("cli/archive", () => {
     });
     expect(archiveMockState.textWrites[0]).toContain(
       [
-        '      "uri": "wikigraph://triple/Q1/mentions/Q2",',
+        '      "uri": "wkg://triple/Q1/mentions/Q2",',
         '      "predicate": "mentions",',
         '      "subjectLabel": "RAG",',
         '      "objectLabel": "agent"',
@@ -1169,33 +1158,33 @@ describe("cli/archive", () => {
   it("prints evidence source ranges", async () => {
     await runArchiveCommand({
       action: "evidence",
-      archivePath: "wikigraph:///tmp/book.sdpub",
+      archivePath: "wkg:///tmp/book.sdpub",
       format: "text",
-      objectId: "wikigraph:///tmp/book.sdpub/triple/Q1/mentions/Q2",
+      objectId: "wkg:///tmp/book.sdpub/triple/Q1/mentions/Q2",
     });
 
     expect(listArchiveEvidence).toHaveBeenCalledWith(
       {},
-      "wikigraph://triple/Q1/mentions/Q2",
+      "wkg://triple/Q1/mentions/Q2",
       {},
     );
     expect(archiveMockState.textWrites[0]).toContain(
-      "wikigraph://chapter/2/source/0#0..1",
+      "wkg://chapter/2/source/0#0..1",
     );
     expect(archiveMockState.textWrites[0]).toContain(
-      "@@ wikigraph://chapter/2/source/0#0..1 @@",
+      "@@ wkg://chapter/2/source/0#0..1 @@",
     );
     expect(archiveMockState.textWrites[0]).toContain(
       "RAG original source fragment.",
     );
     expect(archiveMockState.textWrites[0]).toContain(
       [
-        "@@ wikigraph://chapter/2/source/0#0..1 @@",
+        "@@ wkg://chapter/2/source/0#0..1 @@",
         "RAG original source fragment.",
         "",
         "Second paragraph.",
         "",
-        "@@ wikigraph://chapter/2/source/0#3..3 @@",
+        "@@ wkg://chapter/2/source/0#3..3 @@",
         "Follow-up source fragment.",
       ].join("\n"),
     );
@@ -1204,21 +1193,21 @@ describe("cli/archive", () => {
   it("separates get evidence blocks with blank lines", async () => {
     await runArchiveCommand({
       action: "get",
-      archivePath: "wikigraph:///tmp/book.sdpub",
+      archivePath: "wkg:///tmp/book.sdpub",
       format: "text",
-      objectId: "wikigraph:///tmp/book.sdpub/triple/Q1/mentions/Q2",
+      objectId: "wkg:///tmp/book.sdpub/triple/Q1/mentions/Q2",
     });
 
     expect(archiveMockState.textWrites[0]).toContain(
       [
         "-- evidence 1/2",
-        "@@ wikigraph://chapter/2/source/0#0..1 @@",
+        "@@ wkg://chapter/2/source/0#0..1 @@",
         "RAG original source fragment.",
         "",
         "Second paragraph.",
         "",
         "-- evidence 2/2",
-        "@@ wikigraph://chapter/2/source/0#3..3 @@",
+        "@@ wkg://chapter/2/source/0#3..3 @@",
         "Follow-up source fragment.",
       ].join("\n"),
     );
@@ -1227,33 +1216,29 @@ describe("cli/archive", () => {
   it("passes evidence pagination options", async () => {
     await runArchiveCommand({
       action: "evidence",
-      archivePath: "wikigraph:///tmp/book.sdpub",
+      archivePath: "wkg:///tmp/book.sdpub",
       cursor: "cursor-1",
       format: "json",
       limit: 3,
-      objectId: "wikigraph:///tmp/book.sdpub/entity/Q1",
+      objectId: "wkg:///tmp/book.sdpub/entity/Q1",
     });
 
-    expect(listArchiveEvidence).toHaveBeenCalledWith(
-      {},
-      "wikigraph://entity/Q1",
-      {
-        cursor: "cursor-1",
-        limit: 3,
-      },
-    );
+    expect(listArchiveEvidence).toHaveBeenCalledWith({}, "wkg://entity/Q1", {
+      cursor: "cursor-1",
+      limit: 3,
+    });
   });
 
   it("prints evidence as JSONL", async () => {
     await runArchiveCommand({
       action: "evidence",
-      archivePath: "wikigraph:///tmp/book.sdpub",
+      archivePath: "wkg:///tmp/book.sdpub",
       format: "jsonl",
-      objectId: "wikigraph:///tmp/book.sdpub/entity/Q1",
+      objectId: "wkg:///tmp/book.sdpub/entity/Q1",
     });
 
     expect(archiveMockState.textWrites[0]).toContain(
-      '"uri":"wikigraph://chapter/2/source/0#0..1"',
+      '"uri":"wkg://chapter/2/source/0#0..1"',
     );
     expect(archiveMockState.textWrites[0]).not.toContain('"fragmentId"');
     expect(archiveMockState.textWrites[0]).not.toContain('"chapterId"');
@@ -1266,10 +1251,10 @@ describe("cli/archive", () => {
   it("prints a context pack", async () => {
     await runArchiveCommand({
       action: "pack",
-      archivePath: "wikigraph:///tmp/book.sdpub",
+      archivePath: "wkg:///tmp/book.sdpub",
       budget: 1000,
       format: "text",
-      objectId: "wikigraph:///tmp/book.sdpub/chunk/9",
+      objectId: "wkg:///tmp/book.sdpub/chunk/9",
     });
 
     expect(archiveMockState.textWrites[0]).toContain("Pack Budget: 1000");
@@ -1286,7 +1271,7 @@ describe("cli/archive", () => {
         query: "RAG",
       }),
     ).rejects.toThrow(
-      "Example: wikigraph:///tmp/book.sdpub\nSee: wikigraph help uri",
+      "Example: wkg:///tmp/book.sdpub\nSee: wikigraph help uri",
     );
   });
 });

--- a/test/cli/archive.test.ts
+++ b/test/cli/archive.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   ArchiveCollectionResult,
   ArchiveFindHit,
+  ArchivePage,
 } from "../../src/facade/archive-view.js";
 
 const archiveMockState = vi.hoisted(() => ({
@@ -206,6 +207,7 @@ const archiveMockState = vi.hoisted(() => ({
   },
   entityPage: {
     evidence: {
+      nextCursor: null,
       shown: 1,
       sources: [
         {
@@ -236,9 +238,10 @@ const archiveMockState = vi.hoisted(() => ({
     mentionCount: 1,
     qid: "Q1",
     type: "entity",
-  },
+  } satisfies ArchivePage,
   triplePage: {
     evidence: {
+      nextCursor: null,
       shown: 2,
       sources: [
         {
@@ -271,7 +274,7 @@ const archiveMockState = vi.hoisted(() => ({
     predicate: "mentions",
     subjectQid: "Q1",
     type: "triple",
-  },
+  } satisfies ArchivePage,
   readCalls: [] as string[],
   textWrites: [] as string[],
 }));
@@ -459,6 +462,55 @@ describe("cli/archive", () => {
       "@@ wikigraph://chapter/2/source/0#0..1 @@",
     );
     expect(archiveMockState.textWrites[0]).toContain("2 evidence more...");
+  });
+
+  it("prints text search continuation commands", async () => {
+    const [entityHit] = archiveMockState.entityFindHits;
+
+    if (entityHit === undefined) {
+      throw new Error("Missing entity fixture.");
+    }
+
+    vi.mocked(createContinuationCursor)
+      .mockResolvedValueOnce("c_more_evidence")
+      .mockResolvedValueOnce("c_more_results");
+    vi.mocked(findArchiveObjects).mockResolvedValueOnce({
+      chapters: null,
+      items: [
+        {
+          ...entityHit,
+          evidence: {
+            ...entityHit.evidence,
+            nextCursor: "raw-next-evidence-cursor",
+          },
+        },
+      ],
+      lens: "typed",
+      lensHint: null,
+      limit: 20,
+      match: "any",
+      nextCursor: "raw-next-search-cursor",
+      order: "doc-asc",
+      query: "RAG",
+      terms: ["rag"],
+      types: null,
+    });
+
+    await runArchiveCommand({
+      action: "search",
+      archivePath: "wikigraph:///tmp/book.sdpub",
+      evidenceLimit: 1,
+      format: "text",
+      kinds: ["entity"],
+      query: "RAG",
+    });
+
+    expect(archiveMockState.textWrites[0]).toContain(
+      "More evidence: wikigraph next c_more_evidence",
+    );
+    expect(archiveMockState.textWrites[0]).toContain(
+      "Next page: wikigraph next c_more_results",
+    );
   });
 
   it("prints listed archive objects as Wiki Graph URI objects", async () => {
@@ -974,6 +1026,33 @@ describe("cli/archive", () => {
         "\n",
       ),
     );
+  });
+
+  it("prints text get evidence continuation commands", async () => {
+    vi.mocked(createContinuationCursor).mockResolvedValueOnce(
+      "c_more_evidence",
+    );
+    vi.mocked(readArchivePage).mockResolvedValueOnce({
+      ...archiveMockState.entityPage,
+      evidence: Object.assign({}, archiveMockState.entityPage.evidence, {
+        nextCursor: "raw-next-evidence-cursor",
+        total: 3,
+      }),
+    });
+
+    await runArchiveCommand({
+      action: "get",
+      archivePath: "wikigraph:///tmp/book.sdpub",
+      evidenceLimit: 1,
+      format: "text",
+      objectId: "wikigraph:///tmp/book.sdpub/entity/Q1",
+    });
+
+    expect(archiveMockState.textWrites[0]).toContain("2 evidence more...");
+    expect(archiveMockState.textWrites[0]).toContain(
+      "More evidence: wikigraph next c_more_evidence",
+    );
+    expect(archiveMockState.textWrites[0]).not.toContain("Next page:");
   });
 
   it("gets a triple as concise JSON", async () => {

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -991,6 +991,9 @@ describe("cli/args", () => {
     expect(renderHelpTopicText("command")).toContain(
       "wikigraph <wikigraph-uri-with-sdpub-locator> search",
     );
+    expect(renderHelpTopicText("command")).toContain(
+      "wikigraph <entity|triple|summary|chunk-uri> evidence",
+    );
     expect(renderHelpTopicText("ai")).toContain("Primary contract:");
     expect(renderHelpTopicText("ai")).toContain(
       "Use Wiki Graph URIs as stable object handles",
@@ -1003,6 +1006,9 @@ describe("cli/args", () => {
     );
     expect(renderHelpTopicText("ai")).toContain(
       "wikigraph wkg:///Users/me/book.sdpub search",
+    );
+    expect(renderHelpTopicText("ai")).toContain(
+      "wkg:///absolute/path/book.sdpub/entity/Q8018",
     );
     expect(renderHelpTopicText("uri")).toContain(
       "Do not pass a bare filesystem path to object commands.",

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -319,8 +319,8 @@ describe("cli/args", () => {
 
     expect(
       parseCLIArguments([
+        "wkg://book.sdpub",
         "search",
-        "wikigraph://book.sdpub",
         "RAG",
         "--type",
         "meta,chapter,chunk",
@@ -329,7 +329,7 @@ describe("cli/args", () => {
     ).toStrictEqual({
       args: {
         action: "search",
-        archivePath: "wikigraph://book.sdpub",
+        archivePath: "wkg://book.sdpub",
         format: "json",
         kinds: ["meta", "chapter", "chunk"],
         query: "RAG",
@@ -340,8 +340,8 @@ describe("cli/args", () => {
 
     expect(
       parseCLIArguments([
+        "wkg://book.sdpub/chapter/11",
         "search",
-        "wikigraph://book.sdpub/chapter/11",
         "exact phrase",
         "--type",
         "summary,source",
@@ -354,7 +354,7 @@ describe("cli/args", () => {
     ).toStrictEqual({
       args: {
         action: "search",
-        archivePath: "wikigraph://book.sdpub/chapter/11",
+        archivePath: "wkg://book.sdpub/chapter/11",
         cursor: "cursor-token",
         format: "jsonl",
         kinds: ["summary", "source"],
@@ -366,11 +366,11 @@ describe("cli/args", () => {
     });
 
     expect(
-      parseCLIArguments(["list", "wikigraph://book.sdpub", "--type", "entity"]),
+      parseCLIArguments(["wkg://book.sdpub", "list", "--type", "entity"]),
     ).toStrictEqual({
       args: {
         action: "list",
-        archivePath: "wikigraph://book.sdpub",
+        archivePath: "wkg://book.sdpub",
         format: "text",
         kinds: ["entity"],
       },
@@ -379,26 +379,26 @@ describe("cli/args", () => {
     });
 
     expect(
-      parseCLIArguments(["get", "wikigraph://book.sdpub/chunk/1"]),
+      parseCLIArguments(["wkg://book.sdpub/chunk/1", "get"]),
     ).toStrictEqual({
       args: {
         action: "get",
-        archivePath: "wikigraph://book.sdpub/chunk/1",
+        archivePath: "wkg://book.sdpub/chunk/1",
         format: "text",
-        objectId: "wikigraph://book.sdpub/chunk/1",
+        objectId: "wkg://book.sdpub/chunk/1",
       },
       help: false,
       kind: "archive",
     });
 
     expect(
-      parseCLIArguments(["related", "wikigraph://book.sdpub/chunk/1"]),
+      parseCLIArguments(["wkg://book.sdpub/chunk/1", "related"]),
     ).toStrictEqual({
       args: {
         action: "related",
-        archivePath: "wikigraph://book.sdpub/chunk/1",
+        archivePath: "wkg://book.sdpub/chunk/1",
         format: "text",
-        objectId: "wikigraph://book.sdpub/chunk/1",
+        objectId: "wkg://book.sdpub/chunk/1",
       },
       help: false,
       kind: "archive",
@@ -406,16 +406,16 @@ describe("cli/args", () => {
 
     expect(
       parseCLIArguments([
+        "wkg://book.sdpub/triple/Q1/mentions/Q2",
         "evidence",
-        "wikigraph://book.sdpub/triple/Q1/mentions/Q2",
         "--jsonl",
       ]),
     ).toStrictEqual({
       args: {
         action: "evidence",
-        archivePath: "wikigraph://book.sdpub/triple/Q1/mentions/Q2",
+        archivePath: "wkg://book.sdpub/triple/Q1/mentions/Q2",
         format: "jsonl",
-        objectId: "wikigraph://book.sdpub/triple/Q1/mentions/Q2",
+        objectId: "wkg://book.sdpub/triple/Q1/mentions/Q2",
       },
       help: false,
       kind: "archive",
@@ -423,18 +423,18 @@ describe("cli/args", () => {
 
     expect(
       parseCLIArguments([
+        "wkg://book.sdpub/chunk/1",
         "pack",
-        "wikigraph://book.sdpub/chunk/1",
         "--budget",
         "2000",
       ]),
     ).toStrictEqual({
       args: {
         action: "pack",
-        archivePath: "wikigraph://book.sdpub/chunk/1",
+        archivePath: "wkg://book.sdpub/chunk/1",
         budget: 2000,
         format: "text",
-        objectId: "wikigraph://book.sdpub/chunk/1",
+        objectId: "wkg://book.sdpub/chunk/1",
       },
       help: false,
       kind: "archive",
@@ -443,13 +443,22 @@ describe("cli/args", () => {
     expect(() => parseCLIArguments(["find", "book.sdpub", "RAG"])).toThrow(
       "Unknown command: find.",
     );
-    expect(() =>
-      parseCLIArguments(["search", "wikigraph://book.sdpub"]),
-    ).toThrow("`wikigraph search` requires a search query.");
+    expect(
+      parseCLIArguments(["search", "wkg://book.sdpub", "RAG"]),
+    ).toMatchObject({
+      args: {
+        action: "search",
+        archivePath: "wkg://book.sdpub",
+        query: "RAG",
+      },
+    });
+    expect(() => parseCLIArguments(["wkg://book.sdpub", "search"])).toThrow(
+      "`wikigraph search` requires a search query.",
+    );
     expect(() =>
       parseCLIArguments([
+        "wkg://book.sdpub",
         "search",
-        "wikigraph://book.sdpub",
         "RAG",
         "--order",
         "doc-desc",
@@ -457,16 +466,16 @@ describe("cli/args", () => {
     ).toThrow("Unknown option '--order'.");
     expect(() =>
       parseCLIArguments([
+        "wkg://book.sdpub/chunk/1",
         "related",
-        "wikigraph://book.sdpub/chunk/1",
         "--type",
         "source",
       ]),
     ).toThrow("The `related` command does not support --type.");
     expect(() =>
       parseCLIArguments([
+        "wkg://book.sdpub/entity/Q1",
         "evidence",
-        "wikigraph://book.sdpub/entity/Q1",
         "--type",
         "entity",
       ]),
@@ -489,7 +498,7 @@ describe("cli/args", () => {
     expect(() =>
       parseCLIArguments([
         "search",
-        "wikigraph://book.sdpub",
+        "wkg://book.sdpub",
         "RAG",
         "--evidence",
         "-1",
@@ -953,10 +962,10 @@ describe("cli/args", () => {
 
     expect(rootHelpText).toContain("wikigraph help [topic]");
     expect(rootHelpText).toContain(
-      "wikigraph search <wikigraph-uri-with-sdpub-locator>",
+      "wikigraph <wikigraph-uri-with-sdpub-locator> search",
     );
     expect(rootHelpText).toContain(
-      "wikigraph list <wikigraph-uri-with-sdpub-locator>",
+      "wikigraph <wikigraph-uri-with-sdpub-locator> list",
     );
     expect(rootHelpText).toContain("wikigraph help overview");
     expect(rootHelpText).toContain("wikigraph help uri");
@@ -979,7 +988,9 @@ describe("cli/args", () => {
     expect(rootHelpText).toContain("Queue generation tasks call an LLM");
     expect(renderHelpTopicText("runtime")).toContain("Runtime Behavior");
     expect(renderHelpTopicText("config")).toContain("Configuration Overview");
-    expect(renderHelpTopicText("command")).toContain("wikigraph search");
+    expect(renderHelpTopicText("command")).toContain(
+      "wikigraph <wikigraph-uri-with-sdpub-locator> search",
+    );
     expect(renderHelpTopicText("ai")).toContain("Primary contract:");
     expect(renderHelpTopicText("ai")).toContain(
       "Use Wiki Graph URIs as stable object handles",
@@ -988,22 +999,22 @@ describe("cli/args", () => {
       "Never pass a bare filesystem path to `search`, `list`, `get`, `related`, `evidence`, or `pack`.",
     );
     expect(renderHelpTopicText("ai")).toContain(
-      "/Users/me/book.sdpub -> wikigraph:///Users/me/book.sdpub",
+      "/Users/me/book.sdpub -> wkg:///Users/me/book.sdpub",
     );
     expect(renderHelpTopicText("ai")).toContain(
-      "wikigraph search wikigraph:///Users/me/book.sdpub",
+      "wikigraph wkg:///Users/me/book.sdpub search",
     );
     expect(renderHelpTopicText("uri")).toContain(
       "Do not pass a bare filesystem path to object commands.",
     );
     expect(renderHelpTopicText("uri")).toContain(
-      "wikigraph search wikigraph:///Users/me/book.sdpub",
+      "wikigraph wkg:///Users/me/book.sdpub search",
     );
     expect(renderHelpTopicText("task")).toContain(
-      "wikigraph search wikigraph:///Users/me/book.sdpub",
+      "wikigraph wkg:///Users/me/book.sdpub search",
     );
     expect(renderHelpTopicText("recipe")).toContain(
-      "wikigraph search wikigraph:///Users/me/book.sdpub",
+      "wikigraph wkg:///Users/me/book.sdpub search",
     );
     expect(commandHelpText).toContain("Object commands:");
     expect(commandHelpText).toContain("wikigraph create <archive.sdpub>");

--- a/test/cli/main.test.ts
+++ b/test/cli/main.test.ts
@@ -397,7 +397,7 @@ describe("cli/main", () => {
       "wikigraph",
       "get",
       "/tmp/book.sdpub",
-      "wikigraph://entity/Q1",
+      "wkg://entity/Q1",
       "--json",
     ];
     mainMockState.argsResult = {
@@ -405,7 +405,7 @@ describe("cli/main", () => {
         action: "get",
         archivePath: "/tmp/book.sdpub",
         format: "json",
-        objectId: "wikigraph://entity/Q1",
+        objectId: "wkg://entity/Q1",
       },
       help: false,
       kind: "archive",

--- a/test/facade/archive-view.test.ts
+++ b/test/facade/archive-view.test.ts
@@ -205,10 +205,10 @@ describe("facade/archive-view", () => {
         });
 
         expect(chapterOne.items.map((item) => item.id)).toStrictEqual([
-          "wikigraph://entity/Q1",
+          "wkg://entity/Q1",
         ]);
         expect(chapterTwo.items.map((item) => item.id)).toStrictEqual([
-          "wikigraph://entity/Q2",
+          "wkg://entity/Q2",
         ]);
         expect(sourceOnly.items.map((item) => item.type)).toStrictEqual([
           "fragment",
@@ -294,7 +294,7 @@ describe("facade/archive-view", () => {
         expect(first.items).toStrictEqual([]);
         expect(second.items).toStrictEqual([
           expect.objectContaining({
-            id: "wikigraph://entity/Q1",
+            id: "wkg://entity/Q1",
             title: "Invalidate Me",
             type: "entity",
           }),
@@ -347,14 +347,14 @@ describe("facade/archive-view", () => {
               shown: 1,
               sources: [
                 expect.objectContaining({
-                  id: "wikigraph://chapter/1/source/0#0..0",
+                  id: "wkg://chapter/1/source/0#0..0",
                   source:
                     "An LLM Wiki exposes pages, links, and source fragments to agents.",
                 }),
               ],
               total: 1,
             },
-            id: "wikigraph://entity/Q8018",
+            id: "wkg://entity/Q8018",
             title: "Augustine",
             type: "entity",
           },
@@ -396,7 +396,7 @@ describe("facade/archive-view", () => {
         });
 
         expect(result.items[0]).toMatchObject({
-          id: "wikigraph://entity/Q1336609",
+          id: "wkg://entity/Q1336609",
           title: "陈友谅",
           type: "entity",
         });
@@ -593,7 +593,7 @@ describe("facade/archive-view", () => {
         });
 
         expect(result.items[0]).toMatchObject({
-          id: "wikigraph://entity/Q1",
+          id: "wkg://entity/Q1",
           title: "战舰",
           type: "entity",
         });
@@ -648,7 +648,7 @@ describe("facade/archive-view", () => {
             nextCursor: null,
             total: 1,
           },
-          id: "wikigraph://entity/Q1",
+          id: "wkg://entity/Q1",
           title: "战舰",
           type: "entity",
         });
@@ -696,10 +696,10 @@ describe("facade/archive-view", () => {
           types: ["entity"],
         });
         const multi = result.items.find(
-          (item) => item.id === "wikigraph://entity/Q1",
+          (item) => item.id === "wkg://entity/Q1",
         );
         const single = result.items.find(
-          (item) => item.id === "wikigraph://entity/Q2",
+          (item) => item.id === "wkg://entity/Q2",
         );
 
         expect(multi?.score).toBeCloseTo((single?.score ?? 0) * 1.3, 10);
@@ -756,18 +756,18 @@ describe("facade/archive-view", () => {
         });
 
         const triple = result.items.find(
-          (item) => item.id === "wikigraph://triple/Q1/mentions/Q2",
+          (item) => item.id === "wkg://triple/Q1/mentions/Q2",
         );
 
         expect(triple).toMatchObject({
-          id: "wikigraph://triple/Q1/mentions/Q2",
+          id: "wkg://triple/Q1/mentions/Q2",
           title: "Wiki mentions Source",
           type: "triple",
         });
         expect(triple?.evidence?.total).toBe(1);
         expect(triple?.evidence?.sources).toStrictEqual([
           expect.objectContaining({
-            id: "wikigraph://chapter/1/source/0#2..2",
+            id: "wkg://chapter/1/source/0#2..2",
             source: "Source-only archives should be searchable.",
           }),
         ]);
@@ -824,10 +824,10 @@ describe("facade/archive-view", () => {
           types: ["triple"],
         });
         const multi = result.items.find(
-          (item) => item.id === "wikigraph://triple/Q1/supports/Q2",
+          (item) => item.id === "wkg://triple/Q1/supports/Q2",
         );
         const single = result.items.find(
-          (item) => item.id === "wikigraph://triple/Q3/supports/Q4",
+          (item) => item.id === "wkg://triple/Q3/supports/Q4",
         );
 
         expect(multi?.score).toBeCloseTo((single?.score ?? 0) * 1.3, 10);
@@ -1067,7 +1067,7 @@ describe("facade/archive-view", () => {
         });
 
         await expect(
-          readArchivePage(document, "wikigraph://"),
+          readArchivePage(document, "wkg://"),
         ).resolves.toStrictEqual({
           authors: ["Author One", "Author Two"],
           description: "A searchable description.",
@@ -1201,7 +1201,7 @@ describe("facade/archive-view", () => {
         });
         const [first] = result.items;
 
-        expect(first?.id).toBe("wikigraph://entity/Q1");
+        expect(first?.id).toBe("wkg://entity/Q1");
         expect(first?.evidence?.shown).toBe(1);
         expect(result.nextCursor).not.toBeNull();
       } finally {
@@ -1372,7 +1372,7 @@ describe("facade/archive-view", () => {
         expect(result.items.map((item) => item.id)).toEqual(
           expect.arrayContaining([
             "chapter:1",
-            "wikigraph://entity/Q1",
+            "wkg://entity/Q1",
             "fragment:1:0",
             "node:100",
             "node:101",
@@ -1384,7 +1384,7 @@ describe("facade/archive-view", () => {
             "chapter:2",
             "node:200",
             "summary:2",
-            "wikigraph://triple/Q1/mentions/Q2",
+            "wkg://triple/Q1/mentions/Q2",
           ]),
         );
 
@@ -1397,12 +1397,12 @@ describe("facade/archive-view", () => {
           expect.arrayContaining([
             expect.objectContaining({
               chapter: 2,
-              id: "wikigraph://entity/Q1",
+              id: "wkg://entity/Q1",
               type: "entity",
             }),
             expect.objectContaining({
               chapter: 2,
-              id: "wikigraph://triple/Q1/mentions/Q2",
+              id: "wkg://triple/Q1/mentions/Q2",
               type: "triple",
             }),
           ]),
@@ -1414,13 +1414,13 @@ describe("facade/archive-view", () => {
           types: ["entity"],
         });
         const entityWithEvidence = scopedSecondWithEvidence.items.find(
-          (item) => item.id === "wikigraph://entity/Q1",
+          (item) => item.id === "wkg://entity/Q1",
         );
 
         expect(entityWithEvidence?.type).toBe("entity");
         expect(entityWithEvidence?.evidence?.shown).toBe(1);
         expect(entityWithEvidence?.evidence?.sources[0]?.id).toBe(
-          "wikigraph://chapter/2/source/0#0..0",
+          "wkg://chapter/2/source/0#0..0",
         );
       } finally {
         await document.release();
@@ -1436,10 +1436,10 @@ describe("facade/archive-view", () => {
         await seedSourcedDocument(document);
 
         await expect(
-          readArchivePage(document, "wikigraph://chunk/100/extra"),
+          readArchivePage(document, "wkg://chunk/100/extra"),
         ).rejects.toThrow("Invalid Wiki Graph URI");
         await expect(
-          readArchivePage(document, "wikigraph://entity/Q1/extra"),
+          readArchivePage(document, "wkg://entity/Q1/extra"),
         ).rejects.toThrow("Invalid Wiki Graph URI");
       } finally {
         await document.release();
@@ -1493,7 +1493,7 @@ describe("facade/archive-view", () => {
           });
         });
 
-        const page = await readArchivePage(document, "wikigraph://entity/Q1", {
+        const page = await readArchivePage(document, "wkg://entity/Q1", {
           evidenceLimit: 1,
         });
 
@@ -1596,11 +1596,11 @@ describe("facade/archive-view", () => {
         });
 
         await expect(
-          listArchiveEvidence(document, "wikigraph://chunk/100"),
+          listArchiveEvidence(document, "wkg://chunk/100"),
         ).resolves.toMatchObject({
           items: [
             {
-              id: "wikigraph://chapter/1/source/0#0..0",
+              id: "wkg://chapter/1/source/0#0..0",
               source:
                 "An LLM Wiki exposes pages, links, and source fragments to agents.",
               type: "source",
@@ -1608,39 +1608,39 @@ describe("facade/archive-view", () => {
           ],
         });
         await expect(
-          listArchiveEvidence(document, "wikigraph://entity/Q1"),
+          listArchiveEvidence(document, "wkg://entity/Q1"),
         ).resolves.toMatchObject({
           items: [
             {
-              id: "wikigraph://chapter/1/source/0#0..0",
+              id: "wkg://chapter/1/source/0#0..0",
               type: "source",
             },
           ],
         });
         await expect(
-          listArchiveEvidence(document, "wikigraph://triple/Q1/mentions/Q2"),
+          listArchiveEvidence(document, "wkg://triple/Q1/mentions/Q2"),
         ).resolves.toMatchObject({
           items: [
             {
-              id: "wikigraph://chapter/1/source/0#0..0",
+              id: "wkg://chapter/1/source/0#0..0",
               type: "source",
             },
           ],
         });
         await expect(
-          readArchivePage(document, "wikigraph://entity/Q1"),
+          readArchivePage(document, "wkg://entity/Q1"),
         ).resolves.toMatchObject({
           evidence: {
             shown: 1,
             sources: [
               {
-                id: "wikigraph://chapter/1/source/0#0..0",
+                id: "wkg://chapter/1/source/0#0..0",
                 type: "source",
               },
             ],
             total: 1,
           },
-          id: "wikigraph://entity/Q1",
+          id: "wkg://entity/Q1",
           label: "LLM Wiki",
           labels: ["LLM Wiki"],
           mentionCount: 1,
@@ -1648,29 +1648,29 @@ describe("facade/archive-view", () => {
           type: "entity",
         });
         await expect(
-          readArchivePage(document, "wikigraph://triple/Q1/mentions/Q2"),
+          readArchivePage(document, "wkg://triple/Q1/mentions/Q2"),
         ).resolves.toMatchObject({
           evidence: {
             shown: 1,
             sources: [
               {
-                id: "wikigraph://chapter/1/source/0#0..0",
+                id: "wkg://chapter/1/source/0#0..0",
                 type: "source",
               },
             ],
             total: 1,
           },
-          id: "wikigraph://triple/Q1/mentions/Q2",
+          id: "wkg://triple/Q1/mentions/Q2",
           objectQid: "Q2",
           predicate: "mentions",
           subjectQid: "Q1",
           type: "triple",
         });
         await expect(
-          listRelatedArchiveObjects(document, "wikigraph://entity/Q1"),
+          listRelatedArchiveObjects(document, "wkg://entity/Q1"),
         ).resolves.toStrictEqual([
           {
-            id: "wikigraph://triple/Q1/mentions/Q2",
+            id: "wkg://triple/Q1/mentions/Q2",
             label: "LLM Wiki mentions agents",
             objectLabel: "agents",
             objectQid: "Q2",
@@ -1682,44 +1682,41 @@ describe("facade/archive-view", () => {
           },
         ]);
         await expect(
-          listRelatedArchiveObjects(
-            document,
-            "wikigraph://triple/Q1/mentions/Q2",
-          ),
+          listRelatedArchiveObjects(document, "wkg://triple/Q1/mentions/Q2"),
         ).resolves.toStrictEqual([
           {
-            id: "wikigraph://entity/Q1",
+            id: "wkg://entity/Q1",
             label: "LLM Wiki",
             summary: "1 mentions",
             type: "entity",
           },
           {
-            id: "wikigraph://entity/Q2",
+            id: "wkg://entity/Q2",
             label: "agents",
             summary: "1 mentions",
             type: "entity",
           },
         ]);
         await expect(
-          listArchiveEvidence(document, "wikigraph://entity/Q3"),
+          listArchiveEvidence(document, "wkg://entity/Q3"),
         ).resolves.toMatchObject({
           items: [
             {
-              id: "wikigraph://chapter/1/source/1#1..1",
+              id: "wkg://chapter/1/source/1#1..1",
               source: "Second fragment mentions Augustine.",
               type: "source",
             },
           ],
         });
         await expect(
-          listArchiveEvidence(document, "wikigraph://chapter/1/source/1#1..1"),
+          listArchiveEvidence(document, "wkg://chapter/1/source/1#1..1"),
         ).rejects.toThrow("Evidence is not available");
         await expect(
-          listArchiveEvidence(document, "wikigraph://entity/Q4"),
+          listArchiveEvidence(document, "wkg://entity/Q4"),
         ).resolves.toMatchObject({
           items: [
             {
-              id: "wikigraph://chapter/1/source/0#2..2",
+              id: "wkg://chapter/1/source/0#2..2",
               type: "source",
             },
           ],

--- a/test/wikimatch/policy-judge.test.ts
+++ b/test/wikimatch/policy-judge.test.ts
@@ -403,7 +403,7 @@ function createInput(): {
                     title: "Mercury (planet)",
                   },
                 ],
-                text: "* [[Mercury (planet)|wikigraph://qid=Q308]], the first planet from the Sun",
+                text: "* [[Mercury (planet)|wkg://qid=Q308]], the first planet from the Sun",
                 title: "Mercury",
                 wiki: "enwiki",
               },

--- a/test/wikipage/normalizer.test.ts
+++ b/test/wikipage/normalizer.test.ts
@@ -105,8 +105,8 @@ function createInput(): DisambiguationProfileNormalizerInput {
           },
         ],
         text:
-          "* [[乔治·华盛顿|wikigraph://qid=Q23]]，美国第一任总统\n" +
-          "* [[华盛顿哥伦比亚特区|wikigraph://qid=Q61]]，美国首都",
+          "* [[乔治·华盛顿|wkg://qid=Q23]]，美国第一任总统\n" +
+          "* [[华盛顿哥伦比亚特区|wkg://qid=Q61]]，美国首都",
         title: "华盛顿",
         wiki: "zhwiki",
       },

--- a/test/wikipage/resolver.test.ts
+++ b/test/wikipage/resolver.test.ts
@@ -62,8 +62,8 @@ describe("wikipage/resolver", () => {
               pages: [
                 {
                   text:
-                    "* [[Mercury|wikigraph://qid=Q925]], a chemical element\n" +
-                    "* [[Mercury|wikigraph://qid=Q308]], the first planet from the Sun",
+                    "* [[Mercury|wkg://qid=Q925]], a chemical element\n" +
+                    "* [[Mercury|wkg://qid=Q308]], the first planet from the Sun",
                   title: "Mercury",
                   wiki: "enwiki",
                 },
@@ -82,8 +82,8 @@ describe("wikipage/resolver", () => {
             disambiguationPages: [
               {
                 text:
-                  "* [[Mercury|wikigraph://qid=Q925]], a chemical element\n" +
-                  "* [[Mercury|wikigraph://qid=Q308]], the first planet from the Sun",
+                  "* [[Mercury|wkg://qid=Q925]], a chemical element\n" +
+                  "* [[Mercury|wkg://qid=Q308]], the first planet from the Sun",
                 title: "Mercury",
                 wiki: "enwiki",
               },


### PR DESCRIPTION
## Summary
- make `wikigraph next` use the explicit `--limit` or command default instead of storing page size in cursors
- print copyable continuation commands in text output, including compact evidence continuation hints
- switch public Wiki Graph URIs to `wkg://` and document URI-first object commands while keeping action-first parsing compatible

## Tests
- `pnpm test:run`
- `pnpm verify`
