### PR TITLE
Fix knowledge graph progress output

### DIFF
--- a/data/help/commands/gc.jinja
+++ b/data/help/commands/gc.jinja
@@ -19,7 +19,7 @@ Options:
 Managed areas:
   - Wiki Graph coordinator workspace files and cached SQLite databases.
   - Search query cache.
-  - Completed build job records and their durable event/workspace files.
+  - Completed build job records and their durable event, cache, log, and workspace files.
   - Wiki Graph controlled temporary directories under the state directory.
 
 Output:

--- a/data/help/topics/runtime.jinja
+++ b/data/help/topics/runtime.jinja
@@ -35,9 +35,10 @@ Progress and diagnostics:
 Workspace behavior:
   - Archive creation from URL or stdin uses temporary workspaces.
   - `transform --digest-dir <path>` uses the provided digest workspace for source digest runs.
-  - Queue jobs use workspaces under `~/.wikigraph/jobs/work`.
+  - Queue jobs use per-job directories under `~/.wikigraph/jobs/work`, `~/.wikigraph/jobs/cache`, and `~/.wikigraph/jobs/logs`.
   - Succeeded jobs delete their workspace by default.
   - Failed and canceled jobs keep their workspace for debugging until cleanup.
+  - Job events, logs, and LLM cache are kept until the job record is cleaned.
 
 In-place archive edits:
   - Mutating `.wikg` commands go through the archive coordinator.

