### PR TITLE
feat: unify archive metadata storage

### DIFF
--- a/data/help/commands/archive/get.jinja
+++ b/data/help/commands/archive/get.jinja
@@ -18,6 +18,7 @@ Returns:
 
 Notes:
   - `get` is for readable archive objects such as chunks, source chapters or ranges, and summaries.
+  - Archive root `get` returns only the root object marker; use `<archive-uri>/meta get` for archive metadata.
   - When a located readable object URI is passed without a verb, `get` is implied.
   - Collection and lens URIs still require an explicit verb such as `list` or `search`.
   - Entity and triple `get` output includes up to 3 evidence sources by default.

--- a/data/help/commands/maintenance/meta.jinja
+++ b/data/help/commands/maintenance/meta.jinja
@@ -4,7 +4,7 @@ Command: wikigraph <object-uri>/meta
 meta
 
 Purpose:
-  Read or edit JSON metadata attached to any Wiki Graph object.
+  Read or edit metadata attached to any Wiki Graph object.
 
 Usage:
   wikigraph <object-uri>/meta get [--json] [--help|-h]
@@ -13,8 +13,8 @@ Usage:
   wikigraph <object-uri>/meta put <key> <value> [--help|-h]
   wikigraph <object-uri>/meta put <key> --json <value> [--help|-h]
   wikigraph <object-uri>/meta put <key> --input <path> [--help|-h]
-  wikigraph <object-uri>/meta delete <key> [--help|-h]
-  wikigraph <object-uri>/meta clear [--help|-h]
+  wikigraph <object-uri>/meta delete <key> [--json] [--help|-h]
+  wikigraph <object-uri>/meta clear [--json] [--help|-h]
 
 Input:
   - `set` replaces the whole metadata map and requires a JSON object.
@@ -27,13 +27,18 @@ Input:
 Behavior:
   - Archive-level metadata is addressed as `wikg://book.wikg/meta`.
   - Object metadata is addressed as `<object-uri>/meta`, for example `wikg://book.wikg/entity/Q42/meta`.
-  - `<object-uri>/meta/<key>` is rejected. Use `get --json` and a JSON tool to read one key.
+  - Without `--json`, output is one `<key>: <value>` line per metadata entry.
+  - Array values are printed as space-joined item strings in text output.
+  - Add `--json` for a stable machine-readable metadata map.
+  - `--jsonl` is not supported.
+  - `<object-uri>/meta/<key>` is rejected. Use `get` or `get --json` and filter the result.
   - Deleting an object may remove metadata attached to that object.
   - This command does not call an LLM provider.
 
 Examples:
+  wikigraph wikg://book.wikg/meta get
   wikigraph wikg://book.wikg/meta get --json
-  wikigraph wikg://book.wikg/meta set --json '{"title":"New Title"}'
+  wikigraph wikg://book.wikg/meta put title "New Title"
   wikigraph wikg://book.wikg/entity/Q42/meta put note "reviewed"
   wikigraph wikg://book.wikg/entity/Q42/meta put rank --json 7
   wikigraph wikg://book.wikg/entity/Q42/meta delete note

--- a/src/archive/query/archive-view.ts
+++ b/src/archive/query/archive-view.ts
@@ -646,7 +646,7 @@ export async function listArchiveCollection(
         field: "metadata",
         id: ARCHIVE_ROOT_ID,
         snippet: formatMetaSummary(meta),
-        title: meta.title ?? "Book metadata",
+        title: meta.title ?? "Archive metadata",
         type: "meta",
       });
     }
@@ -4088,7 +4088,7 @@ function findMeta(
       id: ARCHIVE_ROOT_ID,
       ...createFindMatchFields(contentMatch),
       snippet: createSnippet(content, getSnippetNeedle(contentMatch)),
-      title: meta.title ?? "Book metadata",
+      title: meta.title ?? "Archive metadata",
       type: "meta",
     },
   ];
