### PR TITLE
Refine archive create/import TUI

### DIFF
--- a/data/help/commands/maintenance/chapter.jinja
+++ b/data/help/commands/maintenance/chapter.jinja
@@ -7,11 +7,11 @@ Usage:
   wikigraph <archive-uri>/chapter [--llm <json>] [--help|-h]
   wikigraph <chapter-uri>/state [--json] [--help|-h]
   wikigraph <chapter-uri>/state/<source|reading-graph|reading-summary|knowledge-graph> [--json] [--help|-h]
-  wikigraph <archive-uri>/chapter add --stage <planned|source> [--title <title>] [--parent <id>] [--input <path>] [--input-format <format>] [--llm <json>] [--help|-h]
+  wikigraph <archive-uri>/chapter add --stage <planned|source> [--title <title>] [--parent <id>] [--input <path>] [--llm <json>] [--help|-h]
   wikigraph <chapter-uri> move (--parent <id>|--root|--before <id>|--after <id>|--first|--last) [--llm <json>] [--help|-h]
   wikigraph <chapter-uri> remove [--recursive] [--llm <json>] [--help|-h]
   wikigraph <chapter-uri> reset --to <planned|source|reading-graph> [--llm <json>] [--help|-h]
-  wikigraph <chapter-uri>/source set [text] [--input <path>] --input-format <format> [--llm <json>] [--help|-h]
+  wikigraph <chapter-uri>/source set [text] [--input <path>] [--llm <json>] [--help|-h]
   wikigraph <chapter-uri>/summary set [text] [--input <path>] [--llm <json>] [--help|-h]
   wikigraph <chapter-uri>/title set <title> [--llm <json>] [--help|-h]
   wikigraph <chapter-uri>/title clear [--llm <json>] [--help|-h]
@@ -30,7 +30,6 @@ Input rules:
   - `add --stage planned` creates an empty planned chapter. Use this for chapter directories, groups, and drafting placeholders.
   - `add --stage source` creates a chapter and fills it from `--input <path>` or stdin.
   - `<chapter-uri>/source set` and `<chapter-uri>/summary set` read a positional value, `--input <path>`, or stdin.
-  - `<chapter-uri>/source set` accepts only `txt` or `markdown` for `--input-format`.
   - `<chapter-uri>/title set <title>` renames a chapter in the tree; `<chapter-uri>/title clear` removes the explicit title.
   - `move` changes parent/order only; it does not edit source, graph, or summary data.
   - `tree` prints the chapter tree as JSON with `title: null` for untitled chapters.
@@ -48,7 +47,7 @@ See also:
   - wikigraph wikg://book.wikg/chapter/tree
   - wikigraph wikg://book.wikg/chapter/3/title set "New Title"
   - wikigraph wikg://book.wikg/chapter/3/title clear
-  - wikigraph wikg://book.wikg/chapter/3/source set --input chapter.md --input-format markdown
+  - wikigraph wikg://book.wikg/chapter/3/source set --input chapter.txt
   - wikigraph wikg://book.wikg/chapter/3/summary set --input summary.md
   - wikigraph wikg://local/job --help
   - wikigraph help format

--- a/data/help/commands/maintenance/chapter/add.jinja
+++ b/data/help/commands/maintenance/chapter/add.jinja
@@ -7,8 +7,8 @@ Purpose:
   Insert a new chapter into an existing `.wikg` chapter tree.
 
 Usage:
-  wikigraph <archive-uri>/chapter add --stage planned [--title <title>] [--parent <chapter-uri>] [--llm <json>] [--help|-h]
-  wikigraph <archive-uri>/chapter add --stage source [--title <title>] [--parent <chapter-uri>] [--input <path>] [--llm <json>] [--help|-h]
+  wikigraph <archive-uri>/chapter add --stage planned [--title <title>] [--parent <chapter-uri>] [--llm <json>] [--json] [--help|-h]
+  wikigraph <archive-uri>/chapter add --stage source [--title <title>] [--parent <chapter-uri>] [--input <path>] [--llm <json>] [--json] [--help|-h]
 
 Behavior:
   - `--stage planned` creates an empty chapter with no source, graph, or summary.
@@ -24,6 +24,7 @@ Behavior:
 Output shape:
   Prints the new chapter status.
   The `Chapter: <id>` line is the new chapter id for later commands.
+  With `--json`, prints the new chapter status as one JSON object.
 
 Typical next step:
   wikigraph wikg://local/job add --input <archive-uri|chapter-uri> --task reading-graph --accept-cost

--- a/data/help/commands/maintenance/chapter/add.jinja
+++ b/data/help/commands/maintenance/chapter/add.jinja
@@ -8,7 +8,7 @@ Purpose:
 
 Usage:
   wikigraph <archive-uri>/chapter add --stage planned [--title <title>] [--parent <chapter-uri>] [--llm <json>] [--help|-h]
-  wikigraph <archive-uri>/chapter add --stage source [--title <title>] [--parent <chapter-uri>] [--input <path>] --input-format <format> [--llm <json>] [--help|-h]
+  wikigraph <archive-uri>/chapter add --stage source [--title <title>] [--parent <chapter-uri>] [--input <path>] [--llm <json>] [--help|-h]
 
 Behavior:
   - `--stage planned` creates an empty chapter with no source, graph, or summary.
@@ -16,7 +16,6 @@ Behavior:
   - `--stage source` creates a chapter and writes normalized source text.
   - Source input comes from `--input <path>` when provided, otherwise stdin.
   - Source input must not be empty or whitespace-only.
-  - `--stage source` accepts only `txt` or `markdown` for `--input-format`.
   - Omitting `--title` creates an untitled planned chapter.
   - Omitting `--parent` adds the chapter at the top level.
   - `--parent <chapter-uri>` adds the chapter under an existing chapter.
@@ -31,7 +30,7 @@ Typical next step:
 
 Examples:
   wikigraph wikg://book.wikg/chapter add --stage planned --title "Part I"
-  wikigraph wikg://book.wikg/chapter add --stage source --title "Chapter 1" --input ./chapter.md --input-format markdown --parent wikg://book.wikg/chapter/3
+  wikigraph wikg://book.wikg/chapter add --stage source --title "Chapter 1" --input ./chapter.txt --parent wikg://book.wikg/chapter/3
 
 See also:
   - wikigraph wikg://book.wikg/chapter --help

--- a/data/help/commands/maintenance/chapter/set-source.jinja
+++ b/data/help/commands/maintenance/chapter/set-source.jinja
@@ -5,7 +5,7 @@ Purpose:
   Fill a planned chapter with normalized source text.
 
 Usage:
-  wikigraph <chapter-uri>/source set [text] [--input <path>] [--llm <json>] [--help|-h]
+  wikigraph <chapter-uri>/source set [text] [--input <path>] [--llm <json>] [--json] [--help|-h]
 
 Input:
   - Source text is read from a positional value, `--input <path>`, or stdin.
@@ -20,6 +20,7 @@ Behavior:
   - Does not generate Reading Graph data.
   - Does not generate or modify a summary.
   - Does not call an LLM provider.
+  - With `--json`, prints the updated chapter status as one JSON object.
 
 Typical next step:
   wikigraph wikg://local/job add --input <archive-uri|chapter-uri> --task reading-graph --accept-cost

--- a/data/help/commands/maintenance/chapter/set-source.jinja
+++ b/data/help/commands/maintenance/chapter/set-source.jinja
@@ -5,10 +5,9 @@ Purpose:
   Fill a planned chapter with normalized source text.
 
 Usage:
-  wikigraph <chapter-uri>/source set [text] [--input <path>] --input-format <format> [--llm <json>] [--help|-h]
+  wikigraph <chapter-uri>/source set [text] [--input <path>] [--llm <json>] [--help|-h]
 
 Input:
-  - `--input-format` must be `txt` or `markdown`.
   - Source text is read from a positional value, `--input <path>`, or stdin.
 
 Preconditions:

--- a/data/help/commands/predicate.jinja
+++ b/data/help/commands/predicate.jinja
@@ -52,24 +52,20 @@ Purpose:
   Create the archive at this URI.
 
 Usage:
-  wikigraph {{ uri }} create [source] [--input-format <format>] [--llm <json>] [--prompt <text>] [--replace] [--json]
+  wikigraph {{ uri }} create [--import <epub-path>] [--replace] [--json]
 
 Notes:
-  - `source` may be EPUB, Markdown, txt, URL, or another supported input path.
-  - Without `source`, an empty `.wikg` archive is created unless stdin is selected with `--input-format`.
-  - Stdin is supported when `--input-format markdown` or `--input-format txt` is provided.
-  - Input format is inferred from the source extension when possible; use `--input-format` when stdin or the extension is ambiguous.
-  - Creating from EPUB, Markdown, txt, URL, or stdin runs only the import/source stage.
+  - Without `--import`, create an empty `.wikg` archive.
+  - `--import <epub-path>` creates the archive and imports EPUB metadata, cover, chapter tree, and source text.
+  - `create` does not read stdin; `--import` only accepts EPUB input.
+  - EPUB import runs only the import/source stage and does not call an LLM provider.
   - Existing archives are not overwritten by default. Use `--replace` only when the target archive should be discarded and recreated.
   - Parent directories must already exist.
-  - `--llm <json>` passes local LLM settings to the import pipeline when the selected input path needs them.
   - On success, text output is the archive object (`<archive>`). With `--json`, output is `{"uri":"..."}`.
 
 Examples:
-  wikigraph {{ uri }} create ./book.epub
-  wikigraph {{ uri }} create ./notes.md --input-format markdown
-  cat chapter.md | wikigraph {{ uri }} create --input-format markdown
   wikigraph {{ uri }} create --json
+  wikigraph {{ uri }} create --import ./book.epub
 
 Next:
   wikigraph {{ uri }} inspect
@@ -153,10 +149,10 @@ Purpose:
   Replace this chapter source text.
 
 Usage:
-  wikigraph {{ uri }} set [text] [--input <path>] --input-format markdown|txt
+  wikigraph {{ uri }} set [text] [--input <path>]
 
 Notes:
-  - `--input-format` is required and must be markdown or txt.
+  - Source text is read from a positional value, `--input <path>`, or stdin.
   - Source replacement invalidates later generated work for that chapter.
   - Use `wikigraph {{ uri }} --help` to inspect the source object before replacing it.
 {% elif target.name == "chapter-summary-object" %}

--- a/data/help/commands/predicate.jinja
+++ b/data/help/commands/predicate.jinja
@@ -100,10 +100,16 @@ Notes:
   - Use `--json` for a machine-readable report with the same recommendations.
 {% elif predicate == "add" and target.name == "chapter-collection-scope" %}
 Purpose:
-  Add a planned chapter to the archive.
+  Add a planned or source chapter to the archive.
 
 Usage:
-  wikigraph {{ uri }} add [--parent <chapter-uri>] [--title <title>] [--after <chapter-uri>] [--before <chapter-uri>] [--stage planned]
+  wikigraph {{ uri }} add --stage planned [--parent <chapter-uri>] [--title <title>] [--json]
+  wikigraph {{ uri }} add --stage source [--parent <chapter-uri>] [--title <title>] [--input <path>] [--json]
+
+Notes:
+  - `--stage planned` creates an empty chapter placeholder.
+  - `--stage source` creates a chapter and fills source text from `--input <path>` or stdin.
+  - Source input must not be empty.
 {% elif predicate == "add" and target.name == "job-collection-scope" %}
 Purpose:
   Add a local generation job.

--- a/data/help/commands/transform.jinja
+++ b/data/help/commands/transform.jinja
@@ -24,7 +24,8 @@ Existing archive export example:
 
 Where to go next:
   - Prefer reusable archives:
-    wikigraph wikg://book.wikg create <source>
+    wikigraph wikg://book.wikg create
+    wikigraph wikg://book.wikg create --import ./book.epub
   - Configure LLM defaults:
     wikigraph wikg://local/config/llm
   - Format inference, stdin, stdout, and legal conversions:

--- a/data/help/topics/format.jinja
+++ b/data/help/topics/format.jinja
@@ -13,7 +13,7 @@ Archive create/import input:
   epub via `wikigraph <archive-uri> create --import <epub-path>`
 
 Export formats:
-  txt, markdown
+  txt, markdown, epub
 
 Transform input/output formats:
   input: wikg, epub, txt, markdown

--- a/data/help/topics/format.jinja
+++ b/data/help/topics/format.jinja
@@ -9,8 +9,8 @@ Purpose:
 Managed archive format:
   wikg
 
-Source formats for archive creation and import:
-  epub, txt, markdown
+Archive create/import input:
+  epub via `wikigraph <archive-uri> create --import <epub-path>`
 
 Export formats:
   txt, markdown
@@ -21,7 +21,8 @@ Transform input/output formats:
 
 Inference rules:
   - File paths use their extension when the format flag is omitted.
-  - Stdin requires an explicit `--input-format`.
+  - Transform stdin requires an explicit `--input-format`.
+  - Archive chapter/source text commands read plain source text and do not use `--input-format`.
   - Stdout text export requires an explicit or inferable output format.
   - `transform --stage` is only valid when creating `.wikg` from source input.
 
@@ -59,9 +60,8 @@ Stdout and stderr:
   Commands that accept `--json` or `--jsonl` emit machine-readable error objects when those flags are present.
 
 Examples:
-  wikigraph wikg://book.wikg create ./book.epub
-  wikigraph wikg://book.wikg create ./book.md
-  cat chapter.md | wikigraph wikg://book.wikg create --input-format markdown
+  wikigraph wikg://book.wikg create
+  wikigraph wikg://book.wikg create --import ./book.epub
   wikigraph wikg://book.wikg export --output-format markdown --output out.md
   cat chapter.txt | wikigraph transform --input-format txt --output-format markdown
   wikigraph wikg://book.wikg inspect --json

--- a/data/help/topics/recipe.jinja
+++ b/data/help/topics/recipe.jinja
@@ -25,10 +25,9 @@ Choose your starting point:
       wikigraph wikg://book.wikg inspect
 
   - User gave you source content and needs a reusable knowledge-base archive:
-    Create or import a `.wikg` archive.
-      wikigraph wikg://book.wikg create ./book.epub
-      wikigraph wikg://notes.wikg create ./notes.md
-      cat article.md | wikigraph wikg://article.wikg create --input-format markdown
+    Create an empty `.wikg` archive, or create one while importing an EPUB.
+      wikigraph wikg://book.wikg create
+      wikigraph wikg://book.wikg create --import ./book.epub
 
   - User needs one-shot conversion without keeping an archive:
     Use transform. Source input usually requires LLM configuration.

--- a/data/help/topics/runtime.jinja
+++ b/data/help/topics/runtime.jinja
@@ -7,7 +7,8 @@ Purpose:
   This is a low-frequency advanced topic. Read it when a command fails, a job appears stuck, JSON/JSONL behavior matters, or you need to understand workers, cache, logs, and workspaces.
 
 Archive-first streams:
-  - `wikigraph <archive-uri> create --input-format markdown|txt` reads source text from stdin.
+  - `wikigraph <archive-uri> create` creates an empty archive; it does not read stdin.
+  - `wikigraph <archive-uri> create --import <epub-path>` imports EPUB source into a new archive.
   - `wikigraph <archive-uri> export --output-format markdown|txt` can write text projections to stdout.
   - `wikigraph transform --input-format markdown|txt --output-format markdown|txt` runs direct one-shot stream digest/export and usually requires LLM configuration.
   - Retrieval commands print human-readable text by default and support `--json` where documented.
