### PR TITLE
feat(wikg): split FTS index storage

### DIFF
--- a/data/help/commands/archive/search.jinja
+++ b/data/help/commands/archive/search.jinja
@@ -20,6 +20,7 @@ Returns:
   - With a machine-readable format, search result items.
 
 Notes:
+  - Search requires a current FTS index. If the index is missing or outdated, run `<archive-uri>/index build`.
   - Search results are leads, not source evidence.
   - Search the archive URI for broad discovery.
   - Search a lens URI such as `<archive-uri>/source`, `<archive-uri>/summary`, `<archive-uri>/chunk`, `<archive-uri>/entity`, or `<archive-uri>/triple` to choose one object kind.

--- a/data/help/commands/gc.jinja
+++ b/data/help/commands/gc.jinja
@@ -5,11 +5,16 @@ Purpose:
   Try to run Wiki Graph local garbage collection.
 
 Usage:
-  wikigraph gc [--json]
+  wikigraph gc [--force] [--json]
 
 Behavior:
   GC scans local Wiki Graph state and cache resources, then releases expired or low-value resources that are not in use.
   If another GC run is active, this command reports that it was skipped instead of waiting or starting a second run.
+
+Options:
+  --force
+    Ignore normal cache lifetimes and remove disposable resources as soon as they are not in use.
+    This can remove warm SQLite caches and completed or failed build jobs that a normal GC run would keep temporarily.
 
 Managed areas:
   - Search query cache.

--- a/data/help/commands/gc.jinja
+++ b/data/help/commands/gc.jinja
@@ -17,6 +17,7 @@ Options:
     This can remove warm SQLite caches and completed or failed build jobs that a normal GC run would keep temporarily.
 
 Managed areas:
+  - Wiki Graph coordinator workspace files and cached SQLite databases.
   - Search query cache.
   - Completed build job records and their durable event/workspace files.
   - Wiki Graph controlled temporary directories under the state directory.

--- a/data/help/commands/gc.jinja
+++ b/data/help/commands/gc.jinja
@@ -1,0 +1,21 @@
+Help Type: command
+Command: wikigraph gc
+
+Purpose:
+  Try to run Wiki Graph local garbage collection.
+
+Usage:
+  wikigraph gc [--json]
+
+Behavior:
+  GC scans local Wiki Graph state and cache resources, then releases expired or low-value resources that are not in use.
+  If another GC run is active, this command reports that it was skipped instead of waiting or starting a second run.
+
+Managed areas:
+  - Search query cache.
+  - Completed build job records and their durable event/workspace files.
+  - Wiki Graph controlled temporary directories under the state directory.
+
+Output:
+  Text output reports scanned resources, removed resources, and freed disk space.
+  Use `--json` for a machine-readable run report.

--- a/data/help/commands/root.jinja
+++ b/data/help/commands/root.jinja
@@ -62,7 +62,7 @@ Maintenance:
   wikigraph <chapter-uri>/title set <title>
   wikigraph <chapter-uri>/title clear
   wikigraph <archive-uri>/chapter/tree get|set [options]
-  wikigraph gc [--json]
+  wikigraph gc [--force] [--json]
   wikigraph config status [--llm <json>] [--help|-h]
     Prints JSON by default and does not accept `--json`.
   wikigraph help [topic] [--help|-h]

--- a/data/help/commands/root.jinja
+++ b/data/help/commands/root.jinja
@@ -62,6 +62,7 @@ Maintenance:
   wikigraph <chapter-uri>/title set <title>
   wikigraph <chapter-uri>/title clear
   wikigraph <archive-uri>/chapter/tree get|set [options]
+  wikigraph gc [--json]
   wikigraph config status [--llm <json>] [--help|-h]
     Prints JSON by default and does not accept `--json`.
   wikigraph help [topic] [--help|-h]

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -23,6 +23,7 @@ wikigraph <entity-uri> related [query] [--all] [--limit <n>] [--context <n>] [--
 wikigraph <entity-uri|triple-uri|summary-uri|chunk-uri> evidence [query] [--all] [--limit <n>] [--context <n>] [--cursor <token>] [--json|--jsonl]
 wikigraph <located-chunk-uri|located-entity-uri> pack [--budget <chars>] [--json|--jsonl]
 wikigraph <archive-uri> export --output-format <format> [--output <path>]
+wikigraph <archive-uri>/index get|build|embed|external|clear [--json]
 wikigraph <chapter-uri> queue add --task reading-graph|reading-summary|knowledge-graph --accept-cost [--boost] [--llm <json>] [--prompt <text>]
 wikigraph wkg-job:// list [--all] [--active] [--input <archive-uri>] [--json]
 wikigraph wkg-job://<job-id> get [--json]
@@ -41,6 +42,7 @@ Exploration modes:
 Search and collection behavior:
 
 - `search` finds URI-addressable objects from query text. Search results are leads, not source evidence.
+- Search requires a current FTS index. If the index is missing or outdated, run `<archive-uri>/index build`; by default this creates a local cached FTS index instead of storing it in the archive.
 - `list` enumerates URI-addressable objects without query text.
 - Object commands use Wiki Graph URIs. Use an archive or scope URI such as `wkg:///Users/me/book.wikg` for `search` and `list`; use a concrete object URI such as `wkg:///Users/me/book.wikg/chapter/12` for `get` or `evidence`. `related` and `pack` are limited to chunk and entity objects.
 - For content understanding, choose a search lens in the URI: `<archive-uri>/chunk` for Reading Graph structure, `<archive-uri>/summary` for quick overview, `<archive-uri>/source` for original source wording, or `<archive-uri>/entity` and `<archive-uri>/triple` for Knowledge Graph objects.

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -65,6 +65,7 @@ wikigraph wkg-job:// list --input wkg://book.wikg
 
 ```bash
 wikigraph wkg://book.wikg/chapter/tree get
+wikigraph wkg://book.wikg/index build
 wikigraph wkg://book.wikg/chunk search "central argument"
 wikigraph wkg://book.wikg/chapter/3 get
 wikigraph wkg://book.wikg/chunk/84 get

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -23,6 +23,7 @@ wikigraph <entity-uri> related [query] [--all] [--limit <n>] [--context <n>] [--
 wikigraph <entity-uri|triple-uri|summary-uri|chunk-uri> evidence [query] [--all] [--limit <n>] [--context <n>] [--cursor <token>] [--json|--jsonl]
 wikigraph <located-chunk-uri|located-entity-uri> pack [--budget <chars>] [--json|--jsonl]
 wikigraph <archive-uri> export --output-format <format> [--output <path>]
+wikigraph <archive-uri>/index get|build|embed|external|clear [--json]
 wikigraph <chapter-uri> queue add --task reading-graph|reading-summary|knowledge-graph --accept-cost [--boost] [--llm <json>] [--prompt <text>]
 wikigraph wkg-job:// list [--all] [--active] [--input <archive-uri>] [--json]
 wikigraph wkg-job://<job-id> get [--json]
@@ -41,6 +42,7 @@ wikigraph queue clean
 搜索与集合行为：
 
 - `search` 根据 query text 查找可 URI 寻址的对象。Search result 是线索，不等于 source evidence。
+- Search 需要当前可用的 FTS index。如果 index 缺失或过期，先运行 `<archive-uri>/index build`；默认会创建本地缓存 FTS index，不写入归档。
 - `list` 在没有 query text 时枚举可 URI 寻址的对象。
 - Object command 使用 Wiki Graph URI。`search` 和 `list` 使用 archive 或 scope URI，例如 `wkg:///Users/me/book.wikg`；`get`、`related`、`evidence` 和 `pack` 使用具体 object URI，例如 `wkg:///Users/me/book.wikg/chapter/12`。
 - 做内容理解时，在 URI 中选择 search lens：`<archive-uri>/chunk` 用于 Reading Graph 结构，`<archive-uri>/summary` 用于快速概览，`<archive-uri>/source` 用于原文措辞，`<archive-uri>/entity` 和 `<archive-uri>/triple` 用于 Knowledge Graph 对象。

--- a/docs/zh-CN/quickstart.md
+++ b/docs/zh-CN/quickstart.md
@@ -65,6 +65,7 @@ wikigraph wkg-job:// list --input wkg://book.wikg
 
 ```bash
 wikigraph wkg://book.wikg/chapter/tree get
+wikigraph wkg://book.wikg/index build
 wikigraph wkg://book.wikg/chunk search "central argument"
 wikigraph wkg://book.wikg/chapter/3 get
 wikigraph wkg://book.wikg/chunk/84 get

--- a/src/archive/query/archive-view.ts
+++ b/src/archive/query/archive-view.ts
@@ -934,12 +934,7 @@ export async function findArchiveObjects(
         ...(await findTriples(document, search, { mentions: allMentions })),
       ]
     : [];
-  const hits =
-    indexed === undefined
-      ? await findArchiveObjectsUncached(document, search, options, {
-          allMentions,
-        })
-      : [...structuredHits, ...indexed.hits];
+  const hits = [...structuredHits, ...(indexed?.hits ?? [])];
   if (isEntityOnlySearch(options)) {
     const ranked = createRankedFindResult(
       query,
@@ -1123,60 +1118,6 @@ export async function grepArchiveObjects(
     [query.trim().toLowerCase()],
     "exact",
   );
-}
-
-async function findArchiveObjectsUncached(
-  document: ReadonlyDocument,
-  search: LexicalQuery,
-  options: ArchiveFindOptions,
-  context: {
-    readonly allMentions: readonly MentionRecord[];
-  },
-): Promise<readonly ArchiveFindHit[]> {
-  const requestedTypes = options.types ?? null;
-  const shouldFindMeta =
-    requestedTypes === null || requestedTypes.includes("meta");
-  const shouldFindEntities =
-    requestedTypes === null || requestedTypes.includes("entity");
-  const shouldFindTriples =
-    requestedTypes === null || requestedTypes.includes("triple");
-  const hasOnlyStructuredTypeRequest =
-    requestedTypes !== null &&
-    requestedTypes.every((type) => type === "entity" || type === "triple");
-  const hasTextTypeRequest =
-    requestedTypes === null ||
-    requestedTypes.includes("chapter") ||
-    requestedTypes.includes("meta") ||
-    requestedTypes.includes("fragment") ||
-    requestedTypes.includes("node") ||
-    requestedTypes.includes("source") ||
-    requestedTypes.includes("summary");
-  const metaHits = shouldFindMeta
-    ? findMetaLexical(await document.readBookMeta(), search)
-    : [];
-  const structuredHits = [
-    ...metaHits,
-    ...(shouldFindEntities
-      ? findEntities(search, { mentions: context.allMentions })
-      : []),
-    ...(shouldFindTriples
-      ? await findTriples(document, search, { mentions: context.allMentions })
-      : []),
-  ];
-
-  if (structuredHits.length > 0 && hasOnlyStructuredTypeRequest) {
-    return structuredHits;
-  }
-  if (!hasTextTypeRequest) {
-    return structuredHits;
-  }
-
-  const hits: ArchiveFindHit[] = [];
-
-  hits.push(...(await findChaptersLexical(document, search)));
-  hits.push(...(await findNodesLexical(document, search)));
-
-  return [...structuredHits, ...hits];
 }
 
 async function findArchiveObjectsIndexed(
@@ -3684,39 +3625,6 @@ function parseEntityQid(id: string): string | undefined {
   return id.startsWith(prefix) ? id.slice(prefix.length) : undefined;
 }
 
-function findMetaLexical(
-  meta: BookMeta | undefined,
-  search: LexicalQuery,
-): readonly ArchiveFindHit[] {
-  if (meta === undefined) {
-    return [];
-  }
-
-  const fields = [
-    meta.title,
-    ...meta.authors,
-    meta.description,
-    meta.publisher,
-  ].filter(isDefined);
-  const content = fields.join("\n");
-  const contentMatch = scoreLexicalText(content, search);
-
-  if (contentMatch === undefined) {
-    return [];
-  }
-
-  return [
-    {
-      field: "metadata",
-      id: ARCHIVE_ROOT_ID,
-      ...createFindMatchFields(contentMatch),
-      snippet: createSnippet(content, contentMatch.snippetNeedle),
-      title: meta.title ?? "Book metadata",
-      type: "meta",
-    },
-  ];
-}
-
 function filterLexicalHitsByMatch(
   hits: readonly ArchiveFindHit[],
   search: LexicalQuery,
@@ -3735,97 +3643,6 @@ function filterLexicalHitsByMatch(
   return hits.filter((hit) =>
     requiredTerms.every((term) => hit.matchedTerms?.includes(term) === true),
   );
-}
-
-async function findChaptersLexical(
-  document: ReadonlyDocument,
-  search: LexicalQuery,
-): Promise<readonly ArchiveFindHit[]> {
-  const hits: ArchiveFindHit[] = [];
-
-  for (const chapter of await listChapters(document)) {
-    const title = chapter.title ?? `[chapter ${chapter.chapterId}]`;
-    const titleMatch = scoreLexicalText(title, search);
-
-    if (titleMatch !== undefined) {
-      hits.push({
-        chapter: chapter.chapterId,
-        field: "title",
-        id: formatChapterId(chapter.chapterId),
-        ...createFindMatchFields(titleMatch),
-        position: {
-          chapter: chapter.chapterId,
-        },
-        snippet: title,
-        state: await createChapterState(document, chapter),
-        title,
-        type: "chapter",
-      });
-    }
-
-    hits.push(
-      ...(await findTextStreamSentencesLexical(
-        document,
-        chapter.chapterId,
-        "summary",
-        title,
-        search,
-      )),
-    );
-
-    hits.push(
-      ...(await findTextStreamSentencesLexical(
-        document,
-        chapter.chapterId,
-        "source",
-        title,
-        search,
-      )),
-    );
-  }
-
-  return hits;
-}
-
-async function findNodesLexical(
-  document: ReadonlyDocument,
-  search: LexicalQuery,
-): Promise<readonly ArchiveFindHit[]> {
-  const hits: ArchiveFindHit[] = [];
-
-  for (const node of await document.chunks.listAll()) {
-    const position = createNodePosition(node.sentenceIds);
-    const labelMatch = scoreLexicalText(node.label, search);
-
-    if (labelMatch !== undefined) {
-      hits.push({
-        chapter: node.sentenceId[0],
-        field: "title",
-        id: formatNodeId(node.id),
-        ...createFindMatchFields(labelMatch),
-        ...(position === undefined ? {} : { position }),
-        snippet: node.label,
-        title: node.label,
-        type: "node",
-      });
-    }
-    const contentMatch = scoreLexicalText(node.content, search);
-
-    if (contentMatch !== undefined) {
-      hits.push({
-        chapter: node.sentenceId[0],
-        field: "content",
-        id: formatNodeId(node.id),
-        ...createFindMatchFields(contentMatch),
-        ...(position === undefined ? {} : { position }),
-        snippet: createSnippet(node.content, contentMatch.snippetNeedle),
-        title: node.label,
-        type: "node",
-      });
-    }
-  }
-
-  return hits;
 }
 
 async function findChapters(
@@ -3876,46 +3693,6 @@ async function findChapters(
   }
 
   return hits;
-}
-
-async function findTextStreamSentencesLexical(
-  document: ReadonlyDocument,
-  chapterId: number,
-  stream: ArchiveTextStreamKind,
-  title: string,
-  search: LexicalQuery,
-): Promise<readonly ArchiveFindHit[]> {
-  const index = await createTextStreamIndex(document, chapterId, stream);
-
-  return index.sentences.flatMap((sentence) => {
-    const match = scoreLexicalText(sentence.text, search);
-
-    if (match === undefined) {
-      return [];
-    }
-
-    return [
-      {
-        chapter: chapterId,
-        field: stream,
-        id: formatTextStreamRangeUri(
-          chapterId,
-          stream,
-          sentence.globalIndex,
-          sentence.globalIndex,
-        ),
-        ...createFindMatchFields(match),
-        position: {
-          chapter: chapterId,
-          fragment: sentence.fragmentId,
-          sentence: sentence.localIndex,
-        },
-        snippet: createSnippet(sentence.text, match.snippetNeedle),
-        title,
-        type: stream === "source" ? ("source" as const) : ("summary" as const),
-      },
-    ];
-  });
 }
 
 async function findTextStreamSentences(

--- a/src/archive/query/archive-view.ts
+++ b/src/archive/query/archive-view.ts
@@ -7,6 +7,7 @@ import type {
   SentenceId,
 } from "../../document/index.js";
 import type { BookMeta } from "../../source/index.js";
+import type { Document } from "../../document/index.js";
 import {
   WikipageResolver,
   type WikipageResolverOptions,
@@ -1055,7 +1056,7 @@ async function createSearchRevisionScope(
 }
 
 export async function rebuildArchiveSearchIndex(
-  document: ReadonlyDocument,
+  document: Document,
 ): Promise<void> {
   await ensureSearchIndex(document, await createSearchIndexRecords(document));
 }
@@ -1157,19 +1158,10 @@ async function findArchiveObjectsIndexed(
     }
   | undefined
 > {
-  try {
-    if (!(await isSearchIndexCurrent(document))) {
-      await ensureSearchIndex(
-        document,
-        await createSearchIndexRecords(document),
-      );
-    }
-  } catch (error) {
-    if (isReadonlySqliteError(error)) {
-      return undefined;
-    }
-
-    throw error;
+  if (!(await isSearchIndexCurrent(document))) {
+    throw new Error(
+      "Wiki Graph search index is missing or outdated. Run `<archive>/index build` before searching.",
+    );
   }
   const result = await querySearchIndex(document, query, {
     ...(options.chapters === undefined ? {} : { chapters: options.chapters }),
@@ -1187,26 +1179,6 @@ async function findArchiveObjectsIndexed(
         ),
         result,
       };
-}
-
-function isReadonlySqliteError(error: unknown): boolean {
-  const code = getErrorCode(error);
-
-  if (code !== undefined && code.startsWith("SQLITE_READONLY")) {
-    return true;
-  }
-
-  return error instanceof Error && error.message.includes("readonly database");
-}
-
-function getErrorCode(error: unknown): string | undefined {
-  if (typeof error !== "object" || error === null || !("code" in error)) {
-    return undefined;
-  }
-
-  const code = error.code;
-
-  return typeof code === "string" ? code : undefined;
 }
 
 async function hydrateSearchIndexHits(

--- a/src/archive/query/archive-view.ts
+++ b/src/archive/query/archive-view.ts
@@ -941,6 +941,7 @@ export async function findArchiveObjects(
     const sentenceCacheInput = await createSentenceEvidenceSearchCacheInput(
       document,
       indexed?.result,
+      options,
     );
     const sessionId = await createEntitySearchSession({
       archiveKey: options.archiveKey ?? "archive",
@@ -993,6 +994,7 @@ export async function findArchiveObjects(
   const sentenceCacheInput = await createSentenceEvidenceSearchCacheInput(
     document,
     indexed?.result,
+    options,
   );
   const sessionId = await createSearchSession({
     archiveKey: options.archiveKey ?? "archive",
@@ -1166,6 +1168,7 @@ async function findArchiveObjectsIndexed(
   const result = await querySearchIndex(document, query, {
     ...(options.chapters === undefined ? {} : { chapters: options.chapters }),
     ...(options.match === undefined ? {} : { match: options.match }),
+    ...createSearchIndexQueryLimitOptions(options),
     types: options.types ?? null,
   });
 
@@ -1227,7 +1230,21 @@ function createSearchIndexHydrationOptions(options: ArchiveFindOptions): {
     return {};
   }
 
-  return { textHitLimit: options.limit + 1 };
+  return { textHitLimit: createTextOnlySearchCacheWindow(options.limit) };
+}
+
+function createSearchIndexQueryLimitOptions(options: ArchiveFindOptions): {
+  readonly textHitLimit?: number;
+} {
+  if (!isTextOnlySearch(options) || options.limit === undefined) {
+    return {};
+  }
+
+  return { textHitLimit: createTextOnlySearchCacheWindow(options.limit) };
+}
+
+function createTextOnlySearchCacheWindow(limit: number): number {
+  return Math.max(limit + 1, TEXT_ONLY_SEARCH_CACHE_WINDOW);
 }
 
 function isTextOnlySearch(options: ArchiveFindOptions): boolean {
@@ -3451,13 +3468,14 @@ function createEntitySearchCacheInput(
 async function createSentenceEvidenceSearchCacheInput(
   document: ReadonlyDocument,
   indexResult: SearchIndexQueryResult | undefined,
+  options: ArchiveFindOptions,
 ): Promise<{
   readonly chunkHits: readonly SearchChunkHitInput[];
   readonly entityHits: readonly SearchEntityHitInput[];
   readonly evidenceEvents: readonly SearchEvidenceHitEventInput[];
   readonly tripleHits: readonly SearchTripleHitInput[];
 }> {
-  if (indexResult === undefined) {
+  if (indexResult === undefined || isTextOnlySearch(options)) {
     return {
       chunkHits: [],
       entityHits: [],
@@ -5371,6 +5389,7 @@ interface ArchiveTextMatch {
 
 const DEFAULT_FIND_LIMIT = 20;
 const GROUP_SCORE_EVIDENCE_LIMIT = 10;
+const TEXT_ONLY_SEARCH_CACHE_WINDOW = 100;
 const GROUP_SCORE_MAX_EQUAL_EVIDENCE_BONUS = 0.3;
 const ARCHIVE_ROOT_ID = "meta:root";
 

--- a/src/archive/query/archive-view.ts
+++ b/src/archive/query/archive-view.ts
@@ -774,8 +774,12 @@ export async function findArchiveObjects(
   options: ArchiveFindOptions = {},
 ): Promise<ArchiveFindResult> {
   const limit = options.limit ?? DEFAULT_FIND_LIMIT;
+  const textOnlySearch = isTextOnlySearch(options);
 
-  if (options.cursor !== undefined) {
+  if (
+    options.cursor !== undefined &&
+    (!textOnlySearch || !isFindCursor(options.cursor))
+  ) {
     const cursor = decodeSearchSessionCursor(options.cursor);
     const descriptor = await readSearchSessionDescriptor(
       cursor.sessionId,
@@ -832,6 +836,15 @@ export async function findArchiveObjects(
 
   if (search === undefined) {
     return createFindResult(query, [], options);
+  }
+
+  if (textOnlySearch) {
+    return await findTextOnlyArchiveObjectsIndexed(
+      document,
+      query,
+      options,
+      search,
+    );
   }
 
   const revisionScope = await createSearchRevisionScope(
@@ -1032,6 +1045,23 @@ export async function findArchiveObjects(
       nextCursor: firstPage.nextCursor,
     },
     options,
+  );
+}
+
+async function findTextOnlyArchiveObjectsIndexed(
+  document: ReadonlyDocument,
+  query: string,
+  options: ArchiveFindOptions,
+  search: LexicalQuery,
+): Promise<ArchiveFindResult> {
+  const indexed = await findArchiveObjectsIndexed(document, query, options);
+  const hits = indexed?.hits ?? [];
+
+  return createFindResult(
+    query,
+    filterLexicalHitsByMatch(hits, search, options.match ?? "any"),
+    options,
+    indexed?.result.terms ?? search.terms,
   );
 }
 
@@ -6019,6 +6049,15 @@ function decodeFindCursor(cursor: string | undefined): number {
   }
 
   throw new Error("Invalid search cursor.");
+}
+
+function isFindCursor(cursor: string): boolean {
+  try {
+    decodeFindCursor(cursor);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function createSnippet(value: string, needle?: string): string {

--- a/src/archive/query/archive-view.ts
+++ b/src/archive/query/archive-view.ts
@@ -1160,7 +1160,7 @@ async function findArchiveObjectsIndexed(
 > {
   if (!(await isSearchIndexCurrent(document))) {
     throw new Error(
-      "Wiki Graph search index is missing or outdated. Run `<archive>/index build` before searching.",
+      "Wiki Graph search index is missing or outdated. Run `<archive-uri>/index build` before searching.",
     );
   }
   const result = await querySearchIndex(document, query, {

--- a/src/archive/query/continuation-cursor.ts
+++ b/src/archive/query/continuation-cursor.ts
@@ -34,6 +34,7 @@ export type ContinuationCursor =
       readonly evidenceLimit?: number;
       readonly format: "json" | "jsonl" | "text";
       readonly kind: "search";
+      readonly query?: string;
       readonly sourceContext?: number;
       readonly triplePattern?: {
         readonly objectQid?: string;
@@ -196,6 +197,7 @@ function createCursorPayload(input: ContinuationCursor): object {
         ...(input.evidenceLimit === undefined
           ? {}
           : { evidenceLimit: input.evidenceLimit }),
+        ...(input.query === undefined ? {} : { query: input.query }),
         ...(input.sourceContext === undefined
           ? {}
           : { sourceContext: input.sourceContext }),
@@ -265,6 +267,7 @@ function parseContinuationCursorRecord(record: {
       ...getPayloadOptionalPositiveInteger(payload, "evidenceLimit"),
       format: record.format,
       kind: "search",
+      ...getPayloadOptionalString(payload, "query"),
       ...getPayloadOptionalInteger(payload, "sourceContext", "sourceContext"),
       ...getPayloadOptionalTriplePattern(payload),
       types: getPayloadStringArrayOrNull(payload, "types"),

--- a/src/archive/query/index.ts
+++ b/src/archive/query/index.ts
@@ -56,6 +56,7 @@ export {
   createSearchSession,
   deleteArchiveSearchSessions,
   readCachedSearchSessionPage,
+  runSearchCacheGc,
 } from "./search-cache.js";
 export type {
   SearchSessionDescriptor,

--- a/src/archive/query/search-cache.ts
+++ b/src/archive/query/search-cache.ts
@@ -407,6 +407,7 @@ export async function deleteArchiveSearchSessions(
       for (const sessionId of sessionIds) {
         await deleteSearchSession(database, sessionId);
       }
+      await deleteUnusedPredicates(database);
     });
   } finally {
     await database.close();
@@ -441,6 +442,7 @@ export async function runSearchCacheGc(
         for (const sessionId of sessionIds) {
           await deleteSearchSession(database, sessionId);
         }
+        await deleteUnusedPredicates(database);
       });
       await database.run("VACUUM");
     }
@@ -794,6 +796,17 @@ async function deleteSearchSession(
   await database.run("DELETE FROM search_sessions WHERE session_id = ?", [
     sessionId,
   ]);
+}
+
+async function deleteUnusedPredicates(database: Database): Promise<void> {
+  await database.run(`
+    DELETE FROM predicate_dictionary
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM search_triple_hits
+      WHERE search_triple_hits.predicate_id = predicate_dictionary.id
+    )
+  `);
 }
 
 async function insertSearchEvidenceHitEvent(

--- a/src/archive/query/search-cache.ts
+++ b/src/archive/query/search-cache.ts
@@ -1,4 +1,5 @@
 import { createHash } from "crypto";
+import { stat } from "fs/promises";
 import { join, resolve } from "path";
 
 import { resolveWikiGraphStateDirectoryPath } from "../../common/wiki-graph-dir.js";
@@ -6,6 +7,8 @@ import { getNumber, getString } from "../../document/database.js";
 import type { SqlBindValue } from "../../document/database.js";
 import { openSharedStateDatabase } from "../../document/index.js";
 import type { Database } from "../../document/index.js";
+import type { GcContext, GcJobResult } from "../../gc/index.js";
+import { isNodeError } from "../../utils/node-error.js";
 
 import type { ArchiveFindHit } from "./archive-view.js";
 
@@ -265,7 +268,6 @@ export async function createSearchSession(
   const database = await openSearchSessionDatabase();
 
   try {
-    await cleanExpiredSearchSessions(database);
     const now = Date.now();
     const sessionId = createSearchSessionId(input);
     const optionsJSON = JSON.stringify({
@@ -319,7 +321,6 @@ export async function createSearchSession(
       for (const hit of input.chunkHits ?? []) {
         await upsertSearchChunkHit(database, sessionId, hit);
       }
-      await pruneSearchSessions(database);
     });
 
     return sessionId;
@@ -334,7 +335,6 @@ export async function createEntitySearchSession(
   const database = await openSearchSessionDatabase();
 
   try {
-    await cleanExpiredSearchSessions(database);
     const now = Date.now();
     const sessionId = createEntitySearchSessionId(input);
     const optionsJSON = JSON.stringify({
@@ -379,7 +379,6 @@ export async function createEntitySearchSession(
       for (const hit of input.chunkHits ?? []) {
         await upsertSearchChunkHit(database, sessionId, hit);
       }
-      await pruneSearchSessions(database);
     });
 
     return sessionId;
@@ -414,6 +413,46 @@ export async function deleteArchiveSearchSessions(
   }
 }
 
+export async function runSearchCacheGc(
+  context: GcContext,
+): Promise<GcJobResult> {
+  const databasePath = getSearchSessionDatabasePath();
+  const beforeBytes = await readFileSize(databasePath);
+  const database = await openSearchSessionDatabase();
+
+  try {
+    const scanned = await database.queryOne(
+      "SELECT COUNT(*) AS count FROM search_sessions",
+      undefined,
+      (row) => getNumber(row, "count"),
+    );
+    const expiredSessionIds = await listExpiredSearchSessionIds(database);
+    const prunedSessionIds = await listPrunedSearchSessionIds(database);
+    const sessionIds = [
+      ...new Set([...expiredSessionIds, ...prunedSessionIds]),
+    ].sort();
+
+    if (!context.dryRun && sessionIds.length > 0) {
+      await database.transaction(async () => {
+        for (const sessionId of sessionIds) {
+          await deleteSearchSession(database, sessionId);
+        }
+      });
+      await database.run("VACUUM");
+    }
+
+    const afterBytes = await readFileSize(databasePath);
+
+    return {
+      freedBytes: Math.max(0, beforeBytes - afterBytes),
+      removed: sessionIds.length,
+      scanned: scanned ?? 0,
+    };
+  } finally {
+    await database.close();
+  }
+}
+
 export async function readSearchSessionPage(
   sessionId: string,
   offset: number,
@@ -424,7 +463,6 @@ export async function readSearchSessionPage(
   const database = await openSearchSessionDatabase();
 
   try {
-    await cleanExpiredSearchSessions(database);
     const session = await readSearchSessionMetadata(
       database,
       sessionId,
@@ -484,7 +522,6 @@ export async function readEntitySearchSessionPage(
   const database = await openSearchSessionDatabase();
 
   try {
-    await cleanExpiredSearchSessions(database);
     const session = await readSearchSessionMetadata(
       database,
       sessionId,
@@ -536,7 +573,6 @@ export async function readSearchSessionDescriptor(
   const database = await openSearchSessionDatabase();
 
   try {
-    await cleanExpiredSearchSessions(database);
     const session = await readSearchSessionMetadata(
       database,
       sessionId,
@@ -665,9 +701,13 @@ export function decodeSearchSessionCursor(cursor: string): {
 
 async function openSearchSessionDatabase(): Promise<Database> {
   return await openSharedStateDatabase(
-    join(getSearchSessionStateDirectoryPath(), "search-sessions.sqlite"),
+    getSearchSessionDatabasePath(),
     SEARCH_SESSION_SCHEMA_SQL,
   );
+}
+
+function getSearchSessionDatabasePath(): string {
+  return join(getSearchSessionStateDirectoryPath(), "search-sessions.sqlite");
 }
 
 function getSearchSessionStateDirectoryPath(): string {
@@ -680,27 +720,18 @@ function getSearchSessionStateDirectoryPath(): string {
   return resolveWikiGraphStateDirectoryPath();
 }
 
-async function cleanExpiredSearchSessions(database: Database): Promise<void> {
-  const now = Date.now();
-  const expiredSessionIds = await database.queryAll(
+async function listExpiredSearchSessionIds(
+  database: Database,
+): Promise<string[]> {
+  return await database.queryAll(
     `
       SELECT session_id
       FROM search_sessions
       WHERE expires_at < ?
     `,
-    [now],
+    [Date.now()],
     (row) => getString(row, "session_id"),
   );
-
-  if (expiredSessionIds.length === 0) {
-    return;
-  }
-
-  await database.transaction(async () => {
-    for (const sessionId of expiredSessionIds) {
-      await deleteSearchSession(database, sessionId);
-    }
-  });
 }
 
 async function hasSearchSession(
@@ -710,14 +741,14 @@ async function hasSearchSession(
   const database = await openSearchSessionDatabase();
 
   try {
-    await cleanExpiredSearchSessions(database);
     const row = await database.queryOne(
       `
         SELECT session_id
         FROM search_sessions
         WHERE session_id = ? AND archive_key = ?
