### PR TITLE
fix(help): improve agent-facing Wiki Graph help edges

### DIFF
--- a/data/help/commands/maintenance/chapter.jinja
+++ b/data/help/commands/maintenance/chapter.jinja
@@ -37,7 +37,7 @@ Input rules:
   - `<archive-uri>/chapter/tree set` applies a complete chapter tree JSON. It can reorder chapters and change titles when a node includes `title`.
   - `reset --to` accepts `planned`, `source`, or `reading-graph`.
   - Structure edits, `/title set`, `/source set`, `/summary set`, and `reset` do not call an LLM provider.
-  - To generate reading-graph, reading-summary, or knowledge-graph for a chapter, use `wikigraph wikg://local/job add --input <chapter-uri> --task <reading-graph|reading-summary|knowledge-graph> --accept-cost`.
+  - To generate reading-graph, reading-summary, or knowledge-graph, use `wikigraph wikg://local/job add --input <archive-uri|chapter-uri> --task <reading-graph|reading-summary|knowledge-graph> --accept-cost`.
   - `<chapter-uri>/state` shows the aggregate chapter state. `<chapter-uri>/state/<target>` checks one target.
   - Append `--help` after an action for action-specific details, for example `wikigraph wikg://book.wikg/chapter/3 reset --help`.
 

--- a/data/help/commands/maintenance/chapter/add.jinja
+++ b/data/help/commands/maintenance/chapter/add.jinja
@@ -27,7 +27,7 @@ Output shape:
   The `Chapter: <id>` line is the new chapter id for later commands.
 
 Typical next step:
-  wikigraph wikg://local/job add --input <chapter-uri> --task reading-graph --accept-cost
+  wikigraph wikg://local/job add --input <archive-uri|chapter-uri> --task reading-graph --accept-cost
 
 Examples:
   wikigraph wikg://book.wikg/chapter add --stage planned --title "Part I"

--- a/data/help/commands/maintenance/chapter/reset.jinja
+++ b/data/help/commands/maintenance/chapter/reset.jinja
@@ -18,7 +18,7 @@ Behavior:
   - `reading-summary` is not supported because reset is a backward operation.
   - Reset is destructive and may discard work.
   - Does not call an LLM provider.
-  - After resetting to `source` or `reading-graph`, use `wikigraph wikg://local/job add --input <chapter-uri> --task <reading-graph|reading-summary|knowledge-graph> --accept-cost` to generate again.
+  - After resetting to `source` or `reading-graph`, use `wikigraph wikg://local/job add --input <archive-uri|chapter-uri> --task <reading-graph|reading-summary|knowledge-graph> --accept-cost` to generate again.
   - After resetting to `planned`, restore source text before starting generated tasks.
 
 See also:

--- a/data/help/commands/maintenance/chapter/set-source.jinja
+++ b/data/help/commands/maintenance/chapter/set-source.jinja
@@ -23,7 +23,7 @@ Behavior:
   - Does not call an LLM provider.
 
 Typical next step:
-  wikigraph wikg://local/job add --input <chapter-uri> --task reading-graph --accept-cost
+  wikigraph wikg://local/job add --input <archive-uri|chapter-uri> --task reading-graph --accept-cost
 
 See also:
   - wikigraph wikg://book.wikg/chapter/3/state --help

--- a/data/help/commands/maintenance/chapter/set-summary.jinja
+++ b/data/help/commands/maintenance/chapter/set-summary.jinja
@@ -15,7 +15,7 @@ Input:
 Preconditions:
   - The chapter must be `reading-graph`.
   - If the chapter is `source`, run:
-    wikigraph wikg://local/job add --input <chapter-uri> --task reading-graph --accept-cost
+    wikigraph wikg://local/job add --input <archive-uri|chapter-uri> --task reading-graph --accept-cost
 
 Behavior:
   - Moves the chapter to `reading-summary`.

--- a/data/help/commands/predicate.jinja
+++ b/data/help/commands/predicate.jinja
@@ -409,6 +409,9 @@ Notes:
   - Text success output is intentionally short.
   - With `--json`, success and failure both return `{ "ok": true|false, ... }`; failures set a non-zero exit code.
   - Without `--json`, failures print the command error. Use `wikigraph help readiness` and `wikigraph help config` to recover.
+{% if "/wikispine" in uri %}
+  - Runtime setup and recovery guide: https://raw.githubusercontent.com/oomol-lab/wiki-graph/refs/heads/main/docs/wikispine-runtime.md
+{% endif %}
 {% endif %}
 
 Related help:

--- a/data/help/commands/predicate.jinja
+++ b/data/help/commands/predicate.jinja
@@ -53,7 +53,7 @@ Usage:
   wikigraph {{ uri }} create [source] [--input-format <format>] [--llm <json>] [--prompt <text>] [--json]
 
 Notes:
-  - `source` may be EPUB, Markdown, txt, or another supported input path.
+  - `source` may be EPUB, Markdown, txt, URL, or another supported input path.
   - Without `source`, an empty `.wikg` archive is created unless stdin is selected with `--input-format`.
   - Stdin is supported when `--input-format markdown` or `--input-format txt` is provided.
   - Input format is inferred from the source extension when possible; use `--input-format` when stdin or the extension is ambiguous.
@@ -75,7 +75,7 @@ Purpose:
   Export a projection from this archive.
 
 Usage:
-  wikigraph {{ uri }} export --output-format markdown|txt|epub [--output <path>]
+  wikigraph {{ uri }} export [--output-format markdown|txt|epub] [--output <path>]
 
 Notes:
   - Default output format is markdown when omitted by the parser, but explicit `--output-format` is recommended.

--- a/data/help/commands/predicate.jinja
+++ b/data/help/commands/predicate.jinja
@@ -50,20 +50,44 @@ Purpose:
   Create or replace the archive at this URI.
 
 Usage:
-  wikigraph {{ uri }} create [source] [--input-format <format>] [--llm <json>] [--prompt <text>]
+  wikigraph {{ uri }} create [source] [--input-format <format>] [--llm <json>] [--prompt <text>] [--json]
 
 Notes:
-  - `source` may be EPUB, Markdown, txt, or another supported input.
+  - `source` may be EPUB, Markdown, txt, or another supported input path.
+  - Without `source`, an empty `.wikg` archive is created unless stdin is selected with `--input-format`.
   - Stdin is supported when `--input-format markdown` or `--input-format txt` is provided.
+  - Input format is inferred from the source extension when possible; use `--input-format` when stdin or the extension is ambiguous.
+  - Creating from EPUB, Markdown, txt, URL, or stdin runs only the import/source stage.
+  - This command creates or replaces the target archive file; parent directories must already exist.
+  - `--llm <json>` passes local LLM settings to the import pipeline when the selected input path needs them.
+  - On success, text output is the archive object (`<archive>`). With `--json`, output is `{"uri":"..."}`.
+
+Examples:
+  wikigraph {{ uri }} create ./book.epub
+  wikigraph {{ uri }} create ./notes.md --input-format markdown
+  cat chapter.md | wikigraph {{ uri }} create --input-format markdown
+  wikigraph {{ uri }} create --json
+
+Next:
+  wikigraph {{ uri }} inspect
 {% elif predicate == "export" %}
 Purpose:
   Export a projection from this archive.
 
 Usage:
-  wikigraph {{ uri }} export --output-format <format> [--output <path>]
+  wikigraph {{ uri }} export --output-format markdown|txt|epub [--output <path>]
 
 Notes:
+  - Default output format is markdown when omitted by the parser, but explicit `--output-format` is recommended.
+  - Without `--output`, exported content is written to stdout.
+  - `--json` and `--jsonl` are not supported; the output stream is the exported projection.
+  - Text exports depend on available source/summary content. Missing summaries produce an error that points to the generation command.
+  - Export does not build Reading Graph or Knowledge Graph coverage.
   - Projections are portable views; they do not replace the `.wikg` archive.
+
+Examples:
+  wikigraph {{ uri }} export --output-format markdown --output book.md
+  wikigraph {{ uri }} export --output-format txt > book.txt
 {% elif predicate == "inspect" %}
 Purpose:
   Inspect archive readiness before `--query`, retrieval, or starting generated work.
@@ -108,30 +132,136 @@ Purpose:
 Usage:
   wikigraph {{ uri }} reset --to source|reading-graph|reading-summary|knowledge-graph [--confirm]
 {% elif predicate == "set" %}
-Purpose:
-  Modify this writable URI target.
-
 {% if target.name == "chapter-tree-object" %}
+Purpose:
+  Replace the chapter tree with a JSON tree document.
+
 Usage:
   wikigraph {{ uri }} set --input <tree.json>
+
+Notes:
+  - The input is a chapter tree JSON document produced by the chapter tree view.
+  - This rewires chapter hierarchy and order; it does not rewrite chapter source text or generated graph content.
 {% elif target.name == "chapter-source-object" %}