@@ -38,7 +39,7 @@ Progress and diagnostics:
   - Use `wikigraph <archive-uri>/index --help` when `--query`, evidence, or related appears unavailable.
 
 Workspace behavior:
-  - Archive creation from URL or stdin uses temporary workspaces.
+  - Archive creation and EPUB import use temporary workspaces.
   - `transform --digest-dir <path>` uses the provided digest workspace for source digest runs.
   - Generation jobs use per-job directories under `~/.wikigraph/jobs/work`, `~/.wikigraph/jobs/cache`, and `~/.wikigraph/jobs/logs`.
   - Succeeded jobs delete their workspace by default.

--- a/data/help/topics/uri.jinja
+++ b/data/help/topics/uri.jinja
@@ -46,7 +46,7 @@ Common command shapes:
   wikigraph <entity|triple|chunk-uri> evidence
   wikigraph <located-chunk-uri|located-entity-uri> pack
   wikigraph next <cursor>
-  wikigraph <archive-uri> create [source]
+  wikigraph <archive-uri> create [--import <epub-path>]
   wikigraph <archive-uri> export --output-format <format>
   wikigraph <archive-uri> inspect
   wikigraph transform [options]

--- a/src/archive/query/archive-view.ts
+++ b/src/archive/query/archive-view.ts
@@ -4147,17 +4147,22 @@ async function readTextStreamRange(
   readonly text: string;
 }> {
   const index = await getTextStreamIndex(document, chapterId, stream, context);
-  const lastSentenceIndex = Math.max(0, index.sentences.length - 1);
-  const start = clampInteger(startSentenceIndex, 0, lastSentenceIndex);
-  const end = clampInteger(endSentenceIndex, start, lastSentenceIndex);
-  const sentences = index.sentences.slice(start, end + 1);
-  const [firstSentence] = sentences;
-
-  if (firstSentence === undefined) {
+  if (index.sentences.length === 0) {
     throw new Error(
       `Chapter ${formatChapterId(chapterId)} has no ${stream} text.`,
     );
   }
+
+  const lastSentenceIndex = index.sentences.length - 1;
+  if (startSentenceIndex > lastSentenceIndex) {
+    throw new Error(
+      `${stream} range ${formatTextStreamRangeUri(chapterId, stream, startSentenceIndex, endSentenceIndex)} is out of bounds. Last sentence index is ${lastSentenceIndex}.`,
+    );
+  }
+
+  const start = clampInteger(startSentenceIndex, 0, lastSentenceIndex);
+  const end = clampInteger(endSentenceIndex, start, lastSentenceIndex);
+  const sentences = index.sentences.slice(start, end + 1);
 
   return {
     endSentenceIndex: end,

--- a/src/cli/archive-chapter.ts
+++ b/src/cli/archive-chapter.ts
@@ -54,7 +54,7 @@ export async function runArchiveChapterCommand(
           );
         }
 
-        await writeChapterDetails(details);
+        await writeChapterDetails(details, args.json ?? false);
       });
       return;
     case "list":
@@ -87,7 +87,7 @@ export async function runArchiveChapterCommand(
             : { parentChapterId: args.parentChapterId }),
         });
 
-        await writeChapterDetails(details);
+        await writeChapterDetails(details, args.json ?? false);
       });
       return;
     case "remove":
@@ -100,6 +100,12 @@ export async function runArchiveChapterCommand(
         await removeChapter(document, args.chapterId!, {
           recursive: args.recursive ?? false,
         });
+        if (args.json === true) {
+          await writeTextToStdout(
+            formatCLIJSON({ chapterId: args.chapterId!, removed: true }),
+          );
+          return;
+        }
         await writeTextToStdout(`Removed chapter ${args.chapterId!}.\n`);
       });
       return;
@@ -112,7 +118,7 @@ export async function runArchiveChapterCommand(
           args.resetStage!,
         );
 
-        await writeChapterDetails(details);
+        await writeChapterDetails(details, args.json ?? false);
       });
       return;
     case "set-source":
@@ -128,7 +134,7 @@ export async function runArchiveChapterCommand(
           Readable.from([await readRequiredSourceText(args)]),
         );
 
-        await writeChapterDetails(details);
+        await writeChapterDetails(details, args.json ?? false);
       });
       return;
     case "set-summary":
@@ -145,7 +151,7 @@ export async function runArchiveChapterCommand(
           await readContentText(args),
         );
 
-        await writeChapterDetails(details);
+        await writeChapterDetails(details, false);
       });
       return;
     case "set-title":
@@ -161,7 +167,7 @@ export async function runArchiveChapterCommand(
           args.clearTitle === true ? null : args.title,
         );
 
-        await writeChapterDetails(details);
+        await writeChapterDetails(details, false);
       });
       return;
     case "tree":
@@ -259,7 +265,26 @@ async function readRequiredSourceText(
   return content;
 }
 