+          AND expires_at >= ?
       `,
-      [sessionId, archiveKey],
+      [sessionId, archiveKey, Date.now()],
       () => true,
     );
 
@@ -991,8 +1022,10 @@ async function getOrCreatePredicateId(
   return id;
 }
 
-async function pruneSearchSessions(database: Database): Promise<void> {
-  const prunedSessionIds = await database.queryAll(
+async function listPrunedSearchSessionIds(
+  database: Database,
+): Promise<string[]> {
+  return await database.queryAll(
     `
       SELECT session_id
       FROM search_sessions
@@ -1002,9 +1035,17 @@ async function pruneSearchSessions(database: Database): Promise<void> {
     [SEARCH_SESSION_MAX_COUNT],
     (row) => getString(row, "session_id"),
   );
+}
 
-  for (const sessionId of prunedSessionIds) {
-    await deleteSearchSession(database, sessionId);
+async function readFileSize(path: string): Promise<number> {
+  try {
+    return (await stat(path)).size;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return 0;
+    }
+
+    throw error;
   }
 }
 
@@ -1024,6 +1065,7 @@ async function readSearchSessionMetadata(
   readonly query: string;
   readonly sessionId: string;
   readonly terms: readonly string[];
+  readonly expiresAt: number;
 }> {
   const session = await database.queryOne(
     `
@@ -1034,7 +1076,8 @@ async function readSearchSessionMetadata(
         terms_json,
         lens,
         match,
-        created_at
+        created_at,
+        expires_at
       FROM search_sessions
       WHERE session_id = ?
         ${expectedArchiveKey === undefined ? "" : "AND archive_key = ?"}
@@ -1047,6 +1090,7 @@ async function readSearchSessionMetadata(
     ],
     (row) => ({
       createdAt: getNumber(row, "created_at"),
+      expiresAt: getNumber(row, "expires_at"),
       lens: getString(row, "lens"),
       match: getString(row, "match"),
       options: parseSessionOptions(getString(row, "options_json")),
@@ -1056,7 +1100,7 @@ async function readSearchSessionMetadata(
     }),
   );
 
-  if (session === undefined) {
+  if (session === undefined || session.expiresAt < Date.now()) {
     throw new Error("Search cursor expired. Run the search again.");
   }
 

--- a/src/archive/query/search-cache.ts
+++ b/src/archive/query/search-cache.ts
@@ -426,8 +426,12 @@ export async function runSearchCacheGc(
       undefined,
       (row) => getNumber(row, "count"),
     );
-    const expiredSessionIds = await listExpiredSearchSessionIds(database);
-    const prunedSessionIds = await listPrunedSearchSessionIds(database);
+    const expiredSessionIds = context.force
+      ? await listAllSearchSessionIds(database)
+      : await listExpiredSearchSessionIds(database, context.now);
+    const prunedSessionIds = context.force
+      ? []
+      : await listPrunedSearchSessionIds(database);
     const sessionIds = [
       ...new Set([...expiredSessionIds, ...prunedSessionIds]),
     ].sort();
@@ -722,6 +726,7 @@ function getSearchSessionStateDirectoryPath(): string {
 
 async function listExpiredSearchSessionIds(
   database: Database,
+  now: number,
 ): Promise<string[]> {
   return await database.queryAll(
     `
@@ -729,7 +734,15 @@ async function listExpiredSearchSessionIds(
       FROM search_sessions
       WHERE expires_at < ?
     `,
-    [Date.now()],
+    [now],
+    (row) => getString(row, "session_id"),
+  );
+}
+
+async function listAllSearchSessionIds(database: Database): Promise<string[]> {
+  return await database.queryAll(
+    "SELECT session_id FROM search_sessions",
+    undefined,
     (row) => getString(row, "session_id"),
   );
 }

--- a/src/archive/search-index/index.ts
+++ b/src/archive/search-index/index.ts
@@ -2,11 +2,14 @@ export {
   ensureSearchIndex,
   isSearchIndexCurrent,
   querySearchIndex,
+  readArchiveIndexSettings,
   SEARCH_OBJECT_PROPERTY_KIND,
   SEARCH_OBJECT_PROPERTY_OWNER_KIND,
+  setFtsIndexEmbedded,
   TEXT_SENTENCE_KIND,
 } from "./search-index.js";
 export type {
+  ArchiveIndexSettings,
   SearchIndexInput,
   SearchIndexObjectHit,
   SearchIndexQueryResult,

--- a/src/archive/search-index/index.ts
+++ b/src/archive/search-index/index.ts
@@ -3,6 +3,7 @@ export {
   isSearchIndexCurrent,
   querySearchIndex,
   readArchiveIndexSettings,
+  SEARCH_INDEX_FTS_HIT_LIMIT,
   SEARCH_OBJECT_PROPERTY_KIND,
   SEARCH_OBJECT_PROPERTY_OWNER_KIND,
   setFtsIndexEmbedded,

--- a/src/archive/search-index/search-index.ts
+++ b/src/archive/search-index/search-index.ts
@@ -248,6 +248,7 @@ export async function querySearchIndex(
   options: {
     readonly chapters?: readonly number[];
     readonly match?: ArchiveFindMatch;
+    readonly textHitLimit?: number;
     readonly types?: readonly ArchiveFindObjectType[] | null;
   } = {},
 ): Promise<SearchIndexQueryResult | undefined> {
@@ -279,6 +280,12 @@ export async function querySearchIndex(
       }
       for (const hit of textRows) {
         textHitsByKey.set(createTextHitKey(hit), hit);
+      }
+      if (
+        options.textHitLimit !== undefined &&
+        textHitsByKey.size >= options.textHitLimit
+      ) {
+        break;
       }
     }
 
@@ -339,6 +346,7 @@ async function queryTextRows(
   matchExpression: string,
   options: {
     readonly chapters?: readonly number[];
+    readonly textHitLimit?: number;
     readonly types?: readonly ArchiveFindObjectType[] | null;
   },
 ): Promise<readonly SearchIndexTextHit[]> {
@@ -363,12 +371,14 @@ async function queryTextRows(
         AND r.kind IN (${kinds.map(() => "?").join(", ")})
         ${createChapterSql(options.chapters)}
       ORDER BY rank ASC, r.chapter_id, r.sentence_index, r.kind
+      ${createLimitSql(options.textHitLimit)}
     `,
     [
       ...TIER_WEIGHTS,
       matchExpression,
       ...kinds,
       ...createChapterParams(options.chapters),
+      ...createLimitParams(options.textHitLimit),
     ],
     (row) => ({
       chapterId: getNumber(row, "chapter_id"),
@@ -627,6 +637,14 @@ function createChapterParams(
   chapters: readonly number[] | undefined,
 ): readonly SqlBindValue[] {
   return chapters === undefined ? [] : [...chapters];
+}
+
+function createLimitSql(limit: number | undefined): string {
+  return limit === undefined ? "" : "LIMIT ?";
+}
+
+function createLimitParams(limit: number | undefined): readonly SqlBindValue[] {
+  return limit === undefined ? [] : [limit];
 }
 
 function shouldQueryObjects(

--- a/src/archive/search-index/search-index.ts
+++ b/src/archive/search-index/search-index.ts
@@ -5,7 +5,7 @@ import {
   type Database,
   type SqlBindValue,
 } from "../../document/database.js";
-import type { ReadonlyDocument } from "../../document/index.js";
+import type { Document, ReadonlyDocument } from "../../document/index.js";
 
 import {
   createSearchTokenPlan,
@@ -92,37 +92,86 @@ export interface SearchIndexQueryResult {
 const SEARCH_INDEX_VERSION = "3";
 const TIER_WEIGHTS = [1, 0.45, 0.08] as const;
 
+export interface ArchiveIndexSettings {
+  readonly ftsEmbedded: boolean;
+}
+
+export async function readArchiveIndexSettings(
+  document: ReadonlyDocument,
+): Promise<ArchiveIndexSettings> {
+  return await document.readDatabase(async (database) => {
+    const row = await database.queryOne(
+      `
+        SELECT fts_embedded
+        FROM archive_index_settings
+        WHERE id = 1
+      `,
+      undefined,
+      (value) => ({
+        ftsEmbedded: getNumber(value, "fts_embedded") !== 0,
+      }),
+    );
+
+    return row ?? { ftsEmbedded: false };
+  });
+}
+
+export async function setFtsIndexEmbedded(
+  document: ReadonlyDocument,
+  embedded: boolean,
+): Promise<void> {
+  await document.readDatabase(async (database) => {
+    await database.run(
+      `
+        INSERT INTO archive_index_settings(id, fts_embedded)
+        VALUES (1, ?)
+        ON CONFLICT(id)
+        DO UPDATE SET fts_embedded = excluded.fts_embedded
+      `,
+      [embedded ? 1 : 0],
+    );
+  });
+}
+
 export async function isSearchIndexCurrent(
   document: ReadonlyDocument,
 ): Promise<boolean> {
   const chaptersRevision = await document.serials.getChaptersRevision();
 
-  return await document.readDatabase(async (database) => {
-    const current = await database.queryAll(
-      `
-        SELECT key, value
-        FROM search_index_state
-        WHERE key IN ('version', 'chaptersRevision')
-      `,
-      undefined,
-      (row) => [String(row.key), String(row.value)] as const,
-    );
-    const state = new Map(current);
+  try {
+    return await document.readSearchIndexDatabase(async (database) => {
+      const current = await database.queryAll(
+        `
+          SELECT key, value
+          FROM search_index_state
+          WHERE key IN ('version', 'chaptersRevision')
+        `,
+        undefined,
+        (row) => [String(row.key), String(row.value)] as const,
+      );
+      const state = new Map(current);
 
-    return (
-      state.get("version") === SEARCH_INDEX_VERSION &&
-      state.get("chaptersRevision") === String(chaptersRevision)
-    );
-  });
+      return (
+        state.get("version") === SEARCH_INDEX_VERSION &&
+        state.get("chaptersRevision") === String(chaptersRevision)
+      );
+    });
+  } catch (error) {
+    if (isMissingSearchIndexError(error)) {
+      return false;
+    }
+
+    throw error;
+  }
 }
 
 export async function ensureSearchIndex(
-  document: ReadonlyDocument,
+  document: Document,
   input: SearchIndexInput,
 ): Promise<void> {
   const chaptersRevision = await document.serials.getChaptersRevision();
 
-  await document.readDatabase(async (database) => {
+  await document.writeSearchIndexDatabase(async (database) => {
     const fingerprint = createSearchIndexFingerprint(input);
     const current = await database.queryAll(
       `
@@ -210,7 +259,7 @@ export async function querySearchIndex(
 
   const terms = listSearchPlanTerms(plan);
 
-  return await document.readDatabase(async (database) => {
+  return await document.readSearchIndexDatabase(async (database) => {
     const tierQueries = createTierQueries(query, plan, options.match ?? "any");
     const objectHitsByKey = new Map<string, SearchIndexObjectHit>();
     const textHitsByKey = new Map<string, SearchIndexTextHit>();
@@ -544,6 +593,20 @@ function createSearchIndexFingerprint(input: SearchIndexInput): string {
   }
 
   return hash.digest("hex");
+}
+
+function isMissingSearchIndexError(error: unknown): boolean {
+  const code =
+    typeof error === "object" && error !== null && "code" in error
+      ? error.code
+      : undefined;
+
+  return (
+    code === "SQLITE_CANTOPEN" ||
+    (error instanceof Error &&
+      (error.message.includes("Archive SQLite entry is missing: fts.db") ||
+        error.message.includes("no such table: search_index_state")))
+  );
 }
 
 function serializeTokens(

--- a/src/archive/search-index/search-index.ts
+++ b/src/archive/search-index/search-index.ts
@@ -117,7 +117,7 @@ export async function readArchiveIndexSettings(
 }
 
 export async function setFtsIndexEmbedded(
-  document: ReadonlyDocument,
+  document: Document,
   embedded: boolean,
 ): Promise<void> {
   await document.readDatabase(async (database) => {

--- a/src/archive/search-index/search-index.ts
+++ b/src/archive/search-index/search-index.ts
@@ -90,6 +90,7 @@ export interface SearchIndexQueryResult {
 }
 
 const SEARCH_INDEX_VERSION = "3";
+export const SEARCH_INDEX_FTS_HIT_LIMIT = 32_000;
 const TIER_WEIGHTS = [1, 0.45, 0.08] as const;
 
 export interface ArchiveIndexSettings {
@@ -248,6 +249,7 @@ export async function querySearchIndex(
   options: {
     readonly chapters?: readonly number[];
     readonly match?: ArchiveFindMatch;
+    readonly objectHitLimit?: number;
     readonly textHitLimit?: number;
     readonly types?: readonly ArchiveFindObjectType[] | null;
   } = {},
@@ -262,6 +264,10 @@ export async function querySearchIndex(
 
   return await document.readSearchIndexDatabase(async (database) => {
     const tierQueries = createTierQueries(query, plan, options.match ?? "any");
+    const objectHitLimit = options.objectHitLimit ?? SEARCH_INDEX_FTS_HIT_LIMIT;
+    const textHitLimit = options.textHitLimit ?? SEARCH_INDEX_FTS_HIT_LIMIT;
+    const queriesObjects = shouldQueryObjects(options.types);
+    const queriesText = createTextKindFilter(options.types).length > 0;
     const objectHitsByKey = new Map<string, SearchIndexObjectHit>();
     const textHitsByKey = new Map<string, SearchIndexTextHit>();
 
@@ -270,9 +276,28 @@ export async function querySearchIndex(
         continue;
       }
 
+      const objectHitRemaining = Math.max(
+        0,
+        objectHitLimit - objectHitsByKey.size,
+      );
+      const textHitRemaining = Math.max(0, textHitLimit - textHitsByKey.size);
+
+      if (
+        (!queriesObjects || objectHitRemaining <= 0) &&
+        (!queriesText || textHitRemaining <= 0)
+      ) {
+        break;
+      }
+
       const [objectRows, textRows] = await Promise.all([
-        queryObjectRows(database, tierQuery.matchExpression, options),
-        queryTextRows(database, tierQuery.matchExpression, options),
+        queryObjectRows(database, tierQuery.matchExpression, {
+          ...options,
+          objectHitLimit: objectHitRemaining,
+        }),
+        queryTextRows(database, tierQuery.matchExpression, {
+          ...options,
+          textHitLimit: textHitRemaining,
+        }),
       ]);
 
       for (const hit of objectRows) {
@@ -282,8 +307,8 @@ export async function querySearchIndex(
         textHitsByKey.set(createTextHitKey(hit), hit);
       }
       if (
-        options.textHitLimit !== undefined &&
-        textHitsByKey.size >= options.textHitLimit
+        (!queriesObjects || objectHitsByKey.size >= objectHitLimit) &&
+        (!queriesText || textHitsByKey.size >= textHitLimit)
       ) {
         break;
       }
@@ -302,10 +327,11 @@ async function queryObjectRows(
   matchExpression: string,
   options: {
     readonly chapters?: readonly number[];
+    readonly objectHitLimit?: number;
     readonly types?: readonly ArchiveFindObjectType[] | null;
   },
 ): Promise<readonly SearchIndexObjectHit[]> {
-  if (!shouldQueryObjects(options.types)) {
+  if (!shouldQueryObjects(options.types) || options.objectHitLimit === 0) {
     return [];
   }
 
@@ -323,11 +349,13 @@ async function queryObjectRows(
       WHERE search_object_properties_fts MATCH ?
         ${createChapterSql(options.chapters)}
       ORDER BY rank ASC, r.chapter_id, r.owner_kind, r.owner_id, r.property_kind
+      ${createLimitSql(options.objectHitLimit)}
     `,
     [
       ...TIER_WEIGHTS,
       matchExpression,
       ...createChapterParams(options.chapters),
+      ...createLimitParams(options.objectHitLimit),
     ],
     (row) => ({
       ownerId: String(row.owner_id),
@@ -353,6 +381,9 @@ async function queryTextRows(
   const kinds = createTextKindFilter(options.types);
 
   if (kinds.length === 0) {
+    return [];
+  }
+  if (options.textHitLimit === 0) {
     return [];
   }
 

--- a/src/cli/archive-chapter.ts
+++ b/src/cli/archive-chapter.ts
@@ -6,6 +6,7 @@ import type { DirectoryDocument } from "../document/index.js";
 import {
   addChapter,
   applyChapterTree,
+  assertNoActiveBuildJobConflicts,
   assertNoActiveBuildJobs,
   getChapterTree,
   listChapters,
@@ -33,6 +34,11 @@ export async function runArchiveChapterCommand(
   switch (args.action) {
     case "add":
       await runEditableCommand(args.path, async (document) => {
+        await assertNoActiveBuildJobConflicts({
+          archivePath: args.path,
+          operation: "Adding chapter",
+          scope: { kind: "archive" },
+        });
         let details = await addChapter(document, {
           ...(args.parentChapterId === undefined
             ? {}
@@ -61,13 +67,10 @@ export async function runArchiveChapterCommand(
       return;
     case "move":
       await runEditableCommand(args.path, async (document) => {
-        await assertNoActiveBuildJobs({
+        await assertNoActiveBuildJobConflicts({
           archivePath: args.path,
-          chapterIds: collectChapterSubtreeIds(
-            await getChapterTree(document),
-            args.chapterId!,
-          ),
           operation: "Moving chapter",
+          scope: { kind: "archive" },
         });
         const details = await moveChapter(document, args.chapterId!, {
           ...(args.afterChapterId === undefined
@@ -89,16 +92,10 @@ export async function runArchiveChapterCommand(
       return;
     case "remove":
       await runEditableCommand(args.path, async (document) => {
-        await assertNoActiveBuildJobs({
+        await assertNoActiveBuildJobConflicts({
           archivePath: args.path,
-          chapterIds:
-            args.recursive === true
-              ? collectChapterSubtreeIds(
-                  await getChapterTree(document),
-                  args.chapterId!,
-                )
-              : [args.chapterId!],
           operation: "Removing chapter",
+          scope: { kind: "archive" },
         });
         await removeChapter(document, args.chapterId!, {
           recursive: args.recursive ?? false,
@@ -153,6 +150,11 @@ export async function runArchiveChapterCommand(
       return;
     case "set-title":
       await runEditableCommand(args.path, async (document) => {
+        await assertNoActiveBuildJobs({
+          archivePath: args.path,
+          chapterIds: [args.chapterId!],
+          operation: "Setting chapter title",
+        });
         const details = await setChapterTitle(
           document,
           args.chapterId!,
@@ -165,6 +167,13 @@ export async function runArchiveChapterCommand(
     case "tree":
       if (args.treeAction === "apply") {
         await runEditableCommand(args.path, async (document) => {
+          if (args.dryRun !== true) {
+            await assertNoActiveBuildJobConflicts({
+              archivePath: args.path,
+              operation: "Changing chapter tree",
+              scope: { kind: "archive" },
+            });
+          }
           await writeChapterTreeApplyResult(
             await applyChapterTree(
               document,
@@ -422,47 +431,4 @@ async function assertResetAllowed(
       });
       return;
   }
-}
-
-function collectChapterSubtreeIds(
-  tree: ChapterTree,
-  chapterId: number,
-): readonly number[] {
-  for (const node of tree.chapters) {
-    const ids = collectChapterSubtreeIdsFromNode(node, chapterId);
-
-    if (ids.length > 0) {
-      return ids;
-    }
-  }
-
-  return [chapterId];
-}
-
-function collectChapterSubtreeIdsFromNode(
-  node: ChapterTree["chapters"][number],
-  chapterId: number,
-): readonly number[] {
-  if (node.id === chapterId) {
-    return collectAllChapterIds(node);
-  }
-
-  for (const child of node.children) {
-    const ids = collectChapterSubtreeIdsFromNode(child, chapterId);
-
-    if (ids.length > 0) {
-      return ids;
-    }
-  }
-
-  return [];
-}
-
-function collectAllChapterIds(
-  node: ChapterTree["chapters"][number],
-): readonly number[] {
-  return [
-    node.id,
-    ...node.children.flatMap((child) => collectAllChapterIds(child)),
-  ];
 }

--- a/src/cli/archive-index.ts
+++ b/src/cli/archive-index.ts
@@ -1,0 +1,167 @@
+import {
+  deleteArchiveSearchSessions,
+  rebuildArchiveSearchIndex,
+} from "../archive/query/index.js";
+import {
+  isSearchIndexCurrent,
+  readArchiveIndexSettings,
+  setFtsIndexEmbedded,
+} from "../archive/search-index/index.js";
+import { SpineDigestFile } from "../wikg/index.js";
+
+import type { CLIArchiveIndexArguments } from "./args.js";
+import { writeTextToStdout } from "./io.js";
+import { formatCLIJSON } from "./json.js";
+
+export async function runArchiveIndexCommand(
+  args: CLIArchiveIndexArguments,
+): Promise<void> {
+  switch (args.action) {
+    case "get":
+      await readIndexSettings(args);
+      return;
+    case "build":
+      await buildIndex(args);
+      return;
+    case "embed":
+      await embedIndex(args);
+      return;
+    case "external":
+      await externalizeIndex(args);
+      return;
+    case "clear":
+      await clearIndex(args);
+      return;
+  }
+}
+
+async function readIndexSettings(
+  args: CLIArchiveIndexArguments,
+): Promise<void> {
+  await new SpineDigestFile(args.archivePath).readDocument(async (document) => {
+    const settings = await readArchiveIndexSettings(document);
+
+    await writeIndexOutput(args, {
+      ftsEmbedded: settings.ftsEmbedded,
+      ftsCurrent: await isSearchIndexCurrent(document),
+    });
+  });
+}
+
+async function buildIndex(args: CLIArchiveIndexArguments): Promise<void> {
+  let built = false;
+
+  await new SpineDigestFile(args.archivePath).write(
+    async (document) => {
+      const settings = await readArchiveIndexSettings(document);
+
+      if (!(await isSearchIndexCurrent(document))) {
+        await rebuildArchiveSearchIndex(document);
+        built = true;
+      }
+      await writeIndexOutput(args, {
+        built,
+        ftsEmbedded: settings.ftsEmbedded,
+        ftsCurrent: await isSearchIndexCurrent(document),
+      });
+    },
+    {
+      searchIndexWritebackPolicy: await readSearchIndexWritebackPolicy(
+        args.archivePath,
+      ),
+    },
+  );
+  await deleteArchiveSearchSessions(args.archivePath);
+}
+
+async function embedIndex(args: CLIArchiveIndexArguments): Promise<void> {
+  let built = false;
+
+  await new SpineDigestFile(args.archivePath).write(
+    async (document) => {
+      await setFtsIndexEmbedded(document, true);
+      if (await isSearchIndexCurrent(document)) {
+        await document.writeSearchIndexDatabase(async (database) => {
+          await database.run(
+            "UPDATE search_index_state SET value = value WHERE key = 'version'",
+          );
+        });
+      } else {
+        await rebuildArchiveSearchIndex(document);
+        built = true;
+      }
+      await writeIndexOutput(args, {
+        built,
+        ftsEmbedded: true,
+        ftsCurrent: await isSearchIndexCurrent(document),
+      });
+    },
+    { searchIndexWritebackPolicy: "archive" },
+  );
+  await deleteArchiveSearchSessions(args.archivePath);
+}
+
+async function externalizeIndex(args: CLIArchiveIndexArguments): Promise<void> {
+  await new SpineDigestFile(args.archivePath).write(
+    async (document) => {
+      await setFtsIndexEmbedded(document, false);
+      await document.deleteSearchIndexDatabase();
+      await writeIndexOutput(args, {
+        ftsEmbedded: false,
+        ftsCurrent: false,
+      });
+    },
+    { searchIndexWritebackPolicy: "archive" },
+  );
+  await deleteArchiveSearchSessions(args.archivePath);
+}
+
+async function clearIndex(args: CLIArchiveIndexArguments): Promise<void> {
+  await new SpineDigestFile(args.archivePath).write(async (document) => {
+    await document.deleteSearchIndexDatabase();
+    const settings = await readArchiveIndexSettings(document);
+
+    await writeIndexOutput(args, {
+      ftsEmbedded: settings.ftsEmbedded,
+      ftsCurrent: false,
+    });
+  });
+  await deleteArchiveSearchSessions(args.archivePath);
+}
+
+async function readSearchIndexWritebackPolicy(
+  archivePath: string,
+): Promise<"archive" | "cache"> {
+  let embedded = false;
+
+  await new SpineDigestFile(archivePath).readDocument(async (document) => {
+    embedded = (await readArchiveIndexSettings(document)).ftsEmbedded;
+  });
+
+  return embedded ? "archive" : "cache";
+}
+
+async function writeIndexOutput(
+  args: CLIArchiveIndexArguments,
+  payload: {
+    readonly built?: boolean;
+    readonly ftsCurrent: boolean;
+    readonly ftsEmbedded: boolean;
+  },
+): Promise<void> {
+  if (args.json === true) {
+    await writeTextToStdout(formatCLIJSON(payload));
+    return;
+  }
+
+  await writeTextToStdout(
+    [
+      `FTS embedded: ${payload.ftsEmbedded ? "yes" : "no"}`,
+      `FTS current: ${payload.ftsCurrent ? "yes" : "no"}`,
+      ...(payload.built === undefined
+        ? []
+        : [`Built: ${payload.built ? "yes" : "no"}`]),
+      "",
+    ].join("\n"),
+  );
+}

--- a/src/cli/archive-index.ts
+++ b/src/cli/archive-index.ts
@@ -117,15 +117,22 @@ async function externalizeIndex(args: CLIArchiveIndexArguments): Promise<void> {
 }
 
 async function clearIndex(args: CLIArchiveIndexArguments): Promise<void> {
-  await new SpineDigestFile(args.archivePath).write(async (document) => {
-    await document.deleteSearchIndexDatabase();
-    const settings = await readArchiveIndexSettings(document);
+  await new SpineDigestFile(args.archivePath).write(
+    async (document) => {
+      await document.deleteSearchIndexDatabase();
+      const settings = await readArchiveIndexSettings(document);
 
-    await writeIndexOutput(args, {
-      ftsEmbedded: settings.ftsEmbedded,
-      ftsCurrent: false,
-    });
-  });
+      await writeIndexOutput(args, {
+        ftsEmbedded: settings.ftsEmbedded,
+        ftsCurrent: false,
+      });
+    },
+    {
+      searchIndexWritebackPolicy: await readSearchIndexWritebackPolicy(
+        args.archivePath,
+      ),
+    },
+  );
   await deleteArchiveSearchSessions(args.archivePath);
 }
 

--- a/src/cli/archive.ts
+++ b/src/cli/archive.ts
@@ -531,7 +531,7 @@ async function runNextArchivePage(args: CLIArchiveArguments): Promise<void> {
         }
 
         await writeFindHits(
-          await findArchiveObjects(document, "", findOptions),
+          await findArchiveObjects(document, cursor.query ?? "", findOptions),
           {
             archiveKey: cursor.archiveKey,
             archivePath: cursor.archivePath,
@@ -705,12 +705,13 @@ function createArchiveOutputContext(
     ...createOptionalSourceContext(args),
     format: args.format ?? "text",
     limit: args.limit ?? DEFAULT_OUTPUT_LIMIT,
-    ...(args.action !== "evidence" || args.query === undefined
+    ...(args.action !== "evidence" &&
+    args.action !== "related" &&
+    args.action !== "search"
       ? {}
-      : { query: args.query }),
-    ...(args.action !== "related" || args.query === undefined
-      ? {}
-      : { query: args.query }),
+      : args.query === undefined
+        ? {}
+        : { query: args.query }),
     ...(args.role === undefined ? {} : { role: args.role }),
     ...(options.continuationKind === "collection"
       ? createScopeOptions(args.archivePath)
@@ -863,6 +864,7 @@ async function createOutputContinuationCursor(
         : { evidenceLimit: context.evidenceLimit }),
       format: context.format,
       kind: "search",
+      ...(context.query === undefined ? {} : { query: context.query }),
       ...(context.sourceContext === undefined
         ? {}
         : { sourceContext: context.sourceContext }),

--- a/src/cli/archive.ts
+++ b/src/cli/archive.ts
@@ -1,7 +1,7 @@
-import { mkdtemp, rm, writeFile } from "fs/promises";
+import { rm, writeFile } from "fs/promises";
 import { join } from "path";
-import { tmpdir } from "os";
 
+import { createWikiGraphTempDirectory } from "../common/wiki-graph-temp.js";
 import {
   listArchiveCollection,
   listArchiveEvidence,
@@ -395,9 +395,8 @@ async function createArchive(args: CLIArchiveArguments): Promise<void> {
     return;
   }
 
-  const temporaryDirectoryPath = await mkdtemp(
-    join(tmpdir(), "wikigraph-url-create-"),
-  );
+  const temporaryDirectoryPath =
+    await createWikiGraphTempDirectory("url-create");
   const sourcePath = join(temporaryDirectoryPath, "source.md");
 
   try {
@@ -632,9 +631,8 @@ async function createArchiveFromStdin(
     );
   }
 
-  const temporaryDirectoryPath = await mkdtemp(
-    join(tmpdir(), "wikigraph-stdin-create-"),
-  );
+  const temporaryDirectoryPath =
+    await createWikiGraphTempDirectory("stdin-create");
   const extension = args.inputFormat === "markdown" ? ".md" : ".txt";
   const sourcePath = join(temporaryDirectoryPath, `source${extension}`);
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -190,10 +190,17 @@ export type CLIArchiveAction =
   | "search";
 
 export type CLIArchiveMaintenanceCommand = "chapter" | "cover" | "meta";
+export type CLIArchiveIndexAction =
+  | "build"
+  | "clear"
+  | "embed"
+  | "external"
+  | "get";
 type CLIArchiveRootAction = CLIArchiveAction | "queue";
 type CLIArchiveUriAction =
   | CLIArchiveRootAction
   | CLIArchiveChapterAction
+  | CLIArchiveIndexAction
   | CLIMetadataAction;
 type CLIJobAction = CLIQueueAction | "get" | "set";
 type ArchiveUriLens = Exclude<CLIObjectKind, "meta">;
@@ -231,6 +238,12 @@ export interface CLIArchiveArguments {
   readonly sourcePath?: string;
   readonly targetStage?: ChapterStage;
   readonly triplePattern?: ArchiveTriplePattern;
+}
+
+export interface CLIArchiveIndexArguments {
+  readonly action: CLIArchiveIndexAction;
+  readonly archivePath: string;
+  readonly json?: boolean;
 }
 
 interface ArchiveMetaFlagValues {
@@ -343,6 +356,11 @@ export type ParsedCLIArguments =
       readonly args: CLIArchiveArguments;
       readonly help: false;
       readonly kind: "archive";
+    }
+  | {
+      readonly args: CLIArchiveIndexArguments;
+      readonly help: false;
+      readonly kind: "archive-index";
     }
   | {
       readonly args: CLIQueueArguments;
@@ -746,6 +764,10 @@ function parseArchiveUriTargetArguments(
     );
   }
 
+  if (objectUri === "wkg://index") {
+    return parseArchiveIndexUriArguments(archivePath, action, tail, values);
+  }
+
   const chapterTarget = parseChapterTarget(objectUri);
   if (chapterTarget !== undefined) {
     return parseArchiveChapterUriArguments(
@@ -768,6 +790,56 @@ function parseArchiveUriTargetArguments(
   }
 
   return parseArchiveArguments(action, [uri, ...tail], values, helpRoute);
+}
+
+function parseArchiveIndexUriArguments(
+  archivePath: string,
+  action: CLIArchiveUriAction,
+  tail: readonly string[],
+  values: ArchiveArgumentValues,
+): ParsedCLIArguments {
+  const helpRoute = `wikigraph wkg://<archive.wikg>/index ${action} --help`;
+
+  if (values.help === true) {
+    return {
+      help: true,
+      helpText: renderHelpMatrixText({ kind: "object", object: "index" }),
+      kind: "help",
+    };
+  }
+
+  if (!isArchiveIndexAction(action)) {
+    throw new Error(
+      withHelpRoute(
+        `The index object does not support \`${action}\`. Expected get, build, embed, external, or clear.`,
+        "wikigraph help object",
+      ),
+    );
+  }
+  rejectArchiveExtraPositionals(action, tail, 0, helpRoute);
+  rejectArchiveNonReadFlags(action, values, helpRoute);
+  rejectArchiveFlag(action, "--budget", values.budget, helpRoute);
+  rejectArchiveFlag(action, "--chapter", values.chapter, helpRoute);
+  rejectArchiveFlag(action, "--context", values.context, helpRoute);
+  rejectArchiveFlag(action, "--cursor", values.cursor, helpRoute);
+  rejectArchiveFlag(action, "--evidence", values.evidence, helpRoute);
+  rejectArchiveFlag(action, "--from", values.from, helpRoute);
+  rejectArchiveFlag(action, "--limit", values.limit, helpRoute);
+  rejectArchiveFlag(action, "--role", values.role, helpRoute);
+  rejectArchiveFlag(action, "--to", values.to, helpRoute);
+  rejectArchiveBooleanFlag(action, "--all", values.all, helpRoute);
+  rejectArchiveBooleanFlag(action, "--backlinks", values.backlinks, helpRoute);
+  rejectArchiveBooleanFlag(action, "--confirm", values.confirm, helpRoute);
+
+  return {
+    args: {
+      action,
+      archivePath,
+      ...(values.json === undefined ? {} : { json: values.json }),
+    },
+    help: false,
+    kind: "archive-index",
+  };
 }
 
 function parseMetadataUriArguments(
@@ -4239,8 +4311,21 @@ function isArchiveUriAction(
   return (
     isArchiveAction(value) ||
     isArchiveChapterAction(value) ||
+    isArchiveIndexAction(value) ||
     isMetadataAction(value) ||
     value === "queue"
+  );
+}
+
+function isArchiveIndexAction(
+  value: string | undefined,
+): value is CLIArchiveIndexAction {
+  return (
+    value === "build" ||
+    value === "clear" ||
+    value === "embed" ||
+    value === "external" ||
+    value === "get"
   );
 }
 
@@ -4670,7 +4755,7 @@ function isValueInputJsonFlagContext(argv: readonly string[]): boolean {
 }
 
 function rejectArchiveExtraPositionals(
-  action: CLIArchiveAction,
+  action: string,
   positionals: readonly string[],
   allowed: number,
   helpRoute: string,
@@ -4789,7 +4874,7 @@ function rejectCoverMetaFlags(values: ArchiveMetaFlagValues): void {
 }
 
 function rejectArchiveFlag(
-  action: CLIArchiveAction,
+  action: string,
   flag: string,
   value: string | undefined,
   helpRoute: string,
@@ -4805,7 +4890,7 @@ function rejectArchiveFlag(
 }
 
 function rejectArchiveBooleanFlag(
-  action: CLIArchiveAction,
+  action: string,
   flag: string,
   value: boolean | undefined,
   helpRoute: string,
@@ -4821,7 +4906,7 @@ function rejectArchiveBooleanFlag(
 }
 
 function rejectArchiveNonReadFlags(
-  action: CLIArchiveAction,
+  action: string,
   values: {
     readonly input?: string;
     readonly "input-format"?: string;

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -127,6 +127,7 @@ export interface CLIStatusArguments {
 }
 
 export interface CLIGcArguments {
+  readonly force?: boolean;
   readonly json?: boolean;
 }
 
@@ -267,6 +268,7 @@ interface ArchiveArgumentValues extends ArchiveMetaFlagValues {
   readonly "dry-run"?: boolean;
   readonly evidence?: string;
   readonly first?: boolean;
+  readonly force?: boolean;
   readonly from?: string;
   readonly help?: boolean;
   readonly input?: string;
@@ -455,6 +457,9 @@ export function parseCLIArguments(
       from: {
         type: "string",
       },
+      force: {
+        type: "boolean",
+      },
       input: {
         type: "string",
       },
@@ -546,6 +551,8 @@ export function parseCLIArguments(
     },
     strict: true,
   });
+
+  rejectNonGcForceFlag(positionals, values);
 
   if (values.version === true) {
     return {
@@ -1996,6 +2003,7 @@ function parseGcArguments(
 
   return {
     args: {
+      ...(values.force === undefined ? {} : { force: values.force }),
       ...(values.json === undefined ? {} : { json: values.json }),
     },
     help: false,
@@ -4046,6 +4054,22 @@ function rejectArchiveChapterMetaFlags(
 
 function rejectHelpMetaFlags(values: ArchiveMetaFlagValues): void {
   rejectCommandMetaFlags(values, "help", CLI_HELP_ROUTES.root);
+}
+
+function rejectNonGcForceFlag(
+  positionals: readonly string[],
+  values: ArchiveArgumentValues,
+): void {
+  if (values.force !== true || positionals[0] === "gc") {
+    return;
+  }
+
+  throw new Error(
+    withHelpRoute(
+      "The --force option is only supported by `gc`.",
+      CLI_HELP_ROUTES.root,
+    ),
+  );
 }
 
 function rejectGcMetaFlags(values: ArchiveMetaFlagValues): void {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -12,6 +12,7 @@ import {
   parseHelpMatrixPage,
   renderArchiveCommandHelpText,
   renderArchiveMaintenanceCommandHelpText,
+  renderGcCommandHelpText,
   renderHelpMatrixText,
   renderHelpTopicText,
   renderLegacyCommandHelpText,
@@ -123,6 +124,10 @@ export interface CLIObjectMetadataArguments {
 
 export interface CLIStatusArguments {
   readonly llmJSON?: string;
+}
+
+export interface CLIGcArguments {
+  readonly json?: boolean;
 }
 
 export interface CLILegacyArguments {
@@ -346,6 +351,11 @@ export type ParsedCLIArguments =
       readonly help: true;
       readonly helpText: string;
       readonly kind: "help";
+    }
+  | {
+      readonly args: CLIGcArguments;
+      readonly help: false;
+      readonly kind: "gc";
     }
   | {
       readonly args: CLIStatusArguments;
@@ -575,6 +585,10 @@ export function parseCLIArguments(
 
   if (positionals[0] === "config") {
     return parseConfigArguments(positionals.slice(1), values);
+  }
+
+  if (positionals[0] === "gc") {
+    return parseGcArguments(positionals.slice(1), values);
   }
 
   if (positionals[0] === "queue") {
@@ -1938,6 +1952,55 @@ function parseConfigArguments(
   }
 
   return parseConfigStatusArguments(positionals.slice(1), values);
+}
+
+function parseGcArguments(
+  positionals: readonly string[],
+  values: ArchiveArgumentValues & ArchiveMetaFlagValues,
+): ParsedCLIArguments {
+  const helpRoute = "wikigraph gc --help";
+
+  if (values.help === true) {
+    return {
+      help: true,
+      helpText: renderGcCommandHelpText(),
+      kind: "help",
+    };
+  }
+
+  rejectGcFlag("digest-dir", values["digest-dir"], helpRoute);
+  rejectGcFlag("input", values.input, helpRoute);
+  rejectGcFlag("input-format", values["input-format"], helpRoute);
+  rejectGcFlag("jsonl", values.jsonl, helpRoute);
+  rejectGcFlag("limit", values.limit, helpRoute);
+  rejectGcFlag("llm", values.llm, helpRoute);
+  rejectGcFlag("output", values.output, helpRoute);
+  rejectGcFlag("output-format", values["output-format"], helpRoute);
+  rejectGcFlag("prompt", values.prompt, helpRoute);
+  rejectGcFlag("stage", values.stage, helpRoute);
+  rejectGcMetaFlags(values);
+
+  if (values.verbose === true) {
+    throw new Error(
+      withHelpRoute("The `gc` command does not support --verbose.", helpRoute),
+    );
+  }
+  if (positionals.length > 0) {
+    throw new Error(
+      withHelpRoute(
+        `Unexpected positional arguments for \`gc\`: ${positionals.join(" ")}.`,
+        helpRoute,
+      ),
+    );
+  }
+
+  return {
+    args: {
+      ...(values.json === undefined ? {} : { json: values.json }),
+    },
+    help: false,
+    kind: "gc",
+  };
 }
 
 function parseLegacyArguments(
@@ -3982,14 +4045,40 @@ function rejectArchiveChapterMetaFlags(
 }
 
 function rejectHelpMetaFlags(values: ArchiveMetaFlagValues): void {
+  rejectCommandMetaFlags(values, "help", CLI_HELP_ROUTES.root);
+}
+
+function rejectGcMetaFlags(values: ArchiveMetaFlagValues): void {
+  rejectCommandMetaFlags(values, "gc", "wikigraph gc --help");
+}
+
+function rejectCommandMetaFlags(
+  values: ArchiveMetaFlagValues,
+  command: string,
+  helpRoute: string,
+): void {
   for (const flag of listPresentMetaFlags(values)) {
     throw new Error(
       withHelpRoute(
-        `The \`help\` command does not support ${flag}.`,
-        CLI_HELP_ROUTES.root,
+        `The \`${command}\` command does not support ${flag}.`,
+        helpRoute,
       ),
     );
   }
+}
+
+function rejectGcFlag(
+  name: string,
+  value: string | boolean | readonly string[] | undefined,
+  helpRoute: string,
+): void {
+  if (value === undefined || value === false) {
+    return;
+  }
+
+  throw new Error(
+    withHelpRoute(`The \`gc\` command does not support --${name}.`, helpRoute),
+  );
 }
 
 function rejectStatusMetaFlags(values: ArchiveMetaFlagValues): void {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -819,19 +819,42 @@ function parseArchiveIndexUriArguments(
   }
   rejectArchiveExtraPositionals(action, tail, 0, helpRoute);
   rejectArchiveNonReadFlags(action, values, helpRoute);
+  rejectArchiveFlag(action, "--after", values.after, helpRoute);
   rejectArchiveFlag(action, "--budget", values.budget, helpRoute);
+  rejectArchiveFlag(action, "--before", values.before, helpRoute);
   rejectArchiveFlag(action, "--chapter", values.chapter, helpRoute);
   rejectArchiveFlag(action, "--context", values.context, helpRoute);
   rejectArchiveFlag(action, "--cursor", values.cursor, helpRoute);
+  rejectArchiveFlag(action, "--digest-dir", values["digest-dir"], helpRoute);
   rejectArchiveFlag(action, "--evidence", values.evidence, helpRoute);
   rejectArchiveFlag(action, "--from", values.from, helpRoute);
+  rejectArchiveFlag(action, "--json-input", values["json-input"], helpRoute);
   rejectArchiveFlag(action, "--limit", values.limit, helpRoute);
+  rejectArchiveFlag(action, "--parent", values.parent, helpRoute);
+  rejectArchiveFlag(action, "--predicate", values.predicate, helpRoute);
   rejectArchiveFlag(action, "--role", values.role, helpRoute);
+  rejectArchiveFlag(action, "--stage", values.stage, helpRoute);
+  rejectArchiveFlag(action, "--task", values.task, helpRoute);
   rejectArchiveFlag(action, "--to", values.to, helpRoute);
+  rejectArchiveBooleanFlag(
+    action,
+    "--accept-cost",
+    values["accept-cost"],
+    helpRoute,
+  );
+  rejectArchiveBooleanFlag(action, "--active", values.active, helpRoute);
   rejectArchiveBooleanFlag(action, "--all", values.all, helpRoute);
   rejectArchiveBooleanFlag(action, "--backlinks", values.backlinks, helpRoute);
+  rejectArchiveBooleanFlag(action, "--boost", values.boost, helpRoute);
+  rejectArchiveBooleanFlag(action, "--clear", values.clear, helpRoute);
   rejectArchiveBooleanFlag(action, "--confirm", values.confirm, helpRoute);
   rejectArchiveBooleanFlag(action, "--dry-run", values["dry-run"], helpRoute);
+  rejectArchiveBooleanFlag(action, "--first", values.first, helpRoute);
+  rejectArchiveBooleanFlag(action, "--jsonl", values.jsonl, helpRoute);
+  rejectArchiveBooleanFlag(action, "--last", values.last, helpRoute);
+  rejectArchiveBooleanFlag(action, "--root", values.root, helpRoute);
+  rejectArchiveBooleanFlag(action, "--verbose", values.verbose, helpRoute);
+  rejectCommandMetaFlags(values, action, helpRoute);
 
   return {
     args: {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -127,6 +127,7 @@ export interface CLIStatusArguments {
 }
 
 export interface CLIGcArguments {
+  readonly dryRun?: boolean;
   readonly force?: boolean;
   readonly json?: boolean;
 }
@@ -830,6 +831,7 @@ function parseArchiveIndexUriArguments(
   rejectArchiveBooleanFlag(action, "--all", values.all, helpRoute);
   rejectArchiveBooleanFlag(action, "--backlinks", values.backlinks, helpRoute);
   rejectArchiveBooleanFlag(action, "--confirm", values.confirm, helpRoute);
+  rejectArchiveBooleanFlag(action, "--dry-run", values["dry-run"], helpRoute);
 
   return {
     args: {
@@ -2075,6 +2077,7 @@ function parseGcArguments(
 
   return {
     args: {
+      ...(values["dry-run"] === undefined ? {} : { dryRun: values["dry-run"] }),
       ...(values.force === undefined ? {} : { force: values.force }),
       ...(values.json === undefined ? {} : { json: values.json }),
     },

--- a/src/cli/gc.ts
+++ b/src/cli/gc.ts
@@ -5,7 +5,7 @@ import { writeTextToStdout } from "./io.js";
 import { formatCLIJSON } from "./json.js";
 
 export async function runGcCommand(args: CLIGcArguments): Promise<void> {
-  const report = await tryRunWikiGraphGc();
+  const report = await tryRunWikiGraphGc({ force: args.force === true });
 
   if (args.json === true) {
     await writeTextToStdout(formatCLIJSON(report));

--- a/src/cli/gc.ts
+++ b/src/cli/gc.ts
@@ -1,0 +1,48 @@
+import { tryRunWikiGraphGc } from "../gc/index.js";
+
+import type { CLIGcArguments } from "./args.js";
+import { writeTextToStdout } from "./io.js";
+import { formatCLIJSON } from "./json.js";
+
+export async function runGcCommand(args: CLIGcArguments): Promise<void> {
+  const report = await tryRunWikiGraphGc();
+
+  if (args.json === true) {
+    await writeTextToStdout(formatCLIJSON(report));
+    return;
+  }
+
+  if (report.skipped) {
+    await writeTextToStdout("GC skipped: another GC run is active.\n");
+    return;
+  }
+
+  await writeTextToStdout(
+    [
+      `GC completed.`,
+      `Scanned: ${report.scanned}`,
+      `Removed: ${report.removed}`,
+      `Freed: ${formatBytes(report.freedBytes)}`,
+      ...report.jobs.map((job) =>
+        job.error === undefined
+          ? `- ${job.name}: scanned ${job.scanned}, removed ${job.removed}, freed ${formatBytes(job.freedBytes)}`
+          : `- ${job.name}: failed: ${job.error}`,
+      ),
+      "",
+    ].join("\n"),
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  if (bytes < 1024 * 1024 * 1024) {
+    return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+  }
+
+  return `${(bytes / 1024 / 1024 / 1024).toFixed(1)} GB`;
+}

--- a/src/cli/gc.ts
+++ b/src/cli/gc.ts
@@ -5,7 +5,10 @@ import { writeTextToStdout } from "./io.js";
 import { formatCLIJSON } from "./json.js";
 
 export async function runGcCommand(args: CLIGcArguments): Promise<void> {
-  const report = await tryRunWikiGraphGc({ force: args.force === true });
+  const report = await tryRunWikiGraphGc({
+    dryRun: args.dryRun === true,
+    force: args.force === true,
+  });
 
   if (args.json === true) {
     await writeTextToStdout(formatCLIJSON(report));

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -43,6 +43,7 @@ export type HelpObjectName =
   | "cover"
   | "cursor"
   | "entity"
+  | "index"
   | "job"
   | "job-collection"
   | "source"
@@ -51,13 +52,16 @@ export type HelpObjectName =
 
 export type HelpVerbName =
   | "add"
+  | "build"
   | "boost"
   | "cancel"
   | "clear"
   | "create"
   | "estimate"
   | "evidence"
+  | "embed"
   | "export"
+  | "external"
   | "get"
   | "list"
   | "move"
@@ -163,6 +167,39 @@ const HELP_OBJECTS: readonly HelpObjectEntry[] = [
         command: "wikigraph wkg://book.wikg/cover get > cover.bin",
         note: "Write cover bytes to stdout.",
         verb: "get",
+      },
+    ],
+  },
+  {
+    description: "The archive search index policy and FTS materialization.",
+    name: "index",
+    title: "Index",
+    uriForms: ["wkg://book.wikg/index"],
+    verbs: [
+      {
+        command: "wikigraph wkg://book.wikg/index get --json",
+        note: "Read FTS storage policy.",
+        verb: "get",
+      },
+      {
+        command: "wikigraph wkg://book.wikg/index build",
+        note: "Build a usable FTS index if none is available; by default it stays in local cache.",
+        verb: "build",
+      },
+      {
+        command: "wikigraph wkg://book.wikg/index embed",
+        note: "Build if needed, store FTS in the archive, and mark the policy embedded.",
+        verb: "embed",
+      },
+      {
+        command: "wikigraph wkg://book.wikg/index external",
+        note: "Mark FTS as local cache only and remove the embedded index copy.",
+        verb: "external",
+      },
+      {
+        command: "wikigraph wkg://book.wikg/index clear",
+        note: "Delete the current FTS index without changing storage policy.",
+        verb: "clear",
       },
     ],
   },
@@ -582,6 +619,21 @@ const HELP_VERBS: readonly HelpVerbEntry[] = [
     description: "Create a new archive or object.",
     name: "create",
     title: "Create",
+  },
+  {
+    description: "Build a derived resource when it is not already usable.",
+    name: "build",
+    title: "Build",
+  },
+  {
+    description: "Store an externalized resource inside the archive.",
+    name: "embed",
+    title: "Embed",
+  },
+  {
+    description: "Keep a derived resource outside the archive as local cache.",
+    name: "external",
+    title: "External",
   },
   { description: "Open or render an object.", name: "get", title: "Get" },
   {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -809,6 +809,10 @@ export function renderTransformHelpText(): string {
   return renderHelpTemplate("help/commands/transform");
 }
 
+export function renderGcCommandHelpText(): string {
+  return renderHelpTemplate("help/commands/gc");
+}
+
 export function renderLegacyCommandHelpText(action?: "migrate"): string {
   return renderHelpTemplate(
     action === undefined

--- a/src/cli/io.ts
+++ b/src/cli/io.ts
@@ -1,7 +1,8 @@
 import { createReadStream } from "fs";
-import { mkdtemp, rm } from "fs/promises";
+import { rm } from "fs/promises";
 import { join } from "path";
-import { tmpdir } from "os";
+
+import { createWikiGraphTempDirectory } from "../common/wiki-graph-temp.js";
 
 export function readTextStreamFromStdin(): AsyncIterable<string> {
   process.stdin.setEncoding("utf8");
@@ -62,7 +63,8 @@ export async function createTemporaryOutputPath(
   readonly directoryPath: string;
   readonly filePath: string;
 }> {
-  const directoryPath = await mkdtemp(join(tmpdir(), prefix));
+  void prefix;
+  const directoryPath = await createWikiGraphTempDirectory("cli-output");
 
   return {
     directoryPath,

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,6 +1,7 @@
 import { parseCLIArguments } from "./args.js";
 import { runArchiveCommand } from "./archive.js";
 import { runArchiveChapterCommand } from "./archive-chapter.js";
+import { runArchiveIndexCommand } from "./archive-index.js";
 import {
   runArchiveCoverCommand,
   runArchiveMetaCommand,
@@ -52,6 +53,9 @@ export async function main(): Promise<void> {
         return;
       case "archive":
         await runArchiveCommand(parsed.args);
+        return;
+      case "archive-index":
+        await runArchiveIndexCommand(parsed.args);
         return;
       case "queue":
         await runQueueCommand(parsed.args);

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -6,6 +6,7 @@ import {
   runArchiveMetaCommand,
 } from "./archive-maintenance.js";
 import { runConvertCommand } from "./convert.js";
+import { runGcCommand } from "./gc.js";
 import { runLegacyCommand } from "./legacy.js";
 import { renderMainHelpText } from "./help.js";
 import { runObjectMetadataCommand } from "./object-metadata.js";
@@ -54,6 +55,9 @@ export async function main(): Promise<void> {
         return;
       case "queue":
         await runQueueCommand(parsed.args);
+        return;
+      case "gc":
+        await runGcCommand(parsed.args);
         return;
       case "legacy":
         await runLegacyCommand(parsed.args);

--- a/src/cli/queue.ts
+++ b/src/cli/queue.ts
@@ -3,6 +3,7 @@ import { spawn } from "child_process";
 import { SpineDigestScope } from "../common/llm-scope.js";
 import {
   addBuildJob,
+  assertBuildJobInputRevision,
   boostBuildJob,
   buildChapterGraphArtifact,
   buildChapterSummaryArtifactFromSnapshot,
@@ -17,6 +18,7 @@ import {
   pauseBuildJob,
   readChapterBuildInput,
   readBuildJobEvents,
+  recordBuildJobInputRevision,
   resumeBuildJob,
   resolveBuildJobId,
   runBuildJobWorker,
@@ -204,6 +206,11 @@ async function executeBuildJob(
   );
   let { details } = buildInput;
   const { sourceText } = buildInput;
+  await recordBuildJobInputRevision({
+    currentRevision: buildInput.revision,
+    jobId: job.jobId,
+    ownerId: requireRunningJobOwnerId(job),
+  });
 
   await reporter.setTotals({
     totalGraphWords: details.stage === "sourced" ? details.words : 0,
@@ -232,6 +239,7 @@ async function executeBuildJob(
 
     await new SpineDigestFile(job.archivePath).write(async (document) => {
       assertJobStillRunning(await getBuildJob(job.jobId));
+      await assertCurrentBuildInputRevision(job, document);
       await commitChapterKnowledgeGraphArtifact(document, artifact);
     });
     await reporter.stepCompleted("knowledge-graph");
@@ -262,12 +270,21 @@ async function executeBuildJob(
     details = await new SpineDigestFile(job.archivePath).write(
       async (document) => {
         assertJobStillRunning(await getBuildJob(job.jobId));
+        await assertCurrentBuildInputRevision(job, document);
         return await commitChapterGraphArtifact(document, artifact);
       },
     );
-    ({ details } = await new SpineDigestFile(job.archivePath).readDocument(
+    const nextBuildInput = await new SpineDigestFile(
+      job.archivePath,
+    ).readDocument(
       async (document) => await readChapterBuildInput(document, job.chapterId),
-    ));
+    );
+    details = nextBuildInput.details;
+    await recordBuildJobInputRevision({
+      currentRevision: nextBuildInput.revision,
+      jobId: job.jobId,
+      ownerId: requireRunningJobOwnerId(job),
+    });
     await reporter.updateWords({ graphWords: details.words });
     await reporter.stepCompleted("reading-graph");
   }
@@ -291,12 +308,14 @@ async function executeBuildJob(
 
   await reporter.stepStarted("reading-summary");
   const summaryInput = await new SpineDigestFile(job.archivePath).readDocument(
-    async (document) =>
-      await snapshotChapterSummaryInput(
+    async (document) => {
+      await assertCurrentBuildInputRevision(job, document);
+      return await snapshotChapterSummaryInput(
         document,
         job.chapterId,
         job.workspacePath,
-      ),
+      );
+    },
   );
   const summary = await buildChapterSummaryArtifactFromSnapshot(job.chapterId, {
     llm,
@@ -306,6 +325,7 @@ async function executeBuildJob(
   details = await new SpineDigestFile(job.archivePath).write(
     async (document) => {
       assertJobStillRunning(await getBuildJob(job.jobId));
+      await assertCurrentBuildInputRevision(job, document);
       return await commitChapterSummaryArtifact(
         document,
         job.chapterId,
@@ -322,6 +342,29 @@ function assertJobStillRunning(job: BuildJob): void {
   if (job.state !== "running") {
     throw new Error(`Job ${job.jobId} is ${job.state}. Stop before flushing.`);
   }
+}
+
+async function assertCurrentBuildInputRevision(
+  job: BuildJob,
+  document: {
+    readonly serials: {
+      getRevision(serialId: number): Promise<number>;
+    };
+  },
+): Promise<void> {
+  await assertBuildJobInputRevision({
+    currentRevision: await document.serials.getRevision(job.chapterId),
+    jobId: job.jobId,
+    ownerId: requireRunningJobOwnerId(job),
+  });
+}
+
+function requireRunningJobOwnerId(job: BuildJob): string {
+  if (job.ownerId === undefined) {
+    throw new Error(`Job ${job.jobId} is not owned by this worker.`);
+  }
+
+  return job.ownerId;
 }
 
 async function watchBuildJob(

--- a/src/common/wiki-graph-temp.ts
+++ b/src/common/wiki-graph-temp.ts
@@ -1,0 +1,39 @@
+import { mkdir, mkdtemp } from "fs/promises";
+import { join } from "path";
+
+import { resolveWikiGraphStateDirectoryPath } from "./wiki-graph-dir.js";
+
+export type WikiGraphTempCategory =
+  | "archive-open"
+  | "archive-write"
+  | "cli-output"
+  | "sdpub-upgrade"
+  | "stdin-create"
+  | "url-create";
+
+export function resolveWikiGraphStateRootPath(): string {
+  const stateDirectoryPath = process.env.WIKIGRAPH_STATE_DIR;
+
+  if (stateDirectoryPath !== undefined && stateDirectoryPath.trim() !== "") {
+    return stateDirectoryPath;
+  }
+
+  return resolveWikiGraphStateDirectoryPath();
+}
+
+export function resolveWikiGraphTempDirectoryPath(
+  category?: WikiGraphTempCategory,
+): string {
+  const rootPath = join(resolveWikiGraphStateRootPath(), "tmp");
+
+  return category === undefined ? rootPath : join(rootPath, category);
+}
+
+export async function createWikiGraphTempDirectory(
+  category: WikiGraphTempCategory,
+): Promise<string> {
+  const rootPath = resolveWikiGraphTempDirectoryPath(category);
+
+  await mkdir(rootPath, { recursive: true });
+  return await mkdtemp(join(rootPath, `${category}-`));
+}

--- a/src/document/database.ts
+++ b/src/document/database.ts
@@ -17,30 +17,39 @@ type DatabaseOperationScope = symbol;
 
 export class Database {
   readonly #database: SqliteDatabase;
+  readonly #onWrite: (() => void) | undefined;
   readonly #operationScope = new AsyncLocalStorage<DatabaseOperationScope>();
   #activeTransactionScope: DatabaseOperationScope | undefined;
   #closed = false;
   #operationChain: Promise<void> = Promise.resolve();
   #transactionDepth = 0;
 
-  public constructor(database: SqliteDatabase) {
+  public constructor(
+    database: SqliteDatabase,
+    options: { readonly onWrite?: () => void } = {},
+  ) {
     this.#database = database;
+    this.#onWrite = options.onWrite;
   }
 
   public static async open(
     databasePath: string,
     schemaSql = "",
-    options: { readonly readonly?: boolean } = {},
+    options: {
+      readonly onWrite?: () => void;
+      readonly readonly?: boolean;
+    } = {},
   ): Promise<Database> {
     const resolvedDatabasePath = resolve(databasePath);
     const database = await openSqliteDatabase(resolvedDatabasePath, options);
-    const openedDatabase = new Database(database);
+    const openedDatabase = new Database(database, options);
 
     await openedDatabase.#executeSql(
       `PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`,
     );
     if (options.readonly !== true && schemaSql.trim() !== "") {
       await openedDatabase.#executeSql(schemaSql);
+      openedDatabase.#markWritten();
     }
 
     return openedDatabase;
@@ -91,6 +100,7 @@ export class Database {
     await this.#runSerialized(async () => {
       this.#assertOpen();
       await this.#runStatement(sql, params);
+      this.#markWritten();
     });
   }
 
@@ -189,6 +199,10 @@ export class Database {
     );
 
     return await queuedOperation;
+  }
+
+  #markWritten(): void {
+    this.#onWrite?.();
   }
 
   async #closeDatabase(): Promise<void> {

--- a/src/document/database.ts
+++ b/src/document/database.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "async_hooks";
+import { stat } from "fs/promises";
 import { resolve } from "path";
 
 import type * as Sqlite3Namespace from "sqlite3";
@@ -14,6 +15,23 @@ export type SqlRow = Record<string, SqlRowValue>;
 const SQLITE_BUSY_TIMEOUT_MS = 15 * 60 * 1000;
 
 type DatabaseOperationScope = symbol;
+
+async function isMissingOrEmptyFile(path: string): Promise<boolean> {
+  const stats = await stat(path).catch((error: unknown) => {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return undefined;
+    }
+
+    throw error;
+  });
+
+  return stats === undefined || stats.size === 0;
+}
 
 export class Database {
   readonly #database: SqliteDatabase;
@@ -41,6 +59,10 @@ export class Database {
     } = {},
   ): Promise<Database> {
     const resolvedDatabasePath = resolve(databasePath);
+    const shouldMarkSchemaWritten =
+      options.readonly !== true &&
+      schemaSql.trim() !== "" &&
+      (await isMissingOrEmptyFile(resolvedDatabasePath));
     const database = await openSqliteDatabase(resolvedDatabasePath, options);
     const openedDatabase = new Database(database, options);
 
@@ -49,7 +71,9 @@ export class Database {
     );
     if (options.readonly !== true && schemaSql.trim() !== "") {
       await openedDatabase.#executeSql(schemaSql);
-      openedDatabase.#markWritten();
+      if (shouldMarkSchemaWritten) {
+        openedDatabase.#markWritten();
+      }
     }
 
     return openedDatabase;

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -47,6 +47,7 @@ export interface DocumentFileStore {
   deleteTree(path: string): Promise<void>;
   ensureDirectory(path: string): Promise<void>;
   initializeDatabaseSchema(): boolean;
+  markDatabaseDirty?(): void;
   openDatabaseReadonly(): boolean;
   listFileContents?(path: string): Promise<ReadonlyMap<string, Uint8Array>>;
   listFiles(path: string): Promise<readonly string[]>;
@@ -71,6 +72,7 @@ const LOCAL_DOCUMENT_FILE_STORE: DocumentFileStore = {
     await mkdir(path, { recursive: true });
   },
   initializeDatabaseSchema: () => true,
+  markDatabaseDirty: () => undefined,
   openDatabaseReadonly: () => false,
   listFiles: async (path) =>
     (await readdir(path, { withFileTypes: true }))
@@ -234,7 +236,12 @@ export class DirectoryDocument implements Document {
       const database = await Database.open(
         databasePath,
         shouldInitializeDatabaseSchema ? SCHEMA_SQL : "",
-        { readonly: fileStore.openDatabaseReadonly() },
+        {
+          onWrite: () => {
+            fileStore.markDatabaseDirty?.();
+          },
+          readonly: fileStore.openDatabaseReadonly(),
+        },
       );
       if (shouldInitializeDatabaseSchema) {
         await initializeDocumentSchema(database);

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -14,7 +14,11 @@ import {
   type ReadonlySerialTextStream,
   type SerialTextStream,
 } from "./text-streams.js";
-import { initializeDocumentSchema, SCHEMA_SQL } from "./schema.js";
+import {
+  initializeDocumentSchema,
+  SCHEMA_SQL,
+  SEARCH_INDEX_SCHEMA_SQL,
+} from "./schema.js";
 import {
   ChunkStore,
   FragmentGroupStore,
@@ -48,11 +52,13 @@ export interface DocumentFileStore {
   ensureDirectory(path: string): Promise<void>;
   initializeDatabaseSchema(): boolean;
   markDatabaseDirty?(): void;
+  markSearchIndexDatabaseDirty?(): void;
   openDatabaseReadonly(): boolean;
   listFileContents?(path: string): Promise<ReadonlyMap<string, Uint8Array>>;
   listFiles(path: string): Promise<readonly string[]>;
   readFile(path: string): Promise<Uint8Array | undefined>;
   resolveDatabasePath(documentPath: string): Promise<string>;
+  resolveSearchIndexDatabasePath?(documentPath: string): Promise<string>;
   writeFile(
     path: string,
     content: string | Uint8Array,
@@ -73,6 +79,7 @@ const LOCAL_DOCUMENT_FILE_STORE: DocumentFileStore = {
   },
   initializeDatabaseSchema: () => true,
   markDatabaseDirty: () => undefined,
+  markSearchIndexDatabaseDirty: () => undefined,
   openDatabaseReadonly: () => false,
   listFiles: async (path) =>
     (await readdir(path, { withFileTypes: true }))
@@ -91,6 +98,8 @@ const LOCAL_DOCUMENT_FILE_STORE: DocumentFileStore = {
   },
   resolveDatabasePath: (documentPath) =>
     Promise.resolve(join(documentPath, "database.db")),
+  resolveSearchIndexDatabasePath: (documentPath) =>
+    Promise.resolve(join(documentPath, "fts.db")),
   writeFile: async (path, content, options) => {
     if (typeof content === "string") {
       await writeFile(path, content, {
@@ -130,6 +139,9 @@ export interface ReadonlyDocument {
     operation: (document: ReadonlyDocument) => Promise<T> | T,
   ): Promise<T>;
   readDatabase<T>(
+    operation: (database: DocumentDatabase) => Promise<T> | T,
+  ): Promise<T>;
+  readSearchIndexDatabase<T>(
     operation: (database: DocumentDatabase) => Promise<T> | T,
   ): Promise<T>;
   readBookMeta(): Promise<BookMeta | undefined>;
@@ -176,6 +188,9 @@ export interface Document extends ReadonlyDocument {
   writeCover(cover: SourceAsset): Promise<void>;
   writeSummary(serialId: number, summary: string): Promise<void>;
   writeToc(toc: TocFile): Promise<void>;
+  writeSearchIndexDatabase<T>(
+    operation: (database: DocumentDatabase) => Promise<T> | T,
+  ): Promise<T>;
 }
 
 export class DirectoryDocument implements Document {
@@ -363,6 +378,22 @@ export class DirectoryDocument implements Document {
     return await operation(this.#database);
   }
 
+  public async readSearchIndexDatabase<T>(
+    operation: (database: Database) => Promise<T> | T,
+  ): Promise<T> {
+    return await this.#openSearchIndexDatabase(true, operation);
+  }
+
+  public async writeSearchIndexDatabase<T>(
+    operation: (database: Database) => Promise<T> | T,
+  ): Promise<T> {
+    return await this.#openSearchIndexDatabase(false, operation);
+  }
+
+  public async deleteSearchIndexDatabase(): Promise<void> {
+    await this.#fileStore.deleteFile(join(this.path, "fts.db"));
+  }
+
   public async peekNextSerialId(): Promise<number> {
     return (await this.serials.getMaxId()) + 1;
   }
@@ -456,6 +487,32 @@ export class DirectoryDocument implements Document {
 
   public async close(): Promise<void> {
     await this.release();
+  }
+
+  async #openSearchIndexDatabase<T>(
+    readonly: boolean,
+    operation: (database: Database) => Promise<T> | T,
+  ): Promise<T> {
+    const databasePath =
+      this.#fileStore.resolveSearchIndexDatabasePath === undefined
+        ? join(this.path, "fts.db")
+        : await this.#fileStore.resolveSearchIndexDatabasePath(this.path);
+    const database = await Database.open(
+      databasePath,
+      readonly ? "" : SEARCH_INDEX_SCHEMA_SQL,
+      {
+        onWrite: () => {
+          this.#fileStore.markSearchIndexDatabaseDirty?.();
+        },
+        readonly,
+      },
+    );
+
+    try {
+      return await operation(database);
+    } finally {
+      await database.close();
+    }
   }
 
   async #rollbackContext(context: DirectoryDocumentContext): Promise<void> {

--- a/src/document/schema.ts
+++ b/src/document/schema.ts
@@ -20,6 +20,11 @@ export const SCHEMA_SQL = `
     value INTEGER NOT NULL
   );
 
+  CREATE TABLE IF NOT EXISTS archive_index_settings (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    fts_embedded INTEGER NOT NULL DEFAULT 0
+  );
+
   CREATE TABLE IF NOT EXISTS graph_build_parameters (
     hash TEXT PRIMARY KEY,
     prompt TEXT NOT NULL,
@@ -235,6 +240,57 @@ export const SCHEMA_SQL = `
   FROM chapter_entity_relations
   GROUP BY subject_qid, predicate, object_qid;
 
+  CREATE TABLE IF NOT EXISTS text_sentence_records (
+    id INTEGER PRIMARY KEY,
+    kind INTEGER NOT NULL,
+    chapter_id INTEGER NOT NULL,
+    sentence_index INTEGER NOT NULL,
+    words_count INTEGER NOT NULL DEFAULT 0,
+    byte_offset INTEGER NOT NULL DEFAULT 0,
+    byte_length INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(kind, chapter_id, sentence_index)
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_text_sentence_records_chapter
+  ON text_sentence_records(kind, chapter_id, sentence_index);
+
+  CREATE TABLE IF NOT EXISTS object_metadata (
+    id INTEGER PRIMARY KEY,
+    object_kind INTEGER NOT NULL,
+    object_path TEXT NOT NULL,
+    key TEXT NOT NULL,
+    value_json TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    chapter_id INTEGER,
+    chunk_id INTEGER,
+    entity_qid TEXT,
+    triple_subject_qid TEXT,
+    triple_predicate TEXT,
+    triple_object_qid TEXT,
+    UNIQUE(object_path, key)
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_object_metadata_object
+  ON object_metadata(object_path);
+
+  CREATE INDEX IF NOT EXISTS idx_object_metadata_chapter
+  ON object_metadata(chapter_id);
+
+  CREATE INDEX IF NOT EXISTS idx_object_metadata_chunk
+  ON object_metadata(chunk_id);
+
+  CREATE INDEX IF NOT EXISTS idx_object_metadata_entity
+  ON object_metadata(entity_qid);
+
+  CREATE INDEX IF NOT EXISTS idx_object_metadata_triple
+  ON object_metadata(
+    triple_subject_qid,
+    triple_predicate,
+    triple_object_qid
+  );
+`;
+
+export const SEARCH_INDEX_SCHEMA_SQL = `
   CREATE TABLE IF NOT EXISTS search_index_state (
     key TEXT PRIMARY KEY,
     value TEXT NOT NULL
@@ -280,41 +336,6 @@ export const SCHEMA_SQL = `
     tier2,
     tier3,
     tokenize='ascii'
-  );
-
-  CREATE TABLE IF NOT EXISTS object_metadata (
-    id INTEGER PRIMARY KEY,
-    object_kind INTEGER NOT NULL,
-    object_path TEXT NOT NULL,
-    key TEXT NOT NULL,
-    value_json TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
-    chapter_id INTEGER,
-    chunk_id INTEGER,
-    entity_qid TEXT,
-    triple_subject_qid TEXT,
-    triple_predicate TEXT,
-    triple_object_qid TEXT,
-    UNIQUE(object_path, key)
-  );
-
-  CREATE INDEX IF NOT EXISTS idx_object_metadata_object
-  ON object_metadata(object_path);
-
-  CREATE INDEX IF NOT EXISTS idx_object_metadata_chapter
-  ON object_metadata(chapter_id);
-
-  CREATE INDEX IF NOT EXISTS idx_object_metadata_chunk
-  ON object_metadata(chunk_id);
-
-  CREATE INDEX IF NOT EXISTS idx_object_metadata_entity
-  ON object_metadata(entity_qid);
-
-  CREATE INDEX IF NOT EXISTS idx_object_metadata_triple
-  ON object_metadata(
-    triple_subject_qid,
-    triple_predicate,
-    triple_object_qid
   );
 `;
 

--- a/src/facade/build-queue.ts
+++ b/src/facade/build-queue.ts
@@ -849,7 +849,9 @@ export async function runBuildQueueGc(
   context: GcContext,
 ): Promise<GcJobResult> {
   const state = await openBuildQueueDatabase();
-  const cutoff = context.now - 7 * 24 * 60 * 60 * 1000;
+  const cutoff = context.force
+    ? context.now
+    : context.now - 7 * 24 * 60 * 60 * 1000;
 
   try {
     const scanned = await state.queryOne(

--- a/src/facade/build-queue.ts
+++ b/src/facade/build-queue.ts
@@ -1,10 +1,16 @@
 import { createHash, randomUUID } from "crypto";
 import { appendFile, mkdir, mkdtemp, readFile, rm } from "fs/promises";
-import { join, resolve } from "path";
+import { dirname, join, resolve } from "path";
 
 import { resolveWikiGraphStateDirectoryPath } from "../common/wiki-graph-dir.js";
 import { openSharedStateDatabase } from "../document/index.js";
 import type { Database } from "../document/index.js";
+import {
+  readPathSize,
+  removeDisposableChildDirectories,
+  removeDisposableDirectory,
+} from "../gc/files.js";
+import type { GcContext, GcJobResult } from "../gc/index.js";
 
 export const BUILD_JOB_STATES = [
   "queued",
@@ -839,6 +845,56 @@ WHERE state IN (${placeholders})
   }
 }
 
+export async function runBuildQueueGc(
+  context: GcContext,
+): Promise<GcJobResult> {
+  const state = await openBuildQueueDatabase();
+  const cutoff = context.now - 7 * 24 * 60 * 60 * 1000;
+
+  try {
+    const scanned = await state.queryOne(
+      "SELECT COUNT(*) AS count FROM build_jobs",
+      undefined,
+      (row) => getNumber(row, "count"),
+    );
+    const jobs = await state.queryAll(
+      `
+SELECT *
+FROM build_jobs
+WHERE state IN ('succeeded', 'failed', 'canceled')
+  AND updated_at <= ?
+`,
+      [cutoff],
+      mapBuildJob,
+    );
+    const childDirectories = await removeDisposableChildDirectories(
+      getBuildJobWorkspaceRootPath(),
+    );
+    let freedBytes = 0;
+
+    for (const job of jobs) {
+      freedBytes += await readPathSize(job.workspacePath);
+      freedBytes += await readPathSize(job.eventsPath);
+      if (!context.dryRun) {
+        await rm(job.workspacePath, { force: true, recursive: true });
+        freedBytes += await removeDisposableDirectory(
+          dirname(job.workspacePath),
+        );
+        await rm(job.eventsPath, { force: true });
+        await state.run("DELETE FROM build_jobs WHERE job_id = ?", [job.jobId]);
+      }
+    }
+
+    return {
+      freedBytes: freedBytes + childDirectories.freedBytes,
+      removed: jobs.length + childDirectories.removed,
+      scanned: (scanned ?? 0) + childDirectories.scanned,
+    };
+  } finally {
+    await state.close();
+  }
+}
+
 async function updateBuildJobState(
   jobId: string,
   stateName: BuildJobState,
@@ -1346,14 +1402,14 @@ async function createJobWorkspacePath(
   archiveKey: string,
   jobId: string,
 ): Promise<string> {
-  const rootPath = join(
-    getBuildQueueStateDirectoryPath(),
-    "build-jobs",
-    archiveKey,
-  );
+  const rootPath = join(getBuildJobWorkspaceRootPath(), archiveKey);
 
   await mkdir(rootPath, { recursive: true });
   return await mkdtemp(join(rootPath, `${jobId}-`));
+}
+
+function getBuildJobWorkspaceRootPath(): string {
+  return join(getBuildQueueStateDirectoryPath(), "build-jobs");
 }
 
 async function createJobEventsPath(jobId: string): Promise<string> {

--- a/src/facade/build-queue.ts
+++ b/src/facade/build-queue.ts
@@ -52,6 +52,7 @@ export interface BuildJob {
   readonly eventsPath: string;
   readonly finishedAt?: number;
   readonly jobId: string;
+  readonly inputRevision?: number;
   readonly llmJSON?: string;
   readonly ownerId?: string;
   readonly ownerPid?: number;
@@ -181,6 +182,15 @@ export interface BuildJobProgressReporter {
   throwIfStopped(): Promise<void>;
 }
 
+export type BuildJobConflictScope =
+  | {
+      readonly kind: "archive";
+    }
+  | {
+      readonly chapterIds: readonly number[];
+      readonly kind: "chapter";
+    };
+
 const BUILD_QUEUE_SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS build_jobs (
   job_id TEXT PRIMARY KEY,
@@ -193,6 +203,7 @@ CREATE TABLE IF NOT EXISTS build_jobs (
   queue_rank INTEGER NOT NULL,
   workspace_path TEXT NOT NULL,
   events_path TEXT NOT NULL,
+  input_revision INTEGER,
   llm_json TEXT,
   prompt TEXT,
   owner_id TEXT,
@@ -304,6 +315,60 @@ INSERT INTO build_jobs (
   } finally {
     await state.close();
   }
+}
+
+export async function recordBuildJobInputRevision(input: {
+  readonly currentRevision: number;
+  readonly jobId: string;
+  readonly ownerId: string;
+}): Promise<BuildJob> {
+  const state = await openBuildQueueDatabase();
+
+  try {
+    await state.transaction(async () => {
+      await state.run(
+        `
+UPDATE build_jobs
+SET input_revision = ?,
+    updated_at = ?
+WHERE job_id = ?
+  AND owner_id = ?
+  AND state = 'running'
+`,
+        [input.currentRevision, Date.now(), input.jobId, input.ownerId],
+      );
+    });
+
+    return await requireBuildJobById(state, input.jobId);
+  } finally {
+    await state.close();
+  }
+}
+
+export async function assertBuildJobInputRevision(input: {
+  readonly currentRevision: number;
+  readonly jobId: string;
+  readonly ownerId: string;
+}): Promise<void> {
+  const job = await getBuildJob(input.jobId);
+
+  if (job.state !== "running" || job.ownerId !== input.ownerId) {
+    throw new BuildJobStoppedError(
+      `Job ${input.jobId} is ${job.state}. Stop current worker execution.`,
+    );
+  }
+  if (job.inputRevision === undefined) {
+    throw new Error(
+      `Job ${input.jobId} has no recorded chapter input revision. Requeue the job before committing build output.`,
+    );
+  }
+  if (job.inputRevision === input.currentRevision) {
+    return;
+  }
+
+  throw new Error(
+    `Chapter ${job.chapterId} changed while job ${job.jobId} was running. Requeue the job before committing build output.`,
+  );
 }
 
 export async function listBuildJobs(
@@ -607,7 +672,23 @@ export async function assertNoActiveBuildJobs(input: {
   readonly operation: string;
   readonly requiresTarget?: BuildJobTarget;
 }): Promise<void> {
-  if (input.chapterIds.length === 0) {
+  await assertNoActiveBuildJobConflicts({
+    archivePath: input.archivePath,
+    operation: input.operation,
+    ...(input.requiresTarget === undefined
+      ? {}
+      : { requiresTarget: input.requiresTarget }),
+    scope: { chapterIds: input.chapterIds, kind: "chapter" },
+  });
+}
+
+export async function assertNoActiveBuildJobConflicts(input: {
+  readonly archivePath: string;
+  readonly operation: string;
+  readonly requiresTarget?: BuildJobTarget;
+  readonly scope: BuildJobConflictScope;
+}): Promise<void> {
+  if (input.scope.kind === "chapter" && input.scope.chapterIds.length === 0) {
     return;
   }
 
@@ -616,11 +697,17 @@ export async function assertNoActiveBuildJobs(input: {
   try {
     await recoverStaleBuildJobs(state);
     const archiveKey = createArchiveKey(resolve(input.archivePath));
-    const placeholders = input.chapterIds.map(() => "?").join(", ");
-    const params: Array<number | string> = [archiveKey, ...input.chapterIds];
     const targetFilter =
       input.requiresTarget === undefined ? "" : "AND target = ?";
+    const params: Array<number | string> = [archiveKey];
+    let scopeFilter = "";
 
+    if (input.scope.kind === "chapter") {
+      const placeholders = input.scope.chapterIds.map(() => "?").join(", ");
+
+      scopeFilter = `AND chapter_id IN (${placeholders})`;
+      params.push(...input.scope.chapterIds);
+    }
     if (input.requiresTarget !== undefined) {
       params.push(input.requiresTarget);
     }
@@ -630,7 +717,7 @@ export async function assertNoActiveBuildJobs(input: {
 SELECT *
 FROM build_jobs
 WHERE archive_key = ?
-  AND chapter_id IN (${placeholders})
+  ${scopeFilter}
   AND state IN ('queued', 'running', 'canceling', 'paused')
   ${targetFilter}
 ORDER BY updated_at DESC
@@ -1382,22 +1469,53 @@ async function readMinQueueRank(state: Database): Promise<number> {
 }
 
 async function openBuildQueueDatabase(): Promise<Database> {
-  return await openSharedStateDatabase(
+  const database = await openSharedStateDatabase(
     getBuildQueueDatabasePath(),
     BUILD_QUEUE_SCHEMA_SQL,
   );
+
+  await migrateBuildQueueSchema(database);
+  return database;
 }
 
 async function openReadonlyBuildQueueDatabase(): Promise<Database> {
-  return await openSharedStateDatabase(
-    getBuildQueueDatabasePath(),
-    BUILD_QUEUE_SCHEMA_SQL,
-    { readonly: true },
-  );
+  return await openBuildQueueDatabase();
 }
 
 function getBuildQueueDatabasePath(): string {
   return join(getBuildQueueStateDirectoryPath(), "build-queue.sqlite");
+}
+
+async function migrateBuildQueueSchema(database: Database): Promise<void> {
+  if ((await listTableColumns(database, "build_jobs")).has("input_revision")) {
+    return;
+  }
+
+  await database.transaction(async () => {
+    const columns = await listTableColumns(database, "build_jobs");
+
+    if (columns.has("input_revision")) {
+      return;
+    }
+
+    await database.run(`
+      ALTER TABLE build_jobs
+      ADD COLUMN input_revision INTEGER
+    `);
+  });
+}
+
+async function listTableColumns(
+  database: Database,
+  table: string,
+): Promise<ReadonlySet<string>> {
+  const rows = await database.queryAll(
+    `PRAGMA table_info(${table})`,
+    undefined,
+    (row) => getString(row, "name"),
+  );
+
+  return new Set(rows);
 }
 
 async function createJobWorkspacePath(
@@ -1446,6 +1564,8 @@ function mapBuildJob(row: Record<string, unknown>): BuildJob {
   const finishedAt =
     row.finished_at === null ? undefined : getNumber(row, "finished_at");
   const errorJSON = getOptionalString(row, "error_json");
+  const inputRevision =
+    row.input_revision === null ? undefined : getNumber(row, "input_revision");
   const llmJSON = getOptionalString(row, "llm_json");
   const prompt = getOptionalString(row, "prompt");
 
@@ -1459,6 +1579,7 @@ function mapBuildJob(row: Record<string, unknown>): BuildJob {
     eventsPath: getString(row, "events_path"),
     ...(finishedAt === undefined ? {} : { finishedAt }),
     jobId: getString(row, "job_id"),
+    ...(inputRevision === undefined ? {} : { inputRevision }),
     ...(llmJSON === undefined ? {} : { llmJSON }),
     ...(ownerId === undefined ? {} : { ownerId }),
     ...(ownerPid === undefined ? {} : { ownerPid }),

--- a/src/facade/build-queue.ts
+++ b/src/facade/build-queue.ts
@@ -869,9 +869,9 @@ WHERE state IN ('succeeded', 'failed', 'canceled')
       [cutoff],
       mapBuildJob,
     );
-    const childDirectories = await removeDisposableChildDirectories(
-      getBuildJobWorkspaceRootPath(),
-    );
+    const childDirectories = context.dryRun
+      ? { freedBytes: 0, removed: 0, scanned: 0 }
+      : await removeDisposableChildDirectories(getBuildJobWorkspaceRootPath());
     let freedBytes = 0;
 
     for (const job of jobs) {

--- a/src/facade/chapter-build.ts
+++ b/src/facade/chapter-build.ts
@@ -711,6 +711,14 @@ class SummaryInputSnapshotDocument implements ReadonlyDocument {
     );
   }
 
+  public readSearchIndexDatabase<T>(): Promise<T> {
+    return Promise.reject(
+      new Error(
+        "Summary input snapshots do not expose a search index database.",
+      ),
+    );
+  }
+
   public readBookMeta(): Promise<undefined> {
     return Promise.resolve(undefined);
   }

--- a/src/facade/chapter-build.ts
+++ b/src/facade/chapter-build.ts
@@ -181,12 +181,14 @@ export async function readChapterBuildInput(
   chapterId: number,
 ): Promise<{
   readonly details: ChapterDetails;
+  readonly revision: number;
   readonly sourceText: readonly string[];
 }> {
   const details = await getChapterDetails(document, chapterId);
 
   return {
     details,
+    revision: await document.serials.getRevision(chapterId),
     sourceText: await collectReaderText(readChapterSource(document, chapterId)),
   };
 }

--- a/src/facade/digest.ts
+++ b/src/facade/digest.ts
@@ -1,7 +1,7 @@
-import { mkdtemp, rm } from "fs/promises";
-import { join, resolve } from "path";
-import { tmpdir } from "os";
+import { rm } from "fs/promises";
+import { resolve } from "path";
 
+import { createWikiGraphTempDirectory } from "../common/wiki-graph-temp.js";
 import { BOOK_META_VERSION, TOC_FILE_VERSION } from "../source/index.js";
 import {
   EPUB_SOURCE_ADAPTER,
@@ -234,7 +234,7 @@ async function withTemporaryDocumentSession<T>(
 ): Promise<T> {
   const directoryPath =
     documentDirPath === undefined
-      ? await mkdtemp(join(tmpdir(), "wikigraph-digest-"))
+      ? await createWikiGraphTempDirectory("archive-open")
       : resolve(documentDirPath);
   const document = await DirectoryDocument.open(directoryPath);
 

--- a/src/facade/index.ts
+++ b/src/facade/index.ts
@@ -36,6 +36,8 @@ export {
 } from "../archive/query/index.js";
 export {
   addBuildJob,
+  assertBuildJobInputRevision,
+  assertNoActiveBuildJobConflicts,
   assertNoActiveBuildJobs,
   boostBuildJob,
   cancelBuildJob,
@@ -44,6 +46,7 @@ export {
   listBuildJobs,
   pauseBuildJob,
   readBuildJobEvents,
+  recordBuildJobInputRevision,
   resumeBuildJob,
   resolveBuildJobId,
   runBuildQueueGc,
@@ -52,6 +55,7 @@ export {
 } from "./build-queue.js";
 export type {
   AddBuildJobOptions,
+  BuildJobConflictScope,
   BuildJobExecutionContext,
   BuildJob,
   BuildJobEvent,

--- a/src/facade/index.ts
+++ b/src/facade/index.ts
@@ -46,6 +46,7 @@ export {
   readBuildJobEvents,
   resumeBuildJob,
   resolveBuildJobId,
+  runBuildQueueGc,
   runBuildJobWorker,
   updateBuildJobTarget,
 } from "./build-queue.js";

--- a/src/gc/files.ts
+++ b/src/gc/files.ts
@@ -4,6 +4,11 @@ import { join } from "path";
 import { isNodeError } from "../utils/node-error.js";
 
 const DISPOSABLE_DIRECTORY_ENTRIES = new Set([".DS_Store"]);
+const DISPOSABLE_DIRECTORY_TTL_MS = 60_000;
+
+export function isDisposableDirectoryEntry(name: string): boolean {
+  return DISPOSABLE_DIRECTORY_ENTRIES.has(name);
+}
 
 export async function removeDisposableDirectory(
   directoryPath: string,
@@ -19,7 +24,7 @@ export async function removeDisposableDirectory(
   if (entries === undefined) {
     return 0;
   }
-  if (entries.some((entry) => !DISPOSABLE_DIRECTORY_ENTRIES.has(entry))) {
+  if (entries.some((entry) => !isDisposableDirectoryEntry(entry))) {
     return 0;
   }
 
@@ -69,6 +74,21 @@ export async function removeDisposableChildDirectories(
 
     scanned += 1;
     const directoryPath = join(rootPath, entry.name);
+    const stats = await stat(directoryPath).catch((error: unknown) => {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return undefined;
+      }
+
+      throw error;
+    });
+
+    if (
+      stats === undefined ||
+      Date.now() - stats.mtimeMs < DISPOSABLE_DIRECTORY_TTL_MS
+    ) {
+      continue;
+    }
+
     const removedBytes = await removeDisposableDirectory(directoryPath);
 
     if (await pathExists(directoryPath)) {

--- a/src/gc/files.ts
+++ b/src/gc/files.ts
@@ -1,0 +1,122 @@
+import { readdir, rm, rmdir, stat } from "fs/promises";
+import { join } from "path";
+
+import { isNodeError } from "../utils/node-error.js";
+
+const DISPOSABLE_DIRECTORY_ENTRIES = new Set([".DS_Store"]);
+
+export async function removeDisposableDirectory(
+  directoryPath: string,
+): Promise<number> {
+  const entries = await readdir(directoryPath).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  });
+
+  if (entries === undefined) {
+    return 0;
+  }
+  if (entries.some((entry) => !DISPOSABLE_DIRECTORY_ENTRIES.has(entry))) {
+    return 0;
+  }
+
+  let freedBytes = 0;
+
+  for (const entry of entries) {
+    const path = join(directoryPath, entry);
+
+    freedBytes += await readPathSize(path);
+    await rm(path, { force: true, recursive: true });
+  }
+
+  await rmdir(directoryPath).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return;
+    }
+
+    throw error;
+  });
+  return freedBytes;
+}
+
+export async function removeDisposableChildDirectories(
+  rootPath: string,
+): Promise<{
+  readonly freedBytes: number;
+  readonly removed: number;
+  readonly scanned: number;
+}> {
+  const entries = await readdir(rootPath, { withFileTypes: true }).catch(
+    (error: unknown) => {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return [];
+      }
+
+      throw error;
+    },
+  );
+  let freedBytes = 0;
+  let removed = 0;
+  let scanned = 0;
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    scanned += 1;
+    const directoryPath = join(rootPath, entry.name);
+    const removedBytes = await removeDisposableDirectory(directoryPath);
+
+    if (await pathExists(directoryPath)) {
+      freedBytes += removedBytes;
+      continue;
+    }
+
+    freedBytes += removedBytes;
+    removed += 1;
+  }
+
+  return { freedBytes, removed, scanned };
+}
+
+export async function readPathSize(path: string): Promise<number> {
+  try {
+    const stats = await stat(path);
+
+    if (stats.isDirectory()) {
+      const entries = await readdir(path);
+      let size = 0;
+
+      for (const entry of entries) {
+        size += await readPathSize(join(path, entry));
+      }
+
+      return size;
+    }
+
+    return stats.size;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return 0;
+    }
+
+    throw error;
+  }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return false;
+    }
+
+    throw error;
+  }
+}

--- a/src/gc/index.ts
+++ b/src/gc/index.ts
@@ -1,0 +1,8 @@
+export { tryRunWikiGraphGc } from "./runner.js";
+export type {
+  GcContext,
+  GcJob,
+  GcJobReport,
+  GcJobResult,
+  GcRunReport,
+} from "./types.js";

--- a/src/gc/lock.ts
+++ b/src/gc/lock.ts
@@ -1,0 +1,157 @@
+import { randomUUID } from "crypto";
+import { join } from "path";
+
+import { resolveWikiGraphStateRootPath } from "../common/wiki-graph-temp.js";
+import { getNumber, getString, type SqlRow } from "../document/database.js";
+import { openSharedStateDatabase } from "../document/index.js";
+import type { Database } from "../document/index.js";
+import { isNodeError } from "../utils/node-error.js";
+
+const GC_SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS gc_locks (
+  scope TEXT PRIMARY KEY,
+  owner_id TEXT NOT NULL,
+  owner_pid INTEGER NOT NULL,
+  heartbeat_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL
+);
+`;
+
+const GC_LOCK_STALE_TIMEOUT_MS = 60_000;
+const GC_HEARTBEAT_INTERVAL_MS = 20_000;
+
+interface GcLock {
+  readonly createdAt: number;
+  readonly heartbeatAt: number;
+  readonly ownerId: string;
+  readonly ownerPid: number;
+}
+
+export async function tryAcquireGcLock(
+  scope = "global",
+): Promise<(() => Promise<void>) | undefined> {
+  const database = await openGcStateDatabase();
+  const ownerId = `${process.pid}-${randomUUID()}`;
+  const now = Date.now();
+
+  try {
+    await cleanupStaleGcLocks(database);
+    const existing = await database.queryOne(
+      "SELECT * FROM gc_locks WHERE scope = ?",
+      [scope],
+      mapGcLock,
+    );
+
+    if (existing !== undefined) {
+      return undefined;
+    }
+
+    await database.run(
+      `
+INSERT INTO gc_locks (
+  scope, owner_id, owner_pid, heartbeat_at, created_at
+) VALUES (?, ?, ?, ?, ?)
+`,
+      [scope, ownerId, process.pid, now, now],
+    );
+  } finally {
+    await database.close();
+  }
+
+  const heartbeat = setInterval(() => {
+    void heartbeatGcLock(scope, ownerId).catch(() => undefined);
+  }, GC_HEARTBEAT_INTERVAL_MS);
+
+  return async () => {
+    clearInterval(heartbeat);
+    const releaseDatabase = await openGcStateDatabase();
+
+    try {
+      await releaseDatabase.run(
+        "DELETE FROM gc_locks WHERE scope = ? AND owner_id = ?",
+        [scope, ownerId],
+      );
+    } finally {
+      await releaseDatabase.close();
+    }
+  };
+}
+
+async function heartbeatGcLock(scope: string, ownerId: string): Promise<void> {
+  const database = await openGcStateDatabase();
+
+  try {
+    await database.run(
+      `
+UPDATE gc_locks
+SET heartbeat_at = ?, owner_pid = ?
+WHERE scope = ? AND owner_id = ?
+`,
+      [Date.now(), process.pid, scope, ownerId],
+    );
+  } finally {
+    await database.close();
+  }
+}
+
+async function cleanupStaleGcLocks(database: Database): Promise<void> {
+  const locks = await database.queryAll(
+    "SELECT * FROM gc_locks",
+    undefined,
+    mapGcLockWithScope,
+  );
+  const staleScopes = locks
+    .filter(({ lock }) => isStaleGcLock(lock))
+    .map(({ scope }) => scope);
+
+  for (const scope of staleScopes) {
+    await database.run("DELETE FROM gc_locks WHERE scope = ?", [scope]);
+  }
+}
+
+function isStaleGcLock(lock: GcLock): boolean {
+  if (Date.now() - lock.heartbeatAt < GC_LOCK_STALE_TIMEOUT_MS) {
+    return false;
+  }
+
+  return !isProcessAlive(lock.ownerPid);
+}
+
+async function openGcStateDatabase(): Promise<Database> {
+  return await openSharedStateDatabase(
+    join(resolveWikiGraphStateRootPath(), "gc.sqlite"),
+    GC_SCHEMA_SQL,
+  );
+}
+
+function mapGcLock(row: SqlRow): GcLock {
+  return {
+    createdAt: getNumber(row, "created_at"),
+    heartbeatAt: getNumber(row, "heartbeat_at"),
+    ownerId: getString(row, "owner_id"),
+    ownerPid: getNumber(row, "owner_pid"),
+  };
+}
+
+function mapGcLockWithScope(row: SqlRow): {
+  readonly lock: GcLock;
+  readonly scope: string;
+} {
+  return {
+    lock: mapGcLock(row),
+    scope: getString(row, "scope"),
+  };
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ESRCH") {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/src/gc/lock.ts
+++ b/src/gc/lock.ts
@@ -33,29 +33,32 @@ export async function tryAcquireGcLock(
   const database = await openGcStateDatabase();
   const ownerId = `${process.pid}-${randomUUID()}`;
   const now = Date.now();
+  let acquired = false;
 
   try {
-    await cleanupStaleGcLocks(database);
-    const existing = await database.queryOne(
-      "SELECT * FROM gc_locks WHERE scope = ?",
-      [scope],
-      mapGcLock,
-    );
-
-    if (existing !== undefined) {
-      return undefined;
-    }
-
-    await database.run(
-      `
-INSERT INTO gc_locks (
+    await database.transaction(async () => {
+      await cleanupStaleGcLocks(database);
+      await database.run(
+        `
+INSERT OR IGNORE INTO gc_locks (
   scope, owner_id, owner_pid, heartbeat_at, created_at
 ) VALUES (?, ?, ?, ?, ?)
 `,
-      [scope, ownerId, process.pid, now, now],
-    );
+        [scope, ownerId, process.pid, now, now],
+      );
+      acquired =
+        (await database.queryOne(
+          "SELECT owner_id FROM gc_locks WHERE scope = ?",
+          [scope],
+          (row) => getString(row, "owner_id"),
+        )) === ownerId;
+    });
   } finally {
     await database.close();
+  }
+
+  if (!acquired) {
+    return undefined;
   }
 
   const heartbeat = setInterval(() => {
@@ -100,12 +103,19 @@ async function cleanupStaleGcLocks(database: Database): Promise<void> {
     undefined,
     mapGcLockWithScope,
   );
-  const staleScopes = locks
-    .filter(({ lock }) => isStaleGcLock(lock))
-    .map(({ scope }) => scope);
 
-  for (const scope of staleScopes) {
-    await database.run("DELETE FROM gc_locks WHERE scope = ?", [scope]);
+  for (const { lock, scope } of locks.filter(({ lock }) =>
+    isStaleGcLock(lock),
+  )) {
+    await database.run(
+      `
+DELETE FROM gc_locks
+WHERE scope = ?
+  AND owner_id = ?
+  AND heartbeat_at = ?
+`,
+      [scope, lock.ownerId, lock.heartbeatAt],
+    );
   }
 }
 

--- a/src/gc/runner.ts
+++ b/src/gc/runner.ts
@@ -38,6 +38,7 @@ const OPPORTUNISTIC_GC_INTERVAL_MS = 10 * 60 * 1000;
 export async function tryRunWikiGraphGc(
   options: {
     readonly dryRun?: boolean;
+    readonly force?: boolean;
     readonly opportunistic?: boolean;
   } = {},
 ): Promise<GcRunReport> {
@@ -74,8 +75,8 @@ export async function tryRunWikiGraphGc(
     }
 
     const context: GcContext = {
-      aggressive: options.opportunistic !== true,
       dryRun: options.dryRun === true,
+      force: options.force === true,
       now: startedAt,
       stateDirectoryPath,
     };

--- a/src/gc/runner.ts
+++ b/src/gc/runner.ts
@@ -1,0 +1,171 @@
+import { mkdir, readFile, writeFile } from "fs/promises";
+import { join } from "path";
+
+import { resolveWikiGraphStateRootPath } from "../common/wiki-graph-temp.js";
+import { runSearchCacheGc } from "../archive/query/index.js";
+import { runBuildQueueGc } from "../facade/index.js";
+import { runWikgCoordinatorGc } from "../wikg/index.js";
+import { formatError } from "../utils/node-error.js";
+
+import { tryAcquireGcLock } from "./lock.js";
+import type { GcContext, GcJob, GcJobReport, GcRunReport } from "./types.js";
+
+interface NamedGcJob {
+  readonly name: string;
+  readonly run: GcJob;
+}
+
+const GC_JOBS: readonly NamedGcJob[] = [
+  {
+    name: "wikg-coordinator",
+    run: runWikgCoordinatorGc,
+  },
+  {
+    name: "search-cache",
+    run: runSearchCacheGc,
+  },
+  {
+    name: "build-queue",
+    run: runBuildQueueGc,
+  },
+  {
+    name: "tmp",
+    run: runTmpDirectoryGc,
+  },
+];
+const OPPORTUNISTIC_GC_INTERVAL_MS = 10 * 60 * 1000;
+
+export async function tryRunWikiGraphGc(
+  options: {
+    readonly dryRun?: boolean;
+    readonly opportunistic?: boolean;
+  } = {},
+): Promise<GcRunReport> {
+  const startedAt = Date.now();
+  const stateDirectoryPath = resolveWikiGraphStateRootPath();
+  const release = await tryAcquireGcLock();
+
+  if (release === undefined) {
+    return {
+      finishedAt: Date.now(),
+      freedBytes: 0,
+      jobs: [],
+      removed: 0,
+      scanned: 0,
+      skipped: true,
+      startedAt,
+    };
+  }
+
+  try {
+    if (
+      options.opportunistic === true &&
+      !(await shouldRunOpportunisticGc(stateDirectoryPath, startedAt))
+    ) {
+      return {
+        finishedAt: Date.now(),
+        freedBytes: 0,
+        jobs: [],
+        removed: 0,
+        scanned: 0,
+        skipped: true,
+        startedAt,
+      };
+    }
+
+    const context: GcContext = {
+      aggressive: options.opportunistic !== true,
+      dryRun: options.dryRun === true,
+      now: startedAt,
+      stateDirectoryPath,
+    };
+    const jobs: GcJobReport[] = [];
+
+    for (const job of GC_JOBS) {
+      jobs.push(await runJob(job, context));
+    }
+
+    const report = {
+      finishedAt: Date.now(),
+      freedBytes: sum(jobs, "freedBytes"),
+      jobs,
+      removed: sum(jobs, "removed"),
+      scanned: sum(jobs, "scanned"),
+      skipped: false,
+      startedAt,
+    };
+
+    await writeLastGcRunAt(stateDirectoryPath, report.finishedAt);
+    return report;
+  } finally {
+    await release();
+  }
+}
+
+async function runJob(
+  job: NamedGcJob,
+  context: GcContext,
+): Promise<GcJobReport> {
+  try {
+    return {
+      name: job.name,
+      ...(await job.run(context)),
+    };
+  } catch (error) {
+    return {
+      error: formatError(error),
+      freedBytes: 0,
+      name: job.name,
+      removed: 0,
+      scanned: 0,
+    };
+  }
+}
+
+async function runTmpDirectoryGc(context: GcContext): Promise<{
+  readonly freedBytes: number;
+  readonly removed: number;
+  readonly scanned: number;
+}> {
+  const { runTempDirectoryGc } = await import("./tmp-gc.js");
+
+  return await runTempDirectoryGc(context);
+}
+
+function sum(jobs: readonly GcJobReport[], key: keyof GcJobReport): number {
+  return jobs.reduce((total, job) => {
+    const value = job[key];
+
+    return total + (typeof value === "number" ? value : 0);
+  }, 0);
+}
+
+async function shouldRunOpportunisticGc(
+  stateDirectoryPath: string,
+  now: number,
+): Promise<boolean> {
+  const lastRunAt = Number(
+    (
+      await readFile(createLastGcRunPath(stateDirectoryPath), "utf8").catch(
+        () => "",
+      )
+    ).trim(),
+  );
+
+  return (
+    !Number.isFinite(lastRunAt) ||
+    now - lastRunAt >= OPPORTUNISTIC_GC_INTERVAL_MS
+  );
+}
+
+async function writeLastGcRunAt(
+  stateDirectoryPath: string,
+  at: number,
+): Promise<void> {
+  await mkdir(stateDirectoryPath, { recursive: true });
+  await writeFile(createLastGcRunPath(stateDirectoryPath), `${at}\n`, "utf8");
+}
+
+function createLastGcRunPath(stateDirectoryPath: string): string {
+  return join(stateDirectoryPath, "gc.last-run");
+}

--- a/src/gc/runner.ts
+++ b/src/gc/runner.ts
@@ -8,6 +8,7 @@ import { runWikgCoordinatorGc } from "../wikg/index.js";
 import { formatError } from "../utils/node-error.js";
 
 import { tryAcquireGcLock } from "./lock.js";
+import { runTempDirectoryGc } from "./tmp-gc.js";
 import type { GcContext, GcJob, GcJobReport, GcRunReport } from "./types.js";
 
 interface NamedGcJob {
@@ -30,7 +31,7 @@ const GC_JOBS: readonly NamedGcJob[] = [
   },
   {
     name: "tmp",
-    run: runTmpDirectoryGc,
+    run: runTempDirectoryGc,
   },
 ];
 const OPPORTUNISTIC_GC_INTERVAL_MS = 10 * 60 * 1000;
@@ -96,7 +97,9 @@ export async function tryRunWikiGraphGc(
       startedAt,
     };
 
-    await writeLastGcRunAt(stateDirectoryPath, report.finishedAt);
+    await writeLastGcRunAt(stateDirectoryPath, report.finishedAt).catch(
+      () => undefined,
+    );
     return report;
   } finally {
     await release();
@@ -121,16 +124,6 @@ async function runJob(
       scanned: 0,
     };
   }
-}
-
-async function runTmpDirectoryGc(context: GcContext): Promise<{
-  readonly freedBytes: number;
-  readonly removed: number;
-  readonly scanned: number;
-}> {
-  const { runTempDirectoryGc } = await import("./tmp-gc.js");
-
-  return await runTempDirectoryGc(context);
 }
 
 function sum(jobs: readonly GcJobReport[], key: keyof GcJobReport): number {

--- a/src/gc/tmp-gc.ts
+++ b/src/gc/tmp-gc.ts
@@ -28,7 +28,7 @@ export async function runTempDirectoryGc(
 
     if (
       stats === undefined ||
-      context.now - stats.mtimeMs < TEMP_DIRECTORY_TTL_MS
+      (!context.force && context.now - stats.mtimeMs < TEMP_DIRECTORY_TTL_MS)
     ) {
       continue;
     }

--- a/src/gc/tmp-gc.ts
+++ b/src/gc/tmp-gc.ts
@@ -1,0 +1,74 @@
+import { readdir, rm, stat } from "fs/promises";
+import { join } from "path";
+
+import { resolveWikiGraphTempDirectoryPath } from "../common/wiki-graph-temp.js";
+import { isNodeError } from "../utils/node-error.js";
+
+import type { GcContext, GcJobResult } from "./types.js";
+
+const TEMP_DIRECTORY_TTL_MS = 60 * 60 * 1000;
+
+export async function runTempDirectoryGc(
+  context: GcContext,
+): Promise<GcJobResult> {
+  const rootPath = resolveWikiGraphTempDirectoryPath();
+  let scanned = 0;
+  let removed = 0;
+  let freedBytes = 0;
+
+  for (const path of await listTempEntryPaths(rootPath)) {
+    scanned += 1;
+    const stats = await stat(path).catch((error: unknown) => {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return undefined;
+      }
+
+      throw error;
+    });
+
+    if (
+      stats === undefined ||
+      context.now - stats.mtimeMs < TEMP_DIRECTORY_TTL_MS
+    ) {
+      continue;
+    }
+
+    const bytes = stats.size;
+
+    if (!context.dryRun) {
+      await rm(path, { force: true, recursive: true });
+    }
+    removed += 1;
+    freedBytes += bytes;
+  }
+
+  return { freedBytes, removed, scanned };
+}
+
+async function listTempEntryPaths(rootPath: string): Promise<string[]> {
+  try {
+    const categories = await readdir(rootPath, { withFileTypes: true });
+    const paths: string[] = [];
+
+    for (const category of categories) {
+      if (!category.isDirectory()) {
+        continue;
+      }
+
+      const categoryPath = join(rootPath, category.name);
+      const entries = await readdir(categoryPath, { withFileTypes: true });
+
+      for (const entry of entries) {
+        paths.push(join(categoryPath, entry.name));
+      }
+    }
+
+    return paths;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return [];
+    }
+
+    throw error;
+  }
+}

--- a/src/gc/tmp-gc.ts
+++ b/src/gc/tmp-gc.ts
@@ -4,6 +4,7 @@ import { join } from "path";
 import { resolveWikiGraphTempDirectoryPath } from "../common/wiki-graph-temp.js";
 import { isNodeError } from "../utils/node-error.js";
 
+import { readPathSize } from "./files.js";
 import type { GcContext, GcJobResult } from "./types.js";
 
 const TEMP_DIRECTORY_TTL_MS = 60 * 60 * 1000;
@@ -33,7 +34,7 @@ export async function runTempDirectoryGc(
       continue;
     }
 
-    const bytes = stats.size;
+    const bytes = await readPathSize(path);
 
     if (!context.dryRun) {
       await rm(path, { force: true, recursive: true });

--- a/src/gc/types.ts
+++ b/src/gc/types.ts
@@ -1,5 +1,5 @@
 export interface GcContext {
-  readonly aggressive: boolean;
+  readonly force: boolean;
   readonly now: number;
   readonly stateDirectoryPath: string;
   readonly dryRun: boolean;

--- a/src/gc/types.ts
+++ b/src/gc/types.ts
@@ -1,0 +1,26 @@
+export interface GcContext {
+  readonly aggressive: boolean;
+  readonly now: number;
+  readonly stateDirectoryPath: string;
+  readonly dryRun: boolean;
+}
+
+export interface GcJobResult {
+  readonly scanned: number;
+  readonly removed: number;
+  readonly freedBytes: number;
+}
+
+export interface GcJobReport extends GcJobResult {
+  readonly name: string;
+  readonly error?: string;
+}
+
+export interface GcRunReport extends GcJobResult {
+  readonly jobs: readonly GcJobReport[];
+  readonly skipped: boolean;
+  readonly startedAt: number;
+  readonly finishedAt: number;
+}
+
+export type GcJob = (context: GcContext) => Promise<GcJobResult>;

--- a/src/legacy-sdpub/upgrade.ts
+++ b/src/legacy-sdpub/upgrade.ts
@@ -12,7 +12,6 @@ import {
 
 import { Database, type SqlBindValue } from "../document/database.js";
 import { DirectoryDocument } from "../document/document.js";
-import { rebuildArchiveSearchIndex } from "../archive/query/index.js";
 import { writeWikgArchive } from "../wikg/index.js";
 import { isNodeError } from "../utils/node-error.js";
 
@@ -48,22 +47,11 @@ export async function migrateLegacySdpubToWikg(
     await extractLegacySdpubArchive(inputPath, workspacePath);
     await migrateKnowledgeEdgesInDatabase(join(workspacePath, "database.db"));
     await migrateLegacyTextStorage(workspacePath);
-    await rebuildDerivedData(workspacePath);
     await writeWikgArchive(workspacePath, outputPath);
 
     return { inputPath, outputPath };
   } finally {
     await rm(workspacePath, { force: true, recursive: true });
-  }
-}
-
-async function rebuildDerivedData(workspacePath: string): Promise<void> {
-  const document = await DirectoryDocument.open(workspacePath);
-
-  try {
-    await rebuildArchiveSearchIndex(document);
-  } finally {
-    await document.release();
   }
 }
 

--- a/src/legacy-sdpub/upgrade.ts
+++ b/src/legacy-sdpub/upgrade.ts
@@ -1,9 +1,9 @@
 import { createWriteStream } from "fs";
-import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "fs/promises";
+import { mkdir, readdir, readFile, rm, writeFile } from "fs/promises";
 import { dirname, join, posix, resolve, sep } from "path";
-import { tmpdir } from "os";
 import { pipeline } from "stream/promises";
 
+import { createWikiGraphTempDirectory } from "../common/wiki-graph-temp.js";
 import {
   open as openZip,
   type Entry,
@@ -42,7 +42,7 @@ export async function migrateLegacySdpubToWikg(
     );
   }
 
-  const workspacePath = await mkdtemp(join(tmpdir(), "wikigraph-sdpub-"));
+  const workspacePath = await createWikiGraphTempDirectory("sdpub-upgrade");
 
   try {
     await extractLegacySdpubArchive(inputPath, workspacePath);

--- a/src/wikg/archive.ts
+++ b/src/wikg/archive.ts
@@ -19,8 +19,11 @@ import {
 } from "yauzl";
 import { ZipFile as YazlZipFile } from "yazl";
 
+import { Database } from "../document/database.js";
+
 export const WIKG_FORMAT_VERSION = 1;
 const WIKG_MANIFEST_PATH = "manifest.json";
+const SEARCH_INDEX_DATABASE_PATH = "fts.db";
 const WIKG_MANIFEST_CONTENT = `${JSON.stringify({
   formatVersion: WIKG_FORMAT_VERSION,
 })}\n`;
@@ -28,6 +31,7 @@ const WIKG_MANIFEST_CONTENT = `${JSON.stringify({
 const WIKG_ARCHIVE_PATTERNS = [
   /^manifest\.json$/u,
   /^database\.db$/u,
+  /^fts\.db$/u,
   /^book-meta\.json$/u,
   /^toc\.json$/u,
   /^cover\/(?:data\.bin|info\.json)$/u,
@@ -151,8 +155,19 @@ export async function writeWikgArchive(
 
   const zipFile = new YazlZipFile();
   const files = await listDocumentFiles(documentDirectoryPath);
+  const includeSearchIndex = await shouldEmbedSearchIndex(
+    documentDirectoryPath,
+  );
   const entries = [
-    ...files.filter((file) => file.archivePath !== WIKG_MANIFEST_PATH),
+    ...files.filter((file) => {
+      if (file.archivePath === WIKG_MANIFEST_PATH) {
+        return false;
+      }
+
+      return (
+        file.archivePath !== SEARCH_INDEX_DATABASE_PATH || includeSearchIndex
+      );
+    }),
     {
       archivePath: WIKG_MANIFEST_PATH,
       content: Buffer.from(WIKG_MANIFEST_CONTENT, "utf8"),
@@ -330,6 +345,40 @@ async function listDocumentFiles(
   }
 
   return files.filter((file) => isWikgArchivePath(file.archivePath));
+}
+
+async function shouldEmbedSearchIndex(
+  documentDirectoryPath: string,
+): Promise<boolean> {
+  const database = await Database.open(
+    join(documentDirectoryPath, "database.db"),
+    "",
+    {
+      readonly: true,
+    },
+  ).catch(() => undefined);
+
+  if (database === undefined) {
+    return true;
+  }
+
+  try {
+    const row = await database.queryOne(
+      `
+        SELECT fts_embedded
+        FROM archive_index_settings
+        WHERE id = 1
+      `,
+      undefined,
+      (value) => Number(value.fts_embedded) !== 0,
+    );
+
+    return row ?? false;
+  } catch {
+    return true;
+  } finally {
+    await database.close();
+  }
 }
 
 async function openIndexedArchive(inputPath: string): Promise<{

--- a/src/wikg/archive.ts
+++ b/src/wikg/archive.ts
@@ -359,7 +359,7 @@ async function shouldEmbedSearchIndex(
   ).catch(() => undefined);
 
   if (database === undefined) {
-    return true;
+    return false;
   }
 
   try {
@@ -375,7 +375,7 @@ async function shouldEmbedSearchIndex(
 
     return row ?? false;
   } catch {
-    return true;
+    return false;
   } finally {
     await database.close();
   }

--- a/src/wikg/index.ts
+++ b/src/wikg/index.ts
@@ -28,4 +28,4 @@ export {
 } from "./archive-uri.js";
 export type { LocatedWikiGraphUri } from "./archive-uri.js";
 export { SpineDigestFile } from "./spine-digest-file.js";
-export { WikgCoordinator } from "./wikg-coordinator.js";
+export { runWikgCoordinatorGc, WikgCoordinator } from "./wikg-coordinator.js";

--- a/src/wikg/spine-digest-file.ts
+++ b/src/wikg/spine-digest-file.ts
@@ -34,6 +34,7 @@ export class SpineDigestFile {
     ) => Promise<T> | T,
     options: {
       readonly documentDirPath?: string;
+      readonly searchIndexWritebackPolicy?: "archive" | "cache";
     } = {},
   ): Promise<T> {
     return await this.#coordinator.withArchiveSession(
@@ -55,7 +56,15 @@ export class SpineDigestFile {
         }
 
         const document = await DirectoryDocument.open(this.#path, {
-          fileStore: session.createFileStore({ readonlyDatabase: true }),
+          fileStore: session.createFileStore({
+            readonlyDatabase: true,
+            ...(options.searchIndexWritebackPolicy === undefined
+              ? {}
+              : {
+                  searchIndexWritebackPolicy:
+                    options.searchIndexWritebackPolicy,
+                }),
+          }),
         });
 
         try {
@@ -69,12 +78,20 @@ export class SpineDigestFile {
 
   public async write<T>(
     operation: (document: DirectoryDocument) => Promise<T> | T,
+    options: { readonly searchIndexWritebackPolicy?: "archive" | "cache" } = {},
   ): Promise<T> {
     return await this.#coordinator.withArchiveSession(
       this.#path,
       async (session) => {
         const document = await DirectoryDocument.open(this.#path, {
-          fileStore: session.createFileStore(),
+          fileStore: session.createFileStore({
+            ...(options.searchIndexWritebackPolicy === undefined
+              ? {}
+              : {
+                  searchIndexWritebackPolicy:
+                    options.searchIndexWritebackPolicy,
+                }),
+          }),
         });
 
         try {

--- a/src/wikg/wikg-coordinator.ts
+++ b/src/wikg/wikg-coordinator.ts
@@ -78,6 +78,7 @@ CREATE TABLE IF NOT EXISTS archive_owners (
 CREATE TABLE IF NOT EXISTS entry_sqlite_leases (
   archive_key TEXT NOT NULL,
   entry_path TEXT NOT NULL,
+  mode TEXT NOT NULL DEFAULT 'read',
   owner_id TEXT NOT NULL,
   owner_pid INTEGER NOT NULL,
   heartbeat_at INTEGER NOT NULL,
@@ -105,6 +106,7 @@ const ARCHIVE_SESSION_CONSTRUCTOR_TOKEN = Symbol(
 );
 
 type EntryLockMode = "read" | "state" | "write";
+type SqliteLeaseMode = "read" | "write";
 
 export class WikgCoordinator {
   public createFileStore(
@@ -358,9 +360,6 @@ export async function runWikgCoordinatorGc(
   context: GcContext,
 ): Promise<GcJobResult> {
   const candidates = await listSqliteCacheGcCandidates();
-  const childDirectories = await removeDisposableChildDirectories(
-    getCoordinatorWorkspaceRootPath(),
-  );
   let removed = 0;
   let freedBytes = 0;
 
@@ -373,10 +372,17 @@ export async function runWikgCoordinatorGc(
     }
   }
 
+  const orphanedFiles = await removeOrphanedWorkspaceFiles(context);
+  const childDirectories = await removeDisposableChildDirectories(
+    getCoordinatorWorkspaceRootPath(),
+  );
+
   return {
-    freedBytes: freedBytes + childDirectories.freedBytes,
-    removed: removed + childDirectories.removed,
-    scanned: candidates.length + childDirectories.scanned,
+    freedBytes:
+      freedBytes + orphanedFiles.freedBytes + childDirectories.freedBytes,
+    removed: removed + orphanedFiles.removed + childDirectories.removed,
+    scanned:
+      candidates.length + orphanedFiles.scanned + childDirectories.scanned,
   };
 }
 
@@ -507,6 +513,91 @@ WHERE archive_key = ?
   });
 }
 
+async function hasActiveWorkspaceUse(archiveKey: string): Promise<boolean> {
+  return await withStateDatabase(async (state) => {
+    await cleanupStaleState(state);
+    const ownerCount = await state.queryOne(
+      "SELECT COUNT(*) AS count FROM archive_owners WHERE archive_key = ?",
+      [archiveKey],
+      (row) => getNumber(row, "count"),
+    );
+    const leaseCount = await state.queryOne(
+      "SELECT COUNT(*) AS count FROM entry_sqlite_leases WHERE archive_key = ?",
+      [archiveKey],
+      (row) => getNumber(row, "count"),
+    );
+    const lockCount = await state.queryOne(
+      "SELECT COUNT(*) AS count FROM entry_locks WHERE archive_key = ?",
+      [archiveKey],
+      (row) => getNumber(row, "count"),
+    );
+
+    return (
+      (ownerCount ?? 0) > 0 || (leaseCount ?? 0) > 0 || (lockCount ?? 0) > 0
+    );
+  });
+}
+
+async function removeOrphanedWorkspaceFiles(
+  context: GcContext,
+): Promise<Pick<GcJobResult, "freedBytes" | "removed" | "scanned">> {
+  const rootPath = getCoordinatorWorkspaceRootPath();
+  let archiveKeyEntries: readonly WorkspaceDirectoryEntry[];
+
+  try {
+    archiveKeyEntries = await readdir(rootPath, { withFileTypes: true });
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return { freedBytes: 0, removed: 0, scanned: 0 };
+    }
+
+    throw error;
+  }
+
+  let freedBytes = 0;
+  let removed = 0;
+  let scanned = 0;
+
+  for (const archiveKeyEntry of archiveKeyEntries) {
+    if (!archiveKeyEntry.isDirectory()) {
+      continue;
+    }
+
+    const archiveKey = archiveKeyEntry.name;
+
+    if (await hasActiveWorkspaceUse(archiveKey)) {
+      continue;
+    }
+
+    const referencedWorkspacePaths = new Set(
+      (await listOverlays(archiveKey))
+        .map((overlay) => overlay.workspacePath)
+        .filter((path): path is string => path !== undefined),
+    );
+
+    for (const workspacePath of await listWorkspaceFiles(
+      join(rootPath, archiveKey),
+    )) {
+      scanned += 1;
+
+      if (referencedWorkspacePaths.has(workspacePath)) {
+        continue;
+      }
+
+      const size = await readPathSize(workspacePath);
+
+      if (!context.dryRun) {
+        await rm(workspacePath, { force: true });
+      }
+
+      freedBytes += size;
+      removed += 1;
+    }
+  }
+
+  return { freedBytes, removed, scanned };
+}
+
 class WikgDocumentFileStore implements DocumentFileStore {
   readonly #archiveKey: string;
   readonly #archivePath: string;
@@ -615,6 +706,12 @@ class WikgDocumentFileStore implements DocumentFileStore {
 
   public initializeDatabaseSchema(): boolean {
     return false;
+  }
+
+  public markDatabaseDirty(): void {
+    if (!this.#readonlyDatabase) {
+      this.#session?.observeDirtyEntry(DATABASE_ENTRY_PATH);
+    }
   }
 
   public openDatabaseReadonly(): boolean {
@@ -744,11 +841,9 @@ class WikgDocumentFileStore implements DocumentFileStore {
         await acquireSqliteLease({
           archiveKey: this.#archiveKey,
           entryPath: DATABASE_ENTRY_PATH,
+          mode: this.#readonlyDatabase ? "read" : "write",
           ownerId: this.#sqliteLeaseOwnerId,
         });
-        if (!this.#readonlyDatabase) {
-          this.#session?.observeDirtyEntry(DATABASE_ENTRY_PATH);
-        }
         return overlay.workspacePath;
       },
     );
@@ -788,11 +883,9 @@ class WikgDocumentFileStore implements DocumentFileStore {
           this.#archiveKey,
           entryPath,
         );
-        const temporaryWorkspacePath = `${workspacePath}.tmp`;
 
         await mkdir(dirname(workspacePath), { recursive: true });
-        await writeFile(temporaryWorkspacePath, content);
-        await rename(temporaryWorkspacePath, workspacePath);
+        await writeFile(workspacePath, content);
         await upsertOverlay({
           archiveKey: this.#archiveKey,
           archivePath: this.#archivePath,
@@ -1245,6 +1338,7 @@ function lockPathContains(parent: string, child: string): boolean {
 async function acquireSqliteLease(input: {
   readonly archiveKey: string;
   readonly entryPath: string;
+  readonly mode: SqliteLeaseMode;
   readonly ownerId: string;
 }): Promise<void> {
   await withStateDatabase(async (state) => {
@@ -1252,12 +1346,13 @@ async function acquireSqliteLease(input: {
     await state.run(
       `
 INSERT OR REPLACE INTO entry_sqlite_leases (
-  archive_key, entry_path, owner_id, owner_pid, heartbeat_at, created_at
-) VALUES (?, ?, ?, ?, ?, ?)
+  archive_key, entry_path, mode, owner_id, owner_pid, heartbeat_at, created_at
+) VALUES (?, ?, ?, ?, ?, ?, ?)
 `,
       [
         input.archiveKey,
         input.entryPath,
+        input.mode,
         input.ownerId,
         process.pid,
         Date.now(),
@@ -1566,20 +1661,31 @@ async function openStateDatabase(): Promise<Database> {
 }
 
 async function migrateStateDatabase(database: Database): Promise<void> {
-  const columns = await database.queryAll(
+  const overlayColumns = await database.queryAll(
     "PRAGMA table_info(entry_overlays)",
     undefined,
     (row) => getString(row, "name"),
   );
 
-  if (columns.includes("archive_signature")) {
-    return;
+  if (!overlayColumns.includes("archive_signature")) {
+    await database.run(`
+      ALTER TABLE entry_overlays
+      ADD COLUMN archive_signature TEXT
+    `);
   }
 
-  await database.run(`
-    ALTER TABLE entry_overlays
-    ADD COLUMN archive_signature TEXT
-  `);
+  const sqliteLeaseColumns = await database.queryAll(
+    "PRAGMA table_info(entry_sqlite_leases)",
+    undefined,
+    (row) => getString(row, "name"),
+  );
+
+  if (!sqliteLeaseColumns.includes("mode")) {
+    await database.run(`
+      ALTER TABLE entry_sqlite_leases
+      ADD COLUMN mode TEXT NOT NULL DEFAULT 'read'
+    `);
+  }
 }
 
 async function createWorkspaceFilePath(
@@ -1593,7 +1699,7 @@ async function createWorkspaceFilePath(
   );
 
   await mkdir(directoryPath, { recursive: true });
-  return join(directoryPath, `${basename(entryPath)}.${randomUUID()}`);
+  return join(directoryPath, basename(entryPath));
 }
 
 function getCoordinatorWorkspaceRootPath(): string {
@@ -1608,6 +1714,34 @@ async function ensureEmptyDirectory(directoryPath: string): Promise<void> {
   if (entries.length > 0) {
     throw new Error(`Read workspace directory is not empty: ${directoryPath}`);
   }
+}
+
+async function listWorkspaceFiles(directoryPath: string): Promise<string[]> {
+  let entries: readonly WorkspaceDirectoryEntry[];
+
+  try {
+    entries = await readdir(directoryPath, { withFileTypes: true });
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return [];
+    }
+
+    throw error;
+  }
+
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const path = join(directoryPath, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await listWorkspaceFiles(path)));
+    } else if (entry.isFile()) {
+      files.push(path);
+    }
+  }
+
+  return files;
 }
 
 function toArchiveOverlay(overlay: EntryOverlay): WikgArchiveOverlay {
@@ -1701,6 +1835,12 @@ interface EntryLock {
 
 interface ArchiveCommitLock {
   readonly ownerId: string;
+}
+
+interface WorkspaceDirectoryEntry {
+  isDirectory(): boolean;
+  isFile(): boolean;
+  readonly name: string;
 }
 
 function mapEntryOverlay(row: Record<string, unknown>): EntryOverlay {

--- a/src/wikg/wikg-coordinator.ts
+++ b/src/wikg/wikg-coordinator.ts
@@ -461,10 +461,7 @@ async function canRemoveSqliteCacheOverlay(
   if (await hasActiveArchiveOwnerOrSqliteLease(overlay.archiveKey)) {
     return false;
   }
-  if (
-    !context.aggressive &&
-    context.now - overlay.updatedAt < SQLITE_CACHE_TTL_MS
-  ) {
+  if (!context.force && context.now - overlay.updatedAt < SQLITE_CACHE_TTL_MS) {
     return false;
   }
   if (overlay.workspacePath === undefined) {

--- a/src/wikg/wikg-coordinator.ts
+++ b/src/wikg/wikg-coordinator.ts
@@ -96,6 +96,7 @@ CREATE TABLE IF NOT EXISTS archive_commit_locks (
 `;
 
 const DATABASE_ENTRY_PATH = "database.db";
+const SEARCH_INDEX_DATABASE_ENTRY_PATH = "fts.db";
 const LOCK_POLL_INTERVAL_MS = 100;
 const LOCK_STALE_TIMEOUT_MS = 60_000;
 const OWNER_HEARTBEAT_INTERVAL_MS = 20_000;
@@ -107,12 +108,14 @@ const ARCHIVE_SESSION_CONSTRUCTOR_TOKEN = Symbol(
 
 type EntryLockMode = "read" | "state" | "write";
 type SqliteLeaseMode = "read" | "write";
+type WorkspaceWritebackPolicy = "archive" | "cache";
 
 export class WikgCoordinator {
   public createFileStore(
     archivePath: string,
     options: {
       readonly readonlyDatabase?: boolean;
+      readonly searchIndexWritebackPolicy?: WorkspaceWritebackPolicy;
       readonly session?: WikgArchiveSession;
     } = {},
   ): DocumentFileStore {
@@ -232,7 +235,10 @@ export class WikgArchiveSession {
   }
 
   public createFileStore(
-    options: { readonly readonlyDatabase?: boolean } = {},
+    options: {
+      readonly readonlyDatabase?: boolean;
+      readonly searchIndexWritebackPolicy?: WorkspaceWritebackPolicy;
+    } = {},
   ): DocumentFileStore {
     return new WikgDocumentFileStore(this.#archivePath, {
       ...options,
@@ -393,12 +399,12 @@ async function listSqliteCacheGcCandidates(): Promise<readonly EntryOverlay[]> {
       `
 SELECT overlay.*
 FROM entry_overlays AS overlay
-WHERE overlay.entry_path = ?
+WHERE overlay.entry_path IN (?, ?)
   AND overlay.kind = 'file'
   AND overlay.workspace_path IS NOT NULL
 ORDER BY overlay.updated_at ASC
 `,
-      [DATABASE_ENTRY_PATH],
+      [DATABASE_ENTRY_PATH, SEARCH_INDEX_DATABASE_ENTRY_PATH],
       mapEntryOverlay,
     );
   });
@@ -459,6 +465,12 @@ async function canRemoveSqliteCacheOverlay(
   context: GcContext,
 ): Promise<boolean> {
   if (await hasActiveArchiveOwnerOrSqliteLease(overlay.archiveKey)) {
+    return false;
+  }
+  if (
+    overlay.entryPath === SEARCH_INDEX_DATABASE_ENTRY_PATH &&
+    !context.force
+  ) {
     return false;
   }
   if (!context.force && context.now - overlay.updatedAt < SQLITE_CACHE_TTL_MS) {
@@ -608,18 +620,22 @@ class WikgDocumentFileStore implements DocumentFileStore {
       >
     | undefined;
   readonly #readonlyDatabase: boolean;
+  readonly #searchIndexWritebackPolicy: WorkspaceWritebackPolicy;
   readonly #sqliteLeaseOwnerId = createOwnerId();
 
   public constructor(
     archivePath: string,
     options: {
       readonly readonlyDatabase?: boolean;
+      readonly searchIndexWritebackPolicy?: WorkspaceWritebackPolicy;
       readonly session?: WikgArchiveSession;
     },
   ) {
     this.#archivePath = resolve(archivePath);
     this.#archiveKey = createArchiveKey(this.#archivePath);
     this.#readonlyDatabase = options.readonlyDatabase === true;
+    this.#searchIndexWritebackPolicy =
+      options.searchIndexWritebackPolicy ?? "archive";
     this.#session = options.session;
   }
 
@@ -654,6 +670,11 @@ class WikgDocumentFileStore implements DocumentFileStore {
     await releaseSqliteLease({
       archiveKey: this.#archiveKey,
       entryPath: DATABASE_ENTRY_PATH,
+      ownerId: this.#sqliteLeaseOwnerId,
+    });
+    await releaseSqliteLease({
+      archiveKey: this.#archiveKey,
+      entryPath: SEARCH_INDEX_DATABASE_ENTRY_PATH,
       ownerId: this.#sqliteLeaseOwnerId,
     });
   }
@@ -708,6 +729,15 @@ class WikgDocumentFileStore implements DocumentFileStore {
   public markDatabaseDirty(): void {
     if (!this.#readonlyDatabase) {
       this.#session?.observeDirtyEntry(DATABASE_ENTRY_PATH);
+    }
+  }
+
+  public markSearchIndexDatabaseDirty(): void {
+    if (
+      !this.#readonlyDatabase &&
+      this.#searchIndexWritebackPolicy === "archive"
+    ) {
+      this.#session?.observeDirtyEntry(SEARCH_INDEX_DATABASE_ENTRY_PATH);
     }
   }
 
@@ -802,21 +832,45 @@ class WikgDocumentFileStore implements DocumentFileStore {
   }
 
   public async resolveDatabasePath(): Promise<string> {
+    return await this.#resolveSqliteDatabasePath(DATABASE_ENTRY_PATH, {
+      createIfMissing: true,
+      readonly: this.#readonlyDatabase,
+    });
+  }
+
+  public async resolveSearchIndexDatabasePath(): Promise<string> {
+    return await this.#resolveSqliteDatabasePath(
+      SEARCH_INDEX_DATABASE_ENTRY_PATH,
+      {
+        createIfMissing: !this.#readonlyDatabase,
+        readonly: this.#readonlyDatabase,
+      },
+    );
+  }
+
+  async #resolveSqliteDatabasePath(
+    entryPath: string,
+    options: { readonly createIfMissing: boolean; readonly readonly: boolean },
+  ): Promise<string> {
     return await withEntryLock(
       this.#archiveKey,
-      DATABASE_ENTRY_PATH,
+      entryPath,
       "state",
       async () => {
-        let overlay = await this.#readOverlay(DATABASE_ENTRY_PATH);
+        let overlay = await this.#readOverlay(entryPath);
 
         if (overlay?.kind !== "file") {
-          const workspacePath = await createWorkspaceFilePath(
-            this.#archiveKey,
-            DATABASE_ENTRY_PATH,
-          );
           const content = await readWikgArchiveEntry(
             this.#archivePath,
-            DATABASE_ENTRY_PATH,
+            entryPath,
+          );
+
+          if (content === undefined && !options.createIfMissing) {
+            throw new Error(`Archive SQLite entry is missing: ${entryPath}`);
+          }
+          const workspacePath = await createWorkspaceFilePath(
+            this.#archiveKey,
+            entryPath,
           );
 
           await mkdir(dirname(workspacePath), { recursive: true });
@@ -824,11 +878,11 @@ class WikgDocumentFileStore implements DocumentFileStore {
           await upsertOverlay({
             archiveKey: this.#archiveKey,
             archivePath: this.#archivePath,
-            entryPath: DATABASE_ENTRY_PATH,
+            entryPath,
             kind: "file",
             workspacePath,
           });
-          overlay = await this.#readOverlay(DATABASE_ENTRY_PATH);
+          overlay = await this.#readOverlay(entryPath);
         }
 
         if (overlay?.workspacePath === undefined) {
@@ -837,8 +891,8 @@ class WikgDocumentFileStore implements DocumentFileStore {
 
         await acquireSqliteLease({
           archiveKey: this.#archiveKey,
-          entryPath: DATABASE_ENTRY_PATH,
-          mode: this.#readonlyDatabase ? "read" : "write",
+          entryPath,
+          mode: options.readonly ? "read" : "write",
           ownerId: this.#sqliteLeaseOwnerId,
         });
         return overlay.workspacePath;
@@ -1031,6 +1085,12 @@ async function flushArchiveOverlays(
 
     if (entryPaths.includes(DATABASE_ENTRY_PATH)) {
       await waitForSqliteLeasesToDrain(archiveKey, DATABASE_ENTRY_PATH);
+    }
+    if (entryPaths.includes(SEARCH_INDEX_DATABASE_ENTRY_PATH)) {
+      await waitForSqliteLeasesToDrain(
+        archiveKey,
+        SEARCH_INDEX_DATABASE_ENTRY_PATH,
+      );
     }
 
     const currentOverlays = (await listOverlays(archiveKey)).filter((overlay) =>

--- a/src/wikg/wikg-coordinator.ts
+++ b/src/wikg/wikg-coordinator.ts
@@ -21,10 +21,18 @@ import {
 } from "path";
 
 import { resolveWikiGraphStateDirectoryPath } from "../common/wiki-graph-dir.js";
+import { createWikiGraphTempDirectory } from "../common/wiki-graph-temp.js";
 import { openSharedStateDatabase } from "../document/index.js";
 import type { Database } from "../document/index.js";
 import type { DocumentFileStore } from "../document/document.js";
+import {
+  readPathSize,
+  removeDisposableChildDirectories,
+  removeDisposableDirectory,
+} from "../gc/files.js";
+import type { GcContext, GcJobResult } from "../gc/index.js";
 import { AsyncSemaphore } from "../utils/async-semaphore.js";
+import { isNodeError } from "../utils/node-error.js";
 
 import {
   extractWikgArchive,
@@ -90,6 +98,7 @@ const DATABASE_ENTRY_PATH = "database.db";
 const LOCK_POLL_INTERVAL_MS = 100;
 const LOCK_STALE_TIMEOUT_MS = 60_000;
 const OWNER_HEARTBEAT_INTERVAL_MS = 20_000;
+const SQLITE_CACHE_TTL_MS = 60 * 60 * 1000;
 const STATE_DATABASE_SEMAPHORE = new AsyncSemaphore(1);
 const ARCHIVE_SESSION_CONSTRUCTOR_TOKEN = Symbol(
   "WikgArchiveSession constructor token",
@@ -130,7 +139,7 @@ export class WikgCoordinator {
   ): Promise<T> {
     const directoryPath =
       options.documentDirPath === undefined
-        ? await mkdtemp(join(tmpdir(), "wikigraph-open-"))
+        ? await createWikiGraphTempDirectory("archive-open")
         : resolve(options.documentDirPath);
 
     try {
@@ -147,7 +156,7 @@ export class WikgCoordinator {
     archivePath: string,
     operation: (documentDirectoryPath: string) => Promise<T> | T,
   ): Promise<T> {
-    const directoryPath = await mkdtemp(join(tmpdir(), "wikigraph-write-"));
+    const directoryPath = await createWikiGraphTempDirectory("archive-write");
 
     try {
       await extractWikgArchive(resolve(archivePath), directoryPath);
@@ -235,7 +244,7 @@ export class WikgArchiveSession {
   ): Promise<T> {
     const ownsDirectoryPath = directoryPath === undefined;
     const resolvedDirectoryPath = ownsDirectoryPath
-      ? await mkdtemp(join(tmpdir(), "wikigraph-open-"))
+      ? await createWikiGraphTempDirectory("archive-open")
       : resolve(directoryPath);
 
     if (!ownsDirectoryPath) {
@@ -299,6 +308,12 @@ export class WikgArchiveSession {
         ownerId: this.#ownerId,
       });
     }
+
+    await import("../gc/index.js")
+      .then(async ({ tryRunWikiGraphGc }) => {
+        await tryRunWikiGraphGc({ opportunistic: true });
+      })
+      .catch(() => undefined);
   }
 
   async #settle(): Promise<void> {
@@ -337,6 +352,159 @@ ORDER BY archive_key
   for (const archiveKey of archiveKeys) {
     await flushArchiveOverlays(archiveKey);
   }
+}
+
+export async function runWikgCoordinatorGc(
+  context: GcContext,
+): Promise<GcJobResult> {
+  const candidates = await listSqliteCacheGcCandidates();
+  const childDirectories = await removeDisposableChildDirectories(
+    getCoordinatorWorkspaceRootPath(),
+  );
+  let removed = 0;
+  let freedBytes = 0;
+
+  for (const candidate of candidates) {
+    const result = await tryRemoveSqliteCacheCandidate(candidate, context);
+
+    if (result.removed) {
+      removed += 1;
+      freedBytes += result.freedBytes;
+    }
+  }
+
+  return {
+    freedBytes: freedBytes + childDirectories.freedBytes,
+    removed: removed + childDirectories.removed,
+    scanned: candidates.length + childDirectories.scanned,
+  };
+}
+
+async function listSqliteCacheGcCandidates(): Promise<readonly EntryOverlay[]> {
+  return await withStateDatabase(async (state) => {
+    await cleanupStaleState(state);
+    return await state.queryAll(
+      `
+SELECT overlay.*
+FROM entry_overlays AS overlay
+WHERE overlay.entry_path = ?
+  AND overlay.kind = 'file'
+  AND overlay.workspace_path IS NOT NULL
+ORDER BY overlay.updated_at ASC
+`,
+      [DATABASE_ENTRY_PATH],
+      mapEntryOverlay,
+    );
+  });
+}
+
+async function tryRemoveSqliteCacheCandidate(
+  candidate: EntryOverlay,
+  context: GcContext,
+): Promise<{ readonly freedBytes: number; readonly removed: boolean }> {
+  const releaseWriteLock = await acquireEntryLock(
+    candidate.archiveKey,
+    candidate.entryPath,
+    "write",
+  );
+
+  try {
+    const releaseStateLock = await acquireEntryLock(
+      candidate.archiveKey,
+      candidate.entryPath,
+      "state",
+    );
+
+    try {
+      const overlay = await readOverlay(
+        candidate.archiveKey,
+        candidate.entryPath,
+      );
+
+      if (
+        overlay?.workspacePath === undefined ||
+        overlay.workspacePath !== candidate.workspacePath ||
+        !(await canRemoveSqliteCacheOverlay(overlay, context))
+      ) {
+        return { freedBytes: 0, removed: false };
+      }
+
+      let freedBytes = await readPathSize(overlay.workspacePath);
+
+      if (!context.dryRun) {
+        await deleteOverlay(overlay.archiveKey, overlay.entryPath);
+        await rm(overlay.workspacePath, { force: true });
+        freedBytes += await removeDisposableDirectory(
+          dirname(overlay.workspacePath),
+        );
+      }
+
+      return { freedBytes, removed: true };
+    } finally {
+      await releaseStateLock();
+    }
+  } finally {
+    await releaseWriteLock();
+  }
+}
+
+async function canRemoveSqliteCacheOverlay(
+  overlay: EntryOverlay,
+  context: GcContext,
+): Promise<boolean> {
+  if (await hasActiveArchiveOwnerOrSqliteLease(overlay.archiveKey)) {
+    return false;
+  }
+  if (
+    !context.aggressive &&
+    context.now - overlay.updatedAt < SQLITE_CACHE_TTL_MS
+  ) {
+    return false;
+  }
+  if (overlay.workspacePath === undefined) {
+    return false;
+  }
+
+  const workspaceExists = await pathExists(overlay.workspacePath);
+
+  if (!workspaceExists) {
+    return true;
+  }
+
+  await createArchiveSignature(overlay.archivePath).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  });
+
+  return true;
+}
+
+async function hasActiveArchiveOwnerOrSqliteLease(
+  archiveKey: string,
+): Promise<boolean> {
+  return await withStateDatabase(async (state) => {
+    await cleanupStaleState(state);
+    const ownerCount = await state.queryOne(
+      "SELECT COUNT(*) AS count FROM archive_owners WHERE archive_key = ?",
+      [archiveKey],
+      (row) => getNumber(row, "count"),
+    );
+    const leaseCount = await state.queryOne(
+      `
+SELECT COUNT(*) AS count
+FROM entry_sqlite_leases
+WHERE archive_key = ?
+  AND entry_path = ?
+`,
+      [archiveKey, DATABASE_ENTRY_PATH],
+      (row) => getNumber(row, "count"),
+    );
+
+    return (ownerCount ?? 0) > 0 || (leaseCount ?? 0) > 0;
+  });
 }
 
 class WikgDocumentFileStore implements DocumentFileStore {
@@ -1419,14 +1587,17 @@ async function createWorkspaceFilePath(
   entryPath: string,
 ): Promise<string> {
   const directoryPath = join(
-    getCoordinatorStateDirectoryPath(),
-    "workspaces",
+    getCoordinatorWorkspaceRootPath(),
     archiveKey,
     dirname(entryPath),
   );
 
   await mkdir(directoryPath, { recursive: true });
   return join(directoryPath, `${basename(entryPath)}.${randomUUID()}`);
+}
+
+function getCoordinatorWorkspaceRootPath(): string {
+  return join(getCoordinatorStateDirectoryPath(), "workspaces");
 }
 
 async function ensureEmptyDirectory(directoryPath: string): Promise<void> {
@@ -1499,12 +1670,26 @@ async function delay(ms: number): Promise<void> {
   });
 }
 
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
 interface EntryOverlay {
   readonly archiveKey: string;
   readonly archivePath: string;
   readonly archiveSignature?: string;
   readonly entryPath: string;
   readonly kind: "deleted" | "file";
+  readonly updatedAt: number;
   readonly workspacePath?: string;
 }
 
@@ -1528,6 +1713,7 @@ function mapEntryOverlay(row: Record<string, unknown>): EntryOverlay {
     ...(archiveSignature === undefined ? {} : { archiveSignature }),
     entryPath: getString(row, "entry_path"),
     kind: getOverlayKind(row),
+    updatedAt: getNumber(row, "updated_at"),
     ...(workspacePath === undefined ? {} : { workspacePath }),
   };
 }

--- a/src/wikg/wikg-coordinator.ts
+++ b/src/wikg/wikg-coordinator.ts
@@ -26,6 +26,7 @@ import { openSharedStateDatabase } from "../document/index.js";
 import type { Database } from "../document/index.js";
 import type { DocumentFileStore } from "../document/document.js";
 import {
+  isDisposableDirectoryEntry,
   readPathSize,
   removeDisposableChildDirectories,
   removeDisposableDirectory,
@@ -379,9 +380,9 @@ export async function runWikgCoordinatorGc(
   }
 
   const orphanedFiles = await removeOrphanedWorkspaceFiles(context);
-  const childDirectories = await removeDisposableChildDirectories(
-    getCoordinatorWorkspaceRootPath(),
-  );
+  const childDirectories = context.dryRun
+    ? { freedBytes: 0, removed: 0, scanned: 0 }
+    : await removeDisposableChildDirectories(getCoordinatorWorkspaceRootPath());
 
   return {
     freedBytes:
@@ -464,7 +465,12 @@ async function canRemoveSqliteCacheOverlay(
   overlay: EntryOverlay,
   context: GcContext,
 ): Promise<boolean> {
-  if (await hasActiveArchiveOwnerOrSqliteLease(overlay.archiveKey)) {
+  if (
+    await hasActiveArchiveOwnerOrSqliteLease(
+      overlay.archiveKey,
+      overlay.entryPath,
+    )
+  ) {
     return false;
   }
   if (
@@ -499,6 +505,7 @@ async function canRemoveSqliteCacheOverlay(
 
 async function hasActiveArchiveOwnerOrSqliteLease(
   archiveKey: string,
+  entryPath: string,
 ): Promise<boolean> {
   return await withStateDatabase(async (state) => {
     await cleanupStaleState(state);
@@ -514,7 +521,7 @@ FROM entry_sqlite_leases
 WHERE archive_key = ?
   AND entry_path = ?
 `,
-      [archiveKey, DATABASE_ENTRY_PATH],
+      [archiveKey, entryPath],
       (row) => getNumber(row, "count"),
     );
 
@@ -589,6 +596,9 @@ async function removeOrphanedWorkspaceFiles(
     )) {
       scanned += 1;
 
+      if (isDisposableDirectoryEntry(basename(workspacePath))) {
+        continue;
+      }
       if (referencedWorkspacePaths.has(workspacePath)) {
         continue;
       }
@@ -936,7 +946,16 @@ class WikgDocumentFileStore implements DocumentFileStore {
         );
 
         await mkdir(dirname(workspacePath), { recursive: true });
-        await writeFile(workspacePath, content);
+        const temporaryWorkspacePath = `${workspacePath}.${process.pid}.${Date.now()}.tmp`;
+
+        try {
+          await writeFile(temporaryWorkspacePath, content);
+          await rename(temporaryWorkspacePath, workspacePath);
+        } finally {
+          await rm(temporaryWorkspacePath, { force: true }).catch(
+            () => undefined,
+          );
+        }
         await upsertOverlay({
           archiveKey: this.#archiveKey,
           archivePath: this.#archivePath,

--- a/test/archive/query/archive-view.test.ts
+++ b/test/archive/query/archive-view.test.ts
@@ -415,7 +415,7 @@ describe("archive/query/archive-view", () => {
     });
   });
 
-  it("prioritizes entity matches before source fallback", async () => {
+  it("prioritizes entity matches before source hits", async () => {
     await withTempDir("spinedigest-archive-view-", async (path) => {
       const previousStateDir = process.env.WIKIGRAPH_STATE_DIR;
       process.env.WIKIGRAPH_STATE_DIR = `${path}/state`;
@@ -935,39 +935,6 @@ describe("archive/query/archive-view", () => {
         );
 
         expect(multi?.score).toBeCloseTo((single?.score ?? 0) * 1.3, 10);
-      } finally {
-        restoreEnv("WIKIGRAPH_STATE_DIR", previousStateDir);
-        await document.release();
-      }
-    });
-  });
-
-  it("falls back to lexical source scan with session cursors", async () => {
-    await withTempDir("spinedigest-archive-view-", async (path) => {
-      const previousStateDir = process.env.WIKIGRAPH_STATE_DIR;
-      process.env.WIKIGRAPH_STATE_DIR = `${path}/state`;
-      const document = await DirectoryDocument.open(`${path}/document`);
-
-      try {
-        await seedSourcedDocument(document);
-
-        const firstPage = await findArchiveObjects(document, "Wiki", {
-          limit: 1,
-          types: ["source", "node"],
-        });
-        const secondPage = await findArchiveObjects(document, "ignored query", {
-          ...(firstPage.nextCursor === null
-            ? {}
-            : { cursor: firstPage.nextCursor }),
-          limit: 1,
-          types: ["source", "node"],
-        });
-
-        expect(firstPage.items).toHaveLength(1);
-        expect(firstPage.nextCursor).not.toBeNull();
-        expect(["source", "node"]).toContain(firstPage.items[0]?.type);
-        expect(secondPage.query).toBe("Wiki");
-        expect(secondPage.items[0]?.id).not.toBe(firstPage.items[0]?.id);
       } finally {
         restoreEnv("WIKIGRAPH_STATE_DIR", previousStateDir);
         await document.release();

--- a/test/archive/query/archive-view.test.ts
+++ b/test/archive/query/archive-view.test.ts
@@ -317,6 +317,11 @@ describe("archive/query/archive-view", () => {
             "source",
           ]),
         ).resolves.toBe(0);
+        await expect(
+          countSearchSessionsForQuery(`${path}/state`, "Cache Split", [
+            "source",
+          ]),
+        ).resolves.toBe(0);
       } finally {
         restoreEnv("WIKIGRAPH_STATE_DIR", previousStateDir);
         await document.release();
@@ -1059,7 +1064,7 @@ describe("archive/query/archive-view", () => {
         expect(result.items).toStrictEqual([
           expect.objectContaining({
             chapter: 1,
-            id: "wkg://chapter/1/source#0..2",
+            id: "wkg://chapter/1/source#0",
             position: { chapter: 1, sentence: 0 },
             type: "source",
           }),
@@ -1104,7 +1109,7 @@ describe("archive/query/archive-view", () => {
           limit: 5,
           types: ["source"],
         });
-        const secondPage = await findArchiveObjects(document, "ignored", {
+        const secondPage = await findArchiveObjects(document, "CursorOnly", {
           ...(firstPage.nextCursor === null
             ? {}
             : { cursor: firstPage.nextCursor }),
@@ -2844,6 +2849,40 @@ async function countStructuredCacheRowsForQuery(
           (SELECT COUNT(*)
            FROM search_chunk_hits
            WHERE session_id IN (SELECT session_id FROM matching_sessions)) AS count
+      `,
+      [query, optionsJSON],
+      (value) => Number(value.count),
+    );
+
+    return row ?? 0;
+  } finally {
+    await database.close();
+  }
+}
+
+async function countSearchSessionsForQuery(
+  statePath: string,
+  query: string,
+  types: readonly string[],
+): Promise<number> {
+  const database = await Database.open(
+    join(statePath, "search-sessions.sqlite"),
+    "",
+    { readonly: true },
+  );
+
+  try {
+    const optionsJSON = JSON.stringify({
+      chapters: null,
+      order: "doc-asc",
+      types,
+    });
+    const row = await database.queryOne(
+      `
+        SELECT COUNT(*) AS count
+        FROM search_sessions
+        WHERE query = ?
+          AND options_json = ?
       `,
       [query, optionsJSON],
       (value) => Number(value.count),

--- a/test/archive/query/archive-view.test.ts
+++ b/test/archive/query/archive-view.test.ts
@@ -4,7 +4,7 @@ import { join } from "path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { DirectoryDocument } from "../../../src/document/index.js";
+import { Database, DirectoryDocument } from "../../../src/document/index.js";
 import {
   findArchiveObjects,
   grepArchiveObjects,
@@ -312,6 +312,11 @@ describe("archive/query/archive-view", () => {
         expect(sourceOnly.items.map((item) => item.type)).toStrictEqual([
           "source",
         ]);
+        await expect(
+          countStructuredCacheRowsForQuery(`${path}/state`, "Cache Split", [
+            "source",
+          ]),
+        ).resolves.toBe(0);
       } finally {
         restoreEnv("WIKIGRAPH_STATE_DIR", previousStateDir);
         await document.release();
@@ -1059,6 +1064,58 @@ describe("archive/query/archive-view", () => {
             type: "source",
           }),
         ]);
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("keeps indexed text-only cursors paginated beyond the first lookahead", async () => {
+    await withTempDir("spinedigest-archive-view-", async (path) => {
+      const document = await DirectoryDocument.open(`${path}/document`);
+
+      try {
+        await document.openSession(async (openedDocument) => {
+          const tocItems = [];
+
+          for (let index = 0; index < 12; index += 1) {
+            const serialId = await openedDocument.createSerial();
+            const draft = await openedDocument
+              .getSerialFragments(serialId)
+              .createDraft();
+
+            draft.addSentence(`CursorOnly indexed source ${index}.`, 4);
+            await draft.commit();
+            tocItems.push({
+              children: [],
+              serialId,
+              title: `Cursor ${index}`,
+            });
+          }
+
+          await openedDocument.writeToc({
+            items: tocItems,
+            version: 1,
+          });
+        });
+        await rebuildArchiveSearchIndex(document);
+
+        const firstPage = await findArchiveObjects(document, "CursorOnly", {
+          limit: 5,
+          types: ["source"],
+        });
+        const secondPage = await findArchiveObjects(document, "ignored", {
+          ...(firstPage.nextCursor === null
+            ? {}
+            : { cursor: firstPage.nextCursor }),
+          limit: 5,
+          types: ["source"],
+        });
+
+        expect(firstPage.items).toHaveLength(5);
+        expect(firstPage.nextCursor).not.toBeNull();
+        expect(secondPage.items).toHaveLength(5);
+        expect(secondPage.items[0]?.id).not.toBe(firstPage.items[0]?.id);
       } finally {
         await document.release();
       }
@@ -2747,6 +2804,55 @@ async function countSearchIndexRows(
 
     return row ?? 0;
   });
+}
+
+async function countStructuredCacheRowsForQuery(
+  statePath: string,
+  query: string,
+  types: readonly string[],
+): Promise<number> {
+  const database = await Database.open(
+    join(statePath, "search-sessions.sqlite"),
+    "",
+    { readonly: true },
+  );
+
+  try {
+    const optionsJSON = JSON.stringify({
+      chapters: null,
+      order: "doc-asc",
+      types,
+    });
+    const row = await database.queryOne(
+      `
+        WITH matching_sessions AS (
+          SELECT session_id
+          FROM search_sessions
+          WHERE query = ?
+            AND options_json = ?
+        )
+        SELECT
+          (SELECT COUNT(*)
+           FROM search_evidence_hit_events
+           WHERE session_id IN (SELECT session_id FROM matching_sessions)) +
+          (SELECT COUNT(*)
+           FROM search_entity_hits
+           WHERE session_id IN (SELECT session_id FROM matching_sessions)) +
+          (SELECT COUNT(*)
+           FROM search_triple_hits
+           WHERE session_id IN (SELECT session_id FROM matching_sessions)) +
+          (SELECT COUNT(*)
+           FROM search_chunk_hits
+           WHERE session_id IN (SELECT session_id FROM matching_sessions)) AS count
+      `,
+      [query, optionsJSON],
+      (value) => Number(value.count),
+    );
+
+    return row ?? 0;
+  } finally {
+    await database.close();
+  }
 }
 
 function createEntityWikipageMockFetch(): typeof fetch {

--- a/test/archive/query/archive-view.test.ts
+++ b/test/archive/query/archive-view.test.ts
@@ -15,7 +15,12 @@ import {
   listRelatedArchiveObjects,
   readArchiveText,
   readArchivePage,
+  rebuildArchiveSearchIndex,
 } from "../../../src/archive/query/archive-view.js";
+import {
+  isSearchIndexCurrent,
+  readArchiveIndexSettings,
+} from "../../../src/archive/search-index/index.js";
 import { deleteArchiveSearchSessions } from "../../../src/archive/query/search-cache.js";
 import { withTempDir } from "../../helpers/temp.js";
 
@@ -34,6 +39,28 @@ describe("archive/query/archive-view", () => {
       await rm(testStateDir, { force: true, recursive: true });
       testStateDir = undefined;
     }
+  });
+
+  it("distinguishes a missing index from a current empty index", async () => {
+    await withTempDir("spinedigest-archive-view-", async (path) => {
+      const document = await DirectoryDocument.open(`${path}/document`);
+
+      try {
+        await expect(readArchiveIndexSettings(document)).resolves.toStrictEqual(
+          {
+            ftsEmbedded: false,
+          },
+        );
+        await expect(isSearchIndexCurrent(document)).resolves.toBe(false);
+
+        await rebuildArchiveSearchIndex(document);
+
+        await expect(isSearchIndexCurrent(document)).resolves.toBe(true);
+        await expect(countSearchIndexRows(document)).resolves.toBe(0);
+      } finally {
+        await document.release();
+      }
+    });
   });
 
   it("searches sourced sentences before graph or summary build", async () => {
@@ -128,6 +155,17 @@ describe("archive/query/archive-view", () => {
           }),
         );
         await expect(listDocumentTableNames(document)).resolves.toEqual(
+          expect.arrayContaining(["text_sentence_records"]),
+        );
+        await expect(listDocumentTableNames(document)).resolves.not.toEqual(
+          expect.arrayContaining([
+            "search_index_state",
+            "search_object_properties_fts",
+            "search_object_properties_records",
+            "text_sentence_fts",
+          ]),
+        );
+        await expect(listSearchIndexTableNames(document)).resolves.toEqual(
           expect.arrayContaining([
             "search_index_state",
             "search_object_properties_fts",
@@ -232,6 +270,7 @@ describe("archive/query/archive-view", () => {
             version: 1,
           });
         });
+        await rebuildArchiveSearchIndex(document);
 
         const archiveKey = `${path}/book.wikg`;
         const chapterOne = await findArchiveObjects(document, "Cache Split", {
@@ -286,6 +325,7 @@ describe("archive/query/archive-view", () => {
             weight: 1,
           });
         });
+        await rebuildArchiveSearchIndex(document);
 
         const result = await findArchiveObjects(document, "SharedTerm", {
           archiveKey: `${path}/book.wikg`,
@@ -433,6 +473,7 @@ describe("archive/query/archive-view", () => {
             surface: "陈友谅",
           });
         });
+        await rebuildArchiveSearchIndex(document);
 
         const result = await findArchiveObjects(document, "陈友谅", {
           limit: 3,
@@ -723,6 +764,7 @@ describe("archive/query/archive-view", () => {
             },
           ]);
         });
+        await rebuildArchiveSearchIndex(document);
 
         const result = await findArchiveObjects(document, "舰", {
           types: ["entity"],
@@ -735,7 +777,7 @@ describe("archive/query/archive-view", () => {
         );
 
         expect(multi?.score).toBeGreaterThan(single?.score ?? 0);
-        expect(multi?.score).toBeLessThan((single?.score ?? 0) * 4);
+        expect(multi?.score).toBeLessThan((single?.score ?? 0) * 5);
       } finally {
         restoreEnv("WIKIGRAPH_STATE_DIR", previousStateDir);
         await document.release();
@@ -2627,6 +2669,7 @@ async function seedSourcedDocument(
       version: 1,
     });
   });
+  await rebuildArchiveSearchIndex(document);
 }
 
 function restoreEnv(name: string, value: string | undefined): void {
@@ -2654,6 +2697,42 @@ async function listDocumentTableNames(
         (row) => String(row.name),
       ),
   );
+}
+
+async function listSearchIndexTableNames(
+  document: DirectoryDocument,
+): Promise<string[]> {
+  return await document.readSearchIndexDatabase(
+    async (database) =>
+      await database.queryAll(
+        `
+          SELECT name
+          FROM sqlite_master
+          WHERE type IN ('table', 'virtual table')
+          ORDER BY name
+        `,
+        undefined,
+        (row) => String(row.name),
+      ),
+  );
+}
+
+async function countSearchIndexRows(
+  document: DirectoryDocument,
+): Promise<number> {
+  return await document.readSearchIndexDatabase(async (database) => {
+    const row = await database.queryOne(
+      `
+        SELECT
+          (SELECT COUNT(*) FROM text_sentence_records) +
+          (SELECT COUNT(*) FROM search_object_properties_records) AS count
+      `,
+      undefined,
+      (value) => Number(value.count),
+    );
+
+    return row ?? 0;
+  });
 }
 
 function createEntityWikipageMockFetch(): typeof fetch {

--- a/test/archive/query/archive-view.test.ts
+++ b/test/archive/query/archive-view.test.ts
@@ -63,6 +63,20 @@ describe("archive/query/archive-view", () => {
     });
   });
 
+  it("rejects search when the FTS index is missing", async () => {
+    await withTempDir("spinedigest-archive-view-", async (path) => {
+      const document = await DirectoryDocument.open(`${path}/document`);
+
+      try {
+        await expect(findArchiveObjects(document, "missing")).rejects.toThrow(
+          "Wiki Graph search index is missing or outdated. Run `<archive-uri>/index build` before searching.",
+        );
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
   it("searches sourced sentences before graph or summary build", async () => {
     await withTempDir("spinedigest-archive-view-", async (path) => {
       const document = await DirectoryDocument.open(`${path}/document`);

--- a/test/archive/query/archive-view.test.ts
+++ b/test/archive/query/archive-view.test.ts
@@ -19,7 +19,9 @@ import {
 } from "../../../src/archive/query/archive-view.js";
 import {
   isSearchIndexCurrent,
+  querySearchIndex,
   readArchiveIndexSettings,
+  SEARCH_INDEX_FTS_HIT_LIMIT,
 } from "../../../src/archive/search-index/index.js";
 import { deleteArchiveSearchSessions } from "../../../src/archive/query/search-cache.js";
 import { withTempDir } from "../../helpers/temp.js";
@@ -188,6 +190,54 @@ describe("archive/query/archive-view", () => {
             "text_sentence_records",
           ]),
         );
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("limits FTS candidates before search cache hydration", async () => {
+    await withTempDir("spinedigest-archive-view-", async (path) => {
+      const document = await DirectoryDocument.open(`${path}/document`);
+
+      try {
+        expect(SEARCH_INDEX_FTS_HIT_LIMIT).toBe(32_000);
+        await seedSourcedDocument(document);
+        await document.openSession(async (openedDocument) => {
+          await openedDocument.writeSummary(
+            1,
+            "Wiki summary candidate one. Wiki summary candidate two.",
+          );
+          await openedDocument.chunks.save({
+            content: "Wiki limit candidate one",
+            generation: 0,
+            id: 200,
+            label: "Wiki limit one",
+            sentenceId: [1, 0],
+            sentenceIds: [[1, 0]],
+            wordsCount: 4,
+            weight: 1,
+          });
+          await openedDocument.chunks.save({
+            content: "Wiki limit candidate two",
+            generation: 0,
+            id: 201,
+            label: "Wiki limit two",
+            sentenceId: [1, 1],
+            sentenceIds: [[1, 1]],
+            wordsCount: 4,
+            weight: 1,
+          });
+        });
+        await rebuildArchiveSearchIndex(document);
+
+        const result = await querySearchIndex(document, "Wiki", {
+          objectHitLimit: 2,
+          textHitLimit: 2,
+        });
+
+        expect(result?.objectHits).toHaveLength(2);
+        expect(result?.textHits).toHaveLength(2);
       } finally {
         await document.release();
       }

--- a/test/archive/query/search-cache.test.ts
+++ b/test/archive/query/search-cache.test.ts
@@ -3,7 +3,10 @@ import { join } from "path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { Database } from "../../../src/document/index.js";
-import { createSearchSession } from "../../../src/archive/query/search-cache.js";
+import {
+  createSearchSession,
+  deleteArchiveSearchSessions,
+} from "../../../src/archive/query/search-cache.js";
 import { withTempDir } from "../../helpers/temp.js";
 
 const originalStateDir = process.env.WIKIGRAPH_STATE_DIR;
@@ -66,6 +69,68 @@ describe("archive/query/search-cache", () => {
       }
     });
   });
+
+  it("removes predicate dictionary entries after their triple hits are deleted", async () => {
+    await withTempDir("spinedigest-search-cache-", async (path) => {
+      process.env.WIKIGRAPH_STATE_DIR = path;
+
+      await createSearchSession({
+        archiveKey: "archive-a",
+        chapters: null,
+        items: [],
+        lens: "broad",
+        match: "any",
+        order: "rank",
+        query: "query-a",
+        revisionScope: JSON.stringify({ chaptersRevision: 0, scope: "all" }),
+        terms: ["query-a"],
+        tripleHits: [
+          {
+            evidenceTopScores: [1],
+            objectQid: "Q2",
+            predicate: "mentions",
+            subjectQid: "Q1",
+          },
+          {
+            evidenceTopScores: [1],
+            objectQid: "Q3",
+            predicate: "supports",
+            subjectQid: "Q1",
+          },
+        ],
+        types: null,
+      });
+      await createSearchSession({
+        archiveKey: "archive-b",
+        chapters: null,
+        items: [],
+        lens: "broad",
+        match: "any",
+        order: "rank",
+        query: "query-b",
+        revisionScope: JSON.stringify({ chaptersRevision: 0, scope: "all" }),
+        terms: ["query-b"],
+        tripleHits: [
+          {
+            evidenceTopScores: [1],
+            objectQid: "Q4",
+            predicate: "mentions",
+            subjectQid: "Q1",
+          },
+        ],
+        types: null,
+      });
+
+      await expect(listPredicates(path)).resolves.toStrictEqual([
+        "mentions",
+        "supports",
+      ]);
+
+      await deleteArchiveSearchSessions("archive-a");
+
+      await expect(listPredicates(path)).resolves.toStrictEqual(["mentions"]);
+    });
+  });
 });
 
 async function listIndexNames(database: Database): Promise<string[]> {
@@ -93,6 +158,28 @@ async function listTableNames(database: Database): Promise<string[]> {
     undefined,
     (row) => String(row.name),
   );
+}
+
+async function listPredicates(path: string): Promise<string[]> {
+  const database = await Database.open(
+    join(path, "search-sessions.sqlite"),
+    "",
+    { readonly: true },
+  );
+
+  try {
+    return await database.queryAll(
+      `
+        SELECT value
+        FROM predicate_dictionary
+        ORDER BY value
+      `,
+      undefined,
+      (row) => String(row.value),
+    );
+  } finally {
+    await database.close();
+  }
 }
 
 function restoreEnv(name: string, value: string | undefined): void {

--- a/test/cli/archive-chapter.test.ts
+++ b/test/cli/archive-chapter.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const chapterMockState = vi.hoisted(() => ({
+  activeConflictChecks: [] as unknown[],
+  activeJobChecks: [] as unknown[],
   addCalls: [] as unknown[],
   readCalls: [] as string[],
   writeCalls: [] as string[],
@@ -101,7 +103,14 @@ vi.mock("../../src/facade/index.js", () => ({
       title: "New Chapter",
     });
   }),
-  assertNoActiveBuildJobs: vi.fn(() => Promise.resolve()),
+  assertNoActiveBuildJobs: vi.fn((input: unknown) => {
+    chapterMockState.activeJobChecks.push(input);
+    return Promise.resolve();
+  }),
+  assertNoActiveBuildJobConflicts: vi.fn((input: unknown) => {
+    chapterMockState.activeConflictChecks.push(input);
+    return Promise.resolve();
+  }),
   getChapterDetails: vi.fn(() => Promise.resolve(chapterDetails)),
   getChapterTree: vi.fn(() => Promise.resolve(chapterMockState.tree)),
   listChapters: vi.fn(() => Promise.resolve(chapterMockState.listEntries)),
@@ -248,6 +257,8 @@ describe("cli/archive-chapter", () => {
   const originalStdinIsTTY = process.stdin.isTTY;
 
   beforeEach(() => {
+    chapterMockState.activeConflictChecks.length = 0;
+    chapterMockState.activeJobChecks.length = 0;
     chapterMockState.addCalls.length = 0;
     chapterMockState.readCalls.length = 0;
     chapterMockState.writeCalls.length = 0;
@@ -435,6 +446,13 @@ describe("cli/archive-chapter", () => {
       path: "/tmp/book.wikg",
     });
 
+    expect(chapterMockState.activeJobChecks).toStrictEqual([
+      {
+        archivePath: "/tmp/book.wikg",
+        chapterIds: [2],
+        operation: "Setting chapter title",
+      },
+    ]);
     expect(chapterMockState.setTitleCalls).toStrictEqual([
       {
         chapterId: 2,
@@ -452,6 +470,13 @@ describe("cli/archive-chapter", () => {
       path: "/tmp/book.wikg",
     });
 
+    expect(chapterMockState.activeConflictChecks).toStrictEqual([
+      {
+        archivePath: "/tmp/book.wikg",
+        operation: "Moving chapter",
+        scope: { kind: "archive" },
+      },
+    ]);
     expect(chapterMockState.moveCalls).toStrictEqual([
       {
         chapterId: 2,
@@ -532,6 +557,7 @@ describe("cli/archive-chapter", () => {
     expect(chapterMockState.textWrites.at(-1)).toContain(
       "Dry run: chapter tree not changed.",
     );
+    expect(chapterMockState.activeConflictChecks).toStrictEqual([]);
   });
 
   it("removes chapters recursively when requested", async () => {
@@ -542,6 +568,13 @@ describe("cli/archive-chapter", () => {
       recursive: true,
     });
 
+    expect(chapterMockState.activeConflictChecks).toStrictEqual([
+      {
+        archivePath: "/tmp/book.wikg",
+        operation: "Removing chapter",
+        scope: { kind: "archive" },
+      },
+    ]);
     expect(chapterMockState.removeCalls).toStrictEqual([
       {
         chapterId: 1,

--- a/test/cli/archive.test.ts
+++ b/test/cli/archive.test.ts
@@ -1322,6 +1322,7 @@ describe("cli/archive", () => {
       evidenceLimit: 4,
       format: "json",
       kind: "search",
+      query: "RAG",
       types: ["entity"],
     });
   });
@@ -1370,6 +1371,7 @@ describe("cli/archive", () => {
       cursor: "raw-next-evidence-cursor",
       format: "json",
       kind: "evidence",
+      query: "RAG",
       targetUri: "wkg://entity/Q1",
     });
   });

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -147,11 +147,22 @@ describe("cli/args", () => {
       help: false,
       kind: "gc",
     });
+    expect(parseCLIArguments(["gc", "--force", "--json"])).toStrictEqual({
+      args: {
+        force: true,
+        json: true,
+      },
+      help: false,
+      kind: "gc",
+    });
     expect(parseCLIArguments(["gc", "--help"])).toStrictEqual({
       help: true,
       helpText: renderGcCommandHelpText(),
       kind: "help",
     });
+    expect(() => parseCLIArguments(["transform", "--force"])).toThrow(
+      "The --force option is only supported by `gc`.",
+    );
     expect(() => parseCLIArguments(["gc", "--jsonl"])).toThrow(
       "The `gc` command does not support --jsonl",
     );

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -168,6 +168,47 @@ describe("cli/args", () => {
     );
   });
 
+  it("parses archive index object commands", () => {
+    expect(
+      parseCLIArguments(["wkg:///tmp/book.wikg/index", "build", "--json"]),
+    ).toStrictEqual({
+      args: {
+        action: "build",
+        archivePath: "/tmp/book.wikg",
+        json: true,
+      },
+      help: false,
+      kind: "archive-index",
+    });
+    expect(
+      parseCLIArguments(["wkg:///tmp/book.wikg/index", "external"]),
+    ).toStrictEqual({
+      args: {
+        action: "external",
+        archivePath: "/tmp/book.wikg",
+      },
+      help: false,
+      kind: "archive-index",
+    });
+    expect(
+      parseCLIArguments(["wkg:///tmp/book.wikg/index", "build", "--help"]),
+    ).toStrictEqual({
+      help: true,
+      helpText: renderHelpMatrixText({ kind: "object", object: "index" }),
+      kind: "help",
+    });
+    expect(parseCLIArguments(["help", "index"])).toStrictEqual({
+      help: true,
+      helpText: renderHelpMatrixText({ kind: "object", object: "index" }),
+      kind: "help",
+    });
+    expect(parseCLIArguments(["help", "build"])).toStrictEqual({
+      help: true,
+      helpText: renderHelpMatrixText({ kind: "verb", verb: "build" }),
+      kind: "help",
+    });
+  });
+
   it("parses queue commands", () => {
     expect(
       parseCLIArguments([

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -155,6 +155,14 @@ describe("cli/args", () => {
       help: false,
       kind: "gc",
     });
+    expect(parseCLIArguments(["gc", "--force", "--dry-run"])).toStrictEqual({
+      args: {
+        dryRun: true,
+        force: true,
+      },
+      help: false,
+      kind: "gc",
+    });
     expect(parseCLIArguments(["gc", "--help"])).toStrictEqual({
       help: true,
       helpText: renderGcCommandHelpText(),
@@ -207,6 +215,9 @@ describe("cli/args", () => {
       helpText: renderHelpMatrixText({ kind: "verb", verb: "build" }),
       kind: "help",
     });
+    expect(() =>
+      parseCLIArguments(["wkg:///tmp/book.wikg/index", "clear", "--dry-run"]),
+    ).toThrow("The `clear` command does not support --dry-run.");
   });
 
   it("parses queue commands", () => {

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -218,6 +218,17 @@ describe("cli/args", () => {
     expect(() =>
       parseCLIArguments(["wkg:///tmp/book.wikg/index", "clear", "--dry-run"]),
     ).toThrow("The `clear` command does not support --dry-run.");
+    expect(() =>
+      parseCLIArguments(["wkg:///tmp/book.wikg/index", "clear", "--jsonl"]),
+    ).toThrow("The `clear` command does not support --jsonl.");
+    expect(() =>
+      parseCLIArguments([
+        "wkg:///tmp/book.wikg/index",
+        "clear",
+        "--title",
+        "x",
+      ]),
+    ).toThrow("The `clear` command does not support --title.");
   });
 
   it("parses queue commands", () => {

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -7,6 +7,7 @@ import {
   renderArchiveCommandHelpText,
   renderArchiveMaintenanceChapterActionHelpText,
   renderArchiveMaintenanceCommandHelpText,
+  renderGcCommandHelpText,
   renderHelpMatrixText,
   renderHelpTopicText,
   renderLegacyCommandHelpText,
@@ -131,6 +132,29 @@ describe("cli/args", () => {
       help: false,
       kind: "config-status",
     });
+  });
+
+  it("parses gc commands", () => {
+    expect(parseCLIArguments(["gc"])).toStrictEqual({
+      args: {},
+      help: false,
+      kind: "gc",
+    });
+    expect(parseCLIArguments(["gc", "--json"])).toStrictEqual({
+      args: {
+        json: true,
+      },
+      help: false,
+      kind: "gc",
+    });
+    expect(parseCLIArguments(["gc", "--help"])).toStrictEqual({
+      help: true,
+      helpText: renderGcCommandHelpText(),
+      kind: "help",
+    });
+    expect(() => parseCLIArguments(["gc", "--jsonl"])).toThrow(
+      "The `gc` command does not support --jsonl",
+    );
   });
 
   it("parses queue commands", () => {

--- a/test/cli/main.test.ts
+++ b/test/cli/main.test.ts
@@ -354,6 +354,7 @@ describe("cli/main", () => {
   it("runs the gc command", async () => {
     mainMockState.argsResult = {
       args: {
+        force: true,
         json: true,
       },
       help: false,
@@ -362,7 +363,9 @@ describe("cli/main", () => {
 
     await main();
 
-    expect(mainMockState.gcRunCalls).toStrictEqual([{ json: true }]);
+    expect(mainMockState.gcRunCalls).toStrictEqual([
+      { force: true, json: true },
+    ]);
     expect(mainMockState.archiveRunCalls).toHaveLength(0);
     expect(mainMockState.statusRunCalls).toBe(0);
     expect(process.exitCode).toBe(0);

--- a/test/cli/main.test.ts
+++ b/test/cli/main.test.ts
@@ -12,6 +12,7 @@ const mainMockState = vi.hoisted(() => ({
   } as Record<string, unknown>,
   parseError: undefined as Error | undefined,
   archiveRunCalls: [] as unknown[],
+  archiveIndexRunCalls: [] as unknown[],
   convertRunCalls: [] as unknown[],
   statusRunCalls: 0,
   statusRunArgs: [] as unknown[],
@@ -21,6 +22,7 @@ const mainMockState = vi.hoisted(() => ({
   archiveMetaRunCalls: [] as unknown[],
   legacyRunCalls: [] as unknown[],
   archiveRunError: undefined as Error | undefined,
+  archiveIndexRunError: undefined as Error | undefined,
   convertRunError: undefined as Error | undefined,
   statusRunError: undefined as Error | undefined,
   gcRunError: undefined as Error | undefined,
@@ -46,6 +48,18 @@ vi.mock("../../src/cli/archive.js", () => ({
 
     if (mainMockState.archiveRunError !== undefined) {
       return Promise.reject(mainMockState.archiveRunError);
+    }
+
+    return Promise.resolve();
+  }),
+}));
+
+vi.mock("../../src/cli/archive-index.js", () => ({
+  runArchiveIndexCommand: vi.fn((args: unknown) => {
+    mainMockState.archiveIndexRunCalls.push(args);
+
+    if (mainMockState.archiveIndexRunError !== undefined) {
+      return Promise.reject(mainMockState.archiveIndexRunError);
     }
 
     return Promise.resolve();
@@ -158,6 +172,7 @@ describe("cli/main", () => {
     };
     mainMockState.parseError = undefined;
     mainMockState.archiveRunCalls.length = 0;
+    mainMockState.archiveIndexRunCalls.length = 0;
     mainMockState.convertRunCalls.length = 0;
     mainMockState.statusRunCalls = 0;
     mainMockState.statusRunArgs.length = 0;
@@ -167,6 +182,7 @@ describe("cli/main", () => {
     mainMockState.archiveMetaRunCalls.length = 0;
     mainMockState.legacyRunCalls.length = 0;
     mainMockState.archiveRunError = undefined;
+    mainMockState.archiveIndexRunError = undefined;
     mainMockState.convertRunError = undefined;
     mainMockState.statusRunError = undefined;
     mainMockState.gcRunError = undefined;
@@ -253,6 +269,28 @@ describe("cli/main", () => {
     expect(mainMockState.statusRunCalls).toBe(0);
     expect(stdoutChunks).toStrictEqual([]);
     expect(stderrChunks).toStrictEqual([]);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("runs the archive index command", async () => {
+    mainMockState.argsResult = {
+      args: {
+        action: "build",
+        archivePath: "/tmp/book.wikg",
+      },
+      help: false,
+      kind: "archive-index",
+    };
+
+    await main();
+
+    expect(mainMockState.archiveIndexRunCalls).toStrictEqual([
+      {
+        action: "build",
+        archivePath: "/tmp/book.wikg",
+      },
+    ]);
+    expect(mainMockState.archiveRunCalls).toHaveLength(0);
     expect(process.exitCode).toBe(0);
   });
 

--- a/test/cli/main.test.ts
+++ b/test/cli/main.test.ts
@@ -15,6 +15,7 @@ const mainMockState = vi.hoisted(() => ({
   convertRunCalls: [] as unknown[],
   statusRunCalls: 0,
   statusRunArgs: [] as unknown[],
+  gcRunCalls: [] as unknown[],
   archiveChapterRunCalls: [] as unknown[],
   archiveCoverRunCalls: [] as unknown[],
   archiveMetaRunCalls: [] as unknown[],
@@ -22,6 +23,7 @@ const mainMockState = vi.hoisted(() => ({
   archiveRunError: undefined as Error | undefined,
   convertRunError: undefined as Error | undefined,
   statusRunError: undefined as Error | undefined,
+  gcRunError: undefined as Error | undefined,
   archiveChapterRunError: undefined as Error | undefined,
   archiveCoverRunError: undefined as Error | undefined,
   archiveMetaRunError: undefined as Error | undefined,
@@ -69,6 +71,18 @@ vi.mock("../../src/cli/status.js", () => ({
 
     if (mainMockState.statusRunError !== undefined) {
       return Promise.reject(mainMockState.statusRunError);
+    }
+
+    return Promise.resolve();
+  }),
+}));
+
+vi.mock("../../src/cli/gc.js", () => ({
+  runGcCommand: vi.fn((args: unknown) => {
+    mainMockState.gcRunCalls.push(args);
+
+    if (mainMockState.gcRunError !== undefined) {
+      return Promise.reject(mainMockState.gcRunError);
     }
 
     return Promise.resolve();
@@ -147,6 +161,7 @@ describe("cli/main", () => {
     mainMockState.convertRunCalls.length = 0;
     mainMockState.statusRunCalls = 0;
     mainMockState.statusRunArgs.length = 0;
+    mainMockState.gcRunCalls.length = 0;
     mainMockState.archiveChapterRunCalls.length = 0;
     mainMockState.archiveCoverRunCalls.length = 0;
     mainMockState.archiveMetaRunCalls.length = 0;
@@ -154,6 +169,7 @@ describe("cli/main", () => {
     mainMockState.archiveRunError = undefined;
     mainMockState.convertRunError = undefined;
     mainMockState.statusRunError = undefined;
+    mainMockState.gcRunError = undefined;
     mainMockState.archiveChapterRunError = undefined;
     mainMockState.archiveCoverRunError = undefined;
     mainMockState.archiveMetaRunError = undefined;
@@ -332,6 +348,23 @@ describe("cli/main", () => {
       },
     ]);
     expect(mainMockState.archiveMetaRunCalls).toHaveLength(0);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("runs the gc command", async () => {
+    mainMockState.argsResult = {
+      args: {
+        json: true,
+      },
+      help: false,
+      kind: "gc",
+    };
+
+    await main();
+
+    expect(mainMockState.gcRunCalls).toStrictEqual([{ json: true }]);
+    expect(mainMockState.archiveRunCalls).toHaveLength(0);
+    expect(mainMockState.statusRunCalls).toBe(0);
     expect(process.exitCode).toBe(0);
   });
 

--- a/test/cli/main.test.ts
+++ b/test/cli/main.test.ts
@@ -392,6 +392,7 @@ describe("cli/main", () => {
   it("runs the gc command", async () => {
     mainMockState.argsResult = {
       args: {
+        dryRun: true,
         force: true,
         json: true,
       },
@@ -402,7 +403,7 @@ describe("cli/main", () => {
     await main();
 
     expect(mainMockState.gcRunCalls).toStrictEqual([
-      { force: true, json: true },
+      { dryRun: true, force: true, json: true },
     ]);
     expect(mainMockState.archiveRunCalls).toHaveLength(0);
     expect(mainMockState.statusRunCalls).toBe(0);

--- a/test/cli/queue.test.ts
+++ b/test/cli/queue.test.ts
@@ -11,6 +11,9 @@ const queueMockState = vi.hoisted(() => ({
   commitGraphCalls: [] as unknown[],
   commitKnowledgeGraphCalls: [] as unknown[],
   commitSummaryCalls: [] as unknown[],
+  inputRevisionAssertions: [] as unknown[],
+  inputRevisionRecords: [] as unknown[],
+  revision: 1,
   events: [] as unknown[],
   getJobIds: [] as string[],
   jobs: [] as unknown[],
@@ -72,7 +75,11 @@ vi.mock("../../src/wikg/spine-digest-file.js", () => ({
       queueMockState.readDocumentCalls.push(this.#path);
       queueMockState.stepLog.push("read:start");
       try {
-        return await operation({});
+        return await operation({
+          serials: {
+            getRevision: () => Promise.resolve(queueMockState.revision),
+          },
+        });
       } finally {
         queueMockState.stepLog.push("read:end");
       }
@@ -84,7 +91,11 @@ vi.mock("../../src/wikg/spine-digest-file.js", () => ({
       queueMockState.writeCalls.push(this.#path);
       queueMockState.stepLog.push("write:start");
       try {
-        return await operation({});
+        return await operation({
+          serials: {
+            getRevision: () => Promise.resolve(queueMockState.revision),
+          },
+        });
       } finally {
         queueMockState.stepLog.push("write:end");
       }
@@ -110,6 +121,10 @@ vi.mock("../../src/facade/index.js", () => ({
     }
     return Promise.resolve();
   }),
+  assertBuildJobInputRevision: vi.fn((input: unknown) => {
+    queueMockState.inputRevisionAssertions.push(input);
+    return Promise.resolve();
+  }),
   boostBuildJob: vi.fn(),
   buildChapterGraphArtifact: vi.fn((_chapterId: number, options: unknown) => {
     queueMockState.stepLog.push("build-graph");
@@ -132,6 +147,7 @@ vi.mock("../../src/facade/index.js", () => ({
     queueMockState.stepLog.push("commit-graph");
     queueMockState.commitGraphCalls.push({});
     queueMockState.buildInputStage = "graphed";
+    queueMockState.revision = 2;
     return Promise.resolve({
       chapterId: 12,
       stage: "graphed",
@@ -152,6 +168,7 @@ vi.mock("../../src/facade/index.js", () => ({
   commitChapterSummaryArtifact: vi.fn(() => {
     queueMockState.stepLog.push("commit-summary");
     queueMockState.commitSummaryCalls.push({});
+    queueMockState.revision = 3;
     return Promise.resolve({
       chapterId: 12,
       stage: "summarized",
@@ -175,6 +192,10 @@ vi.mock("../../src/facade/index.js", () => ({
   listBuildJobs: vi.fn(() => Promise.resolve(queueMockState.jobs)),
   pauseBuildJob: vi.fn(),
   readBuildJobEvents: vi.fn(() => Promise.resolve(queueMockState.events)),
+  recordBuildJobInputRevision: vi.fn((input: unknown) => {
+    queueMockState.inputRevisionRecords.push(input);
+    return Promise.resolve(queueMockState.job);
+  }),
   resolveBuildJobId: vi.fn((jobId: string) => {
     queueMockState.resolveJobIds.push(jobId);
     return Promise.resolve(jobId === "job-1-short" ? "job-1-full" : jobId);
@@ -193,6 +214,7 @@ vi.mock("../../src/facade/index.js", () => ({
         stage: queueMockState.buildInputStage,
         words: 4,
       },
+      revision: queueMockState.revision,
       sourceText: ["Alpha beta."],
     }),
   ),
@@ -258,6 +280,8 @@ describe("cli/queue", () => {
     queueMockState.commitSummaryCalls.length = 0;
     queueMockState.events = [];
     queueMockState.getJobIds.length = 0;
+    queueMockState.inputRevisionAssertions.length = 0;
+    queueMockState.inputRevisionRecords.length = 0;
     queueMockState.jobs = [];
     queueMockState.job = {
       archiveKey: "archive-key",
@@ -266,6 +290,7 @@ describe("cli/queue", () => {
       createdAt: 1,
       eventsPath: "events.ndjson",
       jobId: "job-1",
+      ownerId: "owner-1",
       queueRank: 10,
       state: "succeeded",
       target: "reading-summary",
@@ -275,6 +300,7 @@ describe("cli/queue", () => {
     queueMockState.openPaths.length = 0;
     queueMockState.readDocumentCalls.length = 0;
     queueMockState.readChapterStageError = undefined;
+    queueMockState.revision = 1;
     queueMockState.resolveJobIds.length = 0;
     queueMockState.runWorkerOptions = undefined;
     queueMockState.stepLog.length = 0;
@@ -496,6 +522,35 @@ describe("cli/queue", () => {
     expect(queueMockState.buildSummaryCalls[0]).not.toHaveProperty(
       "sourceDocumentPath",
     );
+    expect(queueMockState.inputRevisionRecords).toStrictEqual([
+      {
+        currentRevision: 1,
+        jobId: "job-1",
+        ownerId: "owner-1",
+      },
+      {
+        currentRevision: 2,
+        jobId: "job-1",
+        ownerId: "owner-1",
+      },
+    ]);
+    expect(queueMockState.inputRevisionAssertions).toStrictEqual([
+      {
+        currentRevision: 1,
+        jobId: "job-1",
+        ownerId: "owner-1",
+      },
+      {
+        currentRevision: 2,
+        jobId: "job-1",
+        ownerId: "owner-1",
+      },
+      {
+        currentRevision: 2,
+        jobId: "job-1",
+        ownerId: "owner-1",
+      },
+    ]);
   });
 
   it("uses queue concurrency for worker slots", async () => {
@@ -551,6 +606,20 @@ describe("cli/queue", () => {
       {
         chapterId: 12,
         manifestPath: "/tmp/job-workspace/knowledge-graph/manifest.json",
+      },
+    ]);
+    expect(queueMockState.inputRevisionRecords).toStrictEqual([
+      {
+        currentRevision: 1,
+        jobId: "job-1",
+        ownerId: "owner-1",
+      },
+    ]);
+    expect(queueMockState.inputRevisionAssertions).toStrictEqual([
+      {
+        currentRevision: 1,
+        jobId: "job-1",
+        ownerId: "owner-1",
       },
     ]);
     expect(queueMockState.buildGraphCalls).toStrictEqual([]);

--- a/test/facade/build-queue.test.ts
+++ b/test/facade/build-queue.test.ts
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import { Database } from "../../src/document/index.js";
 import {
   addBuildJob,
+  assertBuildJobInputRevision,
+  assertNoActiveBuildJobConflicts,
   getBuildJob,
   listBuildJobs,
   readBuildJobEvents,
@@ -13,6 +15,7 @@ import {
   boostBuildJob,
   updateBuildJobTarget,
   cancelBuildJob,
+  recordBuildJobInputRevision,
 } from "../../src/facade/index.js";
 import { withTempDir } from "../helpers/temp.js";
 
@@ -175,6 +178,76 @@ describe("facade/build-queue", () => {
       await expect(
         updateBuildJobTarget(reading.jobId, "knowledge-graph"),
       ).rejects.toThrow("already has active knowledge-graph job");
+    });
+  });
+
+  it("blocks archive scoped mutations when any build job is active", async () => {
+    await withTempDir("spinedigest-build-queue-", async (path) => {
+      useStateDir(`${path}/state`);
+      await addBuildJob({
+        archivePath: `${path}/book.wikg`,
+        chapterId: 2,
+        target: "reading-summary",
+      });
+
+      await expect(
+        assertNoActiveBuildJobConflicts({
+          archivePath: `${path}/book.wikg`,
+          operation: "Changing chapter tree",
+          scope: { kind: "archive" },
+        }),
+      ).rejects.toThrow("Changing chapter tree is blocked");
+      await expect(
+        assertNoActiveBuildJobConflicts({
+          archivePath: `${path}/book.wikg`,
+          operation: "Setting unrelated chapter source",
+          scope: { chapterIds: [1], kind: "chapter" },
+        }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  it("records and validates running job input revisions", async () => {
+    await withTempDir("spinedigest-build-queue-", async (path) => {
+      useStateDir(`${path}/state`);
+      const job = await addBuildJob({
+        archivePath: `${path}/book.wikg`,
+        chapterId: 1,
+        target: "reading-summary",
+      });
+
+      await runBuildJobWorker({
+        concurrency: 1,
+        executeJob: async (runningJob) => {
+          const recorded = await recordBuildJobInputRevision({
+            currentRevision: 3,
+            jobId: runningJob.jobId,
+            ownerId: runningJob.ownerId!,
+          });
+
+          expect(recorded.inputRevision).toBe(3);
+          await expect(
+            assertBuildJobInputRevision({
+              currentRevision: 3,
+              jobId: runningJob.jobId,
+              ownerId: runningJob.ownerId!,
+            }),
+          ).resolves.toBeUndefined();
+          await expect(
+            assertBuildJobInputRevision({
+              currentRevision: 4,
+              jobId: runningJob.jobId,
+              ownerId: runningJob.ownerId!,
+            }),
+          ).rejects.toThrow("changed while job");
+        },
+        idleTimeoutMs: 0,
+      });
+
+      await expect(getBuildJob(job.jobId)).resolves.toMatchObject({
+        inputRevision: 3,
+        state: "succeeded",
+      });
     });
   });
 

--- a/test/gc/gc.test.ts
+++ b/test/gc/gc.test.ts
@@ -65,7 +65,7 @@ describe("gc", () => {
     });
   });
 
-  it("removes fresh sqlite cache during explicit GC", async () => {
+  it("keeps fresh sqlite cache during normal GC", async () => {
     await withTempDir("spinedigest-gc-", async (path) => {
       process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
       const sqliteCachePath = await createCoordinatorSqliteCache(path, {
@@ -73,6 +73,20 @@ describe("gc", () => {
       });
 
       const report = await tryRunWikiGraphGc();
+
+      expect(report.skipped).toBe(false);
+      await expect(stat(sqliteCachePath)).resolves.toBeDefined();
+    });
+  });
+
+  it("removes fresh sqlite cache during forced GC", async () => {
+    await withTempDir("spinedigest-gc-", async (path) => {
+      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      const sqliteCachePath = await createCoordinatorSqliteCache(path, {
+        updatedAt: Date.now(),
+      });
+
+      const report = await tryRunWikiGraphGc({ force: true });
 
       expect(report.skipped).toBe(false);
       expect(
@@ -158,6 +172,48 @@ describe("gc", () => {
       expect(wikgCoordinatorJob?.removed).toBeGreaterThanOrEqual(1);
       await expect(stat(referencedPath)).resolves.toBeDefined();
       await expect(stat(orphanedPath)).rejects.toThrow();
+    });
+  });
+
+  it("keeps fresh terminal build jobs during normal GC", async () => {
+    await withTempDir("spinedigest-gc-", async (path) => {
+      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      const job = await createCompletedJob(path, {
+        ageMs: 0,
+        state: "failed",
+      });
+
+      const report = await tryRunWikiGraphGc();
+
+      expect(report.skipped).toBe(false);
+      expect(
+        report.jobs.find((item) => item.name === "build-queue"),
+      ).toMatchObject({ removed: 0 });
+      await expect(stat(job.workspacePath)).resolves.toBeDefined();
+      await expect(countRows("build-queue.sqlite", "build_jobs")).resolves.toBe(
+        1,
+      );
+    });
+  });
+
+  it("removes fresh terminal build jobs during forced GC", async () => {
+    await withTempDir("spinedigest-gc-", async (path) => {
+      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      const job = await createCompletedJob(path, {
+        ageMs: 0,
+        state: "failed",
+      });
+
+      const report = await tryRunWikiGraphGc({ force: true });
+
+      expect(report.skipped).toBe(false);
+      expect(
+        report.jobs.find((item) => item.name === "build-queue"),
+      ).toMatchObject({ removed: 1 });
+      await expect(stat(job.workspacePath)).rejects.toThrow();
+      await expect(countRows("build-queue.sqlite", "build_jobs")).resolves.toBe(
+        0,
+      );
     });
   });
 });
@@ -296,6 +352,22 @@ async function createCompletedOldJob(path: string): Promise<{
   readonly eventsPath: string;
   readonly workspacePath: string;
 }> {
+  return await createCompletedJob(path, {
+    ageMs: 8 * 24 * 60 * 60 * 1000,
+    state: "succeeded",
+  });
+}
+
+async function createCompletedJob(
+  path: string,
+  options: {
+    readonly ageMs: number;
+    readonly state: "canceled" | "failed" | "succeeded";
+  },
+): Promise<{
+  readonly eventsPath: string;
+  readonly workspacePath: string;
+}> {
   const job = await addBuildJob({
     archivePath: join(path, "book.wikg"),
     chapterId: 1,
@@ -309,13 +381,15 @@ async function createCompletedOldJob(path: string): Promise<{
   const database = await openStateDatabase("build-queue.sqlite");
 
   try {
+    const updatedAt = Date.now() - options.ageMs;
+
     await database.run(
       `
 UPDATE build_jobs
-SET state = 'succeeded', updated_at = ?, finished_at = ?
+SET state = ?, updated_at = ?, finished_at = ?
 WHERE job_id = ?
 `,
-      [Date.now() - 8 * 24 * 60 * 60 * 1000, Date.now(), job.jobId],
+      [options.state, updatedAt, updatedAt, job.jobId],
     );
   } finally {
     await database.close();

--- a/test/gc/gc.test.ts
+++ b/test/gc/gc.test.ts
@@ -79,7 +79,7 @@ describe("gc", () => {
         report.jobs.find((item) => item.name === "wikg-coordinator"),
       ).toMatchObject({
         removed: 1,
-        scanned: 2,
+        scanned: 1,
       });
       await expect(stat(sqliteCachePath)).rejects.toThrow();
     });
@@ -109,14 +109,55 @@ describe("gc", () => {
       const report = await tryRunWikiGraphGc();
 
       expect(report.skipped).toBe(false);
-      expect(
-        report.jobs.find((item) => item.name === "wikg-coordinator"),
-      ).toMatchObject({ removed: 1 });
+      const wikgCoordinatorJob = report.jobs.find(
+        (item) => item.name === "wikg-coordinator",
+      );
+
+      expect(wikgCoordinatorJob?.removed).toBeGreaterThanOrEqual(1);
       expect(
         report.jobs.find((item) => item.name === "build-queue"),
       ).toMatchObject({ removed: 1 });
       await expect(stat(workspaceBucketPath)).rejects.toThrow();
       await expect(stat(buildJobBucketPath)).rejects.toThrow();
+    });
+  });
+
+  it("removes orphaned coordinator workspace files", async () => {
+    await withTempDir("spinedigest-gc-", async (path) => {
+      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      const workspaceBucketPath = join(
+        path,
+        "state",
+        "workspaces",
+        "archive-key",
+      );
+      const referencedPath = join(workspaceBucketPath, "book-meta.json");
+      const orphanedPath = join(
+        workspaceBucketPath,
+        "texts",
+        "source",
+        "1.txt",
+      );
+
+      await mkdir(dirname(orphanedPath), { recursive: true });
+      await writeFile(referencedPath, "referenced", "utf8");
+      await writeFile(orphanedPath, "orphaned", "utf8");
+      await createCoordinatorOverlay(path, {
+        archiveKey: "archive-key",
+        entryPath: "book-meta.json",
+        workspacePath: referencedPath,
+      });
+
+      const report = await tryRunWikiGraphGc();
+
+      expect(report.skipped).toBe(false);
+      const wikgCoordinatorJob = report.jobs.find(
+        (item) => item.name === "wikg-coordinator",
+      );
+
+      expect(wikgCoordinatorJob?.removed).toBeGreaterThanOrEqual(1);
+      await expect(stat(referencedPath)).resolves.toBeDefined();
+      await expect(stat(orphanedPath)).rejects.toThrow();
     });
   });
 });
@@ -176,6 +217,54 @@ INSERT INTO entry_overlays (
   }
 
   return workspacePath;
+}
+
+async function createCoordinatorOverlay(
+  path: string,
+  input: {
+    readonly archiveKey: string;
+    readonly entryPath: string;
+    readonly workspacePath: string;
+  },
+): Promise<void> {
+  const archivePath = join(path, "book.wikg");
+
+  await writeFile(archivePath, "archive", "utf8");
+  const database = await openStateDatabase(
+    "wikg-coordinator.sqlite",
+    `
+CREATE TABLE IF NOT EXISTS entry_overlays (
+  archive_key TEXT NOT NULL,
+  archive_path TEXT NOT NULL,
+  entry_path TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  workspace_path TEXT,
+  archive_signature TEXT,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (archive_key, entry_path)
+);
+`,
+  );
+
+  try {
+    await database.run(
+      `
+INSERT INTO entry_overlays (
+  archive_key, archive_path, entry_path, kind, workspace_path,
+  archive_signature, updated_at
+) VALUES (?, ?, ?, 'file', ?, 'test-signature', ?)
+`,
+      [
+        input.archiveKey,
+        archivePath,
+        input.entryPath,
+        input.workspacePath,
+        Date.now(),
+      ],
+    );
+  } finally {
+    await database.close();
+  }
 }
 
 async function createExpiredSearchSession(): Promise<void> {

--- a/test/gc/gc.test.ts
+++ b/test/gc/gc.test.ts
@@ -119,6 +119,8 @@ describe("gc", () => {
       await mkdir(buildJobBucketPath, { recursive: true });
       await writeFile(join(workspaceBucketPath, ".DS_Store"), "finder");
       await writeFile(join(buildJobBucketPath, ".DS_Store"), "finder");
+      await makeOldPath(workspaceBucketPath);
+      await makeOldPath(buildJobBucketPath);
 
       const report = await tryRunWikiGraphGc();
 
@@ -133,6 +135,32 @@ describe("gc", () => {
       ).toMatchObject({ removed: 1 });
       await expect(stat(workspaceBucketPath)).rejects.toThrow();
       await expect(stat(buildJobBucketPath)).rejects.toThrow();
+    });
+  });
+
+  it("keeps external fts sqlite cache during normal GC and removes it during forced GC", async () => {
+    await withTempDir("spinedigest-gc-", async (path) => {
+      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      const sqliteCachePath = await createCoordinatorSqliteCache(path, {
+        entryPath: "fts.db",
+        updatedAt: Date.now() - 2 * 60 * 60 * 1000,
+      });
+
+      const normalReport = await tryRunWikiGraphGc();
+
+      expect(normalReport.skipped).toBe(false);
+      await expect(stat(sqliteCachePath)).resolves.toBeDefined();
+
+      const forcedReport = await tryRunWikiGraphGc({ force: true });
+
+      expect(forcedReport.skipped).toBe(false);
+      expect(
+        forcedReport.jobs.find((item) => item.name === "wikg-coordinator"),
+      ).toMatchObject({
+        removed: 1,
+        scanned: 1,
+      });
+      await expect(stat(sqliteCachePath)).rejects.toThrow();
     });
   });
 
@@ -226,10 +254,11 @@ async function createOldCoordinatorSqliteCache(path: string): Promise<string> {
 
 async function createCoordinatorSqliteCache(
   path: string,
-  options: { readonly updatedAt: number },
+  options: { readonly entryPath?: string; readonly updatedAt: number },
 ): Promise<string> {
   const archivePath = join(path, "book.wikg");
   const workspacePath = join(path, "state", "workspaces", "archive-key", "db");
+  const entryPath = options.entryPath ?? "database.db";
 
   await writeFile(archivePath, "archive", "utf8");
   await mkdir(join(path, "state", "workspaces", "archive-key"), {
@@ -264,9 +293,9 @@ CREATE TABLE IF NOT EXISTS entry_overlays (
 INSERT INTO entry_overlays (
   archive_key, archive_path, entry_path, kind, workspace_path,
   archive_signature, updated_at
-) VALUES (?, ?, 'database.db', 'file', ?, 'test-signature', ?)
+) VALUES (?, ?, ?, 'file', ?, 'test-signature', ?)
 `,
-      ["archive-key", archivePath, workspacePath, options.updatedAt],
+      ["archive-key", archivePath, entryPath, workspacePath, options.updatedAt],
     );
   } finally {
     await database.close();
@@ -408,6 +437,12 @@ async function createOldTmpDirectory(): Promise<string> {
   await utimes(tmpPath, oldDate, oldDate);
 
   return tmpPath;
+}
+
+async function makeOldPath(path: string): Promise<void> {
+  const oldDate = new Date(Date.now() - 2 * 60 * 60 * 1000);
+
+  await utimes(path, oldDate, oldDate);
 }
 
 async function insertGcLock(): Promise<void> {

--- a/test/gc/gc.test.ts
+++ b/test/gc/gc.test.ts
@@ -1,0 +1,320 @@
+import { mkdir, stat, utimes, writeFile } from "fs/promises";
+import { dirname, join } from "path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createWikiGraphTempDirectory } from "../../src/common/wiki-graph-temp.js";
+import { Database } from "../../src/document/index.js";
+import { addBuildJob } from "../../src/facade/index.js";
+import { tryRunWikiGraphGc } from "../../src/gc/index.js";
+import { createSearchSession } from "../../src/archive/query/index.js";
+import { withTempDir } from "../helpers/temp.js";
+
+const originalStateDir = process.env.WIKIGRAPH_STATE_DIR;
+
+describe("gc", () => {
+  afterEach(() => {
+    restoreEnv("WIKIGRAPH_STATE_DIR", originalStateDir);
+  });
+
+  it("cleans expired search sessions, completed jobs, and old controlled tmp directories", async () => {
+    await withTempDir("spinedigest-gc-", async (path) => {
+      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+
+      await createExpiredSearchSession();
+      const job = await createCompletedOldJob(path);
+      const tmpPath = await createOldTmpDirectory();
+      const sqliteCachePath = await createOldCoordinatorSqliteCache(path);
+      const sqliteCacheParentPath = dirname(sqliteCachePath);
+      const jobParentPath = dirname(job.workspacePath);
+
+      const report = await tryRunWikiGraphGc();
+
+      expect(report.skipped).toBe(false);
+      expect(report.jobs.map((item) => item.name)).toStrictEqual([
+        "wikg-coordinator",
+        "search-cache",
+        "build-queue",
+        "tmp",
+      ]);
+      expect(report.removed).toBeGreaterThanOrEqual(3);
+      await expect(stat(sqliteCachePath)).rejects.toThrow();
+      await expect(stat(sqliteCacheParentPath)).rejects.toThrow();
+      await expect(stat(tmpPath)).rejects.toThrow();
+      await expect(stat(job.workspacePath)).rejects.toThrow();
+      await expect(stat(jobParentPath)).rejects.toThrow();
+      await expect(stat(job.eventsPath)).rejects.toThrow();
+      await expect(
+        countRows("search-sessions.sqlite", "search_sessions"),
+      ).resolves.toBe(0);
+      await expect(countRows("build-queue.sqlite", "build_jobs")).resolves.toBe(
+        0,
+      );
+    });
+  });
+
+  it("skips when another GC run owns the global lock", async () => {
+    await withTempDir("spinedigest-gc-", async (path) => {
+      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      await insertGcLock();
+
+      const report = await tryRunWikiGraphGc();
+
+      expect(report.skipped).toBe(true);
+      expect(report.jobs).toStrictEqual([]);
+    });
+  });
+
+  it("removes fresh sqlite cache during explicit GC", async () => {
+    await withTempDir("spinedigest-gc-", async (path) => {
+      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      const sqliteCachePath = await createCoordinatorSqliteCache(path, {
+        updatedAt: Date.now(),
+      });
+
+      const report = await tryRunWikiGraphGc();
+
+      expect(report.skipped).toBe(false);
+      expect(
+        report.jobs.find((item) => item.name === "wikg-coordinator"),
+      ).toMatchObject({
+        removed: 1,
+        scanned: 2,
+      });
+      await expect(stat(sqliteCachePath)).rejects.toThrow();
+    });
+  });
+
+  it("removes stale empty workspace bucket directories", async () => {
+    await withTempDir("spinedigest-gc-", async (path) => {
+      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      const workspaceBucketPath = join(
+        path,
+        "state",
+        "workspaces",
+        "archive-key",
+      );
+      const buildJobBucketPath = join(
+        path,
+        "state",
+        "build-jobs",
+        "archive-key",
+      );
+
+      await mkdir(workspaceBucketPath, { recursive: true });
+      await mkdir(buildJobBucketPath, { recursive: true });
+      await writeFile(join(workspaceBucketPath, ".DS_Store"), "finder");
+      await writeFile(join(buildJobBucketPath, ".DS_Store"), "finder");
+
+      const report = await tryRunWikiGraphGc();
+
+      expect(report.skipped).toBe(false);
+      expect(
+        report.jobs.find((item) => item.name === "wikg-coordinator"),
+      ).toMatchObject({ removed: 1 });
+      expect(
+        report.jobs.find((item) => item.name === "build-queue"),
+      ).toMatchObject({ removed: 1 });
+      await expect(stat(workspaceBucketPath)).rejects.toThrow();
+      await expect(stat(buildJobBucketPath)).rejects.toThrow();
+    });
+  });
+});
+
+async function createOldCoordinatorSqliteCache(path: string): Promise<string> {
+  return await createCoordinatorSqliteCache(path, {
+    updatedAt: Date.now() - 2 * 60 * 60 * 1000,
+  });
+}
+
+async function createCoordinatorSqliteCache(
+  path: string,
+  options: { readonly updatedAt: number },
+): Promise<string> {
+  const archivePath = join(path, "book.wikg");
+  const workspacePath = join(path, "state", "workspaces", "archive-key", "db");
+
+  await writeFile(archivePath, "archive", "utf8");
+  await mkdir(join(path, "state", "workspaces", "archive-key"), {
+    recursive: true,
+  });
+  await writeFile(workspacePath, "sqlite-cache", "utf8");
+  await writeFile(
+    join(path, "state", "workspaces", "archive-key", ".DS_Store"),
+    "finder",
+    "utf8",
+  );
+
+  const database = await openStateDatabase(
+    "wikg-coordinator.sqlite",
+    `
+CREATE TABLE IF NOT EXISTS entry_overlays (
+  archive_key TEXT NOT NULL,
+  archive_path TEXT NOT NULL,
+  entry_path TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  workspace_path TEXT,
+  archive_signature TEXT,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (archive_key, entry_path)
+);
+`,
+  );
+
+  try {
+    await database.run(
+      `
+INSERT INTO entry_overlays (
+  archive_key, archive_path, entry_path, kind, workspace_path,
+  archive_signature, updated_at
+) VALUES (?, ?, 'database.db', 'file', ?, 'test-signature', ?)
+`,
+      ["archive-key", archivePath, workspacePath, options.updatedAt],
+    );
+  } finally {
+    await database.close();
+  }
+
+  return workspacePath;
+}
+
+async function createExpiredSearchSession(): Promise<void> {
+  const sessionId = await createSearchSession({
+    archiveKey: "archive-key",
+    chapters: null,
+    items: [],
+    lens: "broad",
+    match: "any",
+    order: "rank",
+    query: "query",
+    revisionScope: JSON.stringify({ chaptersRevision: 0, scope: "all" }),
+    terms: ["query"],
+    types: null,
+  });
+  const database = await openStateDatabase("search-sessions.sqlite");
+
+  try {
+    await database.run(
+      "UPDATE search_sessions SET expires_at = ? WHERE session_id = ?",
+      [Date.now() - 1, sessionId],
+    );
+  } finally {
+    await database.close();
+  }
+}
+
+async function createCompletedOldJob(path: string): Promise<{
+  readonly eventsPath: string;
+  readonly workspacePath: string;
+}> {
+  const job = await addBuildJob({
+    archivePath: join(path, "book.wikg"),
+    chapterId: 1,
+    target: "reading-summary",
+  });
+  await mkdir(job.workspacePath, { recursive: true });
+  await writeFile(join(job.workspacePath, "artifact.txt"), "artifact", "utf8");
+  await writeFile(join(dirname(job.workspacePath), ".DS_Store"), "finder");
+  await writeFile(job.eventsPath, "event\n", "utf8");
+
+  const database = await openStateDatabase("build-queue.sqlite");
+
+  try {
+    await database.run(
+      `
+UPDATE build_jobs
+SET state = 'succeeded', updated_at = ?, finished_at = ?
+WHERE job_id = ?
+`,
+      [Date.now() - 8 * 24 * 60 * 60 * 1000, Date.now(), job.jobId],
+    );
+  } finally {
+    await database.close();
+  }
+
+  return job;
+}
+
+async function createOldTmpDirectory(): Promise<string> {
+  const tmpPath = await createWikiGraphTempDirectory("cli-output");
+  const filePath = join(tmpPath, "output.txt");
+  const oldDate = new Date(Date.now() - 2 * 60 * 60 * 1000);
+
+  await writeFile(filePath, "temporary", "utf8");
+  await utimes(filePath, oldDate, oldDate);
+  await utimes(tmpPath, oldDate, oldDate);
+
+  return tmpPath;
+}
+
+async function insertGcLock(): Promise<void> {
+  const database = await openStateDatabase(
+    "gc.sqlite",
+    `
+CREATE TABLE IF NOT EXISTS gc_locks (
+  scope TEXT PRIMARY KEY,
+  owner_id TEXT NOT NULL,
+  owner_pid INTEGER NOT NULL,
+  heartbeat_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL
+);
+`,
+  );
+  const now = Date.now();
+
+  try {
+    await database.run(
+      `
+INSERT INTO gc_locks (
+  scope, owner_id, owner_pid, heartbeat_at, created_at
+) VALUES ('global', 'test-owner', ?, ?, ?)
+`,
+      [process.pid, now, now],
+    );
+  } finally {
+    await database.close();
+  }
+}
+
+async function countRows(
+  databaseName: string,
+  tableName: string,
+): Promise<number> {
+  const database = await openStateDatabase(databaseName);
+
+  try {
+    return (
+      (await database.queryOne(
+        `SELECT COUNT(*) AS count FROM ${tableName}`,
+        undefined,
+        (row) => Number(row.count),
+      )) ?? 0
+    );
+  } finally {
+    await database.close();
+  }
+}
+
+async function openStateDatabase(
+  databaseName: string,
+  schemaSql = "",
+): Promise<Database> {
+  if (process.env.WIKIGRAPH_STATE_DIR === undefined) {
+    throw new Error("WIKIGRAPH_STATE_DIR is not set.");
+  }
+
+  await mkdir(process.env.WIKIGRAPH_STATE_DIR, { recursive: true });
+  return await Database.open(
+    join(process.env.WIKIGRAPH_STATE_DIR, databaseName),
+    schemaSql,
+  );
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}

--- a/test/legacy-sdpub/upgrade.test.ts
+++ b/test/legacy-sdpub/upgrade.test.ts
@@ -7,6 +7,7 @@ import { ZipFile } from "yazl";
 import { describe, expect, it } from "vitest";
 
 import { Database, DirectoryDocument } from "../../src/document/index.js";
+import { rebuildArchiveSearchIndex } from "../../src/archive/query/index.js";
 import { extractWikgArchive } from "../../src/wikg/archive.js";
 import { migrateLegacySdpubToWikg } from "../../src/legacy-sdpub/upgrade.js";
 import { withTempDir } from "../helpers/temp.js";
@@ -38,6 +39,10 @@ describe("legacy-sdpub/upgrade", () => {
         await expect(document.readSummary(1)).resolves.toBe(
           "Summary sentence one.\nSummary sentence two.",
         );
+        await expect(
+          readFile(`${extractedPath}/fts.db`, "utf8"),
+        ).rejects.toThrow();
+        await rebuildArchiveSearchIndex(document);
         await expect(
           countSearchIndexRecords(document),
         ).resolves.toBeGreaterThan(0);
@@ -330,7 +335,7 @@ async function readFragmentGroupIds(
 async function countSearchIndexRecords(
   document: DirectoryDocument,
 ): Promise<number> {
-  return await document.readDatabase(async (database) => {
+  return await document.readSearchIndexDatabase(async (database) => {
     const row = await database.queryOne(
       `
         SELECT

--- a/test/wikg/archive.test.ts
+++ b/test/wikg/archive.test.ts
@@ -6,6 +6,7 @@ import { ZipFile } from "yazl";
 
 import { describe, expect, it } from "vitest";
 
+import { DirectoryDocument } from "../../src/document/index.js";
 import {
   extractWikgArchive,
   readWikgArchiveEntry,
@@ -76,6 +77,56 @@ describe("wikg/archive", () => {
       await expect(
         readFile(`${extractDir}/texts/source/note.txt`, "utf8"),
       ).rejects.toThrow();
+    });
+  });
+
+  it("omits external FTS databases from new archives", async () => {
+    await withTempDir("spinedigest-archive-", async (path) => {
+      const sourceDir = `${path}/source`;
+      const archivePath = `${path}/book.wikg`;
+      const document = await DirectoryDocument.open(sourceDir);
+
+      try {
+        await writeFile(`${sourceDir}/fts.db`, "fts", "utf8");
+      } finally {
+        await document.release();
+      }
+
+      await writeWikgArchive(sourceDir, archivePath);
+
+      await expect(readWikgArchiveEntry(archivePath, "fts.db")).resolves.toBe(
+        undefined,
+      );
+    });
+  });
+
+  it("includes embedded FTS databases in new archives", async () => {
+    await withTempDir("spinedigest-archive-", async (path) => {
+      const sourceDir = `${path}/source`;
+      const archivePath = `${path}/book.wikg`;
+      const document = await DirectoryDocument.open(sourceDir);
+
+      try {
+        await document.readDatabase(async (database) => {
+          await database.run(
+            `
+              INSERT INTO archive_index_settings(id, fts_embedded)
+              VALUES (1, 1)
+              ON CONFLICT(id)
+              DO UPDATE SET fts_embedded = excluded.fts_embedded
+            `,
+          );
+        });
+        await writeFile(`${sourceDir}/fts.db`, "fts", "utf8");
+      } finally {
+        await document.release();
+      }
+
+      await writeWikgArchive(sourceDir, archivePath);
+
+      await expect(
+        readWikgArchiveEntry(archivePath, "fts.db"),
+      ).resolves.toEqual(Buffer.from("fts", "utf8"));
     });
   });
 

--- a/test/wikg/spine-digest-file.test.ts
+++ b/test/wikg/spine-digest-file.test.ts
@@ -6,7 +6,10 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { DirectoryDocument } from "../../src/document/index.js";
 import { extractWikgArchive } from "../../src/wikg/archive.js";
-import { findArchiveObjects } from "../../src/archive/query/archive-view.js";
+import {
+  findArchiveObjects,
+  rebuildArchiveSearchIndex,
+} from "../../src/archive/query/archive-view.js";
 import { SpineDigest } from "../../src/facade/spine-digest.js";
 import { SpineDigestFile } from "../../src/wikg/spine-digest-file.js";
 import { WikgCoordinator } from "../../src/wikg/wikg-coordinator.js";
@@ -290,6 +293,13 @@ describe("wikg/spine-digest-file", () => {
       try {
         const archivePath = await createSeedArchive(path);
 
+        await new SpineDigestFile(archivePath).write(
+          async (document) => {
+            await rebuildArchiveSearchIndex(document);
+          },
+          { searchIndexWritebackPolicy: "cache" },
+        );
+
         await new SpineDigestFile(archivePath).readDocument(
           async (document) => {
             await expect(
@@ -301,17 +311,23 @@ describe("wikg/spine-digest-file", () => {
         );
 
         await new SpineDigestFile(archivePath).write(async (document) => {
-          const meta = await document.readBookMeta();
-
-          if (meta === undefined) {
-            throw new Error("Missing test metadata.");
-          }
-
-          await document.replaceBookMeta({
-            ...meta,
-            title: "Fresh Cache Title",
+          await document.replaceToc({
+            items: [
+              {
+                children: [],
+                serialId: 1,
+                title: "Fresh Cache Title",
+              },
+            ],
+            version: 1,
           });
         });
+        await new SpineDigestFile(archivePath).write(
+          async (document) => {
+            await rebuildArchiveSearchIndex(document);
+          },
+          { searchIndexWritebackPolicy: "cache" },
+        );
 
         await new SpineDigestFile(archivePath).readDocument(
           async (document) => {
@@ -320,7 +336,7 @@ describe("wikg/spine-digest-file", () => {
                 archiveKey: archivePath,
               }),
             ).resolves.toMatchObject({
-              items: [expect.objectContaining({ id: "meta:root" })],
+              items: [expect.objectContaining({ id: "chapter:1" })],
             });
           },
         );
@@ -660,6 +676,7 @@ async function createSeedArchive(path: string): Promise<string> {
 
   try {
     await seedDocument(document);
+    await rebuildArchiveSearchIndex(document);
 
     const archivePath = `${path}/fixture/book.wikg`;
 

--- a/test/wikg/spine-digest-file.test.ts
+++ b/test/wikg/spine-digest-file.test.ts
@@ -153,13 +153,15 @@ describe("wikg/spine-digest-file", () => {
           });
         });
 
-        await expect(readCoordinatorOverlays(path)).resolves.toStrictEqual([
-          expect.objectContaining({
-            archivePath,
-            entryPath: "database.db",
-            kind: "file",
-          }),
-        ]);
+        const overlays = await readCoordinatorOverlays(path);
+
+        expect(overlays).toHaveLength(1);
+        expect(overlays[0]).toMatchObject({
+          archivePath,
+          entryPath: "database.db",
+          kind: "file",
+        });
+        expect(overlays[0]?.workspacePath).toMatch(/\/database\.db$/u);
       } finally {
         restoreStateDir();
       }
@@ -208,10 +210,73 @@ describe("wikg/spine-digest-file", () => {
           });
         });
 
-        await expect(readCoordinatorOverlays(path)).resolves.toStrictEqual([]);
+        await expect(readCoordinatorOverlays(path)).resolves.toStrictEqual([
+          expect.objectContaining({
+            archivePath,
+            entryPath: "database.db",
+            kind: "file",
+          }),
+        ]);
 
         await expect(readArchivedTitle(path, archivePath)).resolves.toBe(
           "Flushed Title",
+        );
+      } finally {
+        restoreStateDir();
+      }
+    });
+  });
+
+  it("keeps sqlite cache when write sessions only read the database", async () => {
+    await withTempDir("spinedigest-facade-file-", async (path) => {
+      const restoreStateDir = useCoordinatorStateDir(`${path}/state`);
+      try {
+        const archivePath = await createSeedArchive(path);
+
+        await new SpineDigestFile(archivePath).readDocument(
+          async (document) => {
+            await expect(document.peekNextSerialId()).resolves.toBe(2);
+          },
+        );
+
+        await new SpineDigestFile(archivePath).write(async (document) => {
+          await expect(document.peekNextSerialId()).resolves.toBe(2);
+        });
+
+        await expect(readCoordinatorOverlays(path)).resolves.toStrictEqual([
+          expect.objectContaining({
+            archivePath,
+            entryPath: "database.db",
+            kind: "file",
+          }),
+        ]);
+      } finally {
+        restoreStateDir();
+      }
+    });
+  });
+
+  it("flushes sqlite cache when write sessions mutate the database", async () => {
+    await withTempDir("spinedigest-facade-file-", async (path) => {
+      const restoreStateDir = useCoordinatorStateDir(`${path}/state`);
+      try {
+        const archivePath = await createSeedArchive(path);
+
+        await new SpineDigestFile(archivePath).readDocument(
+          async (document) => {
+            await expect(document.peekNextSerialId()).resolves.toBe(2);
+          },
+        );
+
+        await new SpineDigestFile(archivePath).write(async (document) => {
+          await document.createSerial();
+        });
+
+        await expect(readCoordinatorOverlays(path)).resolves.toStrictEqual([]);
+        await new SpineDigestFile(archivePath).readDocument(
+          async (document) => {
+            await expect(document.peekNextSerialId()).resolves.toBe(3);
+          },
         );
       } finally {
         restoreStateDir();
@@ -323,7 +388,13 @@ describe("wikg/spine-digest-file", () => {
           }),
         ).rejects.toThrow("stop before flush");
 
-        await expect(readCoordinatorOverlays(path)).resolves.toStrictEqual([]);
+        await expect(readCoordinatorOverlays(path)).resolves.toStrictEqual([
+          expect.objectContaining({
+            archivePath,
+            entryPath: "database.db",
+            kind: "file",
+          }),
+        ]);
         await expect(readArchivedTitle(path, archivePath)).resolves.toBe(
           "Unflushed Title",
         );
@@ -627,6 +698,7 @@ async function readCoordinatorOverlays(path: string): Promise<
     readonly archivePath: string;
     readonly entryPath: string;
     readonly kind: string;
+    readonly workspacePath?: string;
   }>
 > {
   try {
@@ -645,7 +717,7 @@ async function readCoordinatorOverlays(path: string): Promise<
   try {
     return await database.queryAll(
       `
-SELECT archive_path, entry_path, kind
+SELECT archive_path, entry_path, kind, workspace_path
 FROM entry_overlays
 ORDER BY archive_path, entry_path
 `,
@@ -654,6 +726,7 @@ ORDER BY archive_path, entry_path
         archivePath: expectString(row.archive_path),
         entryPath: expectString(row.entry_path),
         kind: expectString(row.kind),
+        ...expectOptionalStringProperty(row.workspace_path, "workspacePath"),
       }),
     );
   } finally {
@@ -843,4 +916,15 @@ function expectString(value: unknown): string {
   }
 
   return value;
+}
+
+function expectOptionalStringProperty(
+  value: unknown,
+  key: "workspacePath",
+): { readonly workspacePath?: string } {
+  if (value === null || value === undefined) {
+    return {};
+  }
+
+  return { [key]: expectString(value) };
 }


### PR DESCRIPTION
## Summary
- centralize Wiki Graph local GC and add force cleanup mode
- track wikg sqlite dirty state and keep reusable sqlite workspace caches
- split Wiki Graph FTS into fts.db with /index build/embed/external/clear commands
- default FTS storage to local cache, with explicit embedded mode

## Verification
- pnpm run verify
- pnpm test:run
- pnpm run cli:install-local