--- a/src/archive/query/archive-view.ts
+++ b/src/archive/query/archive-view.ts
@@ -4020,7 +4020,9 @@ async function listFragmentNodes(
   chapterId: number,
   fragmentId: number,
 ): Promise<readonly ArchiveNodeLabel[]> {
-  return (await document.chunks.listByFragments(chapterId, [fragmentId]))
+  return (
+    await document.chunks.listBySentenceStartIndexes(chapterId, [fragmentId])
+  )
     .map(createPositionedNodeLabel)
     .sort(comparePositionedNodeLabels)
     .map(({ label }) => label);

--- a/src/cli/progress-output.ts
+++ b/src/cli/progress-output.ts
@@ -8,10 +8,14 @@ export interface ProgressCounter {
   readonly unit: string;
 }
 
-export interface ProgressTokens {
-  readonly cache?: number;
-  readonly input?: number;
-  readonly output?: number;
+export interface ProgressMetric {
+  readonly name: string;
+  readonly value: number;
+}
+
+export interface ProgressMetricGroup {
+  readonly metrics: readonly ProgressMetric[];
+  readonly name: string;
 }
 
 export type ProgressOutputEvent =
@@ -24,8 +28,8 @@ export type ProgressOutputEvent =
       readonly counters?: readonly ProgressCounter[];
       readonly json: unknown;
       readonly kind: "status";
+      readonly metricGroups?: readonly ProgressMetricGroup[];
       readonly phase: string;
-      readonly tokens?: ProgressTokens;
     };
 
 export class ProgressOutputWriter {
@@ -115,17 +119,17 @@ export class ProgressOutputWriter {
 
 export function formatStatusText(input: {
   readonly counters?: readonly ProgressCounter[];
+  readonly metricGroups?: readonly ProgressMetricGroup[];
   readonly phase: string;
-  readonly tokens?: ProgressTokens;
 }): string {
   const counters = input.counters ?? [];
   const counterText =
     counters.length === 0
       ? ""
       : ` ${counters.map(formatCounterText).join(" | ")}`;
-  const tokenText = formatTokensText(input.tokens);
+  const metricText = formatMetricGroupsText(input.metricGroups);
 
-  return `${input.phase}${counterText}${tokenText === "" ? "" : ` ${tokenText}`}`;
+  return `${input.phase}${counterText}${metricText === "" ? "" : ` ${metricText}`}`;
 }
 
 function formatCounterText(counter: ProgressCounter): string {
@@ -136,18 +140,24 @@ function formatCounterText(counter: ProgressCounter): string {
   return `${counter.name} ${counter.done}/${counter.total} ${counter.unit}`;
 }
 
-function formatTokensText(tokens: ProgressTokens | undefined): string {
-  if (tokens === undefined) {
+function formatMetricGroupsText(
+  metricGroups: readonly ProgressMetricGroup[] | undefined,
+): string {
+  if (metricGroups === undefined) {
     return "";
   }
 
-  const parts = [
-    ...(tokens.input === undefined ? [] : [`input: ${tokens.input}`]),
-    ...(tokens.cache === undefined ? [] : [`cache: ${tokens.cache}`]),
-    ...(tokens.output === undefined ? [] : [`output: ${tokens.output}`]),
-  ];
+  const parts = metricGroups.flatMap((group) => {
+    const metrics = group.metrics.map(
+      (metric) => `${metric.name}: ${metric.value}`,
+    );
 
-  return parts.length === 0 ? "" : `[tokens ${parts.join(" / ")}]`;
+    return metrics.length === 0
+      ? []
+      : [`[${group.name} ${metrics.join(" / ")}]`];
+  });
+
+  return parts.join(" ");
 }
 
 function isStatusComplete(input: {

--- a/src/cli/queue.ts
+++ b/src/cli/queue.ts
@@ -47,7 +47,7 @@ import { formatCLIJSON } from "./json.js";
 import {
   ProgressOutputWriter,
   type ProgressCounter,
-  type ProgressTokens,
+  type ProgressMetricGroup,
 } from "./progress-output.js";
 import {
   createStageLLM,
@@ -534,13 +534,13 @@ async function watchBuildJob(
 function formatWatchOutputEvent(event: BuildJobEvent) {
   switch (event.type) {
     case "status_snapshot": {
-      const tokens = formatProgressTokens(event.tokens);
+      const tokenMetrics = formatProgressTokenMetrics(event.tokens);
       return {
         counters: event.counters.map(formatProgressCounter),
         json: event,
         kind: "status" as const,
+        ...(tokenMetrics === undefined ? {} : { metricGroups: [tokenMetrics] }),
         phase: event.phase ?? event.step ?? "status",
-        ...(tokens === undefined ? {} : { tokens }),
       };
     }
     case "target_changed":
@@ -623,25 +623,29 @@ function formatProgressUnit(unit: string): string {
   }
 }
 
-function formatProgressTokens(
+function formatProgressTokenMetrics(
   tokens: Extract<
     BuildJobEvent,
     { readonly type: "status_snapshot" }
   >["tokens"],
-): ProgressTokens | undefined {
+): ProgressMetricGroup | undefined {
   if (tokens === undefined) {
     return undefined;
   }
 
-  return {
+  const metrics = [
+    ...(tokens.inputTokens === undefined
+      ? []
+      : [{ name: "input", value: tokens.inputTokens }]),
     ...(tokens.cacheReadTokens === undefined
-      ? {}
-      : { cache: tokens.cacheReadTokens }),
-    ...(tokens.inputTokens === undefined ? {} : { input: tokens.inputTokens }),
+      ? []
+      : [{ name: "cache", value: tokens.cacheReadTokens }]),
     ...(tokens.outputTokens === undefined
-      ? {}
-      : { output: tokens.outputTokens }),
-  };
+      ? []
+      : [{ name: "output", value: tokens.outputTokens }]),
+  ];
+
+  return metrics.length === 0 ? undefined : { metrics, name: "tokens" };
 }
 
 async function writeJobList(

--- a/src/cli/queue.ts
+++ b/src/cli/queue.ts
@@ -326,10 +326,22 @@ async function executeBuildJobWithLogging(
         }),
     );
 
+    await reporter.updatePhase({
+      done: 0,
+      phase: "committing",
+      total: 1,
+      unit: "item",
+    });
     await new SpineDigestFile(job.archivePath).write(async (document) => {
       assertJobStillRunning(await getBuildJob(job.jobId));
       await assertCurrentBuildInputRevision(job, document);
       await commitChapterKnowledgeGraphArtifact(document, artifact);
+    });
+    await reporter.updatePhase({
+      done: 1,
+      phase: "committing",
+      total: 1,
+      unit: "item",
     });
     await reporter.stepCompleted("knowledge-graph");
     assertJobStillRunning(await getBuildJob(job.jobId));
@@ -356,6 +368,12 @@ async function executeBuildJobWithLogging(
         },
       },
     });
+    await reporter.updatePhase({
+      done: 0,
+      phase: "committing",
+      total: 1,
+      unit: "item",
+    });
     details = await new SpineDigestFile(job.archivePath).write(
       async (document) => {
         assertJobStillRunning(await getBuildJob(job.jobId));
@@ -363,6 +381,12 @@ async function executeBuildJobWithLogging(
         return await commitChapterGraphArtifact(document, artifact);
       },
     );
+    await reporter.updatePhase({
+      done: 1,
+      phase: "committing",
+      total: 1,
+      unit: "item",
+    });
     const nextBuildInput = await new SpineDigestFile(
       job.archivePath,
     ).readDocument(
@@ -411,6 +435,12 @@ async function executeBuildJobWithLogging(
     snapshotPath: summaryInput.filePath,
     workspacePath: job.workspacePath,
   });
+  await reporter.updatePhase({
+    done: 0,
+    phase: "committing",
+    total: 1,
+    unit: "item",
+  });
   details = await new SpineDigestFile(job.archivePath).write(
     async (document) => {
       assertJobStillRunning(await getBuildJob(job.jobId));
@@ -422,6 +452,12 @@ async function executeBuildJobWithLogging(
       );
     },
   );
+  await reporter.updatePhase({
+    done: 1,
+    phase: "committing",
+    total: 1,
+    unit: "item",
+  });
   await reporter.updateWords({ readingSummaryWords: details.words });
   await reporter.stepCompleted("reading-summary");
   assertJobStillRunning(await getBuildJob(job.jobId));
@@ -543,7 +579,7 @@ function formatWatchOutputEvent(event: BuildJobEvent) {
 function formatStepPlan(step: string): string {
   switch (step) {
     case "knowledge-graph":
-      return "screening -> matching -> enrichment -> relation-discovery -> grounding";
+      return "matching -> screening -> enrichment -> grounding -> relation-discovery -> committing";
     case "reading-summary":
       return "reading-graph -> summarizing -> committing";
     case "reading-graph":
@@ -568,6 +604,8 @@ function formatProgressUnit(unit: string): string {
   switch (unit) {
     case "candidate":
       return "candidates";
+    case "item":
+      return "items";
     case "page":
       return "pages";
     case "qid":

--- a/src/cli/queue.ts
+++ b/src/cli/queue.ts
@@ -1,6 +1,7 @@
 import { spawn } from "child_process";
 
 import { SpineDigestScope } from "../common/llm-scope.js";
+import { withLoggingContext } from "../common/logging.js";
 import {
   addBuildJob,
   assertBuildJobInputRevision,
@@ -231,10 +232,28 @@ async function executeBuildJob(
   reporter: BuildJobProgressReporter,
   context: BuildJobExecutionContext,
 ): Promise<void> {
+  await withLoggingContext(
+    {
+      logDirPath: job.logPath,
+      operation: "build-job",
+    },
+    async () => {
+      await executeBuildJobWithLogging(job, reporter, context);
+    },
+  );
+}
+
+async function executeBuildJobWithLogging(
+  job: BuildJob,
+  reporter: BuildJobProgressReporter,
+  context: BuildJobExecutionContext,
+): Promise<void> {
   const config = await loadRequiredStageConfig({
     ...(job.llmJSON === undefined ? {} : { llmJSON: job.llmJSON }),
   });
   const llm = createStageLLM(config, {
+    cacheDirPath: job.cachePath,
+    logDirPath: job.logPath,
     onStreamProgress: async (event) => {
       await reporter.addOutputCharacters(event.outputCharacters);
     },
@@ -633,6 +652,8 @@ async function writeJobStatus(
       `Target: ${job.target}`,
       `Step: ${job.currentStep ?? "-"}`,
       `Workspace: ${job.workspacePath}`,
+      `Cache: ${job.cachePath}`,
+      `Logs: ${job.logPath}`,
       ...(job.errorJSON === undefined ? [] : [`Error: ${job.errorJSON}`]),
     ].join("\n") + "\n",
   );
@@ -642,6 +663,7 @@ function formatJobJSON(job: BuildJob): unknown {
   return {
     archiveKey: job.archiveKey,
     archivePath: job.archivePath,
+    cachePath: job.cachePath,
     chapterId: job.chapterId,
     createdAt: job.createdAt,
     ...(job.currentStep === undefined ? {} : { currentStep: job.currentStep }),
@@ -649,6 +671,7 @@ function formatJobJSON(job: BuildJob): unknown {
     eventsPath: job.eventsPath,
     ...(job.finishedAt === undefined ? {} : { finishedAt: job.finishedAt }),
     jobId: job.jobId,
+    logPath: job.logPath,
     ...(job.llmJSON === undefined ? {} : { llmJSON: job.llmJSON }),
     ...(job.ownerId === undefined ? {} : { ownerId: job.ownerId }),
     ...(job.ownerPid === undefined ? {} : { ownerPid: job.ownerPid }),

--- a/src/cli/stage-runtime.ts
+++ b/src/cli/stage-runtime.ts
@@ -27,6 +27,8 @@ export const DEFAULT_KNOWLEDGE_GRAPH_RECALL_PROMPT = [
 export function createStageLLM(
   config: CLIConfig,
   options?: {
+    readonly cacheDirPath?: string;
+    readonly logDirPath?: string;
     readonly onStreamProgress?: LLMStreamProgressCallback;
     readonly onTokenUsage?: LLMTokenUsageCallback;
   },
@@ -42,6 +44,12 @@ export function createStageLLM(
       ...(llmOptions.topP === undefined ? {} : { topP: llmOptions.topP }),
     }),
     ...llmOptions,
+    ...(options?.cacheDirPath === undefined
+      ? {}
+      : { cacheDirPath: options.cacheDirPath }),
+    ...(options?.logDirPath === undefined
+      ? {}
+      : { logDirPath: options.logDirPath }),
     ...(options?.onStreamProgress === undefined
       ? {}
       : { onStreamProgress: options.onStreamProgress }),

--- a/src/common/logging.ts
+++ b/src/common/logging.ts
@@ -49,7 +49,7 @@ export async function withLoggingContext<T>(
     verbose: input.verbose ?? false,
     ...(runDirPath === undefined
       ? {}
-      : { eventLogPath: join(runDirPath, "events.log") }),
+      : { eventLogPath: join(runDirPath, "run.log") }),
   });
 
   return await loggingContext.run(

--- a/src/document/stores.ts
+++ b/src/document/stores.ts
@@ -43,9 +43,9 @@ export interface ReadonlyChunkStore {
   countAll(): Promise<number>;
   getById(chunkId: number): Promise<ChunkRecord | undefined>;
   listAll(): Promise<ChunkRecord[]>;
-  listByFragments(
+  listBySentenceStartIndexes(
     serialId: number,
-    fragmentIds: readonly number[],
+    sentenceStartIndexes: readonly number[],
   ): Promise<ChunkRecord[]>;
   listBySentenceRange(
     serialId: number,
@@ -806,18 +806,22 @@ export class ChunkStore implements ReadonlyChunkStore {
     );
   }
 
-  public async listByFragments(
+  public async listBySentenceStartIndexes(
     serialId: number,
-    fragmentIds: readonly number[],
+    sentenceStartIndexes: readonly number[],
   ): Promise<ChunkRecord[]> {
-    if (fragmentIds.length === 0) {
+    if (sentenceStartIndexes.length === 0) {
       return [];
     }
 
     const results = await Promise.all(
-      fragmentIds.map(
-        async (fragmentId) =>
-          await this.listBySentenceRange(serialId, fragmentId, fragmentId),
+      sentenceStartIndexes.map(
+        async (sentenceStartIndex) =>
+          await this.listBySentenceRange(
+            serialId,
+            sentenceStartIndex,
+            sentenceStartIndex,
+          ),
       ),
     );
 

--- a/src/facade/build-queue.ts
+++ b/src/facade/build-queue.ts
@@ -1893,7 +1893,6 @@ class BuildJobProgressAccumulator implements BuildJobProgressReporter {
   #createWordCounter(): BuildJobProgressCounter | undefined {
     switch (this.#step) {
       case "reading-graph":
-      case "knowledge-graph":
         return this.#totalGraphWords <= 0
           ? undefined
           : {

--- a/src/facade/build-queue.ts
+++ b/src/facade/build-queue.ts
@@ -24,6 +24,7 @@ export type BuildJobTarget =
   | "reading-graph"
   | "reading-summary";
 export type BuildJobProgressPhase =
+  | "committing"
   | "enrichment"
   | "grounding"
   | "matching"
@@ -32,6 +33,7 @@ export type BuildJobProgressPhase =
   | "screening";
 export type BuildJobProgressUnit =
   | "candidate"
+  | "item"
   | "page"
   | "qid"
   | "sentence"
@@ -1970,6 +1972,8 @@ function formatProgressCounterName(input: {
   switch (input.unit) {
     case "candidate":
       return "candidates";
+    case "item":
+      return "items";
     case "page":
       return "page";
     case "qid":

--- a/src/facade/build-queue.ts
+++ b/src/facade/build-queue.ts
@@ -1,15 +1,11 @@
 import { createHash, randomUUID } from "crypto";
-import { appendFile, mkdir, mkdtemp, readFile, rm } from "fs/promises";
-import { dirname, join, resolve } from "path";
+import { appendFile, mkdir, readFile, rm } from "fs/promises";
+import { join, resolve } from "path";
 
 import { resolveWikiGraphJobsDirectoryPath } from "../common/wiki-graph-dir.js";
 import { openSharedStateDatabase } from "../document/index.js";
 import type { Database } from "../document/index.js";
-import {
-  readPathSize,
-  removeDisposableChildDirectories,
-  removeDisposableDirectory,
-} from "../gc/files.js";
+import { readPathSize, removeDisposableChildDirectories } from "../gc/files.js";
 import type { GcContext, GcJobResult } from "../gc/index.js";
 
 export const BUILD_JOB_STATES = [
@@ -58,6 +54,7 @@ export interface BuildJobTokenUsage {
 export interface BuildJob {
   readonly archiveKey: string;
   readonly archivePath: string;
+  readonly cachePath: string;
   readonly chapterId: number;
   readonly createdAt: number;
   readonly currentStep?: BuildJobTarget;
@@ -66,6 +63,7 @@ export interface BuildJob {
   readonly finishedAt?: number;
   readonly jobId: string;
   readonly inputRevision?: number;
+  readonly logPath: string;
   readonly llmJSON?: string;
   readonly ownerId?: string;
   readonly ownerPid?: number;
@@ -207,6 +205,8 @@ CREATE TABLE IF NOT EXISTS build_jobs (
   state TEXT NOT NULL,
   queue_rank INTEGER NOT NULL,
   workspace_path TEXT NOT NULL,
+  cache_path TEXT NOT NULL,
+  log_path TEXT NOT NULL,
   events_path TEXT NOT NULL,
   input_revision INTEGER,
   llm_json TEXT,
@@ -276,7 +276,9 @@ export async function addBuildJob(
       }
 
       const jobId = options.jobId ?? randomUUID();
-      const workspacePath = await createJobWorkspacePath(archiveKey, jobId);
+      const workspacePath = await createJobWorkspacePath(jobId);
+      const cachePath = await createJobCachePath(jobId);
+      const logPath = await createJobLogPath(jobId);
       const eventsPath = await createJobEventsPath(jobId);
       const queueRank =
         options.boost === true
@@ -287,8 +289,9 @@ export async function addBuildJob(
         `
 INSERT INTO build_jobs (
   job_id, archive_key, archive_path, chapter_id, target, state, queue_rank,
-  workspace_path, events_path, llm_json, prompt, created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, 'queued', ?, ?, ?, ?, ?, ?, ?)
+  workspace_path, cache_path, log_path, events_path, llm_json, prompt,
+  created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, 'queued', ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `,
         [
           jobId,
@@ -298,6 +301,8 @@ INSERT INTO build_jobs (
           options.target,
           queueRank,
           workspacePath,
+          cachePath,
+          logPath,
           eventsPath,
           options.llmJSON ?? null,
           options.prompt ?? null,
@@ -927,6 +932,8 @@ WHERE state IN (${placeholders})
 
     for (const job of jobs) {
       await rm(job.workspacePath, { force: true, recursive: true });
+      await rm(job.cachePath, { force: true, recursive: true });
+      await rm(job.logPath, { force: true, recursive: true });
       await rm(job.eventsPath, { force: true });
       await state.run("DELETE FROM build_jobs WHERE job_id = ?", [job.jobId]);
     }
@@ -968,12 +975,13 @@ WHERE state IN ('succeeded', 'failed', 'canceled')
 
     for (const job of jobs) {
       freedBytes += await readPathSize(job.workspacePath);
+      freedBytes += await readPathSize(job.cachePath);
+      freedBytes += await readPathSize(job.logPath);
       freedBytes += await readPathSize(job.eventsPath);
       if (!context.dryRun) {
         await rm(job.workspacePath, { force: true, recursive: true });
-        freedBytes += await removeDisposableDirectory(
-          dirname(job.workspacePath),
-        );
+        await rm(job.cachePath, { force: true, recursive: true });
+        await rm(job.logPath, { force: true, recursive: true });
         await rm(job.eventsPath, { force: true });
         await state.run("DELETE FROM build_jobs WHERE job_id = ?", [job.jobId]);
       }
@@ -1474,13 +1482,10 @@ async function readMinQueueRank(state: Database): Promise<number> {
 }
 
 async function openBuildQueueDatabase(): Promise<Database> {
-  const database = await openSharedStateDatabase(
+  return await openSharedStateDatabase(
     getBuildQueueDatabasePath(),
     BUILD_QUEUE_SCHEMA_SQL,
   );
-
-  await migrateBuildQueueSchema(database);
-  return database;
 }
 
 async function openReadonlyBuildQueueDatabase(): Promise<Database> {
@@ -1491,50 +1496,37 @@ function getBuildQueueDatabasePath(): string {
   return join(getBuildQueueStateDirectoryPath(), "job.sqlite");
 }
 
-async function migrateBuildQueueSchema(database: Database): Promise<void> {
-  if ((await listTableColumns(database, "build_jobs")).has("input_revision")) {
-    return;
-  }
+async function createJobWorkspacePath(jobId: string): Promise<string> {
+  const workspacePath = join(getBuildJobWorkspaceRootPath(), jobId);
 
-  await database.transaction(async () => {
-    const columns = await listTableColumns(database, "build_jobs");
-
-    if (columns.has("input_revision")) {
-      return;
-    }
-
-    await database.run(`
-      ALTER TABLE build_jobs
-      ADD COLUMN input_revision INTEGER
-    `);
-  });
-}
-
-async function listTableColumns(
-  database: Database,
-  table: string,
-): Promise<ReadonlySet<string>> {
-  const rows = await database.queryAll(
-    `PRAGMA table_info(${table})`,
-    undefined,
-    (row) => getString(row, "name"),
-  );
-
-  return new Set(rows);
-}
-
-async function createJobWorkspacePath(
-  archiveKey: string,
-  jobId: string,
-): Promise<string> {
-  const rootPath = join(getBuildJobWorkspaceRootPath(), archiveKey);
-
-  await mkdir(rootPath, { recursive: true });
-  return await mkdtemp(join(rootPath, `${jobId}-`));
+  await mkdir(workspacePath, { recursive: true });
+  return workspacePath;
 }
 
 function getBuildJobWorkspaceRootPath(): string {
   return join(getBuildQueueStateDirectoryPath(), "work");
+}
+
+async function createJobCachePath(jobId: string): Promise<string> {
+  const cachePath = join(getBuildJobCacheRootPath(), jobId);
+
+  await mkdir(cachePath, { recursive: true });
+  return cachePath;
+}
+
+function getBuildJobCacheRootPath(): string {
+  return join(getBuildQueueStateDirectoryPath(), "cache");
+}
+
+async function createJobLogPath(jobId: string): Promise<string> {
+  const logPath = join(getBuildJobLogRootPath(), jobId);
+
+  await mkdir(logPath, { recursive: true });
+  return logPath;
+}
+
+function getBuildJobLogRootPath(): string {
+  return join(getBuildQueueStateDirectoryPath(), "logs");
 }
 
 async function createJobEventsPath(jobId: string): Promise<string> {
@@ -1571,6 +1563,7 @@ function mapBuildJob(row: Record<string, unknown>): BuildJob {
   return {
     archiveKey: getString(row, "archive_key"),
     archivePath: getString(row, "archive_path"),
+    cachePath: getString(row, "cache_path"),
     chapterId: getNumber(row, "chapter_id"),
     createdAt: getNumber(row, "created_at"),
     ...(currentStep === undefined ? {} : { currentStep }),
@@ -1579,6 +1572,7 @@ function mapBuildJob(row: Record<string, unknown>): BuildJob {
     ...(finishedAt === undefined ? {} : { finishedAt }),
     jobId: getString(row, "job_id"),
     ...(inputRevision === undefined ? {} : { inputRevision }),
+    logPath: getString(row, "log_path"),
     ...(llmJSON === undefined ? {} : { llmJSON }),
     ...(ownerId === undefined ? {} : { ownerId }),
     ...(ownerPid === undefined ? {} : { ownerPid }),

--- a/src/facade/chapter-build.ts
+++ b/src/facade/chapter-build.ts
@@ -445,10 +445,10 @@ async function buildSummaryFromSnapshot(
 
   const document = new SummaryInputSnapshotDocument(snapshot);
   const fragments = document.getSerialFragments(chapterId);
-  const fragmentIds = await fragments.listFragmentIds();
+  const sentenceStartIndexes = await fragments.listFragmentIds();
 
-  if (fragmentIds.length <= 1) {
-    return await readPassthroughSummary(fragments, fragmentIds);
+  if (sentenceStartIndexes.length <= 1) {
+    return await readPassthroughSummary(fragments, sentenceStartIndexes);
   }
 
   const summaryParts: string[] = [];
@@ -499,10 +499,10 @@ async function buildSummaryFromDocument(
   }
 
   const fragments = document.getSerialFragments(chapterId);
-  const fragmentIds = await fragments.listFragmentIds();
+  const sentenceStartIndexes = await fragments.listFragmentIds();
 
-  if (fragmentIds.length <= 1) {
-    return await readPassthroughSummary(fragments, fragmentIds);
+  if (sentenceStartIndexes.length <= 1) {
+    return await readPassthroughSummary(fragments, sentenceStartIndexes);
   }
 
   const summaryParts: string[] = [];
@@ -538,15 +538,16 @@ async function buildSummaryFromDocument(
 
 async function readPassthroughSummary(
   fragments: ReadonlySerialFragments,
-  fragmentIds: readonly number[],
+  sentenceStartIndexes: readonly number[],
 ): Promise<string> {
-  if (fragmentIds.length === 0) {
+  if (sentenceStartIndexes.length === 0) {
     return "";
   }
 
   const records = await Promise.all(
-    fragmentIds.map(
-      async (fragmentId) => await fragments.getFragment(fragmentId),
+    sentenceStartIndexes.map(
+      async (startSentenceIndex) =>
+        await fragments.getFragment(startSentenceIndex),
     ),
   );
 
@@ -947,20 +948,20 @@ class SnapshotChunkStore implements ReadonlyChunkStore {
     return Promise.resolve([...this.#chunks]);
   }
 
-  public listByFragments(
+  public listBySentenceStartIndexes(
     serialId: number,
-    fragmentIds: readonly number[],
+    sentenceStartIndexes: readonly number[],
   ): Promise<ChunkRecord[]> {
-    const fragmentRanges = createFragmentRanges(
+    const segmentRanges = createSegmentRanges(
       this.#fragmentStartIndexesBySerialId.get(serialId) ?? [],
-      fragmentIds,
+      sentenceStartIndexes,
     );
 
     return Promise.resolve(
       this.#chunks.filter(
         (chunk) =>
           chunk.sentenceId[0] === serialId &&
-          fragmentRanges.some(
+          segmentRanges.some(
             (range) =>
               chunk.sentenceId[1] >= range.startSentenceIndex &&
               chunk.sentenceId[1] <= range.endSentenceIndex,
@@ -1368,7 +1369,7 @@ function createFragmentStartIndexesBySerialId(
   );
 }
 
-function createFragmentRanges(
+function createSegmentRanges(
   allStartIndexes: readonly number[],
   selectedStartIndexes: readonly number[],
 ): Array<{

--- a/src/facade/chapter-build.ts
+++ b/src/facade/chapter-build.ts
@@ -655,7 +655,7 @@ class SummaryInputSnapshotDocument implements ReadonlyDocument {
   public constructor(snapshot: SummaryInputSnapshotData) {
     const serialId = snapshot.serial.id;
 
-    this.chunks = new SnapshotChunkStore(snapshot.chunks);
+    this.chunks = new SnapshotChunkStore(snapshot.chunks, snapshot.fragments);
     this.fragmentGroups = new SnapshotFragmentGroupStore(
       snapshot.fragmentGroups,
     );
@@ -920,10 +920,19 @@ class SnapshotSerialFragments implements ReadonlySerialFragments {
 class SnapshotChunkStore implements ReadonlyChunkStore {
   readonly #chunks: readonly ChunkRecord[];
   readonly #chunksById: Map<number, ChunkRecord>;
+  readonly #fragmentStartIndexesBySerialId: ReadonlyMap<
+    number,
+    readonly number[]
+  >;
 
-  public constructor(chunks: readonly ChunkRecord[]) {
+  public constructor(
+    chunks: readonly ChunkRecord[],
+    fragments: readonly FragmentRecord[],
+  ) {
     this.#chunks = [...chunks].sort(compareChunkById);
     this.#chunksById = new Map(chunks.map((chunk) => [chunk.id, chunk]));
+    this.#fragmentStartIndexesBySerialId =
+      createFragmentStartIndexesBySerialId(fragments);
   }
 
   public getById(chunkId: number): Promise<ChunkRecord | undefined> {
@@ -942,13 +951,20 @@ class SnapshotChunkStore implements ReadonlyChunkStore {
     serialId: number,
     fragmentIds: readonly number[],
   ): Promise<ChunkRecord[]> {
-    const fragmentIdSet = new Set(fragmentIds);
+    const fragmentRanges = createFragmentRanges(
+      this.#fragmentStartIndexesBySerialId.get(serialId) ?? [],
+      fragmentIds,
+    );
 
     return Promise.resolve(
       this.#chunks.filter(
         (chunk) =>
           chunk.sentenceId[0] === serialId &&
-          fragmentIdSet.has(chunk.sentenceId[1]),
+          fragmentRanges.some(
+            (range) =>
+              chunk.sentenceId[1] >= range.startSentenceIndex &&
+              chunk.sentenceId[1] <= range.endSentenceIndex,
+          ),
       ),
     );
   }
@@ -1331,6 +1347,53 @@ async function collectReaderText(
 
 function compareNumber(left: number, right: number): number {
   return left - right;
+}
+
+function createFragmentStartIndexesBySerialId(
+  fragments: readonly FragmentRecord[],
+): ReadonlyMap<number, readonly number[]> {
+  const indexesBySerialId = new Map<number, number[]>();
+
+  for (const fragment of fragments) {
+    const indexes = indexesBySerialId.get(fragment.serialId) ?? [];
+
+    indexes.push(fragment.fragmentId);
+    indexesBySerialId.set(fragment.serialId, indexes);
+  }
+
+  return new Map(
+    [...indexesBySerialId.entries()].map(
+      ([serialId, indexes]) => [serialId, indexes.sort(compareNumber)] as const,
+    ),
+  );
+}
+
+function createFragmentRanges(
+  allStartIndexes: readonly number[],
+  selectedStartIndexes: readonly number[],
+): Array<{
+  readonly endSentenceIndex: number;
+  readonly startSentenceIndex: number;
+}> {
+  const selected = new Set(selectedStartIndexes);
+
+  return allStartIndexes.flatMap((startSentenceIndex, index) => {
+    if (!selected.has(startSentenceIndex)) {
+      return [];
+    }
+
+    const nextStartSentenceIndex = allStartIndexes[index + 1];
+
+    return [
+      {
+        endSentenceIndex:
+          nextStartSentenceIndex === undefined
+            ? Infinity
+            : nextStartSentenceIndex - 1,
+        startSentenceIndex,
+      },
+    ];
+  });
 }
 
 function compareChunkById(left: ChunkRecord, right: ChunkRecord): number {

--- a/src/gc/files.ts
+++ b/src/gc/files.ts
@@ -103,6 +103,53 @@ export async function removeDisposableChildDirectories(
   return { freedBytes, removed, scanned };
 }
 
+export async function removeDisposableDescendantDirectories(
+  rootPath: string,
+): Promise<{
+  readonly freedBytes: number;
+  readonly removed: number;
+  readonly scanned: number;
+}> {
+  const entries = await readdir(rootPath, { withFileTypes: true }).catch(
+    (error: unknown) => {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return [];
+      }
+
+      throw error;
+    },
+  );
+  let freedBytes = 0;
+  let removed = 0;
+  let scanned = 0;
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const directoryPath = join(rootPath, entry.name);
+    const childResult =
+      await removeDisposableDescendantDirectories(directoryPath);
+
+    freedBytes += childResult.freedBytes;
+    removed += childResult.removed;
+    scanned += childResult.scanned + 1;
+
+    const removedBytes = await removeDisposableDirectory(directoryPath);
+
+    if (await pathExists(directoryPath)) {
+      freedBytes += removedBytes;
+      continue;
+    }
+
+    freedBytes += removedBytes;
+    removed += 1;
+  }
+
+  return { freedBytes, removed, scanned };
+}
+
 export async function readPathSize(path: string): Promise<number> {
   try {
     const stats = await stat(path);

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -291,11 +291,13 @@ export class LLM<S extends string> {
         await requestLog.append(
           `[[Response]] (from cache):\n${cachedResponse}\n\n`,
         );
+        await requestLog.append(formatRequestResultLog("cache-hit"));
         return cachedResponse;
       }
     }
 
     let response: string | undefined;
+    let tokenUsage: LanguageModelUsage | undefined;
     let lastError: unknown;
 
     for (let attempt = 0; attempt <= this.#retryTimes; attempt += 1) {
@@ -337,12 +339,15 @@ export class LLM<S extends string> {
               textChunks.push(chunk);
               await this.#emitStreamProgress(chunk.length);
             }
-            await this.#emitTokenUsage(await result.totalUsage);
+            tokenUsage = await result.totalUsage;
+            await this.#emitTokenUsage(tokenUsage);
             return textChunks.join("");
           } else {
             const result = await generateText(generationInput);
+
+            tokenUsage = result.usage;
             await this.#emitStreamProgress(result.text.length);
-            await this.#emitTokenUsage(result.usage);
+            await this.#emitTokenUsage(tokenUsage);
             return result.text;
           }
         });
@@ -360,11 +365,13 @@ export class LLM<S extends string> {
           await requestLog.append(
             `[[Error]]:\n${formatError(paymentError)}\n\n`,
           );
+          await requestLog.append(formatRequestResultLog(tokenUsage, error));
           throw paymentError;
         }
 
         if (!isRetryableError(error)) {
           await requestLog.append(`[[Error]]:\n${formatError(error)}\n\n`);
+          await requestLog.append(formatRequestResultLog(tokenUsage, error));
           throw error;
         }
 
@@ -387,6 +394,7 @@ export class LLM<S extends string> {
           : `LLM request failed after ${this.#retryTimes + 1} attempts: ${formatError(lastError)}`;
 
       await requestLog.append(`[[Error]]:\n${failureMessage}\n\n`);
+      await requestLog.append(formatRequestResultLog(tokenUsage, lastError));
 
       throw new Error(failureMessage, {
         ...(lastError === undefined ? {} : { cause: lastError }),
@@ -406,6 +414,7 @@ export class LLM<S extends string> {
       }
     }
 
+    await requestLog.append(formatRequestResultLog(tokenUsage));
     return response;
   }
 
@@ -595,6 +604,49 @@ function formatRequestMessages(messages: readonly LLMessage[]): string {
     .join("\n\n");
 
   return `[[Request]]:\n${body}\n\n`;
+}
+
+function formatRequestResultLog(
+  usage: LanguageModelUsage | "cache-hit" | undefined,
+  error?: unknown,
+): string {
+  return [
+    formatRequestUsageLog(usage),
+    ...(error === undefined ? [] : [formatRequestErrorStackLog(error)]),
+  ].join("");
+}
+
+function formatRequestUsageLog(
+  usage: LanguageModelUsage | "cache-hit" | undefined,
+): string {
+  if (usage === "cache-hit") {
+    return "[[Usage]]:\ncache-hit\n\n";
+  }
+
+  return [
+    "[[Usage]]:",
+    `input: ${formatTokenCount(usage?.inputTokens)}`,
+    `cache: ${formatTokenCount(usage?.inputTokenDetails.cacheReadTokens)}`,
+    `output: ${formatTokenCount(usage?.outputTokens)}`,
+    "",
+    "",
+  ].join("\n");
+}
+
+function formatTokenCount(value: number | undefined): string {
+  return value === undefined ? "unavailable" : String(value);
+}
+
+function formatRequestErrorStackLog(error: unknown): string {
+  return `[[Error Stack]]:\n${formatErrorStack(error)}\n\n`;
+}
+
+function formatErrorStack(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack ?? formatError(error);
+  }
+
+  return formatError(error);
 }
 
 function formatMessageContent(content: LLMessage["content"]): string {

--- a/src/topology/fragment-incision.ts
+++ b/src/topology/fragment-incision.ts
@@ -50,12 +50,24 @@ function computeFragmentIncisions(input: {
   edges: readonly ReadingEdgeRecord[];
   fragmentWordsCounts: Readonly<Record<string, number>>;
 }): FragmentInfo[] {
+  const fragmentIds = Object.keys(input.fragmentWordsCounts)
+    .map(Number)
+    .sort(compareNumber);
   const chunkIdsByFragmentId = createNumberListRecord();
   const chunkWeightsById = createNumberRecord();
   const edgesByChunkId = createReadingEdgeListRecord();
 
   for (const chunk of input.chunks) {
-    const fragmentKey = String(chunk.sentenceId[1]);
+    const fragmentId = findContainingFragmentId(
+      fragmentIds,
+      chunk.sentenceId[1],
+    );
+
+    if (fragmentId === undefined) {
+      continue;
+    }
+
+    const fragmentKey = String(fragmentId);
 
     chunkWeightsById[String(chunk.id)] = chunk.weight;
     if (chunkIdsByFragmentId[fragmentKey] === undefined) {
@@ -85,9 +97,10 @@ function computeFragmentIncisions(input: {
     chunksById[String(chunk.id)] = chunk;
   }
 
-  return Object.keys(chunkIdsByFragmentId)
-    .map(Number)
-    .sort(compareNumber)
+  return fragmentIds
+    .filter(
+      (fragmentId) => chunkIdsByFragmentId[String(fragmentId)] !== undefined,
+    )
     .map((fragmentId) => {
       const chunkIds = chunkIdsByFragmentId[String(fragmentId)] ?? [];
       let endIncision = 0;
@@ -109,7 +122,10 @@ function computeFragmentIncisions(input: {
             }
 
             return {
-              otherFragmentId: otherChunk.sentenceId[1],
+              otherFragmentId: findContainingFragmentId(
+                fragmentIds,
+                otherChunk.sentenceId[1],
+              ),
               weight: edge.weight,
             };
           })
@@ -119,7 +135,10 @@ function computeFragmentIncisions(input: {
             ): edge is {
               otherFragmentId: number;
               weight: number;
-            } => edge !== undefined && edge.otherFragmentId !== fragmentId,
+            } =>
+              edge !== undefined &&
+              edge.otherFragmentId !== undefined &&
+              edge.otherFragmentId !== fragmentId,
           );
 
         if (externalEdges.length === 0) {
@@ -154,6 +173,23 @@ function computeFragmentIncisions(input: {
         wordsCount: input.fragmentWordsCounts[String(fragmentId)] ?? 0,
       };
     });
+}
+
+function findContainingFragmentId(
+  fragmentIds: readonly number[],
+  sentenceIndex: number,
+): number | undefined {
+  let containingFragmentId: number | undefined;
+
+  for (const fragmentId of fragmentIds) {
+    if (fragmentId > sentenceIndex) {
+      break;
+    }
+
+    containingFragmentId = fragmentId;
+  }
+
+  return containingFragmentId;
 }
 
 function normalizeIncisions(

--- a/src/topology/grouping.ts
+++ b/src/topology/grouping.ts
@@ -1,24 +1,24 @@
 import type { SentenceGroupRecord } from "../document/index.js";
-import { computeNormalizedFragmentIncisions } from "./fragment-incision.js";
-import { createFragmentGroups } from "./resource-segmentation.js";
+import { computeNormalizedSegmentIncisions } from "./segment-incision.js";
+import { createSegmentGroups } from "./resource-segmentation.js";
 
-export async function groupFragments(input: {
-  edges: Parameters<typeof computeNormalizedFragmentIncisions>[0]["edges"];
+export async function groupSegments(input: {
+  edges: Parameters<typeof computeNormalizedSegmentIncisions>[0]["edges"];
   fragments: Parameters<
-    typeof computeNormalizedFragmentIncisions
+    typeof computeNormalizedSegmentIncisions
   >[0]["fragments"];
   groupWordsCount: number;
-  chunks: Parameters<typeof computeNormalizedFragmentIncisions>[0]["chunks"];
+  chunks: Parameters<typeof computeNormalizedSegmentIncisions>[0]["chunks"];
   serialId: number;
 }): Promise<SentenceGroupRecord[]> {
-  const fragmentInfos = await computeNormalizedFragmentIncisions({
+  const segmentInfos = await computeNormalizedSegmentIncisions({
     chunks: input.chunks,
     edges: input.edges,
     fragments: input.fragments,
   });
 
-  return createFragmentGroups({
-    fragmentInfos,
+  return createSegmentGroups({
+    segmentInfos,
     groupWordsCount: input.groupWordsCount,
     serialId: input.serialId,
   });

--- a/src/topology/resource-segmentation.ts
+++ b/src/topology/resource-segmentation.ts
@@ -1,53 +1,53 @@
 import type { SentenceGroupRecord } from "../document/index.js";
-import type { FragmentInfo } from "./fragment-incision.js";
+import type { SegmentInfo } from "./segment-incision.js";
 
-interface FragmentResource {
+interface SegmentResource {
   readonly count: number;
   readonly startIncision: number;
   readonly endIncision: number;
-  readonly fragmentId: number;
+  readonly startSentenceIndex: number;
 }
 
-export function createFragmentGroups(input: {
-  fragmentInfos: readonly FragmentInfo[];
+export function createSegmentGroups(input: {
+  segmentInfos: readonly SegmentInfo[];
   groupWordsCount: number;
   serialId: number;
 }): SentenceGroupRecord[] {
-  if (input.fragmentInfos.length === 0) {
+  if (input.segmentInfos.length === 0) {
     return [];
   }
 
-  const resources = input.fragmentInfos.map(
-    (fragmentInfo): FragmentResource => ({
-      count: fragmentInfo.wordsCount,
-      endIncision: fragmentInfo.endIncision,
-      fragmentId: fragmentInfo.fragmentId,
-      startIncision: fragmentInfo.startIncision,
+  const resources = input.segmentInfos.map(
+    (segmentInfo): SegmentResource => ({
+      count: segmentInfo.wordsCount,
+      endIncision: segmentInfo.endIncision,
+      startSentenceIndex: segmentInfo.startSentenceIndex,
+      startIncision: segmentInfo.startIncision,
     }),
   );
-  const groups = allocateFragmentGroups(resources, input.groupWordsCount);
+  const groups = allocateSegmentGroups(resources, input.groupWordsCount);
 
-  return groups.map((fragmentIds, groupId) => ({
-    endSentenceIndex: Math.max(...fragmentIds),
+  return groups.map((startSentenceIndexes, groupId) => ({
+    endSentenceIndex: Math.max(...startSentenceIndexes),
     groupId,
     serialId: input.serialId,
-    startSentenceIndex: Math.min(...fragmentIds),
+    startSentenceIndex: Math.min(...startSentenceIndexes),
   }));
 }
 
-function allocateFragmentGroups(
-  resources: readonly FragmentResource[],
+function allocateSegmentGroups(
+  resources: readonly SegmentResource[],
   maxCount: number,
 ): number[][] {
   return splitResources(resources, maxCount).map((group) =>
-    group.map((resource) => resource.fragmentId),
+    group.map((resource) => resource.startSentenceIndex),
   );
 }
 
 function splitResources(
-  resources: readonly FragmentResource[],
+  resources: readonly SegmentResource[],
   maxCount: number,
-): FragmentResource[][] {
+): SegmentResource[][] {
   if (resources.length === 0) {
     return [];
   }
@@ -89,7 +89,7 @@ function splitResources(
 }
 
 function findPreferredSplitIndex(
-  resources: readonly FragmentResource[],
+  resources: readonly SegmentResource[],
   maxCount: number,
 ): number | undefined {
   const totalCount = resources.reduce((total, resource) => {
@@ -140,11 +140,11 @@ function findPreferredSplitIndex(
 }
 
 function splitGreedily(
-  resources: readonly FragmentResource[],
+  resources: readonly SegmentResource[],
   maxCount: number,
-): FragmentResource[][] {
-  const groups: FragmentResource[][] = [];
-  let currentGroup: FragmentResource[] = [];
+): SegmentResource[][] {
+  const groups: SegmentResource[][] = [];
+  let currentGroup: SegmentResource[] = [];
   let currentCount = 0;
 
   for (const resource of resources) {

--- a/src/topology/segment-incision.ts
+++ b/src/topology/segment-incision.ts
@@ -4,39 +4,39 @@ import type {
   ReadonlySerialFragments,
 } from "../document/index.js";
 
-export interface FragmentInfo {
-  readonly fragmentId: number;
+export interface SegmentInfo {
+  readonly startSentenceIndex: number;
   readonly wordsCount: number;
   readonly startIncision: number;
   readonly endIncision: number;
 }
 
-export async function computeNormalizedFragmentIncisions(input: {
+export async function computeNormalizedSegmentIncisions(input: {
   chunks: readonly ChunkRecord[];
   edges: readonly ReadingEdgeRecord[];
   fragments: ReadonlySerialFragments;
-}): Promise<FragmentInfo[]> {
-  const fragmentWordsCounts = await loadFragmentWordsCounts(input.fragments);
+}): Promise<SegmentInfo[]> {
+  const segmentWordsCounts = await loadSegmentWordsCounts(input.fragments);
 
   return normalizeIncisions(
-    computeFragmentIncisions({
+    computeSegmentIncisions({
       chunks: input.chunks,
       edges: input.edges,
-      fragmentWordsCounts,
+      segmentWordsCounts,
     }),
   );
 }
 
-async function loadFragmentWordsCounts(
+async function loadSegmentWordsCounts(
   fragments: ReadonlySerialFragments,
 ): Promise<Readonly<Record<string, number>>> {
   const wordsCounts = createNumberRecord();
-  const fragmentIds = await fragments.listFragmentIds();
+  const startSentenceIndexes = await fragments.listFragmentIds();
 
-  for (const fragmentId of fragmentIds) {
-    const fragment = await fragments.getFragment(fragmentId);
+  for (const startSentenceIndex of startSentenceIndexes) {
+    const segment = await fragments.getFragment(startSentenceIndex);
 
-    wordsCounts[String(fragmentId)] = fragment.sentences.reduce(
+    wordsCounts[String(startSentenceIndex)] = segment.sentences.reduce(
       (total, sentence) => total + sentence.wordsCount,
       0,
     );
@@ -45,35 +45,35 @@ async function loadFragmentWordsCounts(
   return wordsCounts;
 }
 
-function computeFragmentIncisions(input: {
+function computeSegmentIncisions(input: {
   chunks: readonly ChunkRecord[];
   edges: readonly ReadingEdgeRecord[];
-  fragmentWordsCounts: Readonly<Record<string, number>>;
-}): FragmentInfo[] {
-  const fragmentIds = Object.keys(input.fragmentWordsCounts)
+  segmentWordsCounts: Readonly<Record<string, number>>;
+}): SegmentInfo[] {
+  const startSentenceIndexes = Object.keys(input.segmentWordsCounts)
     .map(Number)
     .sort(compareNumber);
-  const chunkIdsByFragmentId = createNumberListRecord();
+  const chunkIdsBySegmentStartIndex = createNumberListRecord();
   const chunkWeightsById = createNumberRecord();
   const edgesByChunkId = createReadingEdgeListRecord();
 
   for (const chunk of input.chunks) {
-    const fragmentId = findContainingFragmentId(
-      fragmentIds,
+    const startSentenceIndex = findContainingSegmentStartIndex(
+      startSentenceIndexes,
       chunk.sentenceId[1],
     );
 
-    if (fragmentId === undefined) {
+    if (startSentenceIndex === undefined) {
       continue;
     }
 
-    const fragmentKey = String(fragmentId);
+    const segmentKey = String(startSentenceIndex);
 
     chunkWeightsById[String(chunk.id)] = chunk.weight;
-    if (chunkIdsByFragmentId[fragmentKey] === undefined) {
-      chunkIdsByFragmentId[fragmentKey] = [];
+    if (chunkIdsBySegmentStartIndex[segmentKey] === undefined) {
+      chunkIdsBySegmentStartIndex[segmentKey] = [];
     }
-    chunkIdsByFragmentId[fragmentKey]?.push(chunk.id);
+    chunkIdsBySegmentStartIndex[segmentKey]?.push(chunk.id);
   }
 
   for (const edge of input.edges) {
@@ -97,12 +97,14 @@ function computeFragmentIncisions(input: {
     chunksById[String(chunk.id)] = chunk;
   }
 
-  return fragmentIds
+  return startSentenceIndexes
     .filter(
-      (fragmentId) => chunkIdsByFragmentId[String(fragmentId)] !== undefined,
+      (startSentenceIndex) =>
+        chunkIdsBySegmentStartIndex[String(startSentenceIndex)] !== undefined,
     )
-    .map((fragmentId) => {
-      const chunkIds = chunkIdsByFragmentId[String(fragmentId)] ?? [];
+    .map((startSentenceIndex) => {
+      const chunkIds =
+        chunkIdsBySegmentStartIndex[String(startSentenceIndex)] ?? [];
       let endIncision = 0;
       let startIncision = 0;
 
@@ -122,8 +124,8 @@ function computeFragmentIncisions(input: {
             }
 
             return {
-              otherFragmentId: findContainingFragmentId(
-                fragmentIds,
+              otherSegmentStartIndex: findContainingSegmentStartIndex(
+                startSentenceIndexes,
                 otherChunk.sentenceId[1],
               ),
               weight: edge.weight,
@@ -133,12 +135,12 @@ function computeFragmentIncisions(input: {
             (
               edge,
             ): edge is {
-              otherFragmentId: number;
+              otherSegmentStartIndex: number;
               weight: number;
             } =>
               edge !== undefined &&
-              edge.otherFragmentId !== undefined &&
-              edge.otherFragmentId !== fragmentId,
+              edge.otherSegmentStartIndex !== undefined &&
+              edge.otherSegmentStartIndex !== startSentenceIndex,
           );
 
         if (externalEdges.length === 0) {
@@ -157,7 +159,7 @@ function computeFragmentIncisions(input: {
         for (const edge of externalEdges) {
           const halfWeight = (chunkWeight / totalExternalWeight) * edge.weight;
 
-          if (edge.otherFragmentId < fragmentId) {
+          if (edge.otherSegmentStartIndex < startSentenceIndex) {
             startIncision += halfWeight;
             continue;
           }
@@ -168,43 +170,43 @@ function computeFragmentIncisions(input: {
 
       return {
         endIncision,
-        fragmentId,
+        startSentenceIndex,
         startIncision,
-        wordsCount: input.fragmentWordsCounts[String(fragmentId)] ?? 0,
+        wordsCount: input.segmentWordsCounts[String(startSentenceIndex)] ?? 0,
       };
     });
 }
 
-function findContainingFragmentId(
-  fragmentIds: readonly number[],
+function findContainingSegmentStartIndex(
+  startSentenceIndexes: readonly number[],
   sentenceIndex: number,
 ): number | undefined {
-  let containingFragmentId: number | undefined;
+  let containingSegmentStartIndex: number | undefined;
 
-  for (const fragmentId of fragmentIds) {
-    if (fragmentId > sentenceIndex) {
+  for (const startSentenceIndex of startSentenceIndexes) {
+    if (startSentenceIndex > sentenceIndex) {
       break;
     }
 
-    containingFragmentId = fragmentId;
+    containingSegmentStartIndex = startSentenceIndex;
   }
 
-  return containingFragmentId;
+  return containingSegmentStartIndex;
 }
 
 function normalizeIncisions(
-  fragmentInfos: readonly FragmentInfo[],
-): FragmentInfo[] {
-  const allIncisions = fragmentInfos
-    .flatMap((fragmentInfo) => [
-      fragmentInfo.startIncision,
-      fragmentInfo.endIncision,
+  segmentInfos: readonly SegmentInfo[],
+): SegmentInfo[] {
+  const allIncisions = segmentInfos
+    .flatMap((segmentInfo) => [
+      segmentInfo.startIncision,
+      segmentInfo.endIncision,
     ])
     .filter((incision) => incision > 0)
     .sort(compareNumber);
 
   if (allIncisions.length === 0) {
-    return [...fragmentInfos];
+    return [...segmentInfos];
   }
 
   const thresholdIndex = Math.min(
@@ -215,10 +217,10 @@ function normalizeIncisions(
   const normalValues = allIncisions.filter((incision) => incision < threshold);
 
   if (normalValues.length === 0) {
-    return fragmentInfos.map((fragmentInfo) => ({
-      ...fragmentInfo,
-      endIncision: fragmentInfo.endIncision > 0 ? 10 : 0,
-      startIncision: fragmentInfo.startIncision > 0 ? 10 : 0,
+    return segmentInfos.map((segmentInfo) => ({
+      ...segmentInfo,
+      endIncision: segmentInfo.endIncision > 0 ? 10 : 0,
+      startIncision: segmentInfo.startIncision > 0 ? 10 : 0,
     }));
   }
 
@@ -228,14 +230,14 @@ function normalizeIncisions(
   const maxLog = maxValue > 0 ? Math.log(maxValue) : 0;
   const logRange = maxLog - minLog === 0 ? 1 : maxLog - minLog;
 
-  return fragmentInfos.map((fragmentInfo) => ({
-    ...fragmentInfo,
-    endIncision: normalizeIncision(fragmentInfo.endIncision, {
+  return segmentInfos.map((segmentInfo) => ({
+    ...segmentInfo,
+    endIncision: normalizeIncision(segmentInfo.endIncision, {
       logRange,
       minLog,
       threshold,
     }),
-    startIncision: normalizeIncision(fragmentInfo.startIncision, {
+    startIncision: normalizeIncision(segmentInfo.startIncision, {
       logRange,
       minLog,
       threshold,

--- a/src/topology/topology.ts
+++ b/src/topology/topology.ts
@@ -5,7 +5,7 @@ import type {
   SentenceGroupRecord,
 } from "../document/index.js";
 import type { ReaderChunk, ReaderGraphDelta } from "../reader/index.js";
-import { groupFragments } from "./grouping.js";
+import { groupSegments } from "./grouping.js";
 import { buildSnakeGraph } from "./snake-graph-builder.js";
 import {
   detectSnakesInComponent,
@@ -79,7 +79,7 @@ export class Topology {
       ...edge,
       weight: edgeWeights[getReadingEdgeKey(edge.fromId, edge.toId)] ?? 0,
     }));
-    const fragmentGroups = await groupFragments({
+    const sentenceGroups = await groupSegments({
       chunks: weightedChunks,
       edges: weightedEdges,
       fragments: this.#document.getSerialFragments(this.#serialId),
@@ -89,7 +89,7 @@ export class Topology {
     const snakeTopology = buildSnakeTopology({
       chunks: weightedChunks,
       edges: weightedEdges,
-      fragmentGroups,
+      sentenceGroups,
       serialId: this.#serialId,
     });
 
@@ -132,7 +132,7 @@ export class Topology {
       });
     }
 
-    await this.#document.fragmentGroups.saveMany(fragmentGroups);
+    await this.#document.fragmentGroups.saveMany(sentenceGroups);
 
     const snakeIds: number[] = [];
 
@@ -287,7 +287,7 @@ interface SnakeEdgeDraft {
 function buildSnakeTopology(input: {
   chunks: readonly ChunkRecord[];
   edges: readonly ReadingEdgeRecord[];
-  fragmentGroups: readonly SentenceGroupRecord[];
+  sentenceGroups: readonly SentenceGroupRecord[];
   serialId: number;
 }): {
   readonly snakeChunks: readonly SnakeChunkDraft[];
@@ -303,12 +303,12 @@ function buildSnakeTopology(input: {
     readonly startSentenceIndex: number;
   }> = [];
 
-  for (const fragmentGroup of input.fragmentGroups) {
-    if (fragmentGroup.serialId !== input.serialId) {
+  for (const sentenceGroup of input.sentenceGroups) {
+    if (sentenceGroup.serialId !== input.serialId) {
       continue;
     }
 
-    sentenceRangesByGroupId.push(fragmentGroup);
+    sentenceRangesByGroupId.push(sentenceGroup);
   }
 
   for (const chunk of input.chunks) {

--- a/src/wikg/archive.ts
+++ b/src/wikg/archive.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "crypto";
 import { createWriteStream } from "fs";
 import {
   mkdir,
@@ -22,13 +23,17 @@ import { ZipFile as YazlZipFile } from "yazl";
 import { Database } from "../document/database.js";
 
 export const WIKG_FORMAT_VERSION = 1;
+const WIKG_MUTATION_TOKEN_PATH = ".wikg-mutation-token";
 const WIKG_MANIFEST_PATH = "manifest.json";
 const SEARCH_INDEX_DATABASE_PATH = "fts.db";
 const WIKG_MANIFEST_CONTENT = `${JSON.stringify({
   formatVersion: WIKG_FORMAT_VERSION,
 })}\n`;
+const WIKG_MUTATION_TOKEN_MAGIC = "wikg-mutation-token:v1";
+const WIKG_MUTATION_TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/u;
 
 const WIKG_ARCHIVE_PATTERNS = [
+  /^\.wikg-mutation-token$/u,
   /^manifest\.json$/u,
   /^database\.db$/u,
   /^fts\.db$/u,
@@ -158,9 +163,20 @@ export async function writeWikgArchive(
   const includeSearchIndex = await shouldEmbedSearchIndex(
     documentDirectoryPath,
   );
-  const entries = [
+  const entries = sortArchiveEntriesForWrite([
+    {
+      archivePath: WIKG_MUTATION_TOKEN_PATH,
+      content: createWikgMutationTokenContent(),
+    },
+    {
+      archivePath: WIKG_MANIFEST_PATH,
+      content: Buffer.from(WIKG_MANIFEST_CONTENT, "utf8"),
+    },
     ...files.filter((file) => {
       if (file.archivePath === WIKG_MANIFEST_PATH) {
+        return false;
+      }
+      if (file.archivePath === WIKG_MUTATION_TOKEN_PATH) {
         return false;
       }
 
@@ -168,11 +184,7 @@ export async function writeWikgArchive(
         file.archivePath !== SEARCH_INDEX_DATABASE_PATH || includeSearchIndex
       );
     }),
-    {
-      archivePath: WIKG_MANIFEST_PATH,
-      content: Buffer.from(WIKG_MANIFEST_CONTENT, "utf8"),
-    },
-  ].sort((left, right) => left.archivePath.localeCompare(right.archivePath));
+  ]);
 
   for (const entry of entries) {
     if ("content" in entry) {
@@ -221,6 +233,26 @@ export async function readWikgArchiveEntry(
   }
 }
 
+export async function readWikgArchiveMutationToken(
+  inputPath: string,
+): Promise<string> {
+  const reader = await WikgArchiveReader.open(inputPath);
+
+  try {
+    const content = await reader.readEntry(WIKG_MUTATION_TOKEN_PATH);
+
+    if (content === undefined) {
+      throw new Error(
+        `Missing WIKG mutation token: ${WIKG_MUTATION_TOKEN_PATH}.`,
+      );
+    }
+
+    return parseWikgMutationToken(content.toString("utf8"));
+  } finally {
+    reader.close();
+  }
+}
+
 export async function writeWikgArchiveWithOverlays(
   inputPath: string,
   outputPath: string,
@@ -252,17 +284,22 @@ export async function writeWikgArchiveWithOverlays(
       entryPaths.add(archivePath);
     }
   }
+  entryPaths.add(WIKG_MUTATION_TOKEN_PATH);
   entryPaths.add(WIKG_MANIFEST_PATH);
 
   const outputZipFile = new YazlZipFile();
   const sourceFile = await openFile(inputPath, "r");
 
   try {
-    for (const entryPath of [...entryPaths].sort((left, right) =>
-      left.localeCompare(right),
-    )) {
+    for (const entryPath of sortArchiveEntryPathsForWrite(entryPaths)) {
       const overlay = overlayByPath.get(entryPath);
 
+      if (entryPath === WIKG_MUTATION_TOKEN_PATH) {
+        outputZipFile.addBuffer(createWikgMutationTokenContent(), entryPath, {
+          compress: false,
+        });
+        continue;
+      }
       if (entryPath === WIKG_MANIFEST_PATH) {
         outputZipFile.addBuffer(
           Buffer.from(WIKG_MANIFEST_CONTENT, "utf8"),
@@ -431,6 +468,29 @@ function compareDirEntryName(
   return left.name.localeCompare(right.name);
 }
 
+function sortArchiveEntriesForWrite<T extends { readonly archivePath: string }>(
+  entries: readonly T[],
+): T[] {
+  return [...entries].sort((left, right) =>
+    compareArchiveEntryPathsForWrite(left.archivePath, right.archivePath),
+  );
+}
+
+function sortArchiveEntryPathsForWrite(paths: Iterable<string>): string[] {
+  return [...paths].sort(compareArchiveEntryPathsForWrite);
+}
+
+function compareArchiveEntryPathsForWrite(left: string, right: string): number {
+  if (left === WIKG_MUTATION_TOKEN_PATH) {
+    return right === WIKG_MUTATION_TOKEN_PATH ? 0 : -1;
+  }
+  if (right === WIKG_MUTATION_TOKEN_PATH) {
+    return 1;
+  }
+
+  return left.localeCompare(right);
+}
+
 function isWikgArchivePath(archivePath: string): boolean {
   return WIKG_ARCHIVE_PATTERNS.some((pattern) => pattern.test(archivePath));
 }
@@ -439,6 +499,8 @@ async function validateArchiveManifest(
   inputPath: string,
   entries: readonly Entry[],
 ): Promise<void> {
+  await validateArchiveMutationToken(inputPath, entries);
+
   const entry = entries.find(
     (candidate) =>
       normalizeArchivePath(candidate.fileName) === WIKG_MANIFEST_PATH,
@@ -449,6 +511,21 @@ async function validateArchiveManifest(
   }
 
   parseWikgManifest(await readArchiveEntryText(inputPath, entry));
+}
+
+async function validateArchiveMutationToken(
+  inputPath: string,
+  entries: readonly Entry[],
+): Promise<void> {
+  const firstEntryPath = normalizeArchivePath(entries[0]?.fileName ?? "");
+
+  if (firstEntryPath !== WIKG_MUTATION_TOKEN_PATH) {
+    throw new Error(
+      `Missing WIKG mutation token: ${WIKG_MUTATION_TOKEN_PATH}.`,
+    );
+  }
+
+  parseWikgMutationToken(await readArchiveEntryText(inputPath, entries[0]!));
 }
 
 function parseWikgManifest(
@@ -471,6 +548,30 @@ function parseWikgManifest(
   }
 
   return result.data;
+}
+
+function createWikgMutationTokenContent(): Buffer {
+  const token = randomBytes(32).toString("base64url");
+
+  return Buffer.from(`${WIKG_MUTATION_TOKEN_MAGIC}\n${token}\n`, "utf8");
+}
+
+function parseWikgMutationToken(content: string): string {
+  const lines = content.split(/\r?\n/u);
+  const magic = lines[0];
+  const token = lines[1];
+
+  if (
+    magic !== WIKG_MUTATION_TOKEN_MAGIC ||
+    token === undefined ||
+    !WIKG_MUTATION_TOKEN_PATTERN.test(token)
+  ) {
+    throw new Error(
+      `Invalid WIKG mutation token: ${WIKG_MUTATION_TOKEN_PATH}.`,
+    );
+  }
+
+  return token;
 }
 
 function assertWithinDirectory(

--- a/src/wikg/wikg-coordinator.ts
+++ b/src/wikg/wikg-coordinator.ts
@@ -39,6 +39,7 @@ import { isNodeError } from "../utils/node-error.js";
 import {
   extractWikgArchive,
   listWikgArchiveEntries,
+  readWikgArchiveMutationToken,
   readWikgArchiveEntry,
   WikgArchiveReader,
   writeWikgArchiveWithOverlays,
@@ -53,6 +54,7 @@ CREATE TABLE IF NOT EXISTS entry_overlays (
   kind TEXT NOT NULL,
   workspace_path TEXT,
   archive_signature TEXT,
+  mutation_token TEXT,
   updated_at INTEGER NOT NULL,
   PRIMARY KEY (archive_key, entry_path)
 );
@@ -880,6 +882,17 @@ class WikgDocumentFileStore implements DocumentFileStore {
       async () => {
         let overlay = await this.#readOverlay(entryPath);
 
+        if (
+          entryPath === SEARCH_INDEX_DATABASE_ENTRY_PATH &&
+          overlay?.kind !== "file"
+        ) {
+          await tryAdoptSearchIndexCacheOverlay({
+            targetArchiveKey: this.#archiveKey,
+            targetArchivePath: this.#archivePath,
+          });
+          overlay = await this.#readOverlay(entryPath);
+        }
+
         if (overlay?.kind !== "file") {
           const content = await readWikgArchiveEntry(
             this.#archivePath,
@@ -1592,18 +1605,24 @@ async function upsertOverlay(input: {
   readonly kind: "deleted" | "file";
   readonly workspacePath?: string;
 }): Promise<void> {
+  const mutationToken =
+    input.entryPath === SEARCH_INDEX_DATABASE_ENTRY_PATH
+      ? await readWikgArchiveMutationToken(input.archivePath)
+      : undefined;
+
   await withStateDatabase(async (state) => {
     await state.run(
       `
 INSERT INTO entry_overlays (
   archive_key, archive_path, entry_path, kind, workspace_path,
-  archive_signature, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?)
+  archive_signature, mutation_token, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(archive_key, entry_path)
 DO UPDATE SET kind = excluded.kind,
               archive_path = excluded.archive_path,
               workspace_path = excluded.workspace_path,
               archive_signature = excluded.archive_signature,
+              mutation_token = excluded.mutation_token,
               updated_at = excluded.updated_at
 `,
       [
@@ -1613,8 +1632,142 @@ DO UPDATE SET kind = excluded.kind,
         input.kind,
         input.workspacePath ?? null,
         await createArchiveSignature(input.archivePath),
+        mutationToken ?? null,
         Date.now(),
       ],
+    );
+  });
+}
+
+async function tryAdoptSearchIndexCacheOverlay(input: {
+  readonly targetArchiveKey: string;
+  readonly targetArchivePath: string;
+}): Promise<void> {
+  const mutationToken = await readWikgArchiveMutationToken(
+    input.targetArchivePath,
+  );
+  const candidates = await listSearchIndexAdoptionCandidates({
+    mutationToken,
+    targetArchiveKey: input.targetArchiveKey,
+  });
+  const adoptable: EntryOverlay[] = [];
+
+  for (const candidate of candidates) {
+    if (
+      candidate.workspacePath === undefined ||
+      (await pathExists(candidate.archivePath)) ||
+      (await hasActiveWorkspaceUse(candidate.archiveKey))
+    ) {
+      continue;
+    }
+
+    adoptable.push(candidate);
+  }
+
+  if (adoptable.length !== 1) {
+    return;
+  }
+
+  const candidate = adoptable[0]!;
+  const releaseWriteLock = await acquireEntryLock(
+    candidate.archiveKey,
+    SEARCH_INDEX_DATABASE_ENTRY_PATH,
+    "write",
+  );
+
+  try {
+    const releaseStateLock = await acquireEntryLock(
+      candidate.archiveKey,
+      SEARCH_INDEX_DATABASE_ENTRY_PATH,
+      "state",
+    );
+
+    try {
+      const current = await readOverlay(
+        candidate.archiveKey,
+        SEARCH_INDEX_DATABASE_ENTRY_PATH,
+      );
+      const target = await readOverlay(
+        input.targetArchiveKey,
+        SEARCH_INDEX_DATABASE_ENTRY_PATH,
+      );
+
+      if (
+        current?.workspacePath === undefined ||
+        current.workspacePath !== candidate.workspacePath ||
+        current.mutationToken !== mutationToken ||
+        target !== undefined ||
+        (await pathExists(candidate.archivePath)) ||
+        (await hasActiveArchiveOwnerOrSqliteLease(
+          candidate.archiveKey,
+          SEARCH_INDEX_DATABASE_ENTRY_PATH,
+        ))
+      ) {
+        return;
+      }
+
+      const targetWorkspacePath = await createWorkspaceFilePath(
+        input.targetArchiveKey,
+        SEARCH_INDEX_DATABASE_ENTRY_PATH,
+      );
+
+      await rm(targetWorkspacePath, { force: true }).catch(() => undefined);
+      await mkdir(dirname(targetWorkspacePath), { recursive: true });
+      await rename(current.workspacePath, targetWorkspacePath);
+      await withStateDatabase(async (state) => {
+        await state.run(
+          `
+UPDATE entry_overlays
+SET archive_key = ?,
+    archive_path = ?,
+    workspace_path = ?,
+    archive_signature = ?,
+    updated_at = ?
+WHERE archive_key = ?
+  AND entry_path = ?
+`,
+          [
+            input.targetArchiveKey,
+            input.targetArchivePath,
+            targetWorkspacePath,
+            await createArchiveSignature(input.targetArchivePath),
+            Date.now(),
+            candidate.archiveKey,
+            SEARCH_INDEX_DATABASE_ENTRY_PATH,
+          ],
+        );
+      });
+    } finally {
+      await releaseStateLock();
+    }
+  } finally {
+    await releaseWriteLock();
+  }
+}
+
+async function listSearchIndexAdoptionCandidates(input: {
+  readonly mutationToken: string;
+  readonly targetArchiveKey: string;
+}): Promise<readonly EntryOverlay[]> {
+  return await withStateDatabase(async (state) => {
+    await cleanupStaleState(state);
+    return await state.queryAll(
+      `
+SELECT *
+FROM entry_overlays
+WHERE entry_path = ?
+  AND kind = 'file'
+  AND workspace_path IS NOT NULL
+  AND mutation_token = ?
+  AND archive_key <> ?
+ORDER BY updated_at ASC
+`,
+      [
+        SEARCH_INDEX_DATABASE_ENTRY_PATH,
+        input.mutationToken,
+        input.targetArchiveKey,
+      ],
+      mapEntryOverlay,
     );
   });
 }
@@ -1761,6 +1914,13 @@ async function migrateStateDatabase(database: Database): Promise<void> {
     `);
   }
 
+  if (!overlayColumns.includes("mutation_token")) {
+    await database.run(`
+      ALTER TABLE entry_overlays
+      ADD COLUMN mutation_token TEXT
+    `);
+  }
+
   const sqliteLeaseColumns = await database.queryAll(
     "PRAGMA table_info(entry_sqlite_leases)",
     undefined,
@@ -1904,6 +2064,7 @@ interface EntryOverlay {
   readonly archiveSignature?: string;
   readonly entryPath: string;
   readonly kind: "deleted" | "file";
+  readonly mutationToken?: string;
   readonly updatedAt: number;
   readonly workspacePath?: string;
 }
@@ -1927,6 +2088,7 @@ interface WorkspaceDirectoryEntry {
 function mapEntryOverlay(row: Record<string, unknown>): EntryOverlay {
   const workspacePath = getOptionalString(row, "workspace_path");
   const archiveSignature = getOptionalString(row, "archive_signature");
+  const mutationToken = getOptionalString(row, "mutation_token");
 
   return {
     archiveKey: getString(row, "archive_key"),
@@ -1934,6 +2096,7 @@ function mapEntryOverlay(row: Record<string, unknown>): EntryOverlay {
     ...(archiveSignature === undefined ? {} : { archiveSignature }),
     entryPath: getString(row, "entry_path"),
     kind: getOverlayKind(row),
+    ...(mutationToken === undefined ? {} : { mutationToken }),
     updatedAt: getNumber(row, "updated_at"),
     ...(workspacePath === undefined ? {} : { workspacePath }),
   };

--- a/src/wikg/wikg-coordinator.ts
+++ b/src/wikg/wikg-coordinator.ts
@@ -29,6 +29,7 @@ import {
   isDisposableDirectoryEntry,
   readPathSize,
   removeDisposableChildDirectories,
+  removeDisposableDescendantDirectories,
   removeDisposableDirectory,
 } from "../gc/files.js";
 import type { GcContext, GcJobResult } from "../gc/index.js";
@@ -611,6 +612,16 @@ async function removeOrphanedWorkspaceFiles(
 
       freedBytes += size;
       removed += 1;
+    }
+
+    if (!context.dryRun) {
+      const disposableDirectories = await removeDisposableDescendantDirectories(
+        join(rootPath, archiveKey),
+      );
+
+      freedBytes += disposableDirectories.freedBytes;
+      removed += disposableDirectories.removed;
+      scanned += disposableDirectories.scanned;
     }
   }
 

--- a/test/cli/queue.test.ts
+++ b/test/cli/queue.test.ts
@@ -837,6 +837,59 @@ describe("cli/queue", () => {
     ]);
   });
 
+  it("prints knowledge graph step plan in execution order", async () => {
+    queueMockState.events = [
+      {
+        at: 1,
+        jobId: "job-1",
+        seq: 1,
+        step: "knowledge-graph",
+        type: "step_started",
+      },
+    ];
+
+    await runQueueCommand({
+      action: "watch",
+      from: "beginning",
+      jobId: "job-1",
+      jsonl: false,
+    });
+
+    expect(queueMockState.textWrites).toStrictEqual([
+      "knowledge-graph started\nsteps: matching -> screening -> enrichment -> grounding -> relation-discovery -> committing\n",
+    ]);
+  });
+
+  it("prints committing phase progress in human watch output", async () => {
+    queueMockState.events = [
+      {
+        at: 1,
+        counters: [
+          {
+            done: 1,
+            name: "items",
+            total: 1,
+            unit: "item",
+          },
+        ],
+        jobId: "job-1",
+        phase: "committing",
+        seq: 1,
+        step: "knowledge-graph",
+        type: "status_snapshot",
+      },
+    ];
+
+    await runQueueCommand({
+      action: "watch",
+      from: "beginning",
+      jobId: "job-1",
+      jsonl: false,
+    });
+
+    expect(queueMockState.textWrites).toStrictEqual(["committing items 1/1\n"]);
+  });
+
   it("prints knowledge graph phase progress without word counters", async () => {
     queueMockState.events = [
       {

--- a/test/cli/queue.test.ts
+++ b/test/cli/queue.test.ts
@@ -11,6 +11,7 @@ const queueMockState = vi.hoisted(() => ({
   commitGraphCalls: [] as unknown[],
   commitKnowledgeGraphCalls: [] as unknown[],
   commitSummaryCalls: [] as unknown[],
+  createStageLLMCalls: [] as unknown[],
   inputRevisionAssertions: [] as unknown[],
   inputRevisionRecords: [] as unknown[],
   cliConfig: {} as {
@@ -32,9 +33,11 @@ const queueMockState = vi.hoisted(() => ({
     | "summarized",
   job: {
     archivePath: "book.wikg",
+    cachePath: "/tmp/job-cache",
     chapterId: 12,
     eventsPath: "events.ndjson",
     jobId: "job-1",
+    logPath: "/tmp/job-logs",
     state: "succeeded",
     target: "reading-summary",
     workspacePath: "/tmp/job-workspace",
@@ -247,7 +250,10 @@ vi.mock("../../src/cli/config.js", () => ({
 }));
 
 vi.mock("../../src/cli/stage-runtime.js", () => ({
-  createStageLLM: vi.fn(() => ({})),
+  createStageLLM: vi.fn((_config: unknown, options: unknown) => {
+    queueMockState.createStageLLMCalls.push(options);
+    return {};
+  }),
   loadRequiredStageConfig: vi.fn((options: unknown) => {
     queueMockState.loadRequiredStageConfigCalls.push(options);
     if (queueMockState.loadRequiredStageConfigError !== undefined) {
@@ -282,6 +288,7 @@ describe("cli/queue", () => {
     queueMockState.commitGraphCalls.length = 0;
     queueMockState.commitKnowledgeGraphCalls.length = 0;
     queueMockState.commitSummaryCalls.length = 0;
+    queueMockState.createStageLLMCalls.length = 0;
     queueMockState.events = [];
     queueMockState.getJobIds.length = 0;
     queueMockState.inputRevisionAssertions.length = 0;
@@ -293,10 +300,12 @@ describe("cli/queue", () => {
     queueMockState.job = {
       archiveKey: "archive-key",
       archivePath: "book.wikg",
+      cachePath: "/tmp/job-cache",
       chapterId: 12,
       createdAt: 1,
       eventsPath: "events.ndjson",
       jobId: "job-1",
+      logPath: "/tmp/job-logs",
       ownerId: "owner-1",
       queueRank: 10,
       state: "succeeded",
@@ -551,6 +560,10 @@ describe("cli/queue", () => {
     expect(queueMockState.buildSummaryCalls[0]).toMatchObject({
       snapshotPath: "/tmp/job-workspace/summary-input.json",
       workspacePath: "/tmp/job-workspace",
+    });
+    expect(queueMockState.createStageLLMCalls[0]).toMatchObject({
+      cacheDirPath: "/tmp/job-cache",
+      logDirPath: "/tmp/job-logs",
     });
     expect(queueMockState.buildSummaryCalls[0]).not.toHaveProperty(
       "sourceDocumentPath",

--- a/test/common/logging.test.ts
+++ b/test/common/logging.test.ts
@@ -53,7 +53,7 @@ describe("common/logging", () => {
       expect(artifactPath).toContain("/artifacts/llm/request.log");
       expect(artifactPath).not.toContain("/runs/");
       const content = await readFile(artifactPath, "utf8");
-      const eventLog = await readFile(`${runDirPath}/events.log`, "utf8");
+      const eventLog = await readFile(`${runDirPath}/run.log`, "utf8");
 
       expect(content).toBe("request log");
       expect(eventLog).toContain("INFO");

--- a/test/document/stores.test.ts
+++ b/test/document/stores.test.ts
@@ -302,10 +302,13 @@ describe("document/stores", () => {
           },
         ]);
         expect(
-          await openedDocument.chunks.listByFragments(1, []),
+          await openedDocument.chunks.listBySentenceStartIndexes(1, []),
         ).toStrictEqual([]);
         expect(
-          await openedDocument.chunks.listByFragments(1, [20, 10, 99]),
+          await openedDocument.chunks.listBySentenceStartIndexes(
+            1,
+            [20, 10, 99],
+          ),
         ).toStrictEqual([
           {
             content: "Beta",

--- a/test/editor/markup.test.ts
+++ b/test/editor/markup.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ChunkRecord,
+  FragmentRecord,
+  ReadonlySerialFragments,
+} from "../../src/document/index.js";
+import { formatClueAsBook } from "../../src/editor/markup.js";
+
+describe("editor/markup", () => {
+  it("loads the fragment containing a chunk sentence", async () => {
+    const fragments = [
+      createFragmentRecord(0, ["Alpha.", "Beta.", "Gamma."]),
+      createFragmentRecord(3, ["Delta."]),
+    ];
+    const requestedFragmentIds: number[] = [];
+    const result = await formatClueAsBook({
+      chunks: [createChunkRecord(2)],
+      serialFragments: createSerialFragments(fragments, requestedFragmentIds),
+    });
+
+    expect(requestedFragmentIds).toStrictEqual([0]);
+    expect(result).toContain("Gamma.");
+  });
+});
+
+function createSerialFragments(
+  fragments: readonly FragmentRecord[],
+  requestedFragmentIds: number[],
+): ReadonlySerialFragments {
+  const fragmentsById = new Map(
+    fragments.map((fragment) => [fragment.fragmentId, fragment] as const),
+  );
+
+  return {
+    getFragment: (fragmentId: number) => {
+      requestedFragmentIds.push(fragmentId);
+      const fragment = fragmentsById.get(fragmentId);
+
+      if (fragment === undefined) {
+        throw new Error(`Fragment ${fragmentId} does not exist`);
+      }
+
+      return Promise.resolve(fragment);
+    },
+    listFragmentIds: () =>
+      Promise.resolve(fragments.map((fragment) => fragment.fragmentId)),
+    path: "/tmp/fragments",
+    serialId: 1,
+  };
+}
+
+function createChunkRecord(sentenceIndex: number): ChunkRecord {
+  return {
+    content: "Gamma content",
+    generation: 0,
+    id: 1,
+    label: "Gamma chunk",
+    sentenceId: [1, sentenceIndex],
+    sentenceIds: [[1, sentenceIndex]],
+    wordsCount: 2,
+    weight: 1,
+  };
+}
+
+function createFragmentRecord(
+  fragmentId: number,
+  sentences: readonly string[],
+): FragmentRecord {
+  return {
+    fragmentId,
+    sentences: sentences.map((text) => ({
+      text,
+      wordsCount: 1,
+    })),
+    serialId: 1,
+    summary: `Fragment ${fragmentId} summary`,
+  };
+}

--- a/test/facade/build-queue.test.ts
+++ b/test/facade/build-queue.test.ts
@@ -348,6 +348,7 @@ describe("facade/build-queue", () => {
       await runBuildJobWorker({
         concurrency: 1,
         executeJob: async (_job, reporter) => {
+          await reporter.setTotals({ totalGraphWords: 4888 });
           await reporter.stepStarted("knowledge-graph");
           await reporter.updatePhase({
             done: 3,
@@ -364,6 +365,9 @@ describe("facade/build-queue", () => {
       );
       const latest = snapshots.at(-1);
 
+      expect(latest?.counters.some((counter) => counter.name === "words")).toBe(
+        false,
+      );
       expect(latest).toMatchObject({
         counters: [
           {

--- a/test/facade/build-queue.test.ts
+++ b/test/facade/build-queue.test.ts
@@ -1,4 +1,4 @@
-import { access } from "fs/promises";
+import { access, writeFile } from "fs/promises";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -251,7 +251,7 @@ describe("facade/build-queue", () => {
     });
   });
 
-  it("writes structured events and removes succeeded work", async () => {
+  it("writes structured events and keeps job cache and logs after removing succeeded work", async () => {
     await withTempDir("spinedigest-build-queue-", async (path) => {
       useStateDir(`${path}/state`);
       const job = await addBuildJob({
@@ -260,9 +260,18 @@ describe("facade/build-queue", () => {
         target: "reading-graph",
       });
 
+      expect(job.workspacePath).toBe(`${path}/state/jobs/work/${job.jobId}`);
+      expect(job.cachePath).toBe(`${path}/state/jobs/cache/${job.jobId}`);
+      expect(job.logPath).toBe(`${path}/state/jobs/logs/${job.jobId}`);
+      expect(job.eventsPath).toBe(
+        `${path}/state/jobs/events/${job.jobId}.ndjson`,
+      );
+
       await runBuildJobWorker({
         concurrency: 1,
-        executeJob: async (_job, reporter) => {
+        executeJob: async (runningJob, reporter) => {
+          await writeFile(`${runningJob.cachePath}/request.txt`, "cache");
+          await writeFile(`${runningJob.logPath}/run.log`, "log");
           await reporter.setTotals({ totalGraphWords: 100 });
           await reporter.stepStarted("reading-graph");
           await reporter.updateWords({ graphWords: 50 });
@@ -278,6 +287,9 @@ describe("facade/build-queue", () => {
       expect(updated.state).toBe("succeeded");
       expect(events.map((event) => event.type)).toContain("succeeded");
       await expect(access(job.workspacePath)).rejects.toThrow();
+      await expect(access(job.cachePath)).resolves.toBeUndefined();
+      await expect(access(job.logPath)).resolves.toBeUndefined();
+      await expect(access(job.eventsPath)).resolves.toBeUndefined();
     });
   });
 

--- a/test/gc/gc.test.ts
+++ b/test/gc/gc.test.ts
@@ -204,6 +204,50 @@ describe("gc", () => {
     });
   });
 
+  it("removes empty coordinator workspace descendants", async () => {
+    await withTempDir("spinedigest-gc-", async (path) => {
+      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      const workspaceBucketPath = join(
+        path,
+        "state",
+        "staging",
+        "work",
+        "archive-key",
+      );
+      const referencedPath = join(workspaceBucketPath, "fts.db");
+      const sourceDirectoryPath = join(workspaceBucketPath, "texts", "source");
+      const summaryDirectoryPath = join(
+        workspaceBucketPath,
+        "texts",
+        "summary",
+      );
+
+      await mkdir(sourceDirectoryPath, { recursive: true });
+      await mkdir(summaryDirectoryPath, { recursive: true });
+      await writeFile(referencedPath, "referenced", "utf8");
+      await writeFile(join(summaryDirectoryPath, ".DS_Store"), "finder");
+      await createCoordinatorOverlay(path, {
+        archiveKey: "archive-key",
+        entryPath: "fts.db",
+        workspacePath: referencedPath,
+      });
+
+      const report = await tryRunWikiGraphGc();
+
+      expect(report.skipped).toBe(false);
+      const wikgCoordinatorJob = report.jobs.find(
+        (item) => item.name === "wikg-coordinator",
+      );
+
+      expect(wikgCoordinatorJob?.removed).toBeGreaterThanOrEqual(2);
+      await expect(stat(referencedPath)).resolves.toBeDefined();
+      await expect(stat(sourceDirectoryPath)).rejects.toThrow();
+      await expect(stat(summaryDirectoryPath)).rejects.toThrow();
+      await expect(stat(join(workspaceBucketPath, "texts"))).rejects.toThrow();
+      await expect(stat(workspaceBucketPath)).resolves.toBeDefined();
+    });
+  });
+
   it("keeps fresh terminal build jobs during normal GC", async () => {
     await withTempDir("spinedigest-gc-", async (path) => {
       process.env.WIKIGRAPH_STATE_DIR = join(path, "state");

--- a/test/gc/gc.test.ts
+++ b/test/gc/gc.test.ts
@@ -26,7 +26,6 @@ describe("gc", () => {
       const tmpPath = await createOldTmpDirectory();
       const sqliteCachePath = await createOldCoordinatorSqliteCache(path);
       const sqliteCacheParentPath = dirname(sqliteCachePath);
-      const jobParentPath = dirname(job.workspacePath);
 
       const report = await tryRunWikiGraphGc();
 
@@ -42,7 +41,8 @@ describe("gc", () => {
       await expect(stat(sqliteCacheParentPath)).rejects.toThrow();
       await expect(stat(tmpPath)).rejects.toThrow();
       await expect(stat(job.workspacePath)).rejects.toThrow();
-      await expect(stat(jobParentPath)).rejects.toThrow();
+      await expect(stat(job.cachePath)).rejects.toThrow();
+      await expect(stat(job.logPath)).rejects.toThrow();
       await expect(stat(job.eventsPath)).rejects.toThrow();
       await expect(
         countRows("cache/search-sessions.sqlite", "search_sessions"),
@@ -97,7 +97,7 @@ describe("gc", () => {
     });
   });
 
-  it("removes stale empty workspace bucket directories", async () => {
+  it("removes stale empty workspace directories", async () => {
     await withTempDir("spinedigest-gc-", async (path) => {
       process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
       const workspaceBucketPath = join(
@@ -107,13 +107,7 @@ describe("gc", () => {
         "work",
         "archive-key",
       );
-      const buildJobBucketPath = join(
-        path,
-        "state",
-        "jobs",
-        "work",
-        "archive-key",
-      );
+      const buildJobBucketPath = join(path, "state", "jobs", "work", "job-id");
 
       await mkdir(workspaceBucketPath, { recursive: true });
       await mkdir(buildJobBucketPath, { recursive: true });
@@ -263,6 +257,8 @@ describe("gc", () => {
         report.jobs.find((item) => item.name === "build-queue"),
       ).toMatchObject({ removed: 0 });
       await expect(stat(job.workspacePath)).resolves.toBeDefined();
+      await expect(stat(job.cachePath)).resolves.toBeDefined();
+      await expect(stat(job.logPath)).resolves.toBeDefined();
       await expect(countRows("jobs/job.sqlite", "build_jobs")).resolves.toBe(1);
     });
   });
@@ -282,6 +278,8 @@ describe("gc", () => {
         report.jobs.find((item) => item.name === "build-queue"),
       ).toMatchObject({ removed: 1 });
       await expect(stat(job.workspacePath)).rejects.toThrow();
+      await expect(stat(job.cachePath)).rejects.toThrow();
+      await expect(stat(job.logPath)).rejects.toThrow();
       await expect(countRows("jobs/job.sqlite", "build_jobs")).resolves.toBe(0);
     });
   });
@@ -426,7 +424,9 @@ async function createExpiredSearchSession(): Promise<void> {
 }
 
 async function createCompletedOldJob(path: string): Promise<{
+  readonly cachePath: string;
   readonly eventsPath: string;
+  readonly logPath: string;
   readonly workspacePath: string;
 }> {
   return await createCompletedJob(path, {
@@ -442,7 +442,9 @@ async function createCompletedJob(
     readonly state: "canceled" | "failed" | "succeeded";
   },
 ): Promise<{
+  readonly cachePath: string;
   readonly eventsPath: string;
+  readonly logPath: string;
   readonly workspacePath: string;
 }> {
   const job = await addBuildJob({
@@ -452,7 +454,8 @@ async function createCompletedJob(
   });
   await mkdir(job.workspacePath, { recursive: true });
   await writeFile(join(job.workspacePath, "artifact.txt"), "artifact", "utf8");
-  await writeFile(join(dirname(job.workspacePath), ".DS_Store"), "finder");
+  await writeFile(join(job.cachePath, "request.txt"), "cache", "utf8");
+  await writeFile(join(job.logPath, "run.log"), "log", "utf8");
   await writeFile(job.eventsPath, "event\n", "utf8");
 
   const database = await openStateDatabase("jobs/job.sqlite");

--- a/test/llm/client.test.ts
+++ b/test/llm/client.test.ts
@@ -1,3 +1,5 @@
+import { readdir, readFile } from "fs/promises";
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const aiMockState = vi.hoisted(() => ({
@@ -195,6 +197,32 @@ describe("llm/client", () => {
     ]);
   });
 
+  it("writes token usage to request logs when the provider returns it", async () => {
+    await withTempDir("spinedigest-llm-log-", async (logDirPath) => {
+      const llm = new LLM({
+        dataDirPath: process.cwd(),
+        logDirPath,
+        model: {
+          modelId: "test-model",
+          provider: "test-provider",
+        } as never,
+      });
+
+      await expect(
+        llm.request([
+          {
+            content: "hello",
+            role: "user",
+          },
+        ]),
+      ).resolves.toBe("generated response");
+
+      await expect(readOnlyRequestLog(logDirPath)).resolves.toContain(
+        "[[Usage]]:\ninput: 11\ncache: 3\noutput: 7\n\n",
+      );
+    });
+  });
+
   it("moves a leading system message to the top-level system field", async () => {
     const llm = new LLM({
       dataDirPath: process.cwd(),
@@ -261,6 +289,39 @@ describe("llm/client", () => {
 
       await expect(llm.request(messages)).resolves.toBe("generated response");
 
+      expect(aiMockState.generateTextCalls).toHaveLength(1);
+    });
+  });
+
+  it("writes cache-hit usage to request logs for cached responses", async () => {
+    await withTempDir("spinedigest-llm-cache-log-", async (path) => {
+      const cacheDirPath = `${path}/cache`;
+      const logDirPath = `${path}/logs`;
+      const llm = new LLM({
+        cacheDirPath,
+        dataDirPath: process.cwd(),
+        logDirPath,
+        model: {
+          modelId: "test-model",
+          provider: "test-provider",
+        } as never,
+      });
+      const messages = [
+        {
+          content: "hello",
+          role: "user",
+        },
+      ] as const;
+
+      await expect(llm.request(messages)).resolves.toBe("generated response");
+      await expect(llm.request(messages)).resolves.toBe("generated response");
+
+      const logs = await readRequestLogs(logDirPath);
+
+      expect(logs).toHaveLength(2);
+      expect(logs).toContainEqual(
+        expect.stringContaining("[[Usage]]:\ncache-hit\n\n"),
+      );
       expect(aiMockState.generateTextCalls).toHaveLength(1);
     });
   });
@@ -607,6 +668,38 @@ describe("llm/client", () => {
     expect(aiMockState.generateTextCalls).toHaveLength(6);
   });
 
+  it("writes unavailable usage and error stack to request logs after failures", async () => {
+    await withTempDir("spinedigest-llm-error-log-", async (logDirPath) => {
+      aiMockState.generateTextError = new TypeError("terminated");
+
+      const llm = new LLM({
+        dataDirPath: process.cwd(),
+        logDirPath,
+        model: {
+          modelId: "test-model",
+          provider: "test-provider",
+        } as never,
+        retryIntervalSeconds: 0,
+      });
+
+      await expect(
+        llm.request([
+          {
+            content: "hello",
+            role: "user",
+          },
+        ]),
+      ).rejects.toThrow("LLM request failed after 6 attempts: terminated");
+
+      const log = await readOnlyRequestLog(logDirPath);
+
+      expect(log).toContain(
+        "[[Usage]]:\ninput: unavailable\ncache: unavailable\noutput: unavailable\n\n",
+      );
+      expect(log).toContain("[[Error Stack]]:\nTypeError: terminated");
+    });
+  });
+
   it.each(RETRYABLE_TRANSPORT_CODES)(
     "retries transport errors tagged with %s",
     async (code) => {
@@ -824,3 +917,21 @@ describe("llm/client", () => {
     expect(aiMockState.streamTextCalls).toHaveLength(6);
   });
 });
+
+async function readOnlyRequestLog(logDirPath: string): Promise<string> {
+  const logs = await readRequestLogs(logDirPath);
+
+  expect(logs).toHaveLength(1);
+  return logs[0]!;
+}
+
+async function readRequestLogs(logDirPath: string): Promise<string[]> {
+  const entries = await readdir(logDirPath);
+
+  return await Promise.all(
+    entries
+      .filter((entry) => entry.endsWith(".log"))
+      .sort((left, right) => left.localeCompare(right))
+      .map(async (entry) => await readFile(`${logDirPath}/${entry}`, "utf8")),
+  );
+}

--- a/test/topology/fragment-incision.test.ts
+++ b/test/topology/fragment-incision.test.ts
@@ -66,6 +66,38 @@ describe("topology/fragment-incision", () => {
     ]);
   });
 
+  it("maps chunk sentences to sparse fragment start indexes", async () => {
+    const result = await computeNormalizedFragmentIncisions({
+      chunks: [createChunk(1, 2, 5), createChunk(2, 5, 5)],
+      edges: [
+        {
+          fromId: 1,
+          toId: 2,
+          weight: 2,
+        },
+      ] satisfies ReadingEdgeRecord[],
+      fragments: createSerialFragments({
+        0: 10,
+        3: 20,
+      }),
+    });
+
+    expect(result).toStrictEqual([
+      {
+        endIncision: 10,
+        fragmentId: 0,
+        startIncision: 0,
+        wordsCount: 10,
+      },
+      {
+        endIncision: 0,
+        fragmentId: 3,
+        startIncision: 10,
+        wordsCount: 20,
+      },
+    ]);
+  });
+
   it("normalizes mixed incision strengths across multiple fragments", async () => {
     const result = await computeNormalizedFragmentIncisions({
       chunks: [

--- a/test/topology/grouping.test.ts
+++ b/test/topology/grouping.test.ts
@@ -4,11 +4,11 @@ import type {
   ChunkRecord,
   ReadonlySerialFragments,
 } from "../../src/document/index.js";
-import { groupFragments } from "../../src/topology/grouping.js";
+import { groupSegments } from "../../src/topology/grouping.js";
 
 describe("topology/grouping", () => {
-  it("converts normalized fragment incisions into persisted fragment groups", async () => {
-    const result = await groupFragments({
+  it("converts normalized segment incisions into persisted sentence groups", async () => {
+    const result = await groupSegments({
       chunks: [
         createChunk(1, 1, 3),
         createChunk(2, 2, 3),
@@ -59,16 +59,16 @@ function createChunk(
 }
 
 function createSerialFragments(
-  wordsCountsByFragmentId: Record<number, number>,
+  wordsCountsByStartIndex: Record<number, number>,
 ): ReadonlySerialFragments {
   return {
-    getFragment: (fragmentId: number) =>
+    getFragment: (startSentenceIndex: number) =>
       Promise.resolve({
-        fragmentId,
+        fragmentId: startSentenceIndex,
         sentences: [
           {
-            text: `Fragment ${fragmentId}`,
-            wordsCount: wordsCountsByFragmentId[fragmentId] ?? 0,
+            text: `Segment ${startSentenceIndex}`,
+            wordsCount: wordsCountsByStartIndex[startSentenceIndex] ?? 0,
           },
         ],
         serialId: 7,
@@ -76,8 +76,8 @@ function createSerialFragments(
       }),
     listFragmentIds: () =>
       Promise.resolve(
-        Object.keys(wordsCountsByFragmentId).map((fragmentId) =>
-          Number(fragmentId),
+        Object.keys(wordsCountsByStartIndex).map((startSentenceIndex) =>
+          Number(startSentenceIndex),
         ),
       ),
     path: "/tmp/fragments",

--- a/test/topology/resource-segmentation.test.ts
+++ b/test/topology/resource-segmentation.test.ts
@@ -1,36 +1,36 @@
 import { describe, expect, it } from "vitest";
 
-import { createFragmentGroups } from "../../src/topology/resource-segmentation.js";
+import { createSegmentGroups } from "../../src/topology/resource-segmentation.js";
 
 describe("topology/resource-segmentation", () => {
-  it("returns no groups for empty fragment input", () => {
+  it("returns no groups for empty segment input", () => {
     expect(
-      createFragmentGroups({
-        fragmentInfos: [],
+      createSegmentGroups({
+        segmentInfos: [],
         groupWordsCount: 100,
         serialId: 1,
       }),
     ).toStrictEqual([]);
   });
 
-  it("greedily groups adjacent fragments without duplicating ids", () => {
+  it("greedily groups adjacent segments without duplicating ids", () => {
     expect(
-      createFragmentGroups({
-        fragmentInfos: [
+      createSegmentGroups({
+        segmentInfos: [
           {
-            fragmentId: 1,
+            startSentenceIndex: 1,
             endIncision: 0,
             startIncision: 0,
             wordsCount: 40,
           },
           {
-            fragmentId: 2,
+            startSentenceIndex: 2,
             endIncision: 0,
             startIncision: 0,
             wordsCount: 40,
           },
           {
-            fragmentId: 3,
+            startSentenceIndex: 3,
             endIncision: 0,
             startIncision: 0,
             wordsCount: 40,
@@ -47,28 +47,28 @@ describe("topology/resource-segmentation", () => {
 
   it("prefers strong incision boundaries when splitting oversized groups", () => {
     expect(
-      createFragmentGroups({
-        fragmentInfos: [
+      createSegmentGroups({
+        segmentInfos: [
           {
-            fragmentId: 1,
+            startSentenceIndex: 1,
             endIncision: 1,
             startIncision: 0,
             wordsCount: 20,
           },
           {
-            fragmentId: 2,
+            startSentenceIndex: 2,
             endIncision: 9,
             startIncision: 1,
             wordsCount: 20,
           },
           {
-            fragmentId: 3,
+            startSentenceIndex: 3,
             endIncision: 1,
             startIncision: 9,
             wordsCount: 20,
           },
           {
-            fragmentId: 4,
+            startSentenceIndex: 4,
             endIncision: 0,
             startIncision: 1,
             wordsCount: 20,
@@ -83,24 +83,24 @@ describe("topology/resource-segmentation", () => {
     ]);
   });
 
-  it("forces individually oversized fragments into separate groups", () => {
+  it("forces individually oversized segments into separate groups", () => {
     expect(
-      createFragmentGroups({
-        fragmentInfos: [
+      createSegmentGroups({
+        segmentInfos: [
           {
-            fragmentId: 1,
+            startSentenceIndex: 1,
             endIncision: 0,
             startIncision: 0,
             wordsCount: 70,
           },
           {
-            fragmentId: 2,
+            startSentenceIndex: 2,
             endIncision: 0,
             startIncision: 0,
             wordsCount: 70,
           },
           {
-            fragmentId: 3,
+            startSentenceIndex: 3,
             endIncision: 0,
             startIncision: 0,
             wordsCount: 70,

--- a/test/topology/segment-incision.test.ts
+++ b/test/topology/segment-incision.test.ts
@@ -5,11 +5,11 @@ import type {
   ReadingEdgeRecord,
   ReadonlySerialFragments,
 } from "../../src/document/index.js";
-import { computeNormalizedFragmentIncisions } from "../../src/topology/fragment-incision.js";
+import { computeNormalizedSegmentIncisions } from "../../src/topology/segment-incision.js";
 
-describe("topology/fragment-incision", () => {
-  it("returns zero incisions when fragments have no external edges", async () => {
-    const result = await computeNormalizedFragmentIncisions({
+describe("topology/segment-incision", () => {
+  it("returns zero incisions when segments have no external edges", async () => {
+    const result = await computeNormalizedSegmentIncisions({
       chunks: [createChunk(1, 1, 2), createChunk(2, 2, 3)],
       edges: [],
       fragments: createSerialFragments({
@@ -21,21 +21,21 @@ describe("topology/fragment-incision", () => {
     expect(result).toStrictEqual([
       {
         endIncision: 0,
-        fragmentId: 1,
+        startSentenceIndex: 1,
         startIncision: 0,
         wordsCount: 10,
       },
       {
         endIncision: 0,
-        fragmentId: 2,
+        startSentenceIndex: 2,
         startIncision: 0,
         wordsCount: 20,
       },
     ]);
   });
 
-  it("caps uniformly strong cross-fragment incisions to the maximum score", async () => {
-    const result = await computeNormalizedFragmentIncisions({
+  it("caps uniformly strong cross-segment incisions to the maximum score", async () => {
+    const result = await computeNormalizedSegmentIncisions({
       chunks: [createChunk(1, 1, 5), createChunk(2, 2, 5)],
       edges: [
         {
@@ -53,21 +53,21 @@ describe("topology/fragment-incision", () => {
     expect(result).toStrictEqual([
       {
         endIncision: 10,
-        fragmentId: 1,
+        startSentenceIndex: 1,
         startIncision: 0,
         wordsCount: 10,
       },
       {
         endIncision: 0,
-        fragmentId: 2,
+        startSentenceIndex: 2,
         startIncision: 10,
         wordsCount: 20,
       },
     ]);
   });
 
-  it("maps chunk sentences to sparse fragment start indexes", async () => {
-    const result = await computeNormalizedFragmentIncisions({
+  it("maps chunk sentences to sparse segment start indexes", async () => {
+    const result = await computeNormalizedSegmentIncisions({
       chunks: [createChunk(1, 2, 5), createChunk(2, 5, 5)],
       edges: [
         {
@@ -85,21 +85,21 @@ describe("topology/fragment-incision", () => {
     expect(result).toStrictEqual([
       {
         endIncision: 10,
-        fragmentId: 0,
+        startSentenceIndex: 0,
         startIncision: 0,
         wordsCount: 10,
       },
       {
         endIncision: 0,
-        fragmentId: 3,
+        startSentenceIndex: 3,
         startIncision: 10,
         wordsCount: 20,
       },
     ]);
   });
 
-  it("normalizes mixed incision strengths across multiple fragments", async () => {
-    const result = await computeNormalizedFragmentIncisions({
+  it("normalizes mixed incision strengths across multiple segments", async () => {
+    const result = await computeNormalizedSegmentIncisions({
       chunks: [
         createChunk(1, 1, 4),
         createChunk(2, 2, 6),
@@ -127,19 +127,19 @@ describe("topology/fragment-incision", () => {
     expect(result).toStrictEqual([
       {
         endIncision: 9,
-        fragmentId: 1,
+        startSentenceIndex: 1,
         startIncision: 0,
         wordsCount: 10,
       },
       {
         endIncision: 10,
-        fragmentId: 2,
+        startSentenceIndex: 2,
         startIncision: 1,
         wordsCount: 20,
       },
       {
         endIncision: 0,
-        fragmentId: 3,
+        startSentenceIndex: 3,
         startIncision: 10,
         wordsCount: 30,
       },
@@ -165,16 +165,16 @@ function createChunk(
 }
 
 function createSerialFragments(
-  wordsCountsByFragmentId: Record<number, number>,
+  wordsCountsByStartIndex: Record<number, number>,
 ): ReadonlySerialFragments {
   return {
-    getFragment: (fragmentId: number) =>
+    getFragment: (startSentenceIndex: number) =>
       Promise.resolve({
-        fragmentId,
+        fragmentId: startSentenceIndex,
         sentences: [
           {
-            text: `Fragment ${fragmentId}`,
-            wordsCount: wordsCountsByFragmentId[fragmentId] ?? 0,
+            text: `Segment ${startSentenceIndex}`,
+            wordsCount: wordsCountsByStartIndex[startSentenceIndex] ?? 0,
           },
         ],
         serialId: 1,
@@ -182,8 +182,8 @@ function createSerialFragments(
       }),
     listFragmentIds: () =>
       Promise.resolve(
-        Object.keys(wordsCountsByFragmentId).map((fragmentId) =>
-          Number(fragmentId),
+        Object.keys(wordsCountsByStartIndex).map((startSentenceIndex) =>
+          Number(startSentenceIndex),
         ),
       ),
     path: "/tmp/fragments",

--- a/test/topology/topology.test.ts
+++ b/test/topology/topology.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
-const { groupFragmentsMock } = vi.hoisted(() => ({
-  groupFragmentsMock: vi.fn(),
+const { groupSegmentsMock } = vi.hoisted(() => ({
+  groupSegmentsMock: vi.fn(),
 }));
 
 vi.mock("../../src/topology/grouping.js", () => ({
-  groupFragments: groupFragmentsMock,
+  groupSegments: groupSegmentsMock,
 }));
 
 import { ChunkImportance, ChunkRetention } from "../../src/document/index.js";
@@ -19,7 +19,7 @@ import { Topology } from "../../src/topology/topology.js";
 
 describe("topology/topology", () => {
   it("merges deltas, applies annotations, and persists weighted topology output", async () => {
-    groupFragmentsMock.mockResolvedValue([
+    groupSegmentsMock.mockResolvedValue([
       {
         endSentenceIndex: 1,
         groupId: 0,
@@ -39,7 +39,7 @@ describe("topology/topology", () => {
       getSerialFragments,
       saveChunk,
       saveEdge,
-      saveFragmentGroups,
+      saveSentenceGroups,
       createSnake,
       saveSnakeChunk,
       saveSnakeEdge,
@@ -122,7 +122,7 @@ describe("topology/topology", () => {
         weight: 13,
       },
     ]);
-    expect(groupFragmentsMock).toHaveBeenCalledWith({
+    expect(groupSegmentsMock).toHaveBeenCalledWith({
       chunks: [
         {
           content: "Chunk 1",
@@ -160,7 +160,7 @@ describe("topology/topology", () => {
       groupWordsCount: 120,
       serialId: 7,
     });
-    expect(saveFragmentGroups).toHaveBeenCalledWith([
+    expect(saveSentenceGroups).toHaveBeenCalledWith([
       {
         endSentenceIndex: 1,
         groupId: 0,
@@ -205,7 +205,7 @@ describe("topology/topology", () => {
   });
 
   it("keeps cross-group relations out of persisted snake edges", async () => {
-    groupFragmentsMock.mockResolvedValue([
+    groupSegmentsMock.mockResolvedValue([
       {
         endSentenceIndex: 2,
         groupId: 0,
@@ -296,7 +296,7 @@ describe("topology/topology", () => {
   });
 
   it("splits a connected component into multiple snakes and normalizes snake-edge direction", async () => {
-    groupFragmentsMock.mockResolvedValue([
+    groupSegmentsMock.mockResolvedValue([
       {
         endSentenceIndex: 1,
         groupId: 0,
@@ -421,17 +421,17 @@ function createDocumentStub(): {
   readonly getSerialFragments: () => ReadonlySerialFragments;
   readonly saveChunk: ReturnType<typeof vi.fn>;
   readonly saveEdge: ReturnType<typeof vi.fn>;
-  readonly saveFragmentGroups: ReturnType<typeof vi.fn>;
+  readonly saveSentenceGroups: ReturnType<typeof vi.fn>;
   readonly saveSnakeChunk: ReturnType<typeof vi.fn>;
   readonly saveSnakeEdge: ReturnType<typeof vi.fn>;
 } {
   const fragments = {
-    getFragment: (fragmentId: number) =>
+    getFragment: (startSentenceIndex: number) =>
       Promise.resolve({
-        fragmentId,
+        fragmentId: startSentenceIndex,
         sentences: [
           {
-            text: `Fragment ${fragmentId}`,
+            text: `Segment ${startSentenceIndex}`,
             wordsCount: 10,
           },
         ],
@@ -453,7 +453,7 @@ function createDocumentStub(): {
     });
   });
   const saveEdge = vi.fn(() => Promise.resolve());
-  const saveFragmentGroups = vi.fn(() => Promise.resolve());
+  const saveSentenceGroups = vi.fn(() => Promise.resolve());
   let nextSnakeId = 1;
   const createSnake = vi.fn(() => Promise.resolve(nextSnakeId++));
   const saveSnakeChunk = vi.fn(() => Promise.resolve());
@@ -468,7 +468,7 @@ function createDocumentStub(): {
         create: saveChunk,
       },
       fragmentGroups: {
-        saveMany: saveFragmentGroups,
+        saveMany: saveSentenceGroups,
       },
       getSerialFragments,
       readingEdges: {
@@ -491,7 +491,7 @@ function createDocumentStub(): {
     getSerialFragments,
     saveChunk,
     saveEdge,
-    saveFragmentGroups,
+    saveSentenceGroups,
     saveSnakeChunk,
     saveSnakeEdge,
   };

--- a/test/wikg/archive.test.ts
+++ b/test/wikg/archive.test.ts
@@ -9,11 +9,14 @@ import { describe, expect, it } from "vitest";
 import { DirectoryDocument } from "../../src/document/index.js";
 import {
   extractWikgArchive,
+  readWikgArchiveMutationToken,
   readWikgArchiveEntry,
   writeWikgArchive,
   writeWikgArchiveWithOverlays,
 } from "../../src/wikg/archive.js";
 import { withTempDir } from "../helpers/temp.js";
+
+const VALID_MUTATION_TOKEN_CONTENT = `wikg-mutation-token:v1\n${"a".repeat(43)}\n`;
 
 describe("wikg/archive", () => {
   it("writes and extracts only whitelisted wikg document files", async () => {
@@ -47,6 +50,9 @@ describe("wikg/archive", () => {
       await writeWikgArchive(sourceDir, archivePath);
       await extractWikgArchive(archivePath, extractDir);
 
+      expect(
+        await readFile(`${extractDir}/.wikg-mutation-token`, "utf8"),
+      ).toMatch(/^wikg-mutation-token:v1\n[A-Za-z0-9_-]{43}\n$/u);
       expect(
         JSON.parse(await readFile(`${extractDir}/manifest.json`, "utf8")),
       ).toEqual({ formatVersion: 1 });
@@ -184,12 +190,83 @@ describe("wikg/archive", () => {
     });
   });
 
+  it("refreshes the mutation token when overlays rewrite the archive", async () => {
+    await withTempDir("spinedigest-archive-", async (path) => {
+      const sourceDir = `${path}/source`;
+      const archivePath = `${path}/book.wikg`;
+      const rewrittenPath = `${path}/rewritten.wikg`;
+
+      await mkdir(sourceDir, { recursive: true });
+      await writeFile(`${sourceDir}/database.db`, "sqlite", "utf8");
+      await writeWikgArchive(sourceDir, archivePath);
+
+      const before = await readWikgArchiveMutationToken(archivePath);
+
+      await writeWikgArchiveWithOverlays(archivePath, rewrittenPath, [
+        {
+          entryPath: "book-meta.json",
+          kind: "file",
+          workspacePath: `${sourceDir}/database.db`,
+        },
+      ]);
+
+      const after = await readWikgArchiveMutationToken(rewrittenPath);
+
+      expect(after).not.toBe(before);
+    });
+  });
+
+  it("rejects archives that omit the mutation token", async () => {
+    await withTempDir("spinedigest-archive-", async (path) => {
+      const archivePath = `${path}/missing-token.wikg`;
+      const extractDir = `${path}/extract`;
+      const zipFile = new ZipFile();
+
+      zipFile.addBuffer(
+        Buffer.from('{"formatVersion":1}', "utf8"),
+        "manifest.json",
+      );
+      zipFile.addBuffer(Buffer.from("sqlite", "utf8"), "database.db");
+      await writeZipFile(zipFile, archivePath);
+
+      await expect(extractWikgArchive(archivePath, extractDir)).rejects.toThrow(
+        "Missing WIKG mutation token: .wikg-mutation-token.",
+      );
+    });
+  });
+
+  it("rejects archives with malformed mutation tokens", async () => {
+    await withTempDir("spinedigest-archive-", async (path) => {
+      const archivePath = `${path}/malformed-token.wikg`;
+      const zipFile = new ZipFile();
+
+      zipFile.addBuffer(
+        Buffer.from("wikg-mutation-token:v1\nbad\n", "utf8"),
+        ".wikg-mutation-token",
+      );
+      zipFile.addBuffer(
+        Buffer.from('{"formatVersion":1}', "utf8"),
+        "manifest.json",
+      );
+      zipFile.addBuffer(Buffer.from("sqlite", "utf8"), "database.db");
+      await writeZipFile(zipFile, archivePath);
+
+      await expect(
+        extractWikgArchive(archivePath, `${path}/extract`),
+      ).rejects.toThrow("Invalid WIKG mutation token: .wikg-mutation-token.");
+    });
+  });
+
   it("rejects archives that omit the manifest", async () => {
     await withTempDir("spinedigest-archive-", async (path) => {
       const archivePath = `${path}/missing-manifest.wikg`;
       const extractDir = `${path}/extract`;
       const zipFile = new ZipFile();
 
+      zipFile.addBuffer(
+        Buffer.from(VALID_MUTATION_TOKEN_CONTENT, "utf8"),
+        ".wikg-mutation-token",
+      );
       zipFile.addBuffer(Buffer.from("sqlite", "utf8"), "database.db");
       await writeZipFile(zipFile, archivePath);
 
@@ -204,6 +281,10 @@ describe("wikg/archive", () => {
       const archivePath = `${path}/future.wikg`;
       const zipFile = new ZipFile();
 
+      zipFile.addBuffer(
+        Buffer.from(VALID_MUTATION_TOKEN_CONTENT, "utf8"),
+        ".wikg-mutation-token",
+      );
       zipFile.addBuffer(
         Buffer.from('{"formatVersion":2}', "utf8"),
         "manifest.json",
@@ -222,6 +303,10 @@ describe("wikg/archive", () => {
       const archivePath = `${path}/malformed.wikg`;
       const zipFile = new ZipFile();
 
+      zipFile.addBuffer(
+        Buffer.from(VALID_MUTATION_TOKEN_CONTENT, "utf8"),
+        ".wikg-mutation-token",
+      );
       zipFile.addBuffer(Buffer.from("not json", "utf8"), "manifest.json");
       zipFile.addBuffer(Buffer.from("sqlite", "utf8"), "database.db");
       await writeZipFile(zipFile, archivePath);

--- a/test/wikg/spine-digest-file.test.ts
+++ b/test/wikg/spine-digest-file.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "crypto";
-import { access, mkdir, readFile, writeFile } from "fs/promises";
+import { access, mkdir, readFile, rename, writeFile } from "fs/promises";
 import { resolve } from "path";
 
 import { afterEach, describe, expect, it } from "vitest";
@@ -10,6 +10,7 @@ import {
   findArchiveObjects,
   rebuildArchiveSearchIndex,
 } from "../../src/archive/query/archive-view.js";
+import { isSearchIndexCurrent } from "../../src/archive/search-index/index.js";
 import { SpineDigest } from "../../src/facade/spine-digest.js";
 import { SpineDigestFile } from "../../src/wikg/spine-digest-file.js";
 import { WikgCoordinator } from "../../src/wikg/wikg-coordinator.js";
@@ -340,6 +341,64 @@ describe("wikg/spine-digest-file", () => {
             });
           },
         );
+      } finally {
+        restoreStateDir();
+      }
+    });
+  });
+
+  it("adopts orphaned external FTS cache after moving an archive", async () => {
+    await withTempDir("spinedigest-facade-file-", async (path) => {
+      const restoreStateDir = useCoordinatorStateDir(`${path}/state`);
+      try {
+        const archivePath = await createSeedArchive(path);
+        const movedArchivePath = `${path}/moved/book.wikg`;
+
+        await new SpineDigestFile(archivePath).write(
+          async (document) => {
+            await rebuildArchiveSearchIndex(document);
+          },
+          { searchIndexWritebackPolicy: "cache" },
+        );
+
+        const beforeOverlays = await readCoordinatorOverlays(path);
+        const oldFtsOverlay = beforeOverlays.find(
+          (overlay) => overlay.entryPath === "fts.db",
+        );
+
+        expect(oldFtsOverlay).toMatchObject({
+          archivePath,
+          entryPath: "fts.db",
+          kind: "file",
+        });
+        expect(oldFtsOverlay?.workspacePath).toContain(
+          createArchiveKey(archivePath),
+        );
+
+        await mkdir(`${path}/moved`, { recursive: true });
+        await rename(archivePath, movedArchivePath);
+        await new SpineDigestFile(movedArchivePath).readDocument(
+          async (document) => {
+            await expect(isSearchIndexCurrent(document)).resolves.toBe(true);
+          },
+        );
+
+        const afterOverlays = await readCoordinatorOverlays(path);
+        const newFtsOverlay = afterOverlays.find(
+          (overlay) =>
+            overlay.entryPath === "fts.db" &&
+            overlay.archivePath === movedArchivePath,
+        );
+
+        expect(newFtsOverlay).toMatchObject({
+          archivePath: movedArchivePath,
+          entryPath: "fts.db",
+          kind: "file",
+        });
+        expect(newFtsOverlay?.workspacePath).toContain(
+          createArchiveKey(movedArchivePath),
+        );
+        await expect(access(oldFtsOverlay!.workspacePath!)).rejects.toThrow();
       } finally {
         restoreStateDir();
       }


### PR DESCRIPTION
## Summary
- hide the invalid knowledge graph words counter from job progress snapshots
- make progress status output render generic metric groups instead of hard-coded token fields
- add regression coverage for knowledge graph progress counters

## Tests
- pnpm exec tsc -p tsconfig.json --noEmit
- pnpm lint
- pnpm format:check
- pnpm test:run