### PR TITLE
refactor(wikg): coordinate archive sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spinedigest",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "CLI-first tool for digesting long-form text and ebooks into compressed text, EPUB, or reusable .wikg archives.",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/facade/spine-digest-file.ts
+++ b/src/facade/spine-digest-file.ts
@@ -36,30 +36,11 @@ export class SpineDigestFile {
       readonly documentDirPath?: string;
     } = {},
   ): Promise<T> {
-    if (options.documentDirPath === undefined) {
-      return await this.#coordinator.withArchiveSession(
-        this.#path,
-        async (session) => {
-          const document = await DirectoryDocument.open(this.#path, {
-            fileStore: session.createFileStore({
-              readonlyDatabase: true,
-            }),
-          });
-
-          try {
-            return await operation(document, this.#path);
-          } finally {
-            await document.release();
-          }
-        },
-      );
-    }
-
     return await this.#coordinator.withArchiveSession(
       this.#path,
       async (session) =>
         await session.materializeReadWorkspace(
-          options.documentDirPath!,
+          options.documentDirPath,
           async (directoryPath) => {
             const document = await DirectoryDocument.open(directoryPath);
 
@@ -86,9 +67,11 @@ export class SpineDigestFile {
         try {
           return await operation(document);
         } finally {
-          await document.flush();
-          await document.release();
-          await deleteArchiveSearchSessions(this.#path);
+          try {
+            await document.release();
+          } finally {
+            await deleteArchiveSearchSessions(this.#path);
+          }
         }
       },
     );

--- a/src/facade/spine-digest-file.ts
+++ b/src/facade/spine-digest-file.ts
@@ -2,7 +2,7 @@ import { resolve } from "path";
 
 import { DirectoryDocument } from "../document/index.js";
 
-import { WikgCoordinator, tryStartWikgFlusher } from "./wikg-coordinator.js";
+import { WikgCoordinator } from "./wikg-coordinator.js";
 import { deleteArchiveSearchSessions } from "./search-cache.js";
 import { SpineDigest } from "./spine-digest.js";
 
@@ -37,57 +37,60 @@ export class SpineDigestFile {
     } = {},
   ): Promise<T> {
     if (options.documentDirPath === undefined) {
-      const document = await DirectoryDocument.open(this.#path, {
-        fileStore: this.#coordinator.createFileStore(this.#path, {
-          readonlyDatabase: true,
-        }),
-      });
+      return await this.#coordinator.withArchiveSession(
+        this.#path,
+        async (session) => {
+          const document = await DirectoryDocument.open(this.#path, {
+            fileStore: session.createFileStore({
+              readonlyDatabase: true,
+            }),
+          });
 
-      try {
-        return await operation(document, this.#path);
-      } finally {
-        await document.release();
-      }
+          try {
+            return await operation(document, this.#path);
+          } finally {
+            await document.release();
+          }
+        },
+      );
     }
 
-    return await this.#coordinator.withReadWorkspace(
+    return await this.#coordinator.withArchiveSession(
       this.#path,
-      async (directoryPath) => {
-        const document = await DirectoryDocument.open(directoryPath);
+      async (session) =>
+        await session.materializeReadWorkspace(
+          options.documentDirPath!,
+          async (directoryPath) => {
+            const document = await DirectoryDocument.open(directoryPath);
 
-        try {
-          return await operation(document, directoryPath);
-        } finally {
-          await document.release();
-        }
-      },
-      options,
+            try {
+              return await operation(document, directoryPath);
+            } finally {
+              await document.release();
+            }
+          },
+        ),
     );
   }
 
   public async write<T>(
     operation: (document: DirectoryDocument) => Promise<T> | T,
   ): Promise<T> {
-    const document = await DirectoryDocument.open(this.#path, {
-      fileStore: this.#coordinator.createFileStore(this.#path),
-    });
-    let completed = false;
+    return await this.#coordinator.withArchiveSession(
+      this.#path,
+      async (session) => {
+        const document = await DirectoryDocument.open(this.#path, {
+          fileStore: session.createFileStore(),
+        });
 
-    try {
-      const result = await operation(document);
-
-      completed = true;
-      return result;
-    } finally {
-      await document.flush();
-      await document.release();
-      if (completed) {
         try {
-          await deleteArchiveSearchSessions(this.#path);
+          return await operation(document);
         } finally {
-          await tryStartWikgFlusher(this.#path);
+          await document.flush();
+          await document.release();
+          await deleteArchiveSearchSessions(this.#path);
         }
-      }
-    }
+      },
+    );
   }
 }

--- a/src/facade/wikg-coordinator.ts
+++ b/src/facade/wikg-coordinator.ts
@@ -1,7 +1,23 @@
 import { createHash, randomUUID } from "crypto";
-import { mkdir, mkdtemp, readFile, rename, rm, writeFile } from "fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  writeFile,
+} from "fs/promises";
 import { tmpdir } from "os";