+Purpose:
+  Replace this chapter source text.
+
 Usage:
   wikigraph {{ uri }} set [text] [--input <path>] --input-format markdown|txt
+
+Notes:
+  - `--input-format` is required and must be markdown or txt.
+  - Source replacement invalidates later generated work for that chapter.
+  - Use `wikigraph {{ uri }} --help` to inspect the source object before replacing it.
 {% elif target.name == "chapter-summary-object" %}
+Purpose:
+  Replace this chapter summary text.
+
 Usage:
   wikigraph {{ uri }} set [text] [--input <path>]
+
+Notes:
+  - The input is plain summary text.
+  - This sets the summary resource directly; it does not call an LLM provider.
 {% elif target.name == "chapter-title-object" %}
+Purpose:
+  Replace this chapter title.
+
 Usage:
   wikigraph {{ uri }} set <title>
+
+Notes:
+  - Use `clear` on the same title URI to remove an explicit title.
 {% elif target.name == "job-target-object" %}
+Purpose:
+  Change the generation target for this local job.
+
 Usage:
   wikigraph {{ uri }} set reading-graph|reading-summary|knowledge-graph
+
+Notes:
+  - This changes what the job will generate when resumed or picked up by a worker.
+  - Use `wikigraph {{ uri }} --help` to inspect the current job target first.
 {% elif target.name == "local-config-section" %}
+Purpose:
+  Replace this entire local config section with a JSON object.
+
 Usage:
-  wikigraph {{ uri }} set [<json>] [--json <json>|--json-input <json>]
+  wikigraph {{ uri }} set <json> [--json]
+  wikigraph {{ uri }} set --json-input <json> [--json]
+
+{% if "/llm" in uri %}
+Schema:
+  {
+    "provider": "openai|openai-compatible|anthropic|google",
+    "model": "<model-name>",
+    "baseURL": "<url>",
+    "name": "<display-name>"
+  }
+
+Notes:
+  - Allowed keys: provider, model, baseURL, name, apiKey.
+  - `apiKey` is sensitive and cannot be set from JSON.
+  - If current output shows `"apiKey":"****"`, passing the same masked value preserves the existing secret.
+  - To add or replace the secret, use `wikigraph {{ uri }} put apiKey --secret`.
+  - To remove the secret, use `wikigraph {{ uri }} delete apiKey`.
+{% elif "/wikispine" in uri %}
+Schema:
+  {
+    "provider": "fetch|cli",
+    "endpoint": "https://...",
+    "command": "wikispine",
+    "dataDir": "/path/to/data"
+  }
+
+Notes:
+  - `fetch` uses an HTTP endpoint.
+  - `cli` runs a local command and may use a local data directory.
+  - `endpoint` must be a valid URL when present.
+{% elif "/concurrent" in uri %}
+Schema:
+  {
+    "job": 3,
+    "request": 6
+  }
+
+Notes:
+  - Allowed keys: job, request.
+  - Values must be positive integers.
+{% endif %}
+
+Examples:
+{% if "/llm" in uri %}
+  wikigraph {{ uri }} set '{"provider":"openai","model":"gpt-4.1"}'
+  wikigraph {{ uri }} set --json-input '{"provider":"openai-compatible","model":"model-name"}'
+  wikigraph {{ uri }} set '{"provider":"google","model":"gemini-2.5-pro"}' --json
+{% elif "/wikispine" in uri %}
+  wikigraph {{ uri }} set '{"provider":"fetch","endpoint":"https://example.com"}'
+  wikigraph {{ uri }} set '{"provider":"cli","command":"wikispine"}'
+{% elif "/concurrent" in uri %}
+  wikigraph {{ uri }} set '{"job":3,"request":6}'
+  wikigraph {{ uri }} set --json-input '{"job":2,"request":4}'
+{% endif %}
+{% elif "/meta" in uri %}
+Purpose:
+  Replace this metadata object from a JSON object or input value.
+
+Usage:
+  wikigraph {{ uri }} set <json> [--json]
+  wikigraph {{ uri }} set --json-input <json> [--json]
+
+Notes:
+  - Metadata shape depends on whether this is archive metadata or object metadata.
+  - `put`, `delete`, and `clear` are usually safer for single-key metadata edits.
 {% else %}
+Purpose:
+  This URI target has no generic `set` behavior.
+
 Usage:
-  wikigraph {{ uri }} set [options]
+  wikigraph {{ uri }} --help
+
+Notes:
+  - `set` is target-specific. Use the URI help page to find the writable child resource or supported predicate.
 {% endif %}
 {% elif predicate == "clear" %}
 Purpose:
@@ -139,18 +269,46 @@ Purpose:
 
 Usage:
   wikigraph {{ uri }} clear
+
+{% if target.name == "local-config-section" %}
+Notes:
+  - Clears every key in this local config section, including secrets.
+  - No confirmation prompt is shown.
+  - Success output is the now-empty JSON object: `{}`.
+{% elif "/meta" in uri %}
+Notes:
+  - Clears all metadata keys for this metadata object.
+  - No confirmation prompt is shown.
+{% else %}
+Notes:
+  - This predicate is only available on URI targets that explicitly support clearing.
+{% endif %}
 {% elif predicate == "build" %}
 Purpose:
   Build the FTS index for this archive.
 
 Usage:
   wikigraph {{ uri }} build [--jsonl]
+
+Notes:
+  - Safe to run repeatedly; it refreshes a missing or outdated FTS index.
+  - By default the index is stored as local cache outside the `.wikg` archive.
+  - Build uses local CPU and disk only; it does not call an LLM provider.
+  - Text success output is a short status summary.
+  - With `--jsonl`, progress is emitted as line-delimited event records such as step/status/error records.
+  - After build, `--query`, `related --query`, and `evidence --query` become available.
 {% elif predicate == "embed" %}
 Purpose:
   Store the FTS index inside the archive.
 
 Usage:
   wikigraph {{ uri }} embed
+
+Notes:
+  - Embedding writes the current FTS index into the `.wikg` archive.
+  - This makes the archive more portable, but increases archive size.
+  - Run `build` first if the index is missing or outdated.
+  - If embed fails because the index is unavailable, run `wikigraph {{ uri }} build`.
 {% elif predicate == "external" %}
 Purpose:
   Keep the FTS index outside the archive as local cache.
@@ -199,19 +357,65 @@ Purpose:
 
 Usage:
   wikigraph {{ uri }} put <key> <value>
+  wikigraph {{ uri }} put <key> --json-input <json>
+{% if "/llm" in uri %}
   wikigraph {{ uri }} put <key> --secret
+{% endif %}
+
+{% if target.name == "local-config-section" %}
+{% if "/llm" in uri %}
+Keys:
+  - provider: openai, openai-compatible, anthropic, or google
+  - model: non-empty model name
+  - baseURL: non-empty provider base URL string
+  - name: non-empty display name
+  - apiKey: secret; use `--secret`
+{% elif "/wikispine" in uri %}
+Keys:
+  - provider: fetch or cli
+  - endpoint: URL for provider fetch
+  - command: local command for provider cli
+  - dataDir: local data directory for provider cli
+{% elif "/concurrent" in uri %}
+Keys:
+  - job: positive integer
+  - request: positive integer
+{% endif %}
+
+Notes:
+  - Positional `<value>` is stored as a string.
+  - `--json-input` stores a JSON value and is useful for numeric config sections.
+{% if "/llm" in uri %}
+  - `--secret` reads the value from an interactive terminal without echoing it; use it for `apiKey`.
+{% endif %}
+  - Success output is the full section JSON with sensitive values masked.
+{% endif %}
 {% elif predicate == "delete" %}
 Purpose:
   Delete one key from this local config section.
 
 Usage:
   wikigraph {{ uri }} delete <key>
+
+{% if target.name == "local-config-section" %}
+Notes:
+  - Deletes the key if present; deleting an absent key leaves the section unchanged.
+  - Success output is the full section JSON after deletion.
+  - Key aliases are normalized where supported, for example `api-key` to `apiKey`.
+{% endif %}
 {% elif predicate == "test" %}
 Purpose:
   Test connectivity for this local config section.
 
 Usage:
-  wikigraph {{ uri }} test
+  wikigraph {{ uri }} test [--json]
+
+Notes:
+  - For `llm`, this sends a small request to the configured model.
+  - For `wikispine`, this checks the configured fetch endpoint or local command.
+  - Text success output is intentionally short.
+  - With `--json`, success and failure both return `{ "ok": true|false, ... }`; failures set a non-zero exit code.
+  - Without `--json`, failures print the command error. Use `wikigraph help readiness` and `wikigraph help config` to recover.
 {% endif %}
 
 Related help:

--- a/data/help/commands/predicate.jinja
+++ b/data/help/commands/predicate.jinja
@@ -84,10 +84,11 @@ Purpose:
   Add a local generation job.
 
 Usage:
-  wikigraph {{ uri }} add --input <chapter-uri> --task reading-graph|reading-summary|knowledge-graph --accept-cost [--boost] [--llm <json>] [--prompt <text>]
+  wikigraph {{ uri }} add --input <archive-uri|chapter-uri> --task reading-graph|reading-summary|knowledge-graph --accept-cost [--boost] [--llm <json>] [--prompt <text>]
 
 Notes:
   - Generation jobs may call an LLM provider and incur cost.
+  - Archive input adds jobs for all eligible chapters; chapter input adds one job.
 {% elif predicate == "move" %}
 Purpose:
   Move this chapter in the chapter tree.

--- a/data/help/commands/predicate.jinja
+++ b/data/help/commands/predicate.jinja
@@ -208,16 +208,12 @@ Notes:
 {% elif "/wikispine" in uri %}
 Schema:
   {
-    "provider": "fetch|cli",
-    "endpoint": "https://...",
-    "command": "wikispine",
-    "dataDir": "/path/to/data"
+    "provider": "fetch|cli"
   }
 
 Notes:
-  - `fetch` uses an HTTP endpoint.
-  - `cli` runs a local command and may use a local data directory.
-  - `endpoint` must be a valid URL when present.
+  - `fetch` uses the built-in WikiSpine service endpoint.
+  - `cli` runs the local `wikispine` command from PATH.
 {% elif "/concurrent" in uri %}
 Schema:
   {
@@ -236,8 +232,8 @@ Examples:
   wikigraph {{ uri }} set --json-input '{"provider":"openai-compatible","model":"model-name"}'
   wikigraph {{ uri }} set '{"provider":"google","model":"gemini-2.5-pro"}' --json
 {% elif "/wikispine" in uri %}
-  wikigraph {{ uri }} set '{"provider":"fetch","endpoint":"https://example.com"}'
-  wikigraph {{ uri }} set '{"provider":"cli","command":"wikispine"}'
+  wikigraph {{ uri }} set '{"provider":"fetch"}'
+  wikigraph {{ uri }} set '{"provider":"cli"}'
 {% elif "/concurrent" in uri %}
   wikigraph {{ uri }} set '{"job":3,"request":6}'
   wikigraph {{ uri }} set --json-input '{"job":2,"request":4}'
@@ -373,9 +369,6 @@ Keys:
 {% elif "/wikispine" in uri %}
 Keys:
   - provider: fetch or cli
-  - endpoint: URL for provider fetch
-  - command: local command for provider cli
-  - dataDir: local data directory for provider cli
 {% elif "/concurrent" in uri %}
 Keys:
   - job: positive integer
@@ -412,7 +405,7 @@ Usage:
 
 Notes:
   - For `llm`, this sends a small request to the configured model.
-  - For `wikispine`, this checks the configured fetch endpoint or local command.
+  - For `wikispine`, this checks the built-in fetch service or local `wikispine` command.
   - Text success output is intentionally short.
   - With `--json`, success and failure both return `{ "ok": true|false, ... }`; failures set a non-zero exit code.
   - Without `--json`, failures print the command error. Use `wikigraph help readiness` and `wikigraph help config` to recover.

--- a/data/help/commands/transform.jinja
+++ b/data/help/commands/transform.jinja
@@ -3,6 +3,7 @@ Command: wikigraph transform
 
 Purpose:
   Run a direct one-shot digest/export without creating a reusable `.wikg` archive.
+  This is not a plain file-format converter; source inputs usually require LLM-backed digest work.
 
 Usage:
   wikigraph transform [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <planned|source|reading-graph|reading-summary>] [--verbose|-v]
@@ -10,12 +11,16 @@ Usage:
 Behavior:
   - Reads from `--input <path>`, or from stdin when `--input` is omitted.
   - Writes to `--output <path>`, or to stdout when `--output` is omitted.
-  - May call an LLM depending on output format, target stage, and source state.
+  - Source inputs (`epub`, `txt`, `markdown`) call an LLM unless `--output-format wikg --stage planned|source` is used.
+  - Existing `.wikg` input can be exported to text without running digest generation.
   - Does not leave a managed archive unless `--output-format wikg` is selected.
 
-Examples:
+LLM-backed source examples:
   cat chapter.txt | wikigraph transform --input-format txt --output-format markdown
   wikigraph transform --input book.epub --output digest.md --output-format markdown
+
+Existing archive export example:
+  wikigraph transform --input book.wikg --output digest.md --output-format markdown
 
 Where to go next:
   - Prefer reusable archives:

--- a/data/help/commands/transform.jinja
+++ b/data/help/commands/transform.jinja
@@ -2,8 +2,8 @@ Help Type: command
 Command: wikigraph transform
 
 Purpose:
-  Run a direct one-shot digest/export without creating a reusable `.wikg` archive.
-  This is not a plain file-format converter; source inputs usually require LLM-backed digest work.
+  Run a direct one-shot digest/export.
+  This is not a plain file-format converter; source inputs usually require LLM-backed digest work, and `--output-format wikg` can create a reusable `.wikg` archive.
 
 Usage:
   wikigraph transform [--input <path>] [--output <path>] [--input-format <format>] [--output-format <format>] [--digest-dir <path>] [--llm <json>] [--prompt <text>] [--stage <planned|source|reading-graph|reading-summary>] [--verbose|-v]

--- a/data/help/commands/uri.jinja
+++ b/data/help/commands/uri.jinja
@@ -203,6 +203,11 @@ Default behavior:
 
 Use when:
   - You need to read, replace, edit, clear, or test local configuration.
+{% if "/wikispine" in uri %}
+
+WikiSpine runtime guide:
+  https://raw.githubusercontent.com/oomol-lab/wiki-graph/refs/heads/main/docs/wikispine-runtime.md
+{% endif %}
 {% endif %}
 
 Predicate commands:

--- a/data/help/topics/config.jinja
+++ b/data/help/topics/config.jinja
@@ -72,6 +72,8 @@ Examples:
 WikiSpine:
   Knowledge Graph builds require WikiSpine. If `wikispine` is missing,
   configure one provider and run the config test before starting Knowledge Graph work.
+  Runtime setup and recovery guide:
+    https://raw.githubusercontent.com/oomol-lab/wiki-graph/refs/heads/main/docs/wikispine-runtime.md
 
 Where to go next:
   - Need the normal workflow:

--- a/data/help/topics/config.jinja
+++ b/data/help/topics/config.jinja
@@ -19,9 +19,8 @@ Sections:
   `wikg://local/config/wikispine`
     WikiSpine runtime provider for Knowledge Graph builds:
       - `provider`: `cli` or `fetch`.
-      - `command`: local command for `cli`. Default: `wikispine`.
-      - `dataDir`: optional local runtime data directory for `cli`.
-      - `endpoint`: HTTP service endpoint for `fetch`.
+      - `fetch` uses the built-in WikiSpine service endpoint.
+      - `cli` runs the local `wikispine` command from PATH.
 
 Operations:
   Read a section:
@@ -30,9 +29,9 @@ Operations:
     wikigraph wikg://local/config/wikispine
 
   Replace a section with a JSON object:
-    wikigraph wikg://local/config/llm set --json '{"provider":"openai","model":"gpt-4.1"}'
-    wikigraph wikg://local/config/concurrent set --json '{"job":3,"request":6}'
-    wikigraph wikg://local/config/wikispine set --json '{"provider":"fetch","endpoint":"https://example.com"}'
+    wikigraph wikg://local/config/llm set '{"provider":"openai","model":"gpt-4.1"}'
+    wikigraph wikg://local/config/concurrent set '{"job":3,"request":6}'
+    wikigraph wikg://local/config/wikispine set '{"provider":"fetch"}'
 
   Update one key:
     wikigraph wikg://local/config/llm put provider openai
@@ -41,7 +40,6 @@ Operations:
     wikigraph wikg://local/config/concurrent put request 6
     wikigraph wikg://local/config/wikispine put provider cli
     wikigraph wikg://local/config/wikispine put provider fetch
-    wikigraph wikg://local/config/wikispine put endpoint https://example.com
 
   Store the API key:
     wikigraph wikg://local/config/llm put apiKey --secret
@@ -69,7 +67,6 @@ Examples:
   wikigraph wikg://local/config/llm put apiKey --secret
   wikigraph wikg://local/config/llm test
   wikigraph wikg://local/config/wikispine put provider fetch
-  wikigraph wikg://local/config/wikispine put endpoint https://example.com
   wikigraph wikg://local/config/wikispine test
 
 WikiSpine:

--- a/data/help/topics/format.jinja
+++ b/data/help/topics/format.jinja
@@ -31,3 +31,5 @@ Examples:
   cat chapter.md | wikigraph wikg://book.wikg create --input-format markdown
   wikigraph wikg://book.wikg export --output-format markdown --output out.md
   cat chapter.txt | wikigraph transform --input-format txt --output-format markdown
+
+Transforming source input usually requires LLM configuration.

--- a/data/help/topics/readiness.jinja
+++ b/data/help/topics/readiness.jinja
@@ -73,6 +73,9 @@ WikiSpine readiness:
     wikigraph wikg://local/config/wikispine put provider cli
     wikigraph wikg://local/config/wikispine test
 
+  Runtime setup and recovery guide:
+    https://raw.githubusercontent.com/oomol-lab/wiki-graph/refs/heads/main/docs/wikispine-runtime.md
+
 How to choose:
   - Need keyword retrieval on this machine: build local index.
   - Need to send a more self-contained `.wikg`: consider embedding the index after it is built.

--- a/data/help/topics/readiness.jinja
+++ b/data/help/topics/readiness.jinja
@@ -63,16 +63,14 @@ WikiSpine readiness:
   WikiSpine provides entity candidate lookup for Knowledge Graph construction.
 
   Provider choices:
-  - `fetch`: use an HTTP endpoint. This is usually easier for Agents and hosted setups when a service URL is available.
-  - `cli`: run a local `wikispine` command. This is useful for offline or locally controlled environments, but requires local runtime setup and data.
+  - `fetch`: use the built-in WikiSpine HTTP service. This is usually easier for Agents and hosted setups.
+  - `cli`: run the local `wikispine` command from PATH. This is useful for offline or locally controlled environments, but requires local runtime setup and data.
 
   Configure one provider, then test it:
     wikigraph wikg://local/config/wikispine put provider fetch
-    wikigraph wikg://local/config/wikispine put endpoint https://example.com
     wikigraph wikg://local/config/wikispine test
 
     wikigraph wikg://local/config/wikispine put provider cli
-    wikigraph wikg://local/config/wikispine put command wikispine
     wikigraph wikg://local/config/wikispine test
 
 How to choose:

--- a/data/help/topics/recipe.jinja
+++ b/data/help/topics/recipe.jinja
@@ -30,7 +30,7 @@ Choose your starting point:
       cat article.md | wikigraph wikg://article.wikg create --input-format markdown
 
   - User needs one-shot conversion without keeping an archive:
-    Use transform.
+    Use transform. Source input usually requires LLM configuration.
       cat chapter.txt | wikigraph transform --input-format txt --output-format markdown
 
   - User needs a chapter-level file:
@@ -118,6 +118,7 @@ Finding material:
 
   - Need an inventory for a script or Unix pipeline:
     Enumerate object scopes with `--jsonl`, then filter with standard stream tools.
+    JSONL contains object records and may end with a control record such as `{"type":"page","nextCursor":"..."}`.
       wikigraph wikg://book.wikg/entity --jsonl
       wikigraph wikg://book.wikg/triple --jsonl
       wikigraph wikg://book.wikg/chunk --jsonl
@@ -134,7 +135,7 @@ Finding material:
       wikigraph next <cursor>
 
 When to read deeper:
-  - URI details, scope/object routing, pagination, JSON, and JSONL:
+  - URI details, scope/object routing, pagination, JSON, JSONL, and short URI handling:
     wikigraph help uri
   - Format inference, stdin/stdout, create/import, export, and transform:
     wikigraph help format

--- a/data/help/topics/runtime.jinja
+++ b/data/help/topics/runtime.jinja
@@ -9,7 +9,7 @@ Purpose:
 Archive-first streams:
   - `wikigraph <archive-uri> create --input-format markdown|txt` reads source text from stdin.
   - `wikigraph <archive-uri> export --output-format markdown|txt` can write text projections to stdout.
-  - `wikigraph transform --input-format markdown|txt --output-format markdown|txt` runs direct one-shot stream digest/export.
+  - `wikigraph transform --input-format markdown|txt --output-format markdown|txt` runs direct one-shot stream digest/export and usually requires LLM configuration.
   - Retrieval commands print human-readable text by default and support `--json` where documented.
   - A bare `wikigraph` in an interactive terminal prints root help.
   - A bare non-interactive `wikigraph` invocation is not a transform shortcut; use `wikigraph transform`.

--- a/data/help/topics/uri.jinja
+++ b/data/help/topics/uri.jinja
@@ -51,7 +51,7 @@ Common command shapes:
   wikigraph <archive-uri> inspect
   wikigraph transform [options]
   wikigraph wikg://local/job
-  wikigraph wikg://local/job add --input <chapter-uri> --task <reading-graph|reading-summary|knowledge-graph> --accept-cost
+  wikigraph wikg://local/job add --input <archive-uri|chapter-uri> --task <reading-graph|reading-summary|knowledge-graph> --accept-cost
   wikigraph wikg://local/job/<job-id>
   wikigraph <object-uri> related
   wikigraph <object-uri> evidence
@@ -140,6 +140,8 @@ Pagination and object result format:
   - Default text is for reading and inspection.
   - `--json` is for one stable machine-readable page.
   - `--jsonl` is for streamed records, shell pipelines, or full exports.
+  - JSONL contains object records and may include control records such as `{"type":"page","nextCursor":"..."}`.
+  - Filter JSONL by `type` when a pipeline expects only archive objects.
   - `--jsonl` is only an output format; it does not imply `--all`.
   - Avoid `--all` without `--jsonl` for large results because text and JSON output are buffered before printing.
   - Avoid `--all | head` as a preview pattern. Shell truncation only limits what you read.
@@ -150,8 +152,8 @@ Recovery hints:
     wikigraph <archive-uri>/chapter/tree
     wikigraph help readiness
   - Missing generated objects: start the relevant generation job for the chapter.
-    wikigraph wikg://local/job add --input <chapter-uri> --task reading-graph --accept-cost
-    wikigraph wikg://local/job add --input <chapter-uri> --task reading-summary --accept-cost
+    wikigraph wikg://local/job add --input <archive-uri|chapter-uri> --task reading-graph --accept-cost
+    wikigraph wikg://local/job add --input <archive-uri|chapter-uri> --task reading-summary --accept-cost
     wikigraph help readiness
     wikigraph help runtime
   - URI rejected: convert bare filesystem paths to Wiki Graph URIs, and prepend the archive locator to short object URIs.

--- a/docs/wikispine-runtime.md
+++ b/docs/wikispine-runtime.md
@@ -1,47 +1,55 @@
-# Configure WikiSpine for Knowledge Graph
+# WikiSpine Runtime Guide
 
-WikiGraph can create archives, build Reading Graph data, and build Reading Summary data without WikiSpine. WikiSpine is required only when you build Knowledge Graph data.
+WikiGraph can create archives, build Reading Graph data, and build Reading Summary data without WikiSpine. WikiSpine is required only for Knowledge Graph generation.
 
-Knowledge Graph builds need one WikiSpine provider:
-
-- `fetch`: call a WikiSpine HTTP service endpoint.
-- `cli`: run a local `wikispine` command with local runtime data.
-
-After configuring either provider, run:
-
-```bash
-wikigraph wikg://local/config/wikispine test
-```
-
-## Choose a Provider
-
-Use `fetch` when you want the fastest setup and the source text is safe to send to the endpoint. This avoids the large local runtime data download, but it depends on network access and on the endpoint owner's availability and pricing.
-
-Use `cli` when you process private text, need offline or reproducible runs, or do not want chapter text sent to a remote service. This requires installing the WikiSpine CLI and downloading the runtime data package.
-
-For team or production use, self-host a WikiSpine service and configure WikiGraph with `provider: fetch` and your own endpoint. That gives the same HTTP integration without relying on the public convenience endpoint.
-
-## Fetch Provider
-
-Configure an HTTP endpoint:
+The WikiGraph CLI stores only one WikiSpine setting:
 
 ```bash
 wikigraph wikg://local/config/wikispine put provider fetch
-wikigraph wikg://local/config/wikispine put endpoint https://wikispi-service-cxbfjlteab.cn-hangzhou.fcapp.run
 wikigraph wikg://local/config/wikispine test
 ```
 
-The endpoint must implement the WikiSpine runtime API:
+or:
 
-- `GET /readyz`
-- `GET /metadata`
-- `POST /match`
+```bash
+wikigraph wikg://local/config/wikispine put provider cli
+wikigraph wikg://local/config/wikispine test
+```
 
-`POST /match` receives chapter text. Do not use a third-party endpoint for private, customer, paid, or internal source text unless that is acceptable for your use case.
+Use `fetch` for the fastest setup. Use `cli` when source text must stay local, network access is unavailable, or you need a controlled local runtime.
 
-The public endpoint above is a convenience endpoint. It may be rate limited, unavailable, changed, removed, or moved behind paid access. For long-term or high-volume use, run your own WikiSpine service.
+## Fetch Provider
+
+`fetch` sends WikiSpine match requests to the WikiGraph built-in WikiSpine service. No endpoint is configured by the user.
+
+```bash
+wikigraph wikg://local/config/wikispine put provider fetch
+wikigraph wikg://local/config/wikispine test
+```
+
+The test checks the built-in service metadata and performs a small match request.
+
+Use this provider when:
+
+- source text is safe to send to the built-in service;
+- you want to avoid local runtime data downloads;
+- temporary network or service dependency is acceptable.
+
+If `fetch` fails:
+
+- confirm the machine has network access;
+- rerun `wikigraph wikg://local/config/wikispine test --json` to capture the structured failure;
+- try again later if the built-in service is unavailable;
+- switch to `cli` if the text is private or the service is not reachable from the current environment.
 
 ## CLI Provider
+
+`cli` runs a local `wikispine` command from `PATH`.
+
+```bash
+wikigraph wikg://local/config/wikispine put provider cli
+wikigraph wikg://local/config/wikispine test
+```
 
 Install the WikiSpine CLI:
 
@@ -50,42 +58,32 @@ curl -fsSL https://raw.githubusercontent.com/Moskize91/wikispine/main/scripts/in
 wikispine --version
 ```
 
-Install the runtime data package:
+Install or verify runtime data:
 
 ```bash
 wikispine init
 wikispine doctor
 ```
 
-Then configure WikiGraph:
+Use this provider when:
 
-```bash
-wikigraph wikg://local/config/wikispine put provider cli
-wikigraph wikg://local/config/wikispine put command wikispine
-wikigraph wikg://local/config/wikispine test
-```
+- source text must stay on the machine;
+- you need offline or reproducible runs;
+- you can install and maintain the local runtime data.
 
-The runtime data package is large. Before running `wikispine init`, make sure you have enough disk space and a stable network connection.
+If `cli` fails:
 
-## Put Runtime Data in a Known Directory
+- confirm `wikispine --version` works in the same shell that runs `wikigraph`;
+- run `wikispine doctor`;
+- run `wikispine init` if runtime data is missing;
+- make sure the runtime data is on a volume with enough free space;
+- reinstall or update the WikiSpine CLI if output parsing fails.
 
-For local CLI use, prefer an explicit data directory when you want to control disk placement:
+## Runtime Data
 
-```bash
-wikispine init --data-dir /path/to/wikispine-runtime
-wikispine doctor --data-dir /path/to/wikispine-runtime
+The local runtime data package can be large. Before running `wikispine init`, check disk space and network stability.
 
-wikigraph wikg://local/config/wikispine put provider cli
-wikigraph wikg://local/config/wikispine put command wikispine
-wikigraph wikg://local/config/wikispine put dataDir /path/to/wikispine-runtime
-wikigraph wikg://local/config/wikispine test
-```
-
-Use a path on a volume with enough free space. Avoid putting the runtime data inside a source repository.
-
-## Install from an Existing Archive or Mirror
-
-If you already have the runtime archive, install from the local ZIP instead of downloading it again:
+If you already have the runtime archive, install from the local ZIP:
 
 ```bash
 wikispine init --file /path/to/wikigraph-runtime-data-zh-en-20260702.zip
@@ -103,49 +101,43 @@ wikispine doctor
 
 When you pass a known `--version`, WikiSpine verifies the downloaded archive against the built-in checksum.
 
-## Self-Host a WikiSpine Service
+## Self-Hosting
 
-Run WikiSpine as a service when multiple machines or users need Knowledge Graph builds:
+Current WikiGraph CLI configuration does not accept a custom WikiSpine endpoint. Use the built-in `fetch` provider or the local `cli` provider.
 
-```bash
-wikispine serve --data-dir /path/to/wikispine-runtime --bind 0.0.0.0:9000
-```
+If your deployment needs a private or regional WikiSpine service, track the current WikiGraph release notes or runtime guide for the supported connection mechanism. Do not write `endpoint`, `command`, or `dataDir` into `wikg://local/config/wikispine`; these keys are rejected by current CLI config validation.
 
-Then configure WikiGraph clients:
+## Troubleshooting Flow
 
-```bash
-wikigraph wikg://local/config/wikispine put provider fetch
-wikigraph wikg://local/config/wikispine put endpoint http://your-host:9000
-wikigraph wikg://local/config/wikispine test
-```
-
-Self-hosting avoids repeated runtime data downloads and lets you control privacy, availability, and cost.
-
-## Troubleshooting
-
-If WikiGraph says WikiSpine is not configured, choose `fetch` or `cli` and run the config test:
+Start with:
 
 ```bash
 wikigraph wikg://local/config/wikispine
-wikigraph wikg://local/config/wikispine test
+wikigraph wikg://local/config/wikispine test --json
 ```
 
-If `provider: cli` fails:
-
-- Confirm `wikispine --version` works.
-- Run `wikispine doctor`.
-- If you configured `dataDir`, run `wikispine doctor --data-dir <dir>`.
-- If the runtime data is missing, run `wikispine init` or install from a local ZIP or mirror.
-
-If `provider: fetch` fails:
-
-- Confirm the endpoint URL is reachable.
-- Open `<endpoint>/readyz`; it should return `ready`.
-- Open `<endpoint>/metadata`; it should return runtime metadata.
-- Confirm the endpoint supports `POST /match`.
-
-After changing any WikiSpine setting, run:
+If the config object is empty, choose one provider:
 
 ```bash
-wikigraph wikg://local/config/wikispine test
+wikigraph wikg://local/config/wikispine put provider fetch
+```
+
+or:
+
+```bash
+wikigraph wikg://local/config/wikispine put provider cli
+```
+
+Then rerun:
+
+```bash
+wikigraph wikg://local/config/wikispine test --json
+```
+
+If Knowledge Graph jobs still fail after the test succeeds, inspect the archive and the job:
+
+```bash
+wikigraph <archive-uri> inspect
+wikigraph wikg://local/job --help
+wikigraph wikg://local/job/<job-id> watch --jsonl
 ```

--- a/src/cli/archive.ts
+++ b/src/cli/archive.ts
@@ -403,10 +403,12 @@ async function createArchive(args: CLIArchiveArguments): Promise<void> {
   if (args.sourcePath === undefined) {
     if (args.inputFormat === undefined) {
       await new SpineDigestFile(args.archivePath).write(async () => {});
+      await writeCreatedArchive(args);
       return;
     }
 
     await createArchiveFromStdin(args);
+    await writeCreatedArchive(args);
     return;
   }
 
@@ -424,6 +426,7 @@ async function createArchive(args: CLIArchiveArguments): Promise<void> {
       targetStage: "sourced",
       verbose: false,
     });
+    await writeCreatedArchive(args);
     return;
   }
 