-async function writeChapterDetails(details: ChapterDetails): Promise<void> {
+async function writeChapterDetails(
+  details: ChapterDetails,
+  json: boolean,
+): Promise<void> {
+  if (json) {
+    await writeTextToStdout(
+      formatCLIJSON({
+        chapterId: details.chapterId,
+        childCount: details.childCount,
+        graphReady: details.graphReady,
+        hasSummary: details.hasSummary,
+        sourceUnits: details.fragmentCount,
+        stage: formatStage(details.stage),
+        title: details.title,
+        uri: `wikg://chapter/${details.chapterId}`,
+      }),
+    );
+    return;
+  }
+
   const lines = [
     `Chapter: ${details.chapterId}`,
     `Title: ${details.title ?? "[untitled]"}`,

--- a/src/cli/archive.ts
+++ b/src/cli/archive.ts
@@ -1,4 +1,4 @@
-import { rename, rm, stat, writeFile } from "fs/promises";
+import { rename, rm, stat } from "fs/promises";
 import { basename, dirname, join } from "path";
 
 import { createWikiGraphTempDirectory } from "../common/wiki-graph-temp.js";
@@ -37,8 +37,10 @@ import {
   parseLocatedWikiGraphUri,
   requireLocatedObjectOrArchiveUri,
   SpineDigestFile,
+  writeWikgArchive,
 } from "../wikg/index.js";
-import type { ReadonlyDocument } from "../document/index.js";
+import { DirectoryDocument, type ReadonlyDocument } from "../document/index.js";
+import { TOC_FILE_VERSION } from "../source/index.js";
 
 import type { CLIArchiveArguments } from "./args.js";
 import { loadCLIConfig } from "./config.js";
@@ -53,7 +55,7 @@ import {
   type GenerationPerformanceHint,
   type GenerationPlanningCost,
 } from "./generation-planning.js";
-import { readTextStreamFromStdin, writeTextToStdout } from "./io.js";
+import { writeTextToStdout } from "./io.js";
 import { formatCLIJSON, formatCLIJSONLine } from "./json.js";
 import { formatShellCommand } from "./shell.js";
 
@@ -463,61 +465,39 @@ async function writeCreatedArchiveFile(
   args: CLIArchiveArguments,
   outputPath: string,
 ): Promise<void> {
-  if (args.sourcePath === undefined) {
-    if (args.inputFormat === undefined) {
-      await new SpineDigestFile(outputPath).write(async () => {});
-      return;
-    }
-
-    await createArchiveFromStdin(args, outputPath);
+  if (args.importPath === undefined) {
+    await createEmptyArchive(outputPath);
     return;
   }
 
-  if (!isUrl(args.sourcePath)) {
-    await runConvertCommand({
-      help: false,
-      inputPath: args.sourcePath,
-      outputPath,
-      ...(args.inputFormat === undefined
-        ? {}
-        : { inputFormat: args.inputFormat }),
-      ...(args.llmJSON === undefined ? {} : { llmJSON: args.llmJSON }),
-      outputFormat: "wikg",
-      ...(args.prompt === undefined ? {} : { prompt: args.prompt }),
-      targetStage: "sourced",
-      verbose: false,
-    });
-    return;
-  }
+  await runConvertCommand({
+    help: false,
+    inputPath: args.importPath,
+    outputFormat: "wikg",
+    outputPath,
+    targetStage: "sourced",
+    verbose: false,
+  });
+}
 
-  const temporaryDirectoryPath =
-    await createWikiGraphTempDirectory("url-create");
-  const sourcePath = join(temporaryDirectoryPath, "source.md");
+async function createEmptyArchive(outputPath: string): Promise<void> {
+  const directoryPath = await createWikiGraphTempDirectory("archive-write");
+  const document = await DirectoryDocument.open(directoryPath);
 
   try {
-    const response = await fetch(args.sourcePath);
-
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch ${args.sourcePath}: ${response.status} ${response.statusText}`,
-      );
+    try {
+      await document.openSession(async (openedDocument) => {
+        await openedDocument.writeToc({
+          items: [],
+          version: TOC_FILE_VERSION,
+        });
+      });
+    } finally {
+      await document.release();
     }
-
-    const text = await response.text();
-    await writeFile(sourcePath, formatFetchedUrlSource(args.sourcePath, text));
-    await runConvertCommand({
-      help: false,
-      inputFormat: args.inputFormat ?? "markdown",
-      inputPath: sourcePath,
-      ...(args.llmJSON === undefined ? {} : { llmJSON: args.llmJSON }),
-      outputFormat: "wikg",
-      outputPath,
-      ...(args.prompt === undefined ? {} : { prompt: args.prompt }),
-      targetStage: "sourced",
-      verbose: false,
-    });
+    await writeWikgArchive(directoryPath, outputPath);
   } finally {
-    await rm(temporaryDirectoryPath, { force: true, recursive: true });
+    await rm(directoryPath, { force: true, recursive: true });
   }
 }
 
@@ -785,42 +765,6 @@ async function runNextArchivePage(args: CLIArchiveArguments): Promise<void> {
         return;
     }
   });
-}
-
-async function createArchiveFromStdin(
-  args: CLIArchiveArguments,
-  outputPath: string,
-): Promise<void> {
-  if (args.inputFormat === undefined) {
-    throw new Error("Internal error: missing stdin create format.");
-  }
-  if (process.stdin.isTTY) {
-    throw new Error(
-      "Missing source input. Pipe text into stdin or pass a source path.",
-    );
-  }
-
-  const temporaryDirectoryPath =
-    await createWikiGraphTempDirectory("stdin-create");
-  const extension = args.inputFormat === "markdown" ? ".md" : ".txt";
-  const sourcePath = join(temporaryDirectoryPath, `source${extension}`);
-
-  try {
-    await writeFile(sourcePath, await readAllText(readTextStreamFromStdin()));
-    await runConvertCommand({
-      help: false,
-      inputFormat: args.inputFormat,
-      inputPath: sourcePath,
-      ...(args.llmJSON === undefined ? {} : { llmJSON: args.llmJSON }),
-      outputFormat: "wikg",
-      outputPath,
-      ...(args.prompt === undefined ? {} : { prompt: args.prompt }),
-      targetStage: "sourced",
-      verbose: false,
-    });
-  } finally {
-    await rm(temporaryDirectoryPath, { force: true, recursive: true });
-  }
 }
 
 function createFindOptions(args: CLIArchiveArguments): ArchiveFindOptions {
@@ -3155,28 +3099,4 @@ function toArchiveCollectionType(
     case "triple":
       return "triple";
   }
-}
-
-function isUrl(value: string): boolean {
-  try {
-    const url = new URL(value);
-
-    return url.protocol === "http:" || url.protocol === "https:";
-  } catch {
-    return false;
-  }
-}
-
-function formatFetchedUrlSource(url: string, text: string): string {
-  return [`# ${url}`, "", text].join("\n");
-}
-
-async function readAllText(stream: AsyncIterable<string>): Promise<string> {
-  let text = "";
-
-  for await (const chunk of stream) {
-    text += chunk;
-  }
-
-  return text;
 }

--- a/src/cli/archive.ts
+++ b/src/cli/archive.ts
@@ -1434,7 +1434,7 @@ function createInspectImprovements(input: {
         `${input.archiveUri}/chapter`,
         "add",
         "--stage",
-        "sourced",
+        "source",
       ]),
       recommendation:
         "No source content is available yet; add or import source text before graph or summary generation.",

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -3033,6 +3033,8 @@ function parseArchiveArguments(
       rejectArchiveFlag(action, "--role", values.role, helpRoute);
       rejectArchiveFlag(action, "--llm", values.llm, helpRoute);
       rejectArchiveFlag(action, "--prompt", values.prompt, helpRoute);
+      rejectArchiveFlag(action, "--query", values.query, helpRoute);
+      rejectArchiveBooleanFlag(action, "--reverse", values.reverse, helpRoute);
       rejectArchiveBooleanFlag(action, "--confirm", values.confirm, helpRoute);
       rejectArchiveBooleanFlag(action, "--jsonl", values.jsonl, helpRoute);
       if (

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -922,7 +922,9 @@ function parseArchiveUriTargetArguments(
   const parsed = parseLocatedWikiGraphUri(uri);
   const archivePath = parsed.archivePath;
   const objectUri = parsed.objectUri;
-  const helpRoute = formatWikiGraphHelpCommand(uri, action);
+  const helpRoute = isImplicitArchiveReadAction(action)
+    ? formatWikiGraphHelpCommand(uri)
+    : formatWikiGraphHelpCommand(uri, action);
 
   if (archivePath === undefined) {
     throw new Error(formatMissingArchiveLocatorMessage(uri));
@@ -4740,6 +4742,12 @@ function isUriFirstArchiveAction(
     value === "related" ||
     value === "search"
   );
+}
+
+function isImplicitArchiveReadAction(
+  value: CLIArchiveUriAction,
+): value is "get" | "list" | "search" {
+  return value === "get" || value === "list" || value === "search";
 }
 
 function isWikiGraphUri(value: string | undefined): boolean {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -3757,6 +3757,7 @@ function normalizeArchiveChapterArguments(
         path,
         ...(addStage === undefined ? {} : { addStage }),
         ...(values.input === undefined ? {} : { inputPath: values.input }),
+        ...(values.json === undefined ? {} : { json: values.json }),
         ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
         ...(parentChapterId === undefined ? {} : { parentChapterId }),
         ...(values.title === undefined ? {} : { title: values.title }),
@@ -3836,6 +3837,7 @@ function normalizeArchiveChapterArguments(
         ...(beforeChapterId === undefined ? {} : { beforeChapterId }),
         chapterId,
         ...(values.first === undefined ? {} : { first: values.first }),
+        ...(values.json === undefined ? {} : { json: values.json }),
         ...(values.last === undefined ? {} : { last: values.last }),
         ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
         ...(values.root === undefined ? {} : { moveToRoot: values.root }),
@@ -3872,6 +3874,7 @@ function normalizeArchiveChapterArguments(
       return {
         action,
         chapterId,
+        ...(values.json === undefined ? {} : { json: values.json }),
         path,
         ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
         ...(values.recursive === undefined
@@ -3921,6 +3924,7 @@ function normalizeArchiveChapterArguments(
       return {
         action,
         chapterId,
+        ...(values.json === undefined ? {} : { json: values.json }),
         path,
         resetStage,
         ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
@@ -3961,6 +3965,7 @@ function normalizeArchiveChapterArguments(
         action,
         chapterId,
         ...(inputValue === undefined ? {} : { inputValue }),
+        ...(values.json === undefined ? {} : { json: values.json }),
         path,
         ...(values.input === undefined ? {} : { inputPath: values.input }),
         ...(values.llm === undefined ? {} : { llmJSON: values.llm }),

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,6 +1,10 @@
 import { parseArgs } from "util";
 
-import { type CLIFormat, parseCLIFormat } from "./formats.js";
+import {
+  type CLIFormat,
+  inferCLIFormatFromPath,
+  parseCLIFormat,
+} from "./formats.js";
 import { CLI_HELP_ROUTES, withHelpRoute } from "./errors.js";
 import {
   type ArchiveTriplePattern,
@@ -99,7 +103,6 @@ export interface CLIArchiveChapterArguments {
   readonly clearTitle?: boolean;
   readonly dryRun?: boolean;
   readonly first?: boolean;
-  readonly inputFormat?: Extract<CLIFormat, "markdown" | "txt">;
   readonly inputPath?: string;
   readonly inputValue?: string;
   readonly json?: boolean;
@@ -257,6 +260,7 @@ export interface CLIArchiveArguments {
   readonly evidenceLimit?: number;
   readonly format?: CLIResultFormat;
   readonly inputFormat?: CLIFormat;
+  readonly importPath?: string;
   readonly json?: boolean;
   readonly jsonl?: boolean;
   readonly kinds?: readonly CLIObjectKind[];
@@ -270,7 +274,6 @@ export interface CLIArchiveArguments {
   readonly replace?: boolean;
   readonly reverse?: boolean;
   readonly role?: "any" | "object" | "self" | "subject";
-  readonly sourcePath?: string;
   readonly triplePattern?: ArchiveTriplePattern;
 }
 
@@ -319,6 +322,7 @@ interface ArchiveArgumentValues extends ArchiveMetaFlagValues {
   readonly force?: boolean;
   readonly from?: string;
   readonly help?: boolean;
+  readonly import?: string;
   readonly input?: string;
   readonly "input-format"?: string;
   readonly json?: boolean;
@@ -512,6 +516,9 @@ export function parseCLIArguments(
         type: "boolean",
       },
       input: {
+        type: "string",
+      },
+      import: {
         type: "string",
       },
       "input-format": {
@@ -1194,6 +1201,7 @@ function rejectMetadataFlags(
   rejectMetaCommandFlag("chapter", values.chapter, helpRoute);
   rejectMetaCommandFlag("cursor", values.cursor, helpRoute);
   rejectMetaCommandFlag("digest-dir", values["digest-dir"], helpRoute);
+  rejectMetaCommandFlag("import", values.import, helpRoute);
   rejectMetaCommandFlag("input-format", values["input-format"], helpRoute);
   rejectMetaCommandFlag("limit", values.limit, helpRoute);
   rejectMetaCommandFlag("output", values.output, helpRoute);
@@ -1315,6 +1323,7 @@ function parseArchiveCoverUriArguments(
   rejectCoverCommandFlag("chapter", values.chapter, helpRoute);
   rejectCoverCommandFlag("cursor", values.cursor, helpRoute);
   rejectCoverCommandFlag("digest-dir", values["digest-dir"], helpRoute);
+  rejectCoverCommandFlag("import", values.import, helpRoute);
   rejectCoverCommandFlag("input", values.input, helpRoute);
   rejectCoverCommandFlag("input-format", values["input-format"], helpRoute);
   rejectCoverCommandFlag("limit", values.limit, helpRoute);
@@ -2429,6 +2438,7 @@ function parseTransformArguments(
   rejectTransformFlag("cursor", values.cursor, helpRoute);
   rejectTransformFlag("evidence", values.evidence, helpRoute);
   rejectTransformFlag("json", values.json, helpRoute);
+  rejectTransformFlag("import", values.import, helpRoute);
   rejectTransformFlag("limit", values.limit, helpRoute);
   rejectTransformFlag("parent", values.parent, helpRoute);
   rejectTransformFlag("to", values.to, helpRoute);
@@ -2494,6 +2504,7 @@ function parseGcArguments(
   }
 
   rejectGcFlag("digest-dir", values["digest-dir"], helpRoute);
+  rejectGcFlag("import", values.import, helpRoute);
   rejectGcFlag("input", values.input, helpRoute);
   rejectGcFlag("input-format", values["input-format"], helpRoute);
   rejectGcFlag("jsonl", values.jsonl, helpRoute);
@@ -2553,6 +2564,7 @@ function parseLegacyArguments(
     }
 
     rejectLegacyFlag("--input", values.input);
+    rejectLegacyFlag("--import", values.import);
     rejectLegacyFlag("--input-format", values["input-format"]);
     rejectLegacyFlag("--output-format", values["output-format"]);
     rejectLegacyFlag("--llm", values.llm);
@@ -2987,27 +2999,14 @@ function parseArchiveArguments(
 
   switch (action) {
     case "create": {
-      const rawSourcePath = positionals[1] ?? values.input;
-      const sourcePath = rawSourcePath === "-" ? undefined : rawSourcePath;
-      const inputFormat =
-        values["input-format"] === undefined
-          ? undefined
-          : parseCLIFormat(values["input-format"], "--input-format");
-
-      if (
-        sourcePath === undefined &&
-        inputFormat !== undefined &&
-        inputFormat !== "markdown" &&
-        inputFormat !== "txt"
-      ) {
-        throw new Error(
-          withHelpRoute(
-            "stdin create only supports --input-format markdown or txt.",
-            helpRoute,
-          ),
-        );
-      }
-      rejectArchiveExtraPositionals(action, positionals, 2, helpRoute);
+      rejectArchiveExtraPositionals(action, positionals, 1, helpRoute);
+      rejectArchiveFlag(action, "--input", values.input, helpRoute);
+      rejectArchiveFlag(
+        action,
+        "--input-format",
+        values["input-format"],
+        helpRoute,
+      );
       rejectArchiveFlag(action, "--output", values.output, helpRoute);
       rejectArchiveFlag(
         action,
@@ -3030,18 +3029,28 @@ function parseArchiveArguments(
         helpRoute,
       );
       rejectArchiveFlag(action, "--role", values.role, helpRoute);
+      rejectArchiveFlag(action, "--llm", values.llm, helpRoute);
+      rejectArchiveFlag(action, "--prompt", values.prompt, helpRoute);
       rejectArchiveBooleanFlag(action, "--confirm", values.confirm, helpRoute);
       rejectArchiveBooleanFlag(action, "--jsonl", values.jsonl, helpRoute);
+      if (
+        values.import !== undefined &&
+        inferCLIFormatFromPath(values.import) !== "epub"
+      ) {
+        throw new Error(
+          withHelpRoute(
+            "`create --import` only supports EPUB input.",
+            helpRoute,
+          ),
+        );
+      }
       return {
         args: {
           action,
           archivePath,
-          ...(inputFormat === undefined ? {} : { inputFormat }),
+          ...(values.import === undefined ? {} : { importPath: values.import }),
           ...(values.json === undefined ? {} : { json: values.json }),
-          ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
-          ...(values.prompt === undefined ? {} : { prompt: values.prompt }),
           ...(values.replace === undefined ? {} : { replace: values.replace }),
-          ...(sourcePath === undefined ? {} : { sourcePath }),
         },
         help: false,
         kind: "archive",
@@ -3049,6 +3058,7 @@ function parseArchiveArguments(
     }
     case "export":
       rejectArchiveExtraPositionals(action, positionals, 1, helpRoute);
+      rejectArchiveFlag(action, "--import", values.import, helpRoute);
       rejectArchiveFlag(action, "--input", values.input, helpRoute);
       rejectArchiveFlag(
         action,
@@ -3627,7 +3637,7 @@ function formatPackObjectMismatchMessage(uri: string): string {
 function formatMissingArchiveInputMessage(action: CLIArchiveAction): string {
   switch (action) {
     case "create":
-      return "Missing archive URI. Use `wikigraph wikg://<archive.wikg> create [source]`.";
+      return "Missing archive URI. Use `wikigraph wikg://<archive.wikg> create`.";
     case "export":
       return "Missing archive URI. Use `wikigraph wikg://<archive.wikg> export --output-format <format>`.";
     case "inspect":
@@ -3657,6 +3667,7 @@ function normalizeArchiveChapterArguments(
     readonly clear?: boolean;
     readonly "dry-run"?: boolean;
     readonly first?: boolean;
+    readonly import?: string;
     readonly input?: string;
     readonly "input-format"?: string;
     readonly json?: boolean;
@@ -3691,10 +3702,6 @@ function normalizeArchiveChapterArguments(
     values.after === undefined
       ? undefined
       : parseChapterRef(values.after, "--after", path, helpRoute);
-  const inputFormat =
-    values["input-format"] === undefined
-      ? undefined
-      : parseChapterInputFormat(values["input-format"], helpRoute);
   const addStage =
     values.stage === undefined
       ? undefined
@@ -3712,6 +3719,7 @@ function normalizeArchiveChapterArguments(
       );
     case "add":
       rejectActionFlag(values.chapter, "--chapter", action, helpRoute);
+      rejectActionFlag(values.import, "--import", action, helpRoute);
       rejectActionFlag(values.prompt, "--prompt", action, helpRoute);
       rejectActionFlag(values.to, "--to", action, helpRoute);
       rejectActionBooleanFlag(
@@ -3736,19 +3744,18 @@ function normalizeArchiveChapterArguments(
           action,
           helpRoute,
         );
-      } else if (addStage === "sourced" && inputFormat === undefined) {
-        throw new Error(
-          withHelpRoute(
-            "Missing --input-format. `chapter add --stage source` requires txt or markdown.",
-            helpRoute,
-          ),
+      } else if (addStage === "sourced") {
+        rejectActionFlag(
+          values["input-format"],
+          "--input-format",
+          action,
+          helpRoute,
         );
       }
       return {
         action,
         path,
         ...(addStage === undefined ? {} : { addStage }),
-        ...(inputFormat === undefined ? {} : { inputFormat }),
         ...(values.input === undefined ? {} : { inputPath: values.input }),
         ...(values.llm === undefined ? {} : { llmJSON: values.llm }),
         ...(parentChapterId === undefined ? {} : { parentChapterId }),
@@ -3760,6 +3767,7 @@ function normalizeArchiveChapterArguments(
       rejectActionFlag(values.after, "--after", action, helpRoute);
       rejectActionFlag(values.before, "--before", action, helpRoute);
       rejectActionFlag(values.input, "--input", action, helpRoute);
+      rejectActionFlag(values.import, "--import", action, helpRoute);
       rejectActionFlag(
         values["input-format"],
         "--input-format",
@@ -3798,6 +3806,7 @@ function normalizeArchiveChapterArguments(
       requireChapterId(chapterId, action, helpRoute);
       rejectActionFlag(values.stage, "--stage", action, helpRoute);
       rejectActionFlag(values.input, "--input", action, helpRoute);
+      rejectActionFlag(values.import, "--import", action, helpRoute);
       rejectActionFlag(
         values["input-format"],
         "--input-format",
@@ -3839,6 +3848,7 @@ function normalizeArchiveChapterArguments(
       rejectActionFlag(values.after, "--after", action, helpRoute);
       rejectActionFlag(values.before, "--before", action, helpRoute);
       rejectActionFlag(values.input, "--input", action, helpRoute);
+      rejectActionFlag(values.import, "--import", action, helpRoute);
       rejectActionFlag(
         values["input-format"],
         "--input-format",
@@ -3882,6 +3892,7 @@ function normalizeArchiveChapterArguments(
         );
       }
       rejectActionFlag(values.input, "--input", action, helpRoute);
+      rejectActionFlag(values.import, "--import", action, helpRoute);
       rejectActionFlag(
         values["input-format"],
         "--input-format",
@@ -3919,14 +3930,13 @@ function normalizeArchiveChapterArguments(
       rejectActionFlag(values.stage, "--stage", action, helpRoute);
       rejectActionFlag(values.after, "--after", action, helpRoute);
       rejectActionFlag(values.before, "--before", action, helpRoute);
-      if (inputFormat === undefined) {
-        throw new Error(
-          withHelpRoute(
-            "Missing --input-format. `chapter set-source` requires txt or markdown.",
-            helpRoute,
-          ),
-        );
-      }
+      rejectActionFlag(values.import, "--import", action, helpRoute);
+      rejectActionFlag(
+        values["input-format"],
+        "--input-format",
+        action,
+        helpRoute,
+      );
       rejectActionFlag(values.parent, "--parent", action, helpRoute);
       rejectActionFlag(values.prompt, "--prompt", action, helpRoute);
       rejectActionFlag(values.title, "--title", action, helpRoute);
@@ -3950,7 +3960,6 @@ function normalizeArchiveChapterArguments(
       return {
         action,
         chapterId,
-        inputFormat,
         ...(inputValue === undefined ? {} : { inputValue }),
         path,
         ...(values.input === undefined ? {} : { inputPath: values.input }),
@@ -3961,6 +3970,7 @@ function normalizeArchiveChapterArguments(
       rejectActionFlag(values.stage, "--stage", action, helpRoute);
       rejectActionFlag(values.after, "--after", action, helpRoute);
       rejectActionFlag(values.before, "--before", action, helpRoute);
+      rejectActionFlag(values.import, "--import", action, helpRoute);
       rejectActionFlag(
         values["input-format"],
         "--input-format",
@@ -4002,6 +4012,7 @@ function normalizeArchiveChapterArguments(
       rejectActionFlag(values.stage, "--stage", action, helpRoute);
       rejectActionFlag(values.after, "--after", action, helpRoute);
       rejectActionFlag(values.before, "--before", action, helpRoute);
+      rejectActionFlag(values.import, "--import", action, helpRoute);
       rejectActionFlag(values["json-input"], "--json", action, helpRoute);
       rejectActionBooleanFlag(values.json, "--json", action, helpRoute);
       if (values.title !== undefined) {
@@ -4061,6 +4072,7 @@ function normalizeArchiveChapterArguments(
       rejectActionFlag(values.chapter, "--chapter", action, helpRoute);
       rejectActionFlag(values.after, "--after", action, helpRoute);
       rejectActionFlag(values.before, "--before", action, helpRoute);
+      rejectActionFlag(values.import, "--import", action, helpRoute);
       rejectActionFlag(
         values["input-format"],
         "--input-format",
@@ -4132,6 +4144,7 @@ function parseHelpArguments(
     readonly description?: string;
     readonly "digest-dir"?: string;
     readonly help?: boolean;
+    readonly import?: string;
     readonly identifier?: string;
     readonly input?: string;
     readonly "input-format"?: string;
@@ -4149,6 +4162,7 @@ function parseHelpArguments(
   },
 ): ParsedCLIArguments {
   rejectHelpFlag("digest-dir", values["digest-dir"]);
+  rejectHelpFlag("import", values.import);
   rejectHelpFlag("input", values.input);
   rejectHelpFlag("input-format", values["input-format"]);
   rejectHelpFlag("json", values.json);
@@ -4290,24 +4304,6 @@ function parseChapterStage(
   throw new Error(
     withHelpRoute(
       `Invalid ${flag}: ${value}. Expected planned, source, reading-graph, or reading-summary.`,
-      helpRoute,
-    ),
-  );
-}
-
-function parseChapterInputFormat(
-  value: string,
-  helpRoute: string,
-): Extract<CLIFormat, "markdown" | "txt"> {
-  const format = parseCLIFormat(value, "--input-format");
-
-  if (format === "markdown" || format === "txt") {
-    return format;
-  }
-
-  throw new Error(
-    withHelpRoute(
-      `Invalid --input-format for chapter source: ${value}. Expected txt or markdown.`,
       helpRoute,
     ),
   );
@@ -5071,6 +5067,7 @@ function normalizeArchiveInlineOptions(
       case "--chapter":
       case "--context":
       case "--cursor":
+      case "--import":
       case "--input":
       case "--input-format":
       case "--limit":
@@ -5346,6 +5343,7 @@ function rejectArchiveNonReadFlags(
   action: string,
   values: {
     readonly input?: string;
+    readonly import?: string;
     readonly "input-format"?: string;
     readonly llm?: string;
     readonly output?: string;
@@ -5355,6 +5353,7 @@ function rejectArchiveNonReadFlags(
   helpRoute: string,
 ): void {
   rejectArchiveFlag(action, "--input", values.input, helpRoute);
+  rejectArchiveFlag(action, "--import", values.import, helpRoute);
   rejectArchiveFlag(
     action,
     "--input-format",

--- a/test/archive/query/archive-view.test.ts
+++ b/test/archive/query/archive-view.test.ts
@@ -1797,6 +1797,24 @@ describe("archive/query/archive-view", () => {
     });
   });
 
+  it("rejects out-of-bounds source sentence ranges", async () => {
+    await withTempDir("spinedigest-archive-view-", async (path) => {
+      const document = await DirectoryDocument.open(`${path}/document`);
+
+      try {
+        await seedSourcedDocument(document);
+
+        await expect(
+          readArchivePage(document, "wikg://chapter/1/source#99..99"),
+        ).rejects.toThrow(
+          "source range wikg://chapter/1/source#99 is out of bounds.",
+        );
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
   it("shows node pages with generated summaries and source fragments", async () => {
     await withTempDir("spinedigest-archive-view-", async (path) => {
       const document = await DirectoryDocument.open(`${path}/document`);

--- a/test/cli/archive-chapter.test.ts
+++ b/test/cli/archive-chapter.test.ts
@@ -331,6 +331,27 @@ describe("cli/archive-chapter", () => {
     expect(chapterMockState.textWrites[0]).toContain("Chapter: 3\n");
   });
 
+  it("adds a chapter and prints JSON when requested", async () => {
+    await runArchiveChapterCommand({
+      action: "add",
+      addStage: "planned",
+      json: true,
+      path: "/tmp/book.wikg",
+      title: "New Chapter",
+    });
+
+    expect(JSON.parse(chapterMockState.textWrites[0] ?? "")).toStrictEqual({
+      chapterId: 3,
+      childCount: 0,
+      graphReady: false,
+      hasSummary: false,
+      sourceUnits: 2,
+      stage: "planned",
+      title: "New Chapter",
+      uri: "wikg://chapter/3",
+    });
+  });
+
   it("adds a sourced chapter from --input", async () => {
     await runArchiveChapterCommand({
       action: "add",

--- a/test/cli/archive-chapter.test.ts
+++ b/test/cli/archive-chapter.test.ts
@@ -335,7 +335,6 @@ describe("cli/archive-chapter", () => {
     await runArchiveChapterCommand({
       action: "add",
       addStage: "sourced",
-      inputFormat: "markdown",
       inputPath: "/tmp/chapter.md",
       path: "/tmp/book.wikg",
       title: "New Chapter",
@@ -359,7 +358,6 @@ describe("cli/archive-chapter", () => {
     await runArchiveChapterCommand({
       action: "set-source",
       chapterId: 2,
-      inputFormat: "markdown",
       inputPath: "/tmp/chapter.md",
       path: "/tmp/book.wikg",
     });
@@ -376,7 +374,6 @@ describe("cli/archive-chapter", () => {
     await runArchiveChapterCommand({
       action: "set-source",
       chapterId: 2,
-      inputFormat: "txt",
       inputValue: "inline source",
       path: "/tmp/book.wikg",
     });

--- a/test/cli/archive.test.ts
+++ b/test/cli/archive.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "fs/promises";
+import { mkdtemp, rm, stat, writeFile } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
 
@@ -714,14 +714,14 @@ describe("cli/archive", () => {
         archivePath,
       });
 
-      expect(archiveMockState.writeCalls).toStrictEqual([archivePath]);
+      expect((await stat(archivePath)).size).toBeGreaterThan(0);
       expect(archiveMockState.textWrites[0]).toBe("<archive>\n");
     } finally {
       await rm(directoryPath, { force: true, recursive: true });
     }
   });
 
-  it("prints archive object JSON after creating from a source", async () => {
+  it("prints archive object JSON after importing EPUB", async () => {
     const directoryPath = await mkdtemp(join(tmpdir(), "wikigraph-create-"));
     const archivePath = join(directoryPath, "new.wikg");
 
@@ -729,11 +729,18 @@ describe("cli/archive", () => {
       await runArchiveCommand({
         action: "create",
         archivePath,
+        importPath: "/tmp/book.epub",
         json: true,
-        sourcePath: "/tmp/source.md",
       });
 
-      expect(archiveMockState.writeCalls).toStrictEqual([]);
+      expect(archiveMockState.convertCalls).toStrictEqual([
+        expect.objectContaining({
+          inputPath: "/tmp/book.epub",
+          outputFormat: "wikg",
+          outputPath: archivePath,
+          targetStage: "sourced",
+        }),
+      ]);
       expect(JSON.parse(archiveMockState.textWrites[0] ?? "")).toStrictEqual({
         uri: `wikg://${archivePath}`,
       });
@@ -753,7 +760,7 @@ describe("cli/archive", () => {
         runArchiveCommand({
           action: "create",
           archivePath,
-          sourcePath: "/tmp/source.md",
+          importPath: "/tmp/book.epub",
         }),
       ).rejects.toThrow("Archive already exists:");
       expect(archiveMockState.convertCalls).toStrictEqual([]);
@@ -772,8 +779,8 @@ describe("cli/archive", () => {
       await runArchiveCommand({
         action: "create",
         archivePath,
+        importPath: "/tmp/book.epub",
         replace: true,
-        sourcePath: "/tmp/source.md",
       });
 
       const [convertCall] = archiveMockState.convertCalls as Array<{

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -992,6 +992,12 @@ describe("cli/args", () => {
       parseCLIArguments(["wikg://book.wikg", "create", "--role", "subject"]),
     ).toThrow("The `create` command does not support --role.");
     expect(() =>
+      parseCLIArguments(["wikg://book.wikg", "create", "--query", "agent"]),
+    ).toThrow("The `create` command does not support --query.");
+    expect(() =>
+      parseCLIArguments(["wikg://book.wikg", "create", "--reverse"]),
+    ).toThrow("The `create` command does not support --reverse.");
+    expect(() =>
       parseCLIArguments(["wikg://book.wikg", "export", "--backlinks"]),
     ).toThrow("The `export` command does not support --backlinks.");
     expect(() =>
@@ -2159,6 +2165,12 @@ describe("cli/args", () => {
     expect(
       renderArchiveMaintenanceChapterActionHelpText("set-summary"),
     ).toContain("The chapter must be `reading-graph`");
+    expect(renderArchiveMaintenanceChapterActionHelpText("add")).toContain(
+      "[--json]",
+    );
+    expect(
+      renderArchiveMaintenanceChapterActionHelpText("set-source"),
+    ).toContain("[--json]");
     expect(renderArchiveMaintenanceCommandHelpText("cover")).toContain(
       "refuses to write binary data to an interactive terminal",
     );

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -745,6 +745,11 @@ describe("cli/args", () => {
         "--reverse",
       ]),
     ).toThrow("`--reverse` cannot be combined with --query.");
+    expect(() =>
+      parseCLIArguments(["wikg://book.wikg", "--query", "agent", "--reverse"]),
+    ).toThrow(
+      "`--reverse` cannot be combined with --query.\nSee: wikigraph wikg://book.wikg --help",
+    );
 
     expect(
       parseCLIArguments(["wikg://book.wikg/triple/Q1/_/Q2"]),

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -114,7 +114,7 @@ describe("cli/args", () => {
     );
   });
 
-  it("renders archive-first stdin create recipes", () => {
+  it("renders archive-first create recipes", () => {
     const recipeHelp = parseCLIArguments(["help", "recipe"]);
 
     expect(recipeHelp.help).toBe(true);
@@ -123,7 +123,7 @@ describe("cli/args", () => {
       throw new Error("Expected recipe help");
     }
     expect(recipeHelp.helpText).toContain(
-      "cat article.md | wikigraph wikg://article.wikg create --input-format markdown",
+      "wikigraph wikg://book.wikg create --import ./book.epub",
     );
     expect(recipeHelp.helpText).toContain(
       "cat chapter.txt | wikigraph transform --input-format txt --output-format markdown",
@@ -589,39 +589,21 @@ describe("cli/args", () => {
       parseCLIArguments([
         "wikg://book.wikg",
         "create",
-        "book.md",
-        "--input-format",
-        "markdown",
+        "--import",
+        "book.epub",
         "--replace",
       ]),
     ).toStrictEqual({
       args: {
         action: "create",
         archivePath: archivePath,
-        inputFormat: "markdown",
+        importPath: "book.epub",
         replace: true,
-        sourcePath: "book.md",
       },
       help: false,
       kind: "archive",
     });
 
-    expect(
-      parseCLIArguments([
-        "wikg://book.wikg",
-        "create",
-        "--input-format",
-        "markdown",
-      ]),
-    ).toStrictEqual({
-      args: {
-        action: "create",
-        archivePath: archivePath,
-        inputFormat: "markdown",
-      },
-      help: false,
-      kind: "archive",
-    });
     expect(parseCLIArguments(["wikg://book.wikg", "create"])).toStrictEqual({
       args: {
         action: "create",
@@ -630,6 +612,9 @@ describe("cli/args", () => {
       help: false,
       kind: "archive",
     });
+    expect(() =>
+      parseCLIArguments(["wikg://book.wikg", "create", "book.epub"]),
+    ).toThrow("Unexpected positional arguments for `create`: book.epub.");
     expect(
       parseCLIArguments(["wikg://book.wikg", "create", "--json"]),
     ).toStrictEqual({
@@ -990,12 +975,7 @@ describe("cli/args", () => {
       ]),
     ).toThrow("Unknown option '--order'.");
     expect(() =>
-      parseCLIArguments([
-        "wikg://book.wikg",
-        "create",
-        "source.md",
-        "--evidence",
-      ]),
+      parseCLIArguments(["wikg://book.wikg", "create", "--evidence"]),
     ).toThrow("The `create` command does not support --evidence.");
     expect(() =>
       parseCLIArguments(["wikg://book.wikg", "export", "--evidence"]),
@@ -1342,20 +1322,29 @@ describe("cli/args", () => {
         "set",
         "--input",
         "chapter.md",
-        "--input-format",
-        "markdown",
       ]),
     ).toStrictEqual({
       args: {
         action: "set-source",
         chapterId: 12,
-        inputFormat: "markdown",
         inputPath: "chapter.md",
         path: archivePath,
       },
       help: false,
       kind: "chapter",
     });
+    expect(() =>
+      parseCLIArguments([
+        "wikg://book.wikg/chapter/12/source",
+        "set",
+        "--input",
+        "chapter.txt",
+        "--input-format",
+        "txt",
+      ]),
+    ).toThrow(
+      "The `chapter set-source` action does not support --input-format.",
+    );
     expect(
       parseCLIArguments([
         "wikg://book.wikg/chapter",
@@ -1636,6 +1625,31 @@ describe("cli/args", () => {
         "--clear",
       ]),
     ).toThrow("does not support --clear. Use `clear`.");
+    expect(() =>
+      parseCLIArguments([
+        "wikg://book.wikg/chapter/12/summary",
+        "set",
+        "--import",
+        "book.epub",
+      ]),
+    ).toThrow("The `chapter set-summary` action does not support --import.");
+    expect(() =>
+      parseCLIArguments([
+        "wikg://book.wikg/chapter/12/title",
+        "set",
+        "Title",
+        "--import",
+        "book.epub",
+      ]),
+    ).toThrow("The `chapter set-title` action does not support --import.");
+    expect(() =>
+      parseCLIArguments([
+        "wikg://book.wikg/chapter/tree",
+        "set",
+        "--import",
+        "book.epub",
+      ]),
+    ).toThrow("The `chapter tree` action does not support --import.");
   });
 
   it("prints archive maintenance help pages", () => {
@@ -1771,15 +1785,9 @@ describe("cli/args", () => {
 
   it("rejects invalid format flags", () => {
     expect(() =>
-      parseCLIArguments([
-        "wikg://book.wikg",
-        "create",
-        "book.md",
-        "--input-format",
-        "pdf",
-      ]),
+      parseCLIArguments(["wikg://book.wikg", "create", "--import", "pdf"]),
     ).toThrow(
-      "Invalid --input-format: pdf. Expected one of wikg, epub, txt, markdown.\nSee: wikigraph help format",
+      "`create --import` only supports EPUB input.\nSee: wikigraph wikg://book.wikg create --help",
     );
     expect(() =>
       parseCLIArguments([
@@ -1833,9 +1841,7 @@ describe("cli/args", () => {
     );
     expect(() =>
       parseCLIArguments(["wikg://book.wikg/chapter/1/source", "set"]),
-    ).toThrow(
-      "Missing --input-format. `chapter set-source` requires txt or markdown.\nSee: wikigraph wikg://book.wikg/chapter/1/source set --help",
-    );
+    ).not.toThrow();
     expect(() =>
       parseCLIArguments([
         "wikg://book.wikg/chapter/1/source",
@@ -2165,14 +2171,8 @@ describe("cli/args", () => {
     expect(rootHelpText).not.toContain("wikigraph help overview");
     expect(rootHelpText).not.toContain("wikigraph help command");
     expect(() =>
-      parseCLIArguments([
-        "wikg://book.wikg",
-        "create",
-        "book.md",
-        "--input-format",
-        "pdf",
-      ]),
-    ).toThrow("See: wikigraph help format");
+      parseCLIArguments(["wikg://book.wikg", "create", "--import", "book.pdf"]),
+    ).toThrow("See: wikigraph wikg://book.wikg create --help");
     expect(() => parseCLIArguments(["wikg", "inspect"])).toThrow(
       "See: wikigraph --help",
     );


### PR DESCRIPTION
## Summary
- make wikigraph <archive-uri> create create an empty .wikg archive and move EPUB ingestion to create --import <epub-path>
- remove obsolete create/chapter source input-format paths from TUI parsing and help docs
- tighten Agent-facing contracts for --json, inspect recommendations, source range bounds, and implicit query help routes

## Verification
- pnpm run lint:fix
- pnpm test
- pnpm verify
- manual smoke tests for create/import, chapter add --json, source range bounds, and --query --reverse error routing