-import { basename, dirname, join, posix, resolve } from "path";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  posix,
+  relative,
+  resolve,
+} from "path";
 
 import { resolveWikiGraphStateDirectoryPath } from "../common/wiki-graph-dir.js";
 import { openSharedStateDatabase } from "../document/index.js";
@@ -170,11 +186,16 @@ export class WikgArchiveSession {
       ARCHIVE_SESSION_CONSTRUCTOR_TOKEN,
     );
 
-    await registerArchiveOwner({
-      archiveKey: session.#archiveKey,
-      ownerId: session.#ownerId,
-    });
-    return session;
+    try {
+      await registerArchiveOwner({
+        archiveKey: session.#archiveKey,
+        ownerId: session.#ownerId,
+      });
+      return session;
+    } catch (error) {
+      clearInterval(session.#heartbeat);
+      throw error;
+    }
   }
 
   public get archiveKey(): string {
@@ -207,13 +228,17 @@ export class WikgArchiveSession {
   }
 
   public async materializeReadWorkspace<T>(
-    directoryPath: string,
+    directoryPath: string | undefined,
     operation: (documentDirectoryPath: string) => Promise<T> | T,
   ): Promise<T> {
-    const resolvedDirectoryPath = resolve(directoryPath);
+    const ownsDirectoryPath = directoryPath === undefined;
+    const resolvedDirectoryPath = ownsDirectoryPath
+      ? await mkdtemp(join(tmpdir(), "wikigraph-open-"))
+      : resolve(directoryPath);
 
-    await rm(resolvedDirectoryPath, { force: true, recursive: true });
-    await mkdir(resolvedDirectoryPath, { recursive: true });
+    if (!ownsDirectoryPath) {
+      await ensureEmptyDirectory(resolvedDirectoryPath);
+    }
 
     const fileStore = this.createFileStore({ readonlyDatabase: true });
     const entries = await listVisibleEntryPaths(
@@ -232,7 +257,15 @@ export class WikgArchiveSession {
           continue;
         }
 
-        const targetPath = join(resolvedDirectoryPath, entryPath);
+        const targetPath = resolve(resolvedDirectoryPath, entryPath);
+        const relativeTargetPath = relative(resolvedDirectoryPath, targetPath);
+
+        if (
+          relativeTargetPath.startsWith("..") ||
+          isAbsolute(relativeTargetPath)
+        ) {
+          throw new Error(`Archive entry escapes read workspace: ${entryPath}`);
+        }
 
         await mkdir(dirname(targetPath), { recursive: true });
         await writeFile(targetPath, content);
@@ -241,6 +274,9 @@ export class WikgArchiveSession {
       return await operation(resolvedDirectoryPath);
     } finally {
       await fileStore.close();
+      if (ownsDirectoryPath) {
+        await rm(resolvedDirectoryPath, { force: true, recursive: true });
+      }
     }
   }
 
@@ -527,7 +563,7 @@ class WikgDocumentFileStore implements DocumentFileStore {
           kind: "file",
           workspacePath,
         });
-        if (source.kind === "workspace") {
+        if (source.kind === "workspace" && source.path !== workspacePath) {
           await rm(source.path, { force: true }).catch(() => undefined);
         }
         this.#session?.modifyEntry(entryPath);
@@ -1210,6 +1246,16 @@ async function createWorkspaceFilePath(
 
   await mkdir(directoryPath, { recursive: true });
   return join(directoryPath, `${basename(entryPath)}.${randomUUID()}`);
+}
+
+async function ensureEmptyDirectory(directoryPath: string): Promise<void> {
+  await mkdir(directoryPath, { recursive: true });
+
+  const entries = await readdir(directoryPath);
+
+  if (entries.length > 0) {
+    throw new Error(`Read workspace directory is not empty: ${directoryPath}`);
+  }
 }
 
 function toArchiveOverlay(overlay: EntryOverlay): WikgArchiveOverlay {

--- a/src/facade/wikg-coordinator.ts
+++ b/src/facade/wikg-coordinator.ts
@@ -11,6 +11,7 @@ import { AsyncSemaphore } from "../utils/async-semaphore.js";
 
 import {
   extractWikgArchive,
+  listWikgArchiveEntries,
   readWikgArchiveEntry,
   WikgArchiveReader,
   writeWikgArchiveWithOverlays,
@@ -39,6 +40,15 @@ CREATE TABLE IF NOT EXISTS entry_locks (
   PRIMARY KEY (archive_key, entry_path, owner_id)
 );
 
+CREATE TABLE IF NOT EXISTS archive_owners (
+  archive_key TEXT NOT NULL,
+  owner_id TEXT NOT NULL,
+  owner_pid INTEGER NOT NULL,
+  heartbeat_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (archive_key, owner_id)
+);
+
 CREATE TABLE IF NOT EXISTS entry_sqlite_leases (
   archive_key TEXT NOT NULL,
   entry_path TEXT NOT NULL,
@@ -61,16 +71,36 @@ CREATE TABLE IF NOT EXISTS archive_commit_locks (
 const DATABASE_ENTRY_PATH = "database.db";
 const LOCK_POLL_INTERVAL_MS = 100;
 const LOCK_STALE_TIMEOUT_MS = 60_000;
+const OWNER_HEARTBEAT_INTERVAL_MS = 20_000;
 const STATE_DATABASE_SEMAPHORE = new AsyncSemaphore(1);
+const ARCHIVE_SESSION_CONSTRUCTOR_TOKEN = Symbol(
+  "WikgArchiveSession constructor token",
+);
 
 type EntryLockMode = "read" | "state" | "write";
 
 export class WikgCoordinator {
   public createFileStore(
     archivePath: string,
-    options: { readonly readonlyDatabase?: boolean } = {},
+    options: {
+      readonly readonlyDatabase?: boolean;
+      readonly session?: WikgArchiveSession;
+    } = {},
   ): DocumentFileStore {
     return new WikgDocumentFileStore(resolve(archivePath), options);
+  }
+
+  public async withArchiveSession<T>(
+    archivePath: string,
+    operation: (session: WikgArchiveSession) => Promise<T> | T,
+  ): Promise<T> {
+    const session = await WikgArchiveSession.open(resolve(archivePath));
+
+    try {
+      return await operation(session);
+    } finally {
+      await session.close();
+    }
   }
 
   public async withReadWorkspace<T>(
@@ -110,6 +140,143 @@ export class WikgCoordinator {
   }
 }
 
+export class WikgArchiveSession {
+  readonly #archiveKey: string;
+  readonly #archivePath: string;
+  readonly #ownerId = createOwnerId();
+  readonly #heartbeat: NodeJS.Timeout;
+  readonly #observedDirtyEntryPaths = new Set<string>();
+  readonly #modifiedEntryPaths = new Set<string>();
+  #closed = false;
+
+  public constructor(archivePath: string, token?: symbol) {
+    if (token !== ARCHIVE_SESSION_CONSTRUCTOR_TOKEN) {
+      throw new Error("Use WikgCoordinator.withArchiveSession().");
+    }
+
+    this.#archivePath = resolve(archivePath);
+    this.#archiveKey = createArchiveKey(this.#archivePath);
+    this.#heartbeat = setInterval(() => {
+      void heartbeatArchiveOwner({
+        archiveKey: this.#archiveKey,
+        ownerId: this.#ownerId,
+      }).catch(() => undefined);
+    }, OWNER_HEARTBEAT_INTERVAL_MS);
+  }
+
+  public static async open(archivePath: string): Promise<WikgArchiveSession> {
+    const session = new WikgArchiveSession(
+      archivePath,
+      ARCHIVE_SESSION_CONSTRUCTOR_TOKEN,
+    );
+
+    await registerArchiveOwner({
+      archiveKey: session.#archiveKey,
+      ownerId: session.#ownerId,
+    });
+    return session;
+  }
+
+  public get archiveKey(): string {
+    return this.#archiveKey;
+  }
+
+  public get archivePath(): string {
+    return this.#archivePath;
+  }
+
+  public get ownerId(): string {
+    return this.#ownerId;
+  }
+
+  public observeDirtyEntry(entryPath: string): void {
+    this.#observedDirtyEntryPaths.add(entryPath);
+  }
+
+  public modifyEntry(entryPath: string): void {
+    this.#modifiedEntryPaths.add(entryPath);
+  }
+
+  public createFileStore(
+    options: { readonly readonlyDatabase?: boolean } = {},
+  ): DocumentFileStore {
+    return new WikgDocumentFileStore(this.#archivePath, {
+      ...options,
+      session: this,
+    });
+  }
+
+  public async materializeReadWorkspace<T>(
+    directoryPath: string,
+    operation: (documentDirectoryPath: string) => Promise<T> | T,
+  ): Promise<T> {
+    const resolvedDirectoryPath = resolve(directoryPath);
+
+    await rm(resolvedDirectoryPath, { force: true, recursive: true });
+    await mkdir(resolvedDirectoryPath, { recursive: true });
+
+    const fileStore = this.createFileStore({ readonlyDatabase: true });
+    const entries = await listVisibleEntryPaths(
+      await listWikgArchiveEntries(this.#archivePath),
+      {
+        archiveKey: this.#archiveKey,
+        prefix: "",
+      },
+    );
+
+    try {
+      for (const entryPath of entries) {
+        const content = await fileStore.readFile(entryPath);
+
+        if (content === undefined) {
+          continue;
+        }
+
+        const targetPath = join(resolvedDirectoryPath, entryPath);
+
+        await mkdir(dirname(targetPath), { recursive: true });
+        await writeFile(targetPath, content);
+      }
+
+      return await operation(resolvedDirectoryPath);
+    } finally {
+      await fileStore.close();
+    }
+  }
+
+  public async close(): Promise<void> {
+    if (this.#closed) {
+      return;
+    }
+
+    this.#closed = true;
+    clearInterval(this.#heartbeat);
+
+    try {
+      await this.#settle();
+      await reapArchive(this.#archiveKey);
+    } finally {
+      await unregisterArchiveOwner({
+        archiveKey: this.#archiveKey,
+        ownerId: this.#ownerId,
+      });
+    }
+  }
+
+  async #settle(): Promise<void> {
+    const entryPaths = new Set([
+      ...this.#observedDirtyEntryPaths,
+      ...this.#modifiedEntryPaths,
+    ]);
+
+    if (entryPaths.size === 0) {
+      return;
+    }
+
+    await flushArchiveOverlays(this.#archiveKey, entryPaths);
+  }
+}
+
 export async function tryStartWikgFlusher(archivePath?: string): Promise<void> {
   if (archivePath !== undefined) {
     await flushArchiveOverlays(createArchiveKey(resolve(archivePath)));
@@ -143,12 +310,18 @@ class WikgDocumentFileStore implements DocumentFileStore {
 
   public constructor(
     archivePath: string,
-    options: { readonly readonlyDatabase?: boolean },
+    options: {
+      readonly readonlyDatabase?: boolean;
+      readonly session?: WikgArchiveSession;
+    },
   ) {
     this.#archivePath = resolve(archivePath);
     this.#archiveKey = createArchiveKey(this.#archivePath);
     this.#readonlyDatabase = options.readonlyDatabase === true;
+    this.#session = options.session;
   }
+
+  readonly #session: WikgArchiveSession | undefined;
 
   public async close(): Promise<void> {
     if (this.#archiveReader !== undefined) {
@@ -158,7 +331,7 @@ class WikgDocumentFileStore implements DocumentFileStore {
     await releaseSqliteLease({
       archiveKey: this.#archiveKey,
       entryPath: DATABASE_ENTRY_PATH,
-      ownerId: this.#sqliteLeaseOwnerId,
+      ownerId: this.#session?.ownerId ?? this.#sqliteLeaseOwnerId,
     });
   }
 
@@ -169,16 +342,18 @@ class WikgDocumentFileStore implements DocumentFileStore {
       await withEntryLock(this.#archiveKey, entryPath, "state", async () => {
         const overlay = await readOverlay(this.#archiveKey, entryPath);
 
-        if (overlay?.workspacePath !== undefined) {
-          await rm(overlay.workspacePath, { force: true });
-        }
-
         await upsertOverlay({
           archiveKey: this.#archiveKey,
           archivePath: this.#archivePath,
           entryPath,
           kind: "deleted",
         });
+        if (overlay?.workspacePath !== undefined) {
+          await rm(overlay.workspacePath, { force: true }).catch(
+            () => undefined,
+          );
+        }
+        this.#session?.modifyEntry(entryPath);
       });
     });
   }
@@ -248,9 +423,11 @@ class WikgDocumentFileStore implements DocumentFileStore {
         );
 
         if (source.kind === "deleted") {
+          this.#session?.observeDirtyEntry(entryPath);
           return undefined;
         }
         if (source.kind === "workspace") {
+          this.#session?.observeDirtyEntry(entryPath);
           return await readFile(source.path);
         }
 
@@ -296,8 +473,9 @@ class WikgDocumentFileStore implements DocumentFileStore {
         await acquireSqliteLease({
           archiveKey: this.#archiveKey,
           entryPath: DATABASE_ENTRY_PATH,
-          ownerId: this.#sqliteLeaseOwnerId,
+          ownerId: this.#session?.ownerId ?? this.#sqliteLeaseOwnerId,
         });
+        this.#session?.observeDirtyEntry(DATABASE_ENTRY_PATH);
         return overlay.workspacePath;
       },
     );
@@ -333,13 +511,15 @@ class WikgDocumentFileStore implements DocumentFileStore {
       }
 
       await withEntryLock(this.#archiveKey, entryPath, "state", async () => {
-        const workspacePath =
-          source.kind === "workspace"
-            ? source.path
-            : await createWorkspaceFilePath(this.#archiveKey, entryPath);
+        const workspacePath = await createWorkspaceFilePath(
+          this.#archiveKey,
+          entryPath,
+        );
+        const temporaryWorkspacePath = `${workspacePath}.tmp`;
 
         await mkdir(dirname(workspacePath), { recursive: true });
-        await writeFile(workspacePath, content);
+        await writeFile(temporaryWorkspacePath, content);
+        await rename(temporaryWorkspacePath, workspacePath);
         await upsertOverlay({
           archiveKey: this.#archiveKey,
           archivePath: this.#archivePath,
@@ -347,6 +527,10 @@ class WikgDocumentFileStore implements DocumentFileStore {
           kind: "file",
           workspacePath,
         });
+        if (source.kind === "workspace") {
+          await rm(source.path, { force: true }).catch(() => undefined);
+        }
+        this.#session?.modifyEntry(entryPath);
       });
     });
   }
@@ -378,8 +562,15 @@ class WikgDocumentFileStore implements DocumentFileStore {
   }
 }
 
-async function flushArchiveOverlays(archiveKey: string): Promise<void> {
-  const overlays = await listOverlays(archiveKey);
+async function flushArchiveOverlays(
+  archiveKey: string,
+  requestedEntryPaths?: ReadonlySet<string>,
+): Promise<void> {
+  const overlays = (await listOverlays(archiveKey)).filter(
+    (overlay) =>
+      requestedEntryPaths === undefined ||
+      requestedEntryPaths.has(overlay.entryPath),
+  );
   const archivePath = await resolveArchivePathFromKey(archiveKey);
 
   if (overlays.length === 0 || archivePath === undefined) {
@@ -439,10 +630,10 @@ async function flushArchiveOverlays(archiveKey: string): Promise<void> {
     }
 
     for (const overlay of currentOverlays) {
+      await deleteOverlay(archiveKey, overlay.entryPath);
       if (overlay.workspacePath !== undefined) {
         await rm(overlay.workspacePath, { force: true });
       }
-      await deleteOverlay(archiveKey, overlay.entryPath);
     }
   } finally {
     for (const release of releaseLocks.reverse()) {
@@ -495,6 +686,104 @@ INSERT INTO archive_commit_locks (
 
     await delay(LOCK_POLL_INTERVAL_MS);
   }
+}
+
+async function registerArchiveOwner(input: {
+  readonly archiveKey: string;
+  readonly ownerId: string;
+}): Promise<void> {
+  await withStateDatabase(async (state) => {
+    await cleanupStaleState(state);
+    await state.run(
+      `
+INSERT OR REPLACE INTO archive_owners (
+  archive_key, owner_id, owner_pid, heartbeat_at, created_at
+) VALUES (?, ?, ?, ?, ?)
+`,
+      [input.archiveKey, input.ownerId, process.pid, Date.now(), Date.now()],
+    );
+  });
+}
+
+async function heartbeatArchiveOwner(input: {
+  readonly archiveKey: string;
+  readonly ownerId: string;
+}): Promise<void> {
+  await withStateDatabase(async (state) => {
+    await state.run(
+      `
+UPDATE archive_owners
+SET heartbeat_at = ?, owner_pid = ?
+WHERE archive_key = ? AND owner_id = ?
+`,
+      [Date.now(), process.pid, input.archiveKey, input.ownerId],
+    );
+  });
+}
+
+async function unregisterArchiveOwner(input: {
+  readonly archiveKey: string;
+  readonly ownerId: string;
+}): Promise<void> {
+  await withStateDatabase(async (state) => {
+    await state.transaction(async () => {
+      await state.run(
+        "DELETE FROM entry_sqlite_leases WHERE archive_key = ? AND owner_id = ?",
+        [input.archiveKey, input.ownerId],
+      );
+      await state.run(
+        "DELETE FROM archive_owners WHERE archive_key = ? AND owner_id = ?",
+        [input.archiveKey, input.ownerId],
+      );
+    });
+  });
+}
+
+async function reapArchive(archiveKey: string): Promise<void> {
+  await withStateDatabase(async (state) => {
+    await cleanupStaleState(state);
+  });
+
+  const staleOwnerIds = await withStateDatabase(
+    async (state) =>
+      await state.queryAll(
+        `
+SELECT owner_id
+FROM archive_owners
+WHERE archive_key = ?
+  AND heartbeat_at <= ?
+`,
+        [archiveKey, Date.now() - LOCK_STALE_TIMEOUT_MS],
+        (row) => getString(row, "owner_id"),
+      ),
+  );
+
+  if (staleOwnerIds.length === 0) {
+    return;
+  }
+
+  await withStateDatabase(async (state) => {
+    await state.transaction(async () => {
+      await state.run(
+        `
+DELETE FROM entry_sqlite_leases
+WHERE archive_key = ?
+  AND owner_id IN (${createPlaceholders(staleOwnerIds.length)})
+`,
+        [archiveKey, ...staleOwnerIds],
+      );
+      await state.run(
+        `
+DELETE FROM archive_owners
+WHERE archive_key = ?
+  AND owner_id IN (${createPlaceholders(staleOwnerIds.length)})
+`,
+        [archiveKey, ...staleOwnerIds],
+      );
+    });
+  });
+
+  await flushArchiveOverlays(archiveKey);
 }
 
 async function acquireEntryLock(
@@ -642,10 +931,18 @@ async function waitForSqliteLeasesToDrain(
       return await state.queryOne(
         `
 SELECT COUNT(*) AS count
-FROM entry_sqlite_leases
-WHERE archive_key = ? AND entry_path = ?
+FROM entry_sqlite_leases AS lease
+LEFT JOIN archive_owners AS owner
+  ON owner.archive_key = lease.archive_key
+ AND owner.owner_id = lease.owner_id
+WHERE lease.archive_key = ?
+  AND lease.entry_path = ?
+  AND (
+    owner.owner_id IS NULL
+    OR owner.heartbeat_at > ?
+  )
 `,
-        [archiveKey, entryPath],
+        [archiveKey, entryPath, Date.now() - LOCK_STALE_TIMEOUT_MS],
         (row) => getNumber(row, "count"),
       );
     });
@@ -805,6 +1102,7 @@ async function cleanupStaleState(state: Database): Promise<void> {
   const staleOwnerPids = new Set<number>();
 
   for (const tableName of [
+    "archive_owners",
     "entry_locks",
     "entry_sqlite_leases",
     "archive_commit_locks",
@@ -831,6 +1129,13 @@ WHERE owner_pid IS NOT NULL
     return;
   }
 
+  await state.run(
+    `
+DELETE FROM archive_owners
+WHERE owner_pid IN (${createPlaceholders(staleOwnerPids.size)})
+`,
+    [...staleOwnerPids],
+  );
   await state.run(
     `
 DELETE FROM entry_locks

--- a/test/facade/spine-digest-file.test.ts
+++ b/test/facade/spine-digest-file.test.ts
@@ -1,4 +1,6 @@
-import { access, mkdir, readFile } from "fs/promises";
+import { createHash } from "crypto";
+import { access, mkdir, readFile, writeFile } from "fs/promises";
+import { resolve } from "path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -440,6 +442,112 @@ describe("facade/spine-digest-file", () => {
       }
     });
   });
+
+  it("reaps stale owner file overlays through a later archive session", async () => {
+    await withTempDir("spinedigest-facade-file-", async (path) => {
+      const restoreStateDir = useCoordinatorStateDir(`${path}/state`);
+      try {
+        const archivePath = await createSeedArchive(path);
+
+        await seedStalePublishedFileOverlay({
+          archivePath,
+          entryPath: "book-meta.json",
+          ownerId: "stale-owner-file",
+          stateRootPath: `${path}/state`,
+          workspacePath: `${path}/state/workspaces/stale/book-meta.json`,
+          content: `${JSON.stringify({
+            authors: [],
+            description: null,
+            identifier: "urn:test:reaped-file",
+            language: "en",
+            publishedAt: null,
+            publisher: null,
+            sourceFormat: "txt",
+            title: "Reaped File Title",
+            version: 1,
+          })}\n`,
+        });
+
+        await new SpineDigestFile(archivePath).read(async (digest) => {
+          expect(await digest.readMeta()).toMatchObject({
+            title: "Reaped File Title",
+          });
+        });
+
+        await expect(readCoordinatorOverlays(path)).resolves.toStrictEqual([]);
+        await expect(readArchivedTitle(path, archivePath)).resolves.toBe(
+          "Reaped File Title",
+        );
+      } finally {
+        restoreStateDir();
+      }
+    });
+  });
+
+  it("reaps stale owner delete overlays through a later archive session", async () => {
+    await withTempDir("spinedigest-facade-file-", async (path) => {
+      const restoreStateDir = useCoordinatorStateDir(`${path}/state`);
+      try {
+        const archivePath = await createSeedArchive(path);
+
+        await seedStalePublishedDeleteOverlay({
+          archivePath,
+          entryPath: "book-meta.json",
+          ownerId: "stale-owner-delete",
+          stateRootPath: `${path}/state`,
+        });
+
+        await new SpineDigestFile(archivePath).read(async (digest) => {
+          expect(await digest.readMeta()).toBeUndefined();
+        });
+
+        await expect(readCoordinatorOverlays(path)).resolves.toStrictEqual([]);
+        await expect(
+          readArchivedEntry(archivePath, "book-meta.json"),
+        ).resolves.toBeUndefined();
+      } finally {
+        restoreStateDir();
+      }
+    });
+  });
+
+  it("does not reaper unpublished staging files into the archive", async () => {
+    await withTempDir("spinedigest-facade-file-", async (path) => {
+      const restoreStateDir = useCoordinatorStateDir(`${path}/state`);
+      try {
+        const archivePath = await createSeedArchive(path);
+        const stagingPath = `${path}/state/workspaces/stale/book-meta.json.tmp`;
+
+        await initializeCoordinatorState(archivePath);
+        await mkdir(`${path}/state/workspaces/stale`, { recursive: true });
+        await writeFile(
+          stagingPath,
+          `${JSON.stringify({
+            title: "Unpublished Staging Title",
+            version: 1,
+          })}\n`,
+          "utf8",
+        );
+        await insertStaleArchiveOwner({
+          archivePath,
+          ownerId: "stale-owner-staging",
+        });
+
+        await new SpineDigestFile(archivePath).read(async (digest) => {
+          expect(await digest.readMeta()).toMatchObject({
+            title: "Session Fixture",
+          });
+        });
+
+        await expect(readCoordinatorOverlays(path)).resolves.toStrictEqual([]);
+        await expect(readArchivedTitle(path, archivePath)).resolves.toBe(
+          "Session Fixture",
+        );
+      } finally {
+        restoreStateDir();
+      }
+    });
+  });
 });
 
 async function seedDocument(document: DirectoryDocument): Promise<void> {
@@ -497,6 +605,15 @@ async function readArchivedTitle(
   ) as { readonly title: string | null };
 
   return meta.title;
+}
+
+async function readArchivedEntry(
+  archivePath: string,
+  entryPath: string,
+): Promise<Uint8Array | undefined> {
+  const { readWikgArchiveEntry } = await import("../../src/facade/archive.js");
+
+  return await readWikgArchiveEntry(archivePath, entryPath);
 }
 
 async function readCoordinatorOverlays(path: string): Promise<
@@ -576,6 +693,125 @@ INSERT INTO entry_overlays (
   } finally {
     await database.close();
   }
+}
+
+async function initializeCoordinatorState(archivePath: string): Promise<void> {
+  await new WikgCoordinator().withArchiveSession(archivePath, () => {
+    return undefined;
+  });
+}
+
+async function seedStalePublishedFileOverlay(input: {
+  readonly archivePath: string;
+  readonly entryPath: string;
+  readonly ownerId: string;
+  readonly stateRootPath: string;
+  readonly workspacePath: string;
+  readonly content: string;
+}): Promise<void> {
+  await initializeCoordinatorState(input.archivePath);
+  await mkdir(`${input.stateRootPath}/workspaces/stale`, { recursive: true });
+  await writeFile(input.workspacePath, input.content, "utf8");
+  await insertStaleArchiveOwner({
+    archivePath: input.archivePath,
+    ownerId: input.ownerId,
+  });
+  await insertEntryOverlay({
+    archivePath: input.archivePath,
+    entryPath: input.entryPath,
+    kind: "file",
+    workspacePath: input.workspacePath,
+  });
+}
+
+async function seedStalePublishedDeleteOverlay(input: {
+  readonly archivePath: string;
+  readonly entryPath: string;
+  readonly ownerId: string;
+  readonly stateRootPath: string;
+}): Promise<void> {
+  await initializeCoordinatorState(input.archivePath);
+  await mkdir(`${input.stateRootPath}/workspaces/stale`, { recursive: true });
+  await insertStaleArchiveOwner({
+    archivePath: input.archivePath,
+    ownerId: input.ownerId,
+  });
+  await insertEntryOverlay({
+    archivePath: input.archivePath,
+    entryPath: input.entryPath,
+    kind: "deleted",
+  });
+}
+
+async function insertStaleArchiveOwner(input: {
+  readonly archivePath: string;
+  readonly ownerId: string;
+}): Promise<void> {
+  const { Database } = await import("../../src/document/index.js");
+  const database = await Database.open(resolveCoordinatorDatabasePath());
+
+  try {
+    await database.run(
+      `
+INSERT INTO archive_owners (
+  archive_key, owner_id, owner_pid, heartbeat_at, created_at
+) VALUES (?, ?, ?, ?, ?)
+`,
+      [
+        createArchiveKey(input.archivePath),
+        input.ownerId,
+        1,
+        Date.now() - 120_000,
+        Date.now() - 120_000,
+      ],
+    );
+  } finally {
+    await database.close();
+  }
+}
+
+async function insertEntryOverlay(input: {
+  readonly archivePath: string;
+  readonly entryPath: string;
+  readonly kind: "deleted" | "file";
+  readonly workspacePath?: string;
+}): Promise<void> {
+  const { Database } = await import("../../src/document/index.js");
+  const database = await Database.open(resolveCoordinatorDatabasePath());
+
+  try {
+    await database.run(
+      `
+INSERT INTO entry_overlays (
+  archive_key, archive_path, entry_path, kind, workspace_path, updated_at
+) VALUES (?, ?, ?, ?, ?, ?)
+`,
+      [
+        createArchiveKey(input.archivePath),
+        input.archivePath,
+        input.entryPath,
+        input.kind,
+        input.workspacePath ?? null,
+        Date.now(),
+      ],
+    );
+  } finally {
+    await database.close();
+  }
+}
+
+function resolveCoordinatorDatabasePath(): string {
+  const stateDir = process.env.WIKIGRAPH_STATE_DIR;
+
+  if (stateDir === undefined) {
+    throw new Error("WIKIGRAPH_STATE_DIR is not set.");
+  }
+
+  return `${stateDir}/wikg-coordinator.sqlite`;
+}
+
+function createArchiveKey(archivePath: string): string {
+  return createHash("sha256").update(resolve(archivePath)).digest("hex");
 }
 
 function useCoordinatorStateDir(path: string): () => void {

--- a/test/facade/spine-digest-file.test.ts
+++ b/test/facade/spine-digest-file.test.ts
@@ -7,6 +7,7 @@ import { extractWikgArchive } from "../../src/facade/archive.js";
 import { findArchiveObjects } from "../../src/facade/archive-view.js";
 import { SpineDigest } from "../../src/facade/spine-digest.js";
 import { SpineDigestFile } from "../../src/facade/spine-digest-file.js";
+import { WikgCoordinator } from "../../src/facade/wikg-coordinator.js";
 import { withTempDir } from "../helpers/temp.js";
 
 const originalStateDir = process.env.WIKIGRAPH_STATE_DIR;
@@ -94,7 +95,51 @@ describe("facade/spine-digest-file", () => {
     });
   });
 
-  it("materializes sqlite state for plain archive reads", async () => {
+  it("materializes custom read directories from coordinator state", async () => {
+    await withTempDir("spinedigest-facade-file-", async (path) => {
+      const restoreStateDir = useCoordinatorStateDir(`${path}/state`);
+      try {
+        const archivePath = await createSeedArchive(path);
+        const coordinator = new WikgCoordinator();
+        const fileStore = coordinator.createFileStore(archivePath);
+
+        try {
+          await fileStore.writeFile(
+            `${archivePath}/book-meta.json`,
+            `${JSON.stringify({
+              authors: [],
+              description: null,
+              identifier: "urn:test:overlay",
+              language: "en",
+              publishedAt: null,
+              publisher: null,
+              sourceFormat: "txt",
+              title: "Overlay Directory Title",
+              version: 1,
+            })}\n`,
+            { overwrite: true },
+          );
+        } finally {
+          await fileStore.close();
+        }
+
+        await new SpineDigestFile(archivePath).read(
+          async (digest) => {
+            expect(await digest.readMeta()).toMatchObject({
+              title: "Overlay Directory Title",
+            });
+          },
+          {
+            documentDirPath: `${path}/opened-read`,
+          },
+        );
+      } finally {
+        restoreStateDir();
+      }
+    });
+  });
+
+  it("settles materialized sqlite state after plain archive reads", async () => {
     await withTempDir("spinedigest-facade-file-", async (path) => {
       const restoreStateDir = useCoordinatorStateDir(`${path}/state`);
       try {
@@ -106,12 +151,7 @@ describe("facade/spine-digest-file", () => {
           });
         });
 
-        await expect(readCoordinatorOverlays(path)).resolves.toMatchObject([
-          {
-            entryPath: "database.db",
-            kind: "file",
-          },
-        ]);
+        await expect(readCoordinatorOverlays(path)).resolves.toStrictEqual([]);
       } finally {
         restoreStateDir();
       }
@@ -253,7 +293,7 @@ describe("facade/spine-digest-file", () => {
     });
   });
 
-  it("keeps failed archive writes materialized without flushing", async () => {
+  it("settles failed archive writes when leaving the archive session", async () => {
     await withTempDir("spinedigest-facade-file-", async (path) => {
       const restoreStateDir = useCoordinatorStateDir(`${path}/state`);
       try {
@@ -275,13 +315,9 @@ describe("facade/spine-digest-file", () => {
           }),
         ).rejects.toThrow("stop before flush");
 
-        const overlays = await readCoordinatorOverlays(path);
-
-        expect(
-          overlays.map((overlay) => overlay.entryPath).sort(),
-        ).toStrictEqual(["book-meta.json", "database.db"]);
+        await expect(readCoordinatorOverlays(path)).resolves.toStrictEqual([]);
         await expect(readArchivedTitle(path, archivePath)).resolves.toBe(
-          "Session Fixture",
+          "Unflushed Title",
         );
       } finally {
         restoreStateDir();

--- a/test/facade/spine-digest-file.test.ts
+++ b/test/facade/spine-digest-file.test.ts
@@ -757,13 +757,7 @@ INSERT INTO archive_owners (
   archive_key, owner_id, owner_pid, heartbeat_at, created_at
 ) VALUES (?, ?, ?, ?, ?)
 `,
-      [
-        createArchiveKey(input.archivePath),
-        input.ownerId,
-        1,
-        Date.now() - 120_000,
-        Date.now() - 120_000,
-      ],
+      [createArchiveKey(input.archivePath), input.ownerId, 1, 0, 0],
     );
   } finally {
     await database.close();


### PR DESCRIPTION
## Summary
- add archive-session owner tracking and heartbeat-based settlement around WIKG facade reads/writes
- make custom read directories materialize the coordinator logical view instead of bypassing overlays
- add reaper-state regression tests and bump package version to 0.3.0

## Tests
- pnpm lint
- pnpm typecheck
- pnpm format:check
- pnpm test:run
- pnpm test:run test/facade/spine-digest-file.test.ts