@@ -453,9 +456,21 @@ async function createArchive(args: CLIArchiveArguments): Promise<void> {
       targetStage: "sourced",
       verbose: false,
     });
+    await writeCreatedArchive(args);
   } finally {
     await rm(temporaryDirectoryPath, { force: true, recursive: true });
   }
+}
+
+async function writeCreatedArchive(args: CLIArchiveArguments): Promise<void> {
+  if (args.json === true) {
+    await writeTextToStdout(
+      formatCLIJSON({ uri: formatLocatedWikiGraphUri(args.archivePath) }),
+    );
+    return;
+  }
+
+  await writeTextToStdout("<archive>\n");
 }
 
 async function runNextArchivePage(args: CLIArchiveArguments): Promise<void> {

--- a/src/cli/archive.ts
+++ b/src/cli/archive.ts
@@ -1521,7 +1521,7 @@ async function writeList(
   }
 
   await writeTextToStdout(
-    `${objects.map(formatFindObject).join(getListObjectSeparator(objects))}${formatNextCursor(nextCursor)}\n`,
+    `${objects.map(formatFindObject).join(getListObjectSeparator(objects))}${formatOpenShortUriHint(objects, context)}${formatNextCursor(nextCursor)}\n`,
   );
 }
 
@@ -1698,7 +1698,7 @@ async function writeFindHits(
       .map((object) => formatFindObject(object))
       .join(
         getListObjectSeparator(outputObjects),
-      )}${formatNextCursor(nextCursor)}${formatFindLensHint(result)}\n`,
+      )}${formatOpenShortUriHint(outputObjects, context)}${formatNextCursor(nextCursor)}${formatFindLensHint(result)}\n`,
   );
 }
 