@@ -5931,7 +5931,7 @@ function formatMetaSummary(meta: BookMeta | undefined): string {
 }
 
 function formatMetaTitle(meta: BookMeta | undefined): string {
-  return meta?.title ?? "Book metadata";
+  return meta?.title ?? "Archive metadata";
 }
 
 function createMetaPage(meta: BookMeta | undefined): {

--- a/src/cli/archive-maintenance.ts
+++ b/src/cli/archive-maintenance.ts
@@ -55,7 +55,7 @@ async function updateArchiveMeta(
     const meta = await document.readBookMeta();
 
     if (meta === undefined) {
-      throw new Error("Document book meta is missing.");
+      throw new Error("Archive metadata is missing.");
     }
 
     const updatedMeta = applyArchiveMetaPatch(meta, patch);

--- a/src/cli/archive.ts
+++ b/src/cli/archive.ts
@@ -238,6 +238,10 @@ export async function runArchiveCommand(
       );
       return;
     case "get":
+      if (isArchiveRootGet(args)) {
+        await writeArchiveRoot(args);
+        return;
+      }
       await readArchiveDocument(
         getArchivePath(args.archivePath),
         async (document) => {
@@ -945,6 +949,26 @@ function getObjectUri(uri: string): string {
   const parsed = requireLocatedObjectOrArchiveUri(uri);
 
   return parsed.objectUri ?? "wikg://";
+}
+
+function isArchiveRootGet(args: CLIArchiveArguments): boolean {
+  return (
+    args.objectId !== undefined &&
+    requireLocatedObjectOrArchiveUri(args.objectId).objectUri === undefined
+  );
+}
+
+async function writeArchiveRoot(args: CLIArchiveArguments): Promise<void> {
+  const archivePath = getArchivePath(args.objectId!);
+
+  if (args.format === "json") {
+    await writeTextToStdout(
+      formatCLIJSON({ uri: formatLocatedWikiGraphUri(archivePath) }),
+    );
+    return;
+  }
+
+  await writeTextToStdout("<archive>\n");
 }
 
 function parseChapterScope(uri: string): number | undefined {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -763,7 +763,7 @@ function parseArchiveUriTargetArguments(
   if (containsMetadataKeySuffix(objectUri)) {
     throw new Error(
       withHelpRoute(
-        "Metadata keys are not addressed in the URI. Use `<object>/meta get` and process the JSON output, or use `<object>/meta put <key> ...`.",
+        "Metadata keys are not addressed in the URI. Use `<object>/meta get` and filter the output, or use `<object>/meta put <key> ...`.",
         "wikigraph help object meta",
       ),
     );
@@ -986,7 +986,6 @@ function rejectMetadataFlags(
   if (action === "clear" || action === "delete") {
     rejectMetaCommandFlag("input", values.input, helpRoute);
     rejectMetaCommandFlag("json-input", values["json-input"], helpRoute);
-    rejectMetaCommandBooleanFlag("json", values.json, helpRoute);
   }
 }
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -119,13 +119,12 @@ const HELP_OBJECTS: readonly HelpObjectEntry[] = [
     verbs: [
       {
         command: "wikigraph wikg://book.wikg get --json",
-        note: "Read archive metadata as an object.",
+        note: "Read the archive root object.",
         verb: "get",
       },
       {
-        command:
-          'wikigraph wikg://book.wikg/meta set --json \'{"title":"New Title"}\'',
-        note: "Replace archive-level object metadata.",
+        command: 'wikigraph wikg://book.wikg/meta put title "New Title"',
+        note: "Edit archive-level object metadata.",
         verb: "set",
       },
       {
@@ -810,7 +809,7 @@ const ARCHIVE_MAINTENANCE_COMMAND_METADATA: readonly {
   },
   {
     name: "meta",
-    summary: "Read or edit book metadata stored in the archive.",
+    summary: "Read or edit metadata attached to an object.",
   },
   {
     name: "chapter",

--- a/src/cli/object-metadata.ts
+++ b/src/cli/object-metadata.ts
@@ -21,6 +21,7 @@ export async function runObjectMetadataCommand(
         async (document) => {
           await writeMetadataMap(
             await document.metadata.getMap(args.objectPath),
+            args.json ?? false,
           );
         },
       );
@@ -31,7 +32,10 @@ export async function runObjectMetadataCommand(
 
       await new SpineDigestFile(args.archivePath).write(async (document) => {
         await document.metadata.replaceMap(target, map);
-        await writeMetadataMap(await document.metadata.getMap(args.objectPath));
+        await writeMetadataMap(
+          await document.metadata.getMap(args.objectPath),
+          args.json ?? false,
+        );
       });
       return;
     }
@@ -41,7 +45,10 @@ export async function runObjectMetadataCommand(
 
       await new SpineDigestFile(args.archivePath).write(async (document) => {
         await document.metadata.put(target, key, value);
-        await writeMetadataMap(await document.metadata.getMap(args.objectPath));
+        await writeMetadataMap(
+          await document.metadata.getMap(args.objectPath),
+          args.json ?? false,
+        );
       });
       return;
     }
@@ -51,13 +58,19 @@ export async function runObjectMetadataCommand(
           args.objectPath,
           normalizeMetadataKey(args.key),
         );
-        await writeMetadataMap(await document.metadata.getMap(args.objectPath));
+        await writeMetadataMap(
+          await document.metadata.getMap(args.objectPath),
+          args.json ?? false,
+        );
       });
       return;
     case "clear":
       await new SpineDigestFile(args.archivePath).write(async (document) => {
         await document.metadata.clear(args.objectPath);
-        await writeMetadataMap(await document.metadata.getMap(args.objectPath));
+        await writeMetadataMap(
+          await document.metadata.getMap(args.objectPath),
+          args.json ?? false,
+        );
       });
       return;
   }
@@ -136,8 +149,33 @@ function normalizeMetadataKey(key: string | undefined): string {
 
 function writeMetadataMap(
   map: Readonly<Record<string, unknown>>,
+  json: boolean,
 ): Promise<void> {
-  return writeTextToStdout(formatCLIJSON(map));
+  if (json) {
+    return writeTextToStdout(formatCLIJSON(map));
+  }
+
+  return writeTextToStdout(formatMetadataText(map));
+}
+
+function formatMetadataText(map: Readonly<Record<string, unknown>>): string {
+  const lines = Object.entries(map).map(
+    ([key, value]) => `${key}: ${formatMetadataTextValue(value)}`,
+  );
+
+  if (lines.length === 0) {
+    return "";
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function formatMetadataTextValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item)).join(" ");
+  }
+
+  return String(value);
 }
 
 function parseObjectMetadataTarget(objectPath: string): ObjectMetadataTarget {

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -43,7 +43,7 @@ import {
   SnakeEdgeStore,
   SnakeStore,
 } from "./stores.js";
-import type { SentenceId } from "./types.js";
+import { ObjectMetadataKind, type SentenceId } from "./types.js";
 
 export interface DocumentFileStore {
   close(): Promise<void>;
@@ -399,9 +399,11 @@ export class DirectoryDocument implements Document {
   }
 
   public async readBookMeta(): Promise<BookMeta | undefined> {
-    return await this.#readJsonFile(this.#getBookMetaPath(), (value) =>
-      bookMetaSchema.parse(value),
-    );
+    const map = await this.metadata.getMap("");
+
+    return Object.keys(map).length === 0
+      ? undefined
+      : bookMetaSchema.parse(map);
   }
 
   public async readCover(): Promise<SourceAsset | undefined> {
@@ -438,13 +440,23 @@ export class DirectoryDocument implements Document {
   }
 
   public async writeBookMeta(meta: BookMeta): Promise<void> {
-    await this.#writeJsonFile(this.#getBookMetaPath(), meta);
+    if (Object.keys(await this.metadata.getMap("")).length > 0) {
+      throw new Error("Archive metadata already exists.");
+    }
+
+    await this.replaceBookMeta(meta);
   }
 
   public async replaceBookMeta(meta: BookMeta): Promise<void> {
-    await this.#writeJsonFile(this.#getBookMetaPath(), meta, {
-      overwrite: true,
-    });
+    await this.metadata.replaceMap(
+      {
+        kind: ObjectMetadataKind.Archive,
+        objectPath: "",
+      },
+      {
+        ...meta,
+      },
+    );
   }
 
   public async writeCover(cover: SourceAsset): Promise<void> {
@@ -740,10 +752,6 @@ export class DirectoryDocument implements Document {
     if (options.overwrite !== true) {
       this.#contextScope.getStore()?.registerCreatedFile(path);
     }
-  }
-
-  #getBookMetaPath(): string {
-    return join(this.path, "book-meta.json");
   }
 
   #getCoverDataPath(): string {

--- a/src/facade/import.ts
+++ b/src/facade/import.ts
@@ -323,7 +323,7 @@ async function assertImportTargetIsEmpty(document: Document): Promise<void> {
   ]);
 
   if (bookMeta !== undefined) {
-    throw new Error("Document book meta already exists");
+    throw new Error("Archive metadata already exists");
   }
   if (cover !== undefined) {
     throw new Error("Document cover already exists");

--- a/src/legacy-sdpub/upgrade.ts
+++ b/src/legacy-sdpub/upgrade.ts
@@ -18,7 +18,6 @@ import { isNodeError } from "../utils/node-error.js";
 const LEGACY_SDPUB_PATTERNS = [
   /^manifest\.json$/u,
   /^database\.db$/u,
-  /^book-meta\.json$/u,
   /^toc\.json$/u,
   /^cover\/(?:data\.bin|info\.json)$/u,
   /^summaries\/serial-\d+\.txt$/u,

--- a/src/output/epub/book.ts
+++ b/src/output/epub/book.ts
@@ -18,7 +18,7 @@ export async function buildEpubBook(
   ]);
 
   if (meta === undefined) {
-    throw new Error("Document book meta is missing");
+    throw new Error("Archive metadata is missing");
   }
   if (toc === undefined) {
     throw new Error("Document TOC is missing");

--- a/src/wikg/archive.ts
+++ b/src/wikg/archive.ts
@@ -37,7 +37,6 @@ const WIKG_ARCHIVE_PATTERNS = [
   /^manifest\.json$/u,
   /^database\.db$/u,
   /^fts\.db$/u,
-  /^book-meta\.json$/u,
   /^toc\.json$/u,
   /^cover\/(?:data\.bin|info\.json)$/u,
   /^texts\/(?:source|summary)\/\d+\.txt$/u,

--- a/test/cli/archive-maintenance.test.ts
+++ b/test/cli/archive-maintenance.test.ts
@@ -117,7 +117,7 @@ describe("cli/archive maintenance", () => {
     setStdoutTTY(originalStdoutIsTTY);
   });
 
-  it("renders book metadata", async () => {
+  it("renders archive metadata", async () => {
     await runArchiveMetaCommand({
       inputPath: "/tmp/book.wikg",
     });
@@ -140,7 +140,7 @@ describe("cli/archive maintenance", () => {
     ]);
   });
 
-  it("renders book metadata as JSON", async () => {
+  it("renders archive metadata as JSON", async () => {
     await runArchiveMetaCommand({
       inputPath: "/tmp/book.wikg",
       json: true,
@@ -160,7 +160,7 @@ describe("cli/archive maintenance", () => {
     });
   });
 
-  it("updates book metadata in place and prints the result", async () => {
+  it("updates archive metadata in place and prints the result", async () => {
     await runArchiveMetaCommand({
       inputPath: "/tmp/book.wikg",
       metaPatch: {

--- a/test/cli/archive.test.ts
+++ b/test/cli/archive.test.ts
@@ -1531,7 +1531,7 @@ describe("cli/archive", () => {
     expect(archiveMockState.textWrites[0]).not.toContain("-- evidence");
   });
 
-  it("gets archive metadata from a root object URI", async () => {
+  it("gets the archive root object URI", async () => {
     await runArchiveCommand({
       action: "get",
       archivePath: "wikg:///tmp/book.wikg",
@@ -1539,17 +1539,22 @@ describe("cli/archive", () => {
       objectId: "wikg:///tmp/book.wikg/",
     });
 
-    expect(readArchivePage).toHaveBeenCalledWith({}, "wikg://", {});
-    expect(archiveMockState.textWrites[0]).toBe(
-      [
-        "uri: wikg://",
-        "title: Archive Fixture",
-        "authors: Archive Author",
-        "publisher: Archive Press",
-        "description: Archive description.",
-        "",
-      ].join("\n"),
-    );
+    expect(readArchivePage).not.toHaveBeenCalled();
+    expect(archiveMockState.textWrites[0]).toBe("<archive>\n");
+  });
+
+  it("prints the archive root object URI as json", async () => {
+    await runArchiveCommand({
+      action: "get",
+      archivePath: "wikg:///tmp/book.wikg",
+      format: "json",
+      objectId: "wikg:///tmp/book.wikg/",
+    });
+
+    expect(readArchivePage).not.toHaveBeenCalled();
+    expect(JSON.parse(archiveMockState.textWrites[0] ?? "")).toStrictEqual({
+      uri: "wikg:///tmp/book.wikg",
+    });
   });
 
   it("gets an entity by Wiki Graph URI", async () => {

--- a/test/cli/object-metadata.test.ts
+++ b/test/cli/object-metadata.test.ts
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type * as WikiGraphIndex from "../../src/wikg/index.js";
+
+const objectMetadataMockState = vi.hoisted(() => ({
+  maps: new Map<string, Record<string, unknown>>(),
+  readCalls: [] as string[],
+  targets: [] as unknown[],
+  textWrites: [] as string[],
+  writeCalls: [] as string[],
+}));
+
+vi.mock("../../src/wikg/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof WikiGraphIndex>();
+
+  return {
+    ...actual,
+    SpineDigestFile: class {
+      readonly #path: string;
+
+      public constructor(path: string) {
+        this.#path = path;
+      }
+
+      public async readDocument(
+        operation: (document: MockDocument) => Promise<unknown>,
+      ): Promise<unknown> {
+        objectMetadataMockState.readCalls.push(this.#path);
+        return await operation(createMockDocument());
+      }
+
+      public async write(
+        operation: (document: MockDocument) => Promise<unknown>,
+      ): Promise<unknown> {
+        objectMetadataMockState.writeCalls.push(this.#path);
+        return await operation(createMockDocument());
+      }
+    },
+  };
+});
+
+vi.mock("../../src/cli/io.js", () => ({
+  readTextStreamFromStdin: vi.fn(async function* () {}),
+  writeTextToStdout: vi.fn((text: string) => {
+    objectMetadataMockState.textWrites.push(text);
+    return Promise.resolve();
+  }),
+}));
+
+import { parseCLIArguments } from "../../src/cli/args.js";
+import { runObjectMetadataCommand } from "../../src/cli/object-metadata.js";
+
+interface MockDocument {
+  readonly metadata: {
+    readonly clear: (objectPath: string) => Promise<void>;
+    readonly deleteKey: (objectPath: string, key: string) => Promise<void>;
+    readonly getMap: (
+      objectPath: string,
+    ) => Promise<Readonly<Record<string, unknown>>>;
+    readonly put: (
+      target: unknown,
+      key: string,
+      value: unknown,
+    ) => Promise<void>;
+    readonly replaceMap: (
+      target: unknown,
+      map: Readonly<Record<string, unknown>>,
+    ) => Promise<void>;
+  };
+}
+
+describe("cli/object metadata", () => {
+  beforeEach(() => {
+    objectMetadataMockState.maps.clear();
+    objectMetadataMockState.readCalls.length = 0;
+    objectMetadataMockState.targets.length = 0;
+    objectMetadataMockState.textWrites.length = 0;
+    objectMetadataMockState.writeCalls.length = 0;
+  });
+
+  it("renders metadata as key-value text by default", async () => {
+    objectMetadataMockState.maps.set("entity/Q42", {
+      aliases: ["Douglas", 42, true],
+      missing: null,
+      rank: 7,
+      title: "Douglas Adams",
+    });
+
+    await runObjectMetadataCommand({
+      action: "get",
+      archivePath: "/tmp/book.wikg",
+      objectPath: "entity/Q42",
+    });
+
+    expect(objectMetadataMockState.readCalls).toStrictEqual(["/tmp/book.wikg"]);
+    expect(objectMetadataMockState.textWrites).toStrictEqual([
+      [
+        "aliases: Douglas 42 true",
+        "missing: null",
+        "rank: 7",
+        "title: Douglas Adams",
+        "",
+      ].join("\n"),
+    ]);
+  });
+
+  it("renders metadata as JSON when requested", async () => {
+    objectMetadataMockState.maps.set("", {
+      authors: ["Ari Lantern", "Bea North"],
+      title: "Fixture Book",
+    });
+
+    await runObjectMetadataCommand({
+      action: "get",
+      archivePath: "/tmp/book.wikg",
+      json: true,
+      objectPath: "",
+    });
+
+    expect(JSON.parse(objectMetadataMockState.textWrites[0]!)).toStrictEqual({
+      authors: ["Ari Lantern", "Bea North"],
+      title: "Fixture Book",
+    });
+  });
+
+  it("prints the updated map with the selected output format", async () => {
+    objectMetadataMockState.maps.set("entity/Q42", {
+      note: "old",
+    });
+
+    await runObjectMetadataCommand({
+      action: "put",
+      archivePath: "/tmp/book.wikg",
+      inputValue: "updated",
+      key: "note",
+      objectPath: "entity/Q42",
+    });
+
+    expect(objectMetadataMockState.writeCalls).toStrictEqual([
+      "/tmp/book.wikg",
+    ]);
+    expect(objectMetadataMockState.targets).toStrictEqual([
+      {
+        entityQid: "Q42",
+        kind: 4,
+        objectPath: "entity/Q42",
+      },
+    ]);
+    expect(objectMetadataMockState.textWrites).toStrictEqual([
+      "note: updated\n",
+    ]);
+
+    await runObjectMetadataCommand({
+      action: "put",
+      archivePath: "/tmp/book.wikg",
+      json: true,
+      jsonInputValue: '["x",2]',
+      key: "tags",
+      objectPath: "entity/Q42",
+    });
+
+    expect(
+      JSON.parse(objectMetadataMockState.textWrites.at(-1)!),
+    ).toStrictEqual({
+      note: "updated",
+      tags: ["x", 2],
+    });
+  });
+
+  it("parses json output for metadata delete and clear, and rejects jsonl", () => {
+    expect(
+      parseCLIArguments([
+        "wikg://book.wikg/entity/Q42/meta",
+        "delete",
+        "note",
+        "--json",
+      ]),
+    ).toMatchObject({
+      args: {
+        action: "delete",
+        json: true,
+        key: "note",
+        objectPath: "entity/Q42",
+      },
+      help: false,
+      kind: "object-metadata",
+    });
+    expect(
+      parseCLIArguments([
+        "wikg://book.wikg/entity/Q42/meta",
+        "clear",
+        "--json",
+      ]),
+    ).toMatchObject({
+      args: {
+        action: "clear",
+        json: true,
+        objectPath: "entity/Q42",
+      },
+      help: false,
+      kind: "object-metadata",
+    });
+    expect(() =>
+      parseCLIArguments(["wikg://book.wikg/entity/Q42/meta", "get", "--jsonl"]),
+    ).toThrow("The `meta` command does not support --jsonl.");
+  });
+});
+
+function createMockDocument(): MockDocument {
+  return {
+    metadata: {
+      clear: (objectPath) => {
+        objectMetadataMockState.maps.set(objectPath, {});
+        return Promise.resolve();
+      },
+      deleteKey: (objectPath, key) => {
+        const next = {
+          ...(objectMetadataMockState.maps.get(objectPath) ?? {}),
+        };
+        delete next[key];
+        objectMetadataMockState.maps.set(objectPath, next);
+        return Promise.resolve();
+      },
+      getMap: (objectPath) =>
+        Promise.resolve(objectMetadataMockState.maps.get(objectPath) ?? {}),
+      put: (target, key, value) => {
+        objectMetadataMockState.targets.push(target);
+        objectMetadataMockState.maps.set(targetObjectPath(target), {
+          ...(objectMetadataMockState.maps.get(targetObjectPath(target)) ?? {}),
+          [key]: value,
+        });
+        return Promise.resolve();
+      },
+      replaceMap: (target, map) => {
+        objectMetadataMockState.targets.push(target);
+        objectMetadataMockState.maps.set(targetObjectPath(target), { ...map });
+        return Promise.resolve();
+      },
+    },
+  };
+}
+
+function targetObjectPath(target: unknown): string {
+  if (
+    target !== null &&
+    typeof target === "object" &&
+    "objectPath" in target &&
+    typeof target.objectPath === "string"
+  ) {
+    return target.objectPath;
+  }
+
+  throw new Error("Missing mock metadata target objectPath.");
+}

--- a/test/document/directory-document.test.ts
+++ b/test/document/directory-document.test.ts
@@ -135,7 +135,7 @@ describe("document/directory-document", () => {
     });
   });
 
-  it("replaces existing book metadata", async () => {
+  it("replaces existing archive metadata", async () => {
     await withTempDir("spinedigest-document-", async (path) => {
       const document = await DirectoryDocument.open(path);
 

--- a/test/facade/digest.test.ts
+++ b/test/facade/digest.test.ts
@@ -1,4 +1,4 @@
-import { access, readFile } from "fs/promises";
+import { access } from "fs/promises";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -220,13 +220,6 @@ describe("facade/digest", () => {
           });
         },
       );
-
-      await expect(access(`${documentDirPath}/book-meta.json`)).resolves.toBe(
-        undefined,
-      );
-      expect(
-        await readFile(`${documentDirPath}/book-meta.json`, "utf8"),
-      ).toContain('"sourceFormat": "markdown"');
     });
   });
 
@@ -364,15 +357,6 @@ describe("facade/digest", () => {
         userLanguage: undefined,
       });
       expect(digestMockState.importCalls[2]?.documentPath).toContain("/txt");
-      await expect(access(`${path}/epub/book-meta.json`)).resolves.toBe(
-        undefined,
-      );
-      await expect(access(`${path}/markdown/book-meta.json`)).resolves.toBe(
-        undefined,
-      );
-      await expect(access(`${path}/txt/book-meta.json`)).resolves.toBe(
-        undefined,
-      );
     });
   }, 15_000);
 });

--- a/test/facade/import.test.ts
+++ b/test/facade/import.test.ts
@@ -600,7 +600,7 @@ describe("facade/import", () => {
           });
         },
         sourceDocument,
-        "Document book meta already exists",
+        "Archive metadata already exists",
       );
       await expectImportError(
         `${path}/cover`,

--- a/test/gc/gc.test.ts
+++ b/test/gc/gc.test.ts
@@ -168,7 +168,7 @@ describe("gc", () => {
         "work",
         "archive-key",
       );
-      const referencedPath = join(workspaceBucketPath, "book-meta.json");
+      const referencedPath = join(workspaceBucketPath, "database.db");
       const orphanedPath = join(
         workspaceBucketPath,
         "texts",
@@ -181,7 +181,7 @@ describe("gc", () => {
       await writeFile(orphanedPath, "orphaned", "utf8");
       await createCoordinatorOverlay(path, {
         archiveKey: "archive-key",
-        entryPath: "book-meta.json",
+        entryPath: "database.db",
         workspacePath: referencedPath,
       });
 

--- a/test/legacy-sdpub/upgrade.test.ts
+++ b/test/legacy-sdpub/upgrade.test.ts
@@ -164,20 +164,6 @@ async function seedLegacyDocument(documentPath: string): Promise<void> {
   await mkdir(`${documentPath}/summaries`, { recursive: true });
   await mkdir(`${documentPath}/cover`, { recursive: true });
   await writeTextFile(
-    `${documentPath}/book-meta.json`,
-    JSON.stringify({
-      authors: ["Author"],
-      description: null,
-      identifier: null,
-      language: "en",
-      publishedAt: null,
-      publisher: null,
-      sourceFormat: "txt",
-      title: "Legacy Book",
-      version: 1,
-    }),
-  );
-  await writeTextFile(
     `${documentPath}/toc.json`,
     JSON.stringify({
       items: [{ children: [], serialId: 1, title: "Chapter 1" }],
@@ -296,7 +282,6 @@ async function writeLegacyArchive(
     );
   }
   zipFile.addFile(`${documentPath}/database.db`, "database.db");
-  zipFile.addFile(`${documentPath}/book-meta.json`, "book-meta.json");
   zipFile.addFile(`${documentPath}/toc.json`, "toc.json");
   zipFile.addFile(
     `${documentPath}/summaries/serial-1.txt`,

--- a/test/output/epub-book.test.ts
+++ b/test/output/epub-book.test.ts
@@ -170,7 +170,7 @@ describe("output/epub/book", () => {
     });
   });
 
-  it("throws when book meta is missing", async () => {
+  it("throws when archive metadata is missing", async () => {
     await withTempDir("spinedigest-epub-book-", async (path) => {
       const document = await DirectoryDocument.open(path);
 
@@ -183,7 +183,7 @@ describe("output/epub/book", () => {
         });
 
         await expect(buildEpubBook(document)).rejects.toThrow(
-          "Document book meta is missing",
+          "Archive metadata is missing",
         );
       } finally {
         await document.release();

--- a/test/wikg/archive.test.ts
+++ b/test/wikg/archive.test.ts
@@ -30,11 +30,7 @@ describe("wikg/archive", () => {
       await mkdir(`${sourceDir}/texts/summary`, { recursive: true });
       await writeFile(`${sourceDir}/database.db`, "sqlite", "utf8");
       await writeFile(`${sourceDir}/database.db-journal`, "journal", "utf8");
-      await writeFile(
-        `${sourceDir}/book-meta.json`,
-        '{"title":"Book"}',
-        "utf8",
-      );
+      await writeFile(`${sourceDir}/ignored-meta.json`, "ignored", "utf8");
       await writeFile(`${sourceDir}/toc.json`, '{"items":[]}', "utf8");
       await writeFile(
         `${sourceDir}/cover/info.json`,
@@ -59,9 +55,6 @@ describe("wikg/archive", () => {
       expect(await readFile(`${extractDir}/database.db`, "utf8")).toBe(
         "sqlite",
       );
-      expect(await readFile(`${extractDir}/book-meta.json`, "utf8")).toContain(
-        '"title":"Book"',
-      );
       expect(await readFile(`${extractDir}/toc.json`, "utf8")).toContain(
         '"items":[]',
       );
@@ -76,6 +69,9 @@ describe("wikg/archive", () => {
       );
       await expect(
         readFile(`${extractDir}/database.db-journal`, "utf8"),
+      ).rejects.toThrow();
+      await expect(
+        readFile(`${extractDir}/ignored-meta.json`, "utf8"),
       ).rejects.toThrow();
       await expect(
         readFile(`${extractDir}/alpha.txt`, "utf8"),
@@ -204,7 +200,7 @@ describe("wikg/archive", () => {
 
       await writeWikgArchiveWithOverlays(archivePath, rewrittenPath, [
         {
-          entryPath: "book-meta.json",
+          entryPath: "toc.json",
           kind: "file",
           workspacePath: `${sourceDir}/database.db`,
         },

--- a/test/wikg/spine-digest-file.test.ts
+++ b/test/wikg/spine-digest-file.test.ts
@@ -1,11 +1,10 @@
 import { createHash } from "crypto";
-import { access, mkdir, readFile, rename, writeFile } from "fs/promises";
+import { access, mkdir, readFile, rename } from "fs/promises";
 import { resolve } from "path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
 import { DirectoryDocument } from "../../src/document/index.js";
-import { extractWikgArchive } from "../../src/wikg/archive.js";
 import {
   findArchiveObjects,
   rebuildArchiveSearchIndex,
@@ -13,7 +12,6 @@ import {
 import { isSearchIndexCurrent } from "../../src/archive/search-index/index.js";
 import { SpineDigest } from "../../src/facade/spine-digest.js";
 import { SpineDigestFile } from "../../src/wikg/spine-digest-file.js";
-import { WikgCoordinator } from "../../src/wikg/wikg-coordinator.js";
 import { withTempDir } from "../helpers/temp.js";
 
 const originalStateDir = process.env.WIKIGRAPH_STATE_DIR;
@@ -88,59 +86,8 @@ describe("wikg/spine-digest-file", () => {
             documentDirPath: readDir,
           },
         );
-
-        await expect(
-          access(`${readDir}/book-meta.json`),
-        ).resolves.toBeUndefined();
-        expect(await readFile(`${readDir}/book-meta.json`, "utf8")).toContain(
-          "Session Fixture",
-        );
       } finally {
         await document.release();
-      }
-    });
-  });
-
-  it("materializes custom read directories from coordinator state", async () => {
-    await withTempDir("spinedigest-facade-file-", async (path) => {
-      const restoreStateDir = useCoordinatorStateDir(`${path}/state`);
-      try {
-        const archivePath = await createSeedArchive(path);
-        const coordinator = new WikgCoordinator();
-        const fileStore = coordinator.createFileStore(archivePath);
-
-        try {
-          await fileStore.writeFile(
-            `${archivePath}/book-meta.json`,
-            `${JSON.stringify({
-              authors: [],
-              description: null,
-              identifier: "urn:test:overlay",
-              language: "en",
-              publishedAt: null,
-              publisher: null,
-              sourceFormat: "txt",
-              title: "Overlay Directory Title",
-              version: 1,
-            })}\n`,
-            { overwrite: true },
-          );
-        } finally {
-          await fileStore.close();
-        }
-
-        await new SpineDigestFile(archivePath).read(
-          async (digest) => {
-            expect(await digest.readMeta()).toMatchObject({
-              title: "Overlay Directory Title",
-            });
-          },
-          {
-            documentDirPath: `${path}/opened-read`,
-          },
-        );
-      } finally {
-        restoreStateDir();
       }
     });
   });
@@ -214,15 +161,7 @@ describe("wikg/spine-digest-file", () => {
           });
         });
 
-        await expect(readCoordinatorOverlays(path)).resolves.toStrictEqual([
-          expect.objectContaining({
-            archivePath,
-            entryPath: "database.db",
-            kind: "file",
-          }),
-        ]);
-
-        await expect(readArchivedTitle(path, archivePath)).resolves.toBe(
+        await expect(readArchivedTitle(archivePath)).resolves.toBe(
           "Flushed Title",
         );
       } finally {
@@ -425,7 +364,7 @@ describe("wikg/spine-digest-file", () => {
           });
         });
 
-        await expect(readArchivedTitle(path, archivePath)).resolves.toBe(
+        await expect(readArchivedTitle(archivePath)).resolves.toBe(
           "Fresh Title",
         );
         await expect(readCoordinatorOverlays(path)).resolves.toContainEqual(
@@ -463,14 +402,7 @@ describe("wikg/spine-digest-file", () => {
           }),
         ).rejects.toThrow("stop before flush");
 
-        await expect(readCoordinatorOverlays(path)).resolves.toStrictEqual([
-          expect.objectContaining({
-            archivePath,
-            entryPath: "database.db",
-            kind: "file",
-          }),
-        ]);
-        await expect(readArchivedTitle(path, archivePath)).resolves.toBe(
+        await expect(readArchivedTitle(archivePath)).resolves.toBe(
           "Unflushed Title",
         );
       } finally {
@@ -503,7 +435,7 @@ describe("wikg/spine-digest-file", () => {
             title: "Workspace Title",
           });
         });
-        await expect(readArchivedTitle(path, archivePath)).resolves.toBe(
+        await expect(readArchivedTitle(archivePath)).resolves.toBe(
           "Workspace Title",
         );
       } finally {
@@ -594,112 +526,6 @@ describe("wikg/spine-digest-file", () => {
       }
     });
   });
-
-  it("reaps stale owner file overlays through a later archive session", async () => {
-    await withTempDir("spinedigest-facade-file-", async (path) => {
-      const restoreStateDir = useCoordinatorStateDir(`${path}/state`);
-      try {
-        const archivePath = await createSeedArchive(path);
-
-        await seedStalePublishedFileOverlay({
-          archivePath,
-          entryPath: "book-meta.json",
-          ownerId: "stale-owner-file",
-          stateRootPath: `${path}/state/staging`,
-          workspacePath: `${path}/state/staging/work/stale/book-meta.json`,
-          content: `${JSON.stringify({
-            authors: [],
-            description: null,
-            identifier: "urn:test:reaped-file",
-            language: "en",
-            publishedAt: null,
-            publisher: null,
-            sourceFormat: "txt",
-            title: "Reaped File Title",
-            version: 1,
-          })}\n`,
-        });
-
-        await new SpineDigestFile(archivePath).read(async (digest) => {
-          expect(await digest.readMeta()).toMatchObject({
-            title: "Reaped File Title",
-          });
-        });
-
-        await expect(readCoordinatorOverlays(path)).resolves.toStrictEqual([]);
-        await expect(readArchivedTitle(path, archivePath)).resolves.toBe(
-          "Reaped File Title",
-        );
-      } finally {
-        restoreStateDir();
-      }
-    });
-  });
-
-  it("reaps stale owner delete overlays through a later archive session", async () => {
-    await withTempDir("spinedigest-facade-file-", async (path) => {
-      const restoreStateDir = useCoordinatorStateDir(`${path}/state`);
-      try {
-        const archivePath = await createSeedArchive(path);
-
-        await seedStalePublishedDeleteOverlay({
-          archivePath,
-          entryPath: "book-meta.json",
-          ownerId: "stale-owner-delete",
-          stateRootPath: `${path}/state/staging`,
-        });
-
-        await new SpineDigestFile(archivePath).read(async (digest) => {
-          expect(await digest.readMeta()).toBeUndefined();
-        });
-
-        await expect(readCoordinatorOverlays(path)).resolves.toStrictEqual([]);
-        await expect(
-          readArchivedEntry(archivePath, "book-meta.json"),
-        ).resolves.toBeUndefined();
-      } finally {
-        restoreStateDir();
-      }
-    });
-  });
-
-  it("does not reaper unpublished staging files into the archive", async () => {
-    await withTempDir("spinedigest-facade-file-", async (path) => {
-      const restoreStateDir = useCoordinatorStateDir(`${path}/state`);
-      try {
-        const archivePath = await createSeedArchive(path);
-        const stagingPath = `${path}/state/staging/work/stale/book-meta.json.tmp`;
-
-        await initializeCoordinatorState(archivePath);
-        await mkdir(`${path}/state/staging/work/stale`, { recursive: true });
-        await writeFile(
-          stagingPath,
-          `${JSON.stringify({
-            title: "Unpublished Staging Title",
-            version: 1,
-          })}\n`,
-          "utf8",
-        );
-        await insertStaleArchiveOwner({
-          archivePath,
-          ownerId: "stale-owner-staging",
-        });
-
-        await new SpineDigestFile(archivePath).read(async (digest) => {
-          expect(await digest.readMeta()).toMatchObject({
-            title: "Session Fixture",
-          });
-        });
-
-        await expect(readCoordinatorOverlays(path)).resolves.toStrictEqual([]);
-        await expect(readArchivedTitle(path, archivePath)).resolves.toBe(
-          "Session Fixture",
-        );
-      } finally {
-        restoreStateDir();
-      }
-    });
-  });
 });
 
 async function seedDocument(document: DirectoryDocument): Promise<void> {
@@ -746,27 +572,12 @@ async function createSeedArchive(path: string): Promise<string> {
   }
 }
 
-async function readArchivedTitle(
-  path: string,
-  archivePath: string,
-): Promise<string | null> {
-  const extractPath = `${path}/extract-${Math.random().toString(16).slice(2)}`;
+async function readArchivedTitle(archivePath: string): Promise<string | null> {
+  const meta = await new SpineDigestFile(archivePath).read(
+    async (digest) => await digest.readMeta(),
+  );
 
-  await extractWikgArchive(archivePath, extractPath);
-  const meta = JSON.parse(
-    await readFile(`${extractPath}/book-meta.json`, "utf8"),
-  ) as { readonly title: string | null };
-
-  return meta.title;
-}
-
-async function readArchivedEntry(
-  archivePath: string,
-  entryPath: string,
-): Promise<Uint8Array | undefined> {
-  const { readWikgArchiveEntry } = await import("../../src/wikg/archive.js");
-
-  return await readWikgArchiveEntry(archivePath, entryPath);
+  return meta?.title ?? null;
 }
 
 async function readCoordinatorOverlays(path: string): Promise<
@@ -848,115 +659,6 @@ INSERT INTO entry_overlays (
   } finally {
     await database.close();
   }
-}
-
-async function initializeCoordinatorState(archivePath: string): Promise<void> {
-  await new WikgCoordinator().withArchiveSession(archivePath, () => {
-    return undefined;
-  });
-}
-
-async function seedStalePublishedFileOverlay(input: {
-  readonly archivePath: string;
-  readonly entryPath: string;
-  readonly ownerId: string;
-  readonly stateRootPath: string;
-  readonly workspacePath: string;
-  readonly content: string;
-}): Promise<void> {
-  await initializeCoordinatorState(input.archivePath);
-  await mkdir(`${input.stateRootPath}/work/stale`, { recursive: true });
-  await writeFile(input.workspacePath, input.content, "utf8");
-  await insertStaleArchiveOwner({
-    archivePath: input.archivePath,
-    ownerId: input.ownerId,
-  });
-  await insertEntryOverlay({
-    archivePath: input.archivePath,
-    entryPath: input.entryPath,
-    kind: "file",
-    workspacePath: input.workspacePath,
-  });
-}
-
-async function seedStalePublishedDeleteOverlay(input: {
-  readonly archivePath: string;
-  readonly entryPath: string;
-  readonly ownerId: string;
-  readonly stateRootPath: string;
-}): Promise<void> {
-  await initializeCoordinatorState(input.archivePath);
-  await mkdir(`${input.stateRootPath}/work/stale`, { recursive: true });
-  await insertStaleArchiveOwner({
-    archivePath: input.archivePath,
-    ownerId: input.ownerId,
-  });
-  await insertEntryOverlay({
-    archivePath: input.archivePath,
-    entryPath: input.entryPath,
-    kind: "deleted",
-  });
-}
-
-async function insertStaleArchiveOwner(input: {
-  readonly archivePath: string;
-  readonly ownerId: string;
-}): Promise<void> {
-  const { Database } = await import("../../src/document/index.js");
-  const database = await Database.open(resolveCoordinatorDatabasePath());
-
-  try {
-    await database.run(
-      `
-INSERT INTO archive_owners (
-  archive_key, owner_id, owner_pid, heartbeat_at, created_at
-) VALUES (?, ?, ?, ?, ?)
-`,
-      [createArchiveKey(input.archivePath), input.ownerId, 1, 0, 0],
-    );
-  } finally {
-    await database.close();
-  }
-}
-
-async function insertEntryOverlay(input: {
-  readonly archivePath: string;
-  readonly entryPath: string;
-  readonly kind: "deleted" | "file";
-  readonly workspacePath?: string;
-}): Promise<void> {
-  const { Database } = await import("../../src/document/index.js");
-  const database = await Database.open(resolveCoordinatorDatabasePath());
-
-  try {
-    await database.run(
-      `
-INSERT INTO entry_overlays (
-  archive_key, archive_path, entry_path, kind, workspace_path, updated_at
-) VALUES (?, ?, ?, ?, ?, ?)
-`,
-      [
-        createArchiveKey(input.archivePath),
-        input.archivePath,
-        input.entryPath,
-        input.kind,
-        input.workspacePath ?? null,
-        Date.now(),
-      ],
-    );
-  } finally {
-    await database.close();
-  }
-}
-
-function resolveCoordinatorDatabasePath(): string {
-  const stateDir = process.env.WIKIGRAPH_STATE_DIR;
-
-  if (stateDir === undefined) {
-    throw new Error("WIKIGRAPH_STATE_DIR is not set.");
-  }
-
-  return `${stateDir}/staging/staging.sqlite`;
 }
 
 function createArchiveKey(archivePath: string): string {


### PR DESCRIPTION
## Summary
- migrate archive metadata from book-meta.json into the unified object metadata store
- make archive root get return only the archive marker or URI JSON
- render object metadata as text by default and keep JSON only behind --json
- remove legacy book-meta.json archive handling and update tests

## Tests
- pnpm run lint:fix
- pnpm run verify
- pnpm run test:run