@@ -2584,6 +2584,26 @@ function formatFindObject(object: ArchiveOutputObject): string {
   }
 
   return lines.join("\n");
+}
+
+function formatOpenShortUriHint(
+  objects: readonly ArchiveOutputObject[],
+  context: ArchiveOutputContext,
+): string {
+  const shortUri = objects.find((object) => isShortOutputUri(object.uri))?.uri;
+
+  if (shortUri === undefined) {
+    return "";
+  }
+
+  return `\n\nOpen short URIs with the archive locator, for example:\n  wikigraph ${formatLocatedWikiGraphUri(context.archivePath, shortUri)}`;
+}
+
+function isShortOutputUri(uri: string): boolean {
+  return (
+    uri.startsWith("wikg://") &&
+    parseLocatedWikiGraphUri(uri).archivePath === undefined
+  );
 }
 
 function formatScoredLines(

--- a/src/cli/archive.ts
+++ b/src/cli/archive.ts
@@ -35,6 +35,7 @@ import {
 } from "../archive/search-index/index.js";
 import {
   formatLocatedWikiGraphUri,
+  formatWikiGraphCommandUri,
   parseLocatedWikiGraphUri,
   requireLocatedObjectOrArchiveUri,
   SpineDigestFile,
@@ -1015,7 +1016,7 @@ async function writeArchiveInspectReport(
   document: ReadonlyDocument,
   args: CLIArchiveArguments,
 ): Promise<void> {
-  const archiveUri = formatLocatedWikiGraphUri(args.archivePath);
+  const archiveUri = formatWikiGraphCommandUri(args.archivePath);
   const scopeUri =
     args.chapterId === undefined
       ? archiveUri
@@ -2168,7 +2169,7 @@ function appendEntityNextSteps(
   if (!isEntityOutputUri(uri)) {
     return text;
   }
-  const entityUri = formatLocatedWikiGraphUri(
+  const entityUri = formatWikiGraphCommandUri(
     archivePath,
     uri.replace(/\/$/u, ""),
   );
@@ -2596,7 +2597,7 @@ function formatOpenShortUriHint(
     return "";
   }
 
-  return `\n\nOpen short URIs with the archive locator, for example:\n  wikigraph ${formatLocatedWikiGraphUri(context.archivePath, shortUri)}`;
+  return `\n\nOpen short URIs with the archive locator, for example:\n  wikigraph ${formatWikiGraphCommandUri(context.archivePath, shortUri)}`;
 }
 
 function isShortOutputUri(uri: string): boolean {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -2951,12 +2951,13 @@ function parseArchiveArguments(
       );
       rejectArchiveFlag(action, "--role", values.role, helpRoute);
       rejectArchiveBooleanFlag(action, "--confirm", values.confirm, helpRoute);
-      rejectArchiveBooleanFlag(action, "--json", values.json, helpRoute);
+      rejectArchiveBooleanFlag(action, "--jsonl", values.jsonl, helpRoute);
       return {
         args: {
           action,
           archivePath,
           ...(inputFormat === undefined ? {} : { inputFormat }),
+          ...(values.json === undefined ? {} : { json: values.json }),
           ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
           ...(values.prompt === undefined ? {} : { prompt: values.prompt }),
           ...(sourcePath === undefined ? {} : { sourcePath }),

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -48,9 +48,6 @@ export interface CLIConfig {
     readonly request?: number;
   };
   readonly wikispine?: {
-    readonly command?: string;
-    readonly dataDir?: string;
-    readonly endpoint?: string;
     readonly provider?: "cli" | "fetch";
   };
 }
@@ -259,25 +256,12 @@ function createWikispineConfig(
   value: Record<string, unknown>,
 ): CLIConfig["wikispine"] | undefined {
   const provider = readWikispineProvider(value.provider);
-  const command = readString(value.command);
-  const dataDir = readString(value.dataDir);
-  const endpoint = readString(value.endpoint);
 
-  if (
-    command === undefined &&
-    dataDir === undefined &&
-    endpoint === undefined &&
-    provider === undefined
-  ) {
+  if (provider === undefined) {
     return undefined;
   }
 
-  return {
-    ...(command === undefined ? {} : { command }),
-    ...(dataDir === undefined ? {} : { dataDir }),
-    ...(endpoint === undefined ? {} : { endpoint }),
-    ...(provider === undefined ? {} : { provider }),
-  };
+  return { provider };
 }
 
 function readWikispineProvider(value: unknown): "cli" | "fetch" | undefined {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -78,7 +78,7 @@ interface UriHelpTarget {
 const URI_HELP_TARGETS: readonly UriHelpTarget[] = [
   {
     name: "archive-scope",
-    predicates: ["create", "export", "inspect", "set"],
+    predicates: ["create", "export", "inspect"],
   },
   { name: "chapter-collection-scope", predicates: ["add"] },
   {

--- a/src/cli/local-config-store.ts
+++ b/src/cli/local-config-store.ts
@@ -118,15 +118,6 @@ export function normalizeLocalConfigKey(
         return normalized;
     }
   }
-  if (section === "wikispine") {
-    switch (normalized) {
-      case "data-dir":
-        return "dataDir";
-      default:
-        return normalized;
-    }
-  }
-
   return normalized;
 }
 
@@ -272,7 +263,7 @@ function validateConcurrentConfig(value: LocalConfigObject): LocalConfigObject {
 }
 
 function validateWikispineConfig(value: LocalConfigObject): LocalConfigObject {
-  const allowedKeys = new Set(["command", "dataDir", "endpoint", "provider"]);
+  const allowedKeys = new Set(["provider"]);
   const allowedProviders = new Set(["cli", "fetch"]);
   const next: Record<string, unknown> = {};
 
@@ -287,13 +278,6 @@ function validateWikispineConfig(value: LocalConfigObject): LocalConfigObject {
 
     if (key === "provider" && !allowedProviders.has(normalized)) {
       throw new Error(`Unknown wikispine.provider: ${normalized}`);
-    }
-    if (key === "endpoint") {
-      try {
-        new URL(normalized);
-      } catch {
-        throw new Error("wikispine.endpoint must be a valid URL.");
-      }
     }
 
     next[key] = normalized;

--- a/src/cli/local-config.ts
+++ b/src/cli/local-config.ts
@@ -6,6 +6,7 @@ import { generateText } from "ai";
 import type { CLILocalConfigArguments } from "./args.js";
 import type { CLIProvider } from "./config.js";
 import {
+  DEFAULT_WIKISPINE_FETCH_ENDPOINT,
   testWikispineRuntime,
   type WikispineProvider,
 } from "../wikimatch/index.js";
@@ -175,21 +176,14 @@ async function runWikispineConfigTest(
   try {
     const provider = parseWikispineProvider(wikispine.provider);
     const result = await testWikispineRuntime({
-      ...(typeof wikispine.command === "string"
-        ? { command: wikispine.command }
-        : {}),
-      ...(typeof wikispine.dataDir === "string"
-        ? { dataDir: wikispine.dataDir }
-        : {}),
-      ...(typeof wikispine.endpoint === "string"
-        ? { endpoint: wikispine.endpoint }
-        : {}),
       provider,
     });
     const output = {
       durationMs: result.durationMs,
-      ...(typeof wikispine.endpoint === "string"
-        ? { endpoint: wikispine.endpoint }
+      ...(provider === "fetch"
+        ? {
+            endpoint: DEFAULT_WIKISPINE_FETCH_ENDPOINT,
+          }
         : {}),
       ...(result.metadata === undefined ? {} : { metadata: result.metadata }),
       ok: true,

--- a/src/common/wiki-graph-uri.ts
+++ b/src/common/wiki-graph-uri.ts
@@ -1,4 +1,4 @@
-import { resolve } from "path";
+import { isAbsolute, relative, resolve } from "path";
 import { homedir } from "os";
 
 export const WIKI_GRAPH_URI_PREFIX = "wikg://";
@@ -79,6 +79,35 @@ export function formatLocatedWikiGraphUri(
   return `${WIKI_GRAPH_URI_PREFIX}${uriArchivePath}/${stripWikiGraphUriPrefix(
     objectUri,
   )}`;
+}
+
+export function formatWikiGraphCommandUri(
+  archivePath: string,
+  objectUri?: string,
+  cwd = process.cwd(),
+): string {
+  return formatLocatedWikiGraphUri(
+    formatCommandArchivePath(archivePath, cwd),
+    objectUri,
+  );
+}
+
+function formatCommandArchivePath(archivePath: string, cwd: string): string {
+  const resolvedCwd = resolve(cwd);
+  const resolvedArchivePath = isAbsolute(archivePath)
+    ? resolve(archivePath)
+    : resolve(resolvedCwd, archivePath);
+  const relativeArchivePath = relative(resolvedCwd, resolvedArchivePath);
+
+  if (
+    relativeArchivePath !== "" &&
+    !relativeArchivePath.startsWith("..") &&
+    !isAbsolute(relativeArchivePath)
+  ) {
+    return relativeArchivePath;
+  }
+
+  return resolvedArchivePath;
 }
 
 export function formatLocatedChapterUri(

--- a/src/wikg/archive-uri.ts
+++ b/src/wikg/archive-uri.ts
@@ -3,6 +3,7 @@ export {
   formatLocatedChapterSourceCollectionUri,
   formatLocatedChapterUri,
   formatLocatedWikiGraphUri,
+  formatWikiGraphCommandUri,
   formatWikiGraphObjectUri,
   formatWikiGraphUriExpectedError,
   isWikiGraphJobUri,

--- a/src/wikg/index.ts
+++ b/src/wikg/index.ts
@@ -14,6 +14,7 @@ export {
   formatLocatedChapterSourceCollectionUri,
   formatLocatedChapterUri,
   formatLocatedWikiGraphUri,
+  formatWikiGraphCommandUri,
   formatWikiGraphObjectUri,
   formatWikiGraphUriExpectedError,
   isWikiGraphJobUri,

--- a/src/wikimatch/index.ts
+++ b/src/wikimatch/index.ts
@@ -32,6 +32,7 @@ export {
 export { buildWikimatchSurfaceProtectionInput } from "./surface-window.js";
 export { suppressContainedRanges } from "./range-suppression.js";
 export {
+  DEFAULT_WIKISPINE_FETCH_ENDPOINT,
   matchWikispineSentenceCandidates,
   type MatchWikispineSentenceCandidatesOptions,
   testWikispineRuntime,

--- a/src/wikimatch/wikispine.ts
+++ b/src/wikimatch/wikispine.ts
@@ -67,7 +67,7 @@ interface WikispineMetadata {
 }
 
 const WIKISPINE_RUNTIME_GUIDE_URL =
-  "https://raw.githubusercontent.com/oomol-lab/spinedigest/main/docs/wikispine-runtime.md";
+  "https://raw.githubusercontent.com/oomol-lab/wiki-graph/refs/heads/main/docs/wikispine-runtime.md";
 export const DEFAULT_WIKISPINE_FETCH_ENDPOINT =
   "https://wikispi-service-cxbfjlteab.cn-hangzhou.fcapp.run";
 

--- a/src/wikimatch/wikispine.ts
+++ b/src/wikimatch/wikispine.ts
@@ -68,6 +68,8 @@ interface WikispineMetadata {
 
 const WIKISPINE_RUNTIME_GUIDE_URL =
   "https://raw.githubusercontent.com/oomol-lab/spinedigest/main/docs/wikispine-runtime.md";
+export const DEFAULT_WIKISPINE_FETCH_ENDPOINT =
+  "https://wikispi-service-cxbfjlteab.cn-hangzhou.fcapp.run";
 
 export async function matchWikispineSentenceCandidates(
   options: MatchWikispineSentenceCandidatesOptions,
@@ -434,12 +436,14 @@ function resolveProvider(options: {
 }
 
 function requireEndpoint(endpoint: string | undefined): string {
-  const normalized = endpoint?.trim().replace(/\/+$/u, "");
+  const normalized = (endpoint ?? DEFAULT_WIKISPINE_FETCH_ENDPOINT)
+    .trim()
+    .replace(/\/+$/u, "");
 
-  if (normalized === undefined || normalized === "") {
+  if (normalized === "") {
     throw new Error(
       formatWikispineRuntimeError(
-        "WikiSpine fetch provider requires wikispine.endpoint.",
+        "WikiSpine fetch provider has no default endpoint.",
       ),
     );
   }

--- a/test/cli/archive.test.ts
+++ b/test/cli/archive.test.ts
@@ -443,6 +443,7 @@ const archiveMockState = vi.hoisted(() => ({
   ]),
   summaryWords: 120,
   textWrites: [] as string[],
+  writeCalls: [] as string[],
 }));
 
 function parseJSONLLastLine(text: string | undefined): unknown {
@@ -468,6 +469,11 @@ vi.mock("../../src/wikg/spine-digest-file.js", () => ({
     ): Promise<unknown> {
       archiveMockState.readCalls.push(this.#path);
       return await operation(createArchiveMockDocument());
+    }
+
+    public async write(operation: () => Promise<unknown>): Promise<unknown> {
+      archiveMockState.writeCalls.push(this.#path);
+      return await operation();
     }
   },
 }));
@@ -679,6 +685,31 @@ describe("cli/archive", () => {
     archiveMockState.serials = createDefaultInspectSerials();
     archiveMockState.summaryWords = 120;
     archiveMockState.textWrites.length = 0;
+    archiveMockState.writeCalls.length = 0;
+  });
+
+  it("prints archive object output after creating an empty archive", async () => {
+    await runArchiveCommand({
+      action: "create",
+      archivePath: "/tmp/new.wikg",
+    });
+
+    expect(archiveMockState.writeCalls).toStrictEqual(["/tmp/new.wikg"]);
+    expect(archiveMockState.textWrites[0]).toBe("<archive>\n");
+  });
+
+  it("prints archive object JSON after creating from a source", async () => {
+    await runArchiveCommand({
+      action: "create",
+      archivePath: "/tmp/new.wikg",
+      json: true,
+      sourcePath: "/tmp/source.md",
+    });
+
+    expect(archiveMockState.writeCalls).toStrictEqual([]);
+    expect(JSON.parse(archiveMockState.textWrites[0] ?? "")).toStrictEqual({
+      uri: "wikg:///tmp/new.wikg",
+    });
   });
 
   it("gets chapter state", async () => {

--- a/test/cli/archive.test.ts
+++ b/test/cli/archive.test.ts
@@ -830,6 +830,12 @@ describe("cli/archive", () => {
     );
     expect(archiveMockState.textWrites[0]).toContain("wikg://entity/Q1");
     expect(archiveMockState.textWrites[0]).toContain("RAG");
+    expect(archiveMockState.textWrites[0]).toContain(
+      "Open short URIs with the archive locator",
+    );
+    expect(archiveMockState.textWrites[0]).toContain(
+      "wikigraph wikg:///tmp/book.wikg/entity/Q1",
+    );
   });
 
   it("passes backlinks to listed source objects", async () => {

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -17,6 +17,8 @@ import {
 
 describe("cli/args", () => {
   const archivePath = resolve("book.wikg");
+  const wikispineRuntimeGuideUrl =
+    "https://raw.githubusercontent.com/oomol-lab/wiki-graph/refs/heads/main/docs/wikispine-runtime.md";
 
   it("parses --version", () => {
     expect(parseCLIArguments(["--version"])).toStrictEqual({
@@ -1897,6 +1899,23 @@ describe("cli/args", () => {
     expect(renderHelpTopicText("readiness")).toContain("LLM readiness:");
     expect(renderHelpTopicText("readiness")).toContain("WikiSpine readiness:");
     expect(renderHelpTopicText("readiness")).toContain("provider fetch");
+    expect(renderHelpTopicText("readiness")).toContain(
+      wikispineRuntimeGuideUrl,
+    );
+    expect(renderHelpTopicText("config")).toContain(wikispineRuntimeGuideUrl);
+    expect(
+      renderUriHelpText(
+        "local-config-section",
+        "wikg://local/config/wikispine",
+      ),
+    ).toContain(wikispineRuntimeGuideUrl);
+    expect(
+      renderUriPredicateHelpText(
+        "local-config-section",
+        "test",
+        "wikg://local/config/wikispine",
+      ),
+    ).toContain(wikispineRuntimeGuideUrl);
     expect(renderTransformHelpText()).toContain(
       "This is not a plain file-format converter",
     );

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -612,6 +612,20 @@ describe("cli/args", () => {
       help: false,
       kind: "archive",
     });
+    expect(
+      parseCLIArguments(["wikg://book.wikg", "create", "--json"]),
+    ).toStrictEqual({
+      args: {
+        action: "create",
+        archivePath: archivePath,
+        json: true,
+      },
+      help: false,
+      kind: "archive",
+    });
+    expect(() =>
+      parseCLIArguments(["wikg://book.wikg", "create", "--jsonl"]),
+    ).toThrow("The `create` command does not support --jsonl.");
 
     expect(() => parseCLIArguments(["build", "book.wikg"])).toThrow(
       "Unknown command: build.",

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -1883,10 +1883,21 @@ describe("cli/args", () => {
     expect(renderHelpTopicText("readiness")).toContain("LLM readiness:");
     expect(renderHelpTopicText("readiness")).toContain("WikiSpine readiness:");
     expect(renderHelpTopicText("readiness")).toContain("provider fetch");
+    expect(renderTransformHelpText()).toContain(
+      "This is not a plain file-format converter",
+    );
+    expect(renderTransformHelpText()).toContain(
+      "Source inputs (`epub`, `txt`, `markdown`) call an LLM",
+    );
     expect(uriHelpText).toContain("wikigraph <scope-uri> --query <query>");
     expect(uriHelpText).toContain(
       "wikigraph <entity|triple|chunk-uri> evidence",
     );
+    expect(uriHelpText).toContain(
+      "wikigraph wikg://local/job add --input <archive-uri|chapter-uri>",
+    );
+    expect(uriHelpText).toContain("JSONL contains object records");
+    expect(uriHelpText).toContain('"type":"page"');
     expect(() => parseCLIArguments(["help", "ai"])).toThrow(
       "Invalid help topic: ai.",
     );
@@ -1966,6 +1977,9 @@ describe("cli/args", () => {
     );
     expect(renderHelpTopicText("recipe")).toContain(
       "wikigraph wikg://book.wikg/chapter/3/entity --jsonl",
+    );
+    expect(renderHelpTopicText("recipe")).toContain(
+      "JSONL contains object records",
     );
     expect(renderHelpTopicText("recipe")).toContain(
       "If Reading Graph data is missing",

--- a/test/cli/config.test.ts
+++ b/test/cli/config.test.ts
@@ -38,7 +38,6 @@ describe("cli/config", () => {
         provider: "openai-compatible",
       },
       wikispine: {
-        endpoint: "https://wikispine.example",
         provider: "fetch",
       },
     };
@@ -55,7 +54,6 @@ describe("cli/config", () => {
         request: 6,
       },
       wikispine: {
-        endpoint: "https://wikispine.example",
         provider: "fetch",
       },
     });

--- a/test/cli/local-config.test.ts
+++ b/test/cli/local-config.test.ts
@@ -15,8 +15,7 @@ describe("cli/local-config", () => {
   });
 
   it("normalizes wikispine kebab-case keys", () => {
-    expect(normalizeLocalConfigKey("wikispine", "data-dir")).toBe("dataDir");
-    expect(normalizeLocalConfigKey("wikispine", "endpoint")).toBe("endpoint");
+    expect(normalizeLocalConfigKey("wikispine", "provider")).toBe("provider");
   });
 
   it("validates concurrent values as positive integers", () => {
@@ -70,22 +69,16 @@ describe("cli/local-config", () => {
   it("validates wikispine provider values at write time", () => {
     expect(
       validateLocalConfigSection("wikispine", {
-        endpoint: "https://wikispine.example",
         provider: "fetch",
       }),
     ).toStrictEqual({
-      endpoint: "https://wikispine.example",
       provider: "fetch",
     });
     expect(
       validateLocalConfigSection("wikispine", {
-        command: "wikispine",
-        dataDir: "/runtime",
         provider: "cli",
       }),
     ).toStrictEqual({
-      command: "wikispine",
-      dataDir: "/runtime",
       provider: "cli",
     });
     expect(() =>
@@ -93,7 +86,7 @@ describe("cli/local-config", () => {
     ).toThrow("Unknown wikispine.provider: unknown");
     expect(() =>
       validateLocalConfigSection("wikispine", { endpoint: "not a url" }),
-    ).toThrow("wikispine.endpoint must be a valid URL.");
+    ).toThrow("Unknown wikispine config key: endpoint");
   });
 
   it("preserves masked apiKey during llm set --json", () => {

--- a/test/cli/queue.test.ts
+++ b/test/cli/queue.test.ts
@@ -709,7 +709,6 @@ describe("cli/queue", () => {
   it("runs knowledge graph work without reading graph or summary builds", async () => {
     queueMockState.cliConfig = {
       wikispine: {
-        endpoint: "https://wikispine.example",
         provider: "fetch",
       },
     };
@@ -752,7 +751,6 @@ describe("cli/queue", () => {
       policyPrompt: "Keep key beats",
       progressTracker: reporter,
       wikispine: {
-        endpoint: "https://wikispine.example",
         provider: "fetch",
       },
       workspacePath: "/tmp/job-workspace",

--- a/test/common/wiki-graph-uri.test.ts
+++ b/test/common/wiki-graph-uri.test.ts
@@ -4,6 +4,7 @@ import { resolve } from "path";
 
 import {
   formatLocatedWikiGraphUri,
+  formatWikiGraphCommandUri,
   formatWikiGraphObjectUri,
   parseLocatedWikiGraphUri,
 } from "../../src/common/wiki-graph-uri.js";
@@ -16,6 +17,36 @@ describe("wiki graph URI helpers", () => {
         formatWikiGraphObjectUri("entity/Q9957"),
       ),
     ).toBe("wikg://C:/books/book.wikg/entity/Q9957");
+  });
+
+  it("formats command URIs relative to cwd when the archive is below cwd", () => {
+    expect(
+      formatWikiGraphCommandUri(
+        "/workspace/books/book.wikg",
+        formatWikiGraphObjectUri("entity/Q9957"),
+        "/workspace",
+      ),
+    ).toBe("wikg://books/book.wikg/entity/Q9957");
+  });
+
+  it("formats command URIs with absolute paths outside cwd", () => {
+    expect(
+      formatWikiGraphCommandUri(
+        "/other/books/book.wikg",
+        formatWikiGraphObjectUri("entity/Q9957"),
+        "/workspace",
+      ),
+    ).toBe("wikg:///other/books/book.wikg/entity/Q9957");
+  });
+
+  it("formats relative command URI archive paths against the provided cwd", () => {
+    expect(
+      formatWikiGraphCommandUri(
+        "books/book.wikg",
+        formatWikiGraphObjectUri("entity/Q9957"),
+        "/workspace",
+      ),
+    ).toBe("wikg://books/book.wikg/entity/Q9957");
   });
 
   it("expands home only for wikg://~/ archive paths", () => {

--- a/test/wikimatch/wikispine.test.ts
+++ b/test/wikimatch/wikispine.test.ts
@@ -206,4 +206,21 @@ describe("wikimatch/wikispine", () => {
       },
     ]);
   });
+
+  it("includes the runtime guide URL in fetch provider failures", async () => {
+    await expect(
+      matchWikispineSentenceCandidates({
+        fetch: () => Promise.resolve(new Response("down", { status: 503 })),
+        provider: "fetch",
+        sentences: [
+          {
+            range: { end: 4, start: 0 },
+            text: "北京大学",
+          },
+        ],
+      }),
+    ).rejects.toThrow(
+      "https://raw.githubusercontent.com/oomol-lab/wiki-graph/refs/heads/main/docs/wikispine-runtime.md",
+    );
+  });
 });

--- a/test/wikimatch/wikispine.test.ts
+++ b/test/wikimatch/wikispine.test.ts
@@ -4,7 +4,10 @@ import { tmpdir } from "os";
 
 import { describe, expect, it } from "vitest";
 
-import { matchWikispineSentenceCandidates } from "../../src/wikimatch/index.js";
+import {
+  DEFAULT_WIKISPINE_FETCH_ENDPOINT,
+  matchWikispineSentenceCandidates,
+} from "../../src/wikimatch/index.js";
 
 describe("wikimatch/wikispine", () => {
   it("matches each sentence separately and converts sentence offsets to document ranges", async () => {
@@ -146,6 +149,60 @@ describe("wikimatch/wikispine", () => {
           text: "北京大学",
         },
         url: "https://wikispine.example/match",
+      },
+    ]);
+  });
+
+  it("uses the default fetch endpoint when none is configured", async () => {
+    const requests: Array<{ readonly url: string }> = [];
+    const fetchMock: typeof fetch = (input) => {
+      requests.push({
+        url:
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url,
+      });
+
+      return Promise.resolve(
+        new Response(
+          [
+            JSON.stringify({
+              match: {
+                end: 4,
+                qids: [{ disambiguation: false, qid: "Q16952" }],
+                start: 0,
+                surface_id: 1,
+              },
+              type: "match",
+            }),
+            JSON.stringify({ stats: { matches: 1 }, type: "done" }),
+          ].join("\n"),
+          {
+            headers: {
+              "content-type": "application/x-ndjson",
+            },
+            status: 200,
+          },
+        ),
+      );
+    };
+
+    await matchWikispineSentenceCandidates({
+      fetch: fetchMock,
+      provider: "fetch",
+      sentences: [
+        {
+          range: { end: 4, start: 0 },
+          text: "北京大学",
+        },
+      ],
+    });
+
+    expect(requests).toStrictEqual([
+      {
+        url: `${DEFAULT_WIKISPINE_FETCH_ENDPOINT}/match`,
       },
     ]);
   });


### PR DESCRIPTION
## Summary
- render command URIs with copyable archive locators while keeping object output short
- expand URI predicate help for create/export/index/config flows and add create success output with JSON support
- reduce WikiSpine local config to provider-only and route runtime recovery to the remote guide

## Verification
- pnpm run lint:fix
- pnpm exec vitest run test/cli test/wikimatch/wikispine.test.ts
- pnpm exec tsc -p tsconfig.json --noEmit