### PR TITLE
fix(wikipage): log wikipage fetches for jobs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-graph",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "CLI-first tool for building and querying .wikg knowledge-base archives from long-form text and ebooks.",
   "keywords": [
     "wiki-graph",

--- a/src/cli/queue.ts
+++ b/src/cli/queue.ts
@@ -422,6 +422,9 @@ async function executeBuildJobWithLogging(
         policyPrompt: knowledgeGraphRecallPrompt,
         progressTracker: reporter,
         request,
+        resolverOptions: {
+          logDirPath: job.logPath,
+        },
         wikispine,
         workspacePath: job.workspacePath,
       },

--- a/src/common/logging.ts
+++ b/src/common/logging.ts
@@ -99,6 +99,7 @@ export function resolveArtifactPath(input: {
 }
 
 export function allocateArtifactPath(input: {
+  readonly alwaysNumbered?: boolean;
   readonly category: string;
   readonly extension?: string;
   readonly logDirPath?: string;
@@ -118,9 +119,11 @@ export function allocateArtifactPath(input: {
 
   for (let index = startIndex; ; index += 1) {
     const fileName =
-      index === 1
-        ? `${input.prefix}${extension}`
-        : `${input.prefix}-${index}${extension}`;
+      input.alwaysNumbered === true
+        ? `${input.prefix}-${index}${extension}`
+        : index === 1
+          ? `${input.prefix}${extension}`
+          : `${input.prefix}-${index}${extension}`;
     const resolvedPath = resolveArtifactPath({
       category: input.category,
       fileName,

--- a/src/llm/request-log.ts
+++ b/src/llm/request-log.ts
@@ -27,6 +27,7 @@ export function createRequestLog(logDirPath?: string): RequestLog {
 
   return new RequestLog(
     allocateArtifactPath({
+      alwaysNumbered: true,
       category: "llm",
       logDirPath,
       prefix: "request",

--- a/src/wikipage/fetch-log.ts
+++ b/src/wikipage/fetch-log.ts
@@ -1,0 +1,202 @@
+import { createHash } from "crypto";
+import { appendFile } from "fs/promises";
+
+import { getLogger, resolveArtifactPath } from "../common/logging.js";
+import { formatError } from "../utils/node-error.js";
+
+const MAX_RESPONSE_TEXT_LENGTH = 16_384;
+
+export interface WikipageFetchLog {
+  readonly filePath: string | undefined;
+  append(entry: WikipageFetchLogEntry): Promise<void>;
+  warnFailed(): void;
+}
+
+interface WikipageFetchLogEntry {
+  readonly attempt: number;
+  readonly durationMs: number;
+  readonly error?: unknown;
+  readonly response?: Response;
+  readonly responseText?: string;
+  readonly startedAt: number;
+  readonly url: URL;
+}
+
+class SilentWikipageFetchLog implements WikipageFetchLog {
+  public readonly filePath = undefined;
+
+  public append(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public warnFailed(): void {
+    return undefined;
+  }
+}
+
+class FileWikipageFetchLog implements WikipageFetchLog {
+  readonly #filePath: string;
+  #failedWarned = false;
+
+  public constructor(filePath: string) {
+    this.#filePath = filePath;
+  }
+
+  public get filePath(): string {
+    return this.#filePath;
+  }
+
+  public async append(entry: WikipageFetchLogEntry): Promise<void> {
+    await appendFile(
+      this.#filePath,
+      `${JSON.stringify(formatEntry(entry))}\n`,
+      "utf8",
+    );
+  }
+
+  public warnFailed(): void {
+    if (this.#failedWarned) {
+      return;
+    }
+    this.#failedWarned = true;
+
+    getLogger({ component: "wikipage" }).warn(
+      `\n[Wikipage] Failed with fetch log: ${this.#filePath}`,
+    );
+  }
+}
+
+export function createWikipageFetchLog(logDirPath?: string): WikipageFetchLog {
+  if (logDirPath === undefined) {
+    return new SilentWikipageFetchLog();
+  }
+
+  const filePath = resolveArtifactPath({
+    category: "wikipage",
+    fileName: "wikipage-fetch.jsonl",
+    logDirPath,
+  });
+
+  return filePath === undefined
+    ? new SilentWikipageFetchLog()
+    : new FileWikipageFetchLog(filePath);
+}
+
+function formatEntry(entry: WikipageFetchLogEntry): Record<string, unknown> {
+  return {
+    action: entry.url.searchParams.get("action") ?? null,
+    attempt: entry.attempt,
+    batch: summarizeBatch(entry.url),
+    durationMs: entry.durationMs,
+    endpoint: `${entry.url.origin}${entry.url.pathname}`,
+    host: entry.url.host,
+    ok: entry.response?.ok ?? false,
+    startedAt: new Date(entry.startedAt).toISOString(),
+    ...(entry.response === undefined
+      ? {}
+      : {
+          retryAfter: entry.response.headers.get("retry-after"),
+          status: entry.response.status,
+        }),
+    ...(entry.error === undefined
+      ? {}
+      : { error: formatLogError(entry.error) }),
+    ...(entry.responseText === undefined
+      ? {}
+      : { responseText: truncateResponseText(entry.responseText) }),
+  };
+}
+
+function summarizeBatch(url: URL): Record<string, unknown> | undefined {
+  const ids = url.searchParams.get("ids");
+  if (ids !== null) {
+    return summarizeList("qid", ids.split("|"));
+  }
+
+  const titles = url.searchParams.get("titles");
+  if (titles !== null) {
+    return summarizeList("title", titles.split("|"));
+  }
+
+  const page = url.searchParams.get("page");
+  if (page !== null) {
+    return summarizeList("page", [page]);
+  }
+
+  return undefined;
+}
+
+function summarizeList(
+  kind: "page" | "qid" | "title",
+  values: readonly string[],
+): Record<string, unknown> {
+  const joined = values.join("|");
+
+  return {
+    count: values.length,
+    hash: createHash("sha256").update(joined).digest("hex").slice(0, 16),
+    kind,
+    sample: values.slice(0, 5),
+  };
+}
+
+function formatLogError(error: unknown): Record<string, unknown> {
+  return {
+    message: formatError(error),
+    name: error instanceof Error ? error.name : typeof error,
+    ...formatErrorCause(error),
+  };
+}
+
+function formatErrorCause(error: unknown): Record<string, unknown> {
+  if (!(error instanceof Error) || error.cause === undefined) {
+    return {};
+  }
+
+  const cause = error.cause;
+
+  return {
+    cause:
+      cause instanceof Error
+        ? {
+            message: formatError(cause),
+            name: cause.name,
+            ...formatNodeErrorCode(cause),
+          }
+        : stringifyUnknown(cause),
+  };
+}
+
+function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint" ||
+    typeof value === "symbol"
+  ) {
+    return value.toString();
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "unserializable error cause";
+  }
+}
+
+function formatNodeErrorCode(error: Error): Record<string, unknown> {
+  const code = (error as { readonly code?: unknown }).code;
+
+  return typeof code === "string" ? { code } : {};
+}
+
+function truncateResponseText(text: string): string {
+  if (text.length <= MAX_RESPONSE_TEXT_LENGTH) {
+    return text;
+  }
+
+  return `${text.slice(0, MAX_RESPONSE_TEXT_LENGTH)}\n[truncated ${text.length - MAX_RESPONSE_TEXT_LENGTH} chars]`;
+}

--- a/src/wikipage/resolver.ts
+++ b/src/wikipage/resolver.ts
@@ -1,4 +1,5 @@
 import { WikipageCache } from "./cache.js";
+import { createWikipageFetchLog } from "./fetch-log.js";
 import {
   WikimediaClient,
   replaceTitleUriWithQidUri,
@@ -70,6 +71,7 @@ export class WikipageResolver {
       client: new WikimediaClient({
         concurrency: options.concurrency ?? DEFAULT_CONCURRENCY,
         language,
+        requestLog: createWikipageFetchLog(options.logDirPath),
         minRequestIntervalMs:
           options.minRequestIntervalMs ?? DEFAULT_MIN_REQUEST_INTERVAL_MS,
         retryBaseDelayMs:

--- a/src/wikipage/types.ts
+++ b/src/wikipage/types.ts
@@ -3,6 +3,7 @@ export interface WikipageResolverOptions {
   readonly concurrency?: number;
   readonly fetch?: typeof fetch;
   readonly language?: string;
+  readonly logDirPath?: string;
   readonly maxBatchSize?: number;
   readonly minRequestIntervalMs?: number;
   readonly normalizer?: DisambiguationProfileNormalizer;

--- a/src/wikipage/wikimedia-client.ts
+++ b/src/wikipage/wikimedia-client.ts
@@ -1,5 +1,6 @@
 import { DomUtils, parseDocument } from "htmlparser2";
 
+import type { WikipageFetchLog } from "./fetch-log.js";
 import { RateLimiter, parseRetryAfterMs } from "./rate-limiter.js";
 
 export type SupportedWiki = "enwiki" | "zhwiki";
@@ -9,6 +10,7 @@ export interface WikimediaClientOptions {
   readonly fetch?: typeof fetch;
   readonly language: string;
   readonly minRequestIntervalMs: number;
+  readonly requestLog: WikipageFetchLog;
   readonly retryBaseDelayMs: number;
   readonly retryTimes: number;
   readonly userAgent?: string;
@@ -66,6 +68,7 @@ export class WikimediaClient {
   readonly #fetch: typeof fetch;
   readonly #language: string;
   readonly #limiter: RateLimiter;
+  readonly #requestLog: WikipageFetchLog;
   readonly #retryBaseDelayMs: number;
   readonly #retryTimes: number;
   readonly #userAgent: string | undefined;
@@ -74,6 +77,7 @@ export class WikimediaClient {
   public constructor(options: WikimediaClientOptions) {
     this.#fetch = options.fetch ?? fetch;
     this.#language = options.language;
+    this.#requestLog = options.requestLog;
     this.#wiki = options.wiki;
     this.#userAgent = options.userAgent;
     this.#retryBaseDelayMs = Math.max(0, Math.floor(options.retryBaseDelayMs));
@@ -206,12 +210,13 @@ export class WikimediaClient {
     for (let attempt = 0; attempt <= this.#retryTimes; attempt += 1) {
       try {
         return await this.#limiter.use(
-          async () => await this.#fetchJsonOnce(url),
+          async () => await this.#fetchJsonOnce(url, attempt + 1),
         );
       } catch (error) {
         lastError = error;
 
         if (!isRetryableError(error) || attempt >= this.#retryTimes) {
+          this.#requestLog.warnFailed();
           throw error;
         }
 
@@ -222,17 +227,34 @@ export class WikimediaClient {
     throw lastError instanceof Error ? lastError : new Error(String(lastError));
   }
 
-  async #fetchJsonOnce(url: URL): Promise<Record<string, unknown>> {
-    const response = await this.#fetch(
-      url,
-      this.#userAgent === undefined
-        ? undefined
-        : {
-            headers: {
-              "User-Agent": this.#userAgent,
+  async #fetchJsonOnce(
+    url: URL,
+    attempt: number,
+  ): Promise<Record<string, unknown>> {
+    const startedAt = Date.now();
+    let response: Response;
+
+    try {
+      response = await this.#fetch(
+        url,
+        this.#userAgent === undefined
+          ? undefined
+          : {
+              headers: {
+                "User-Agent": this.#userAgent,
+              },
             },
-          },
-    );
+      );
+    } catch (error) {
+      await this.#requestLog.append({
+        attempt,
+        durationMs: Date.now() - startedAt,
+        error,
+        startedAt,
+        url,
+      });
+      throw error;
+    }
 
     const retryAfterMs = parseRetryAfterMs(response.headers.get("retry-after"));
 
@@ -240,11 +262,41 @@ export class WikimediaClient {
       this.#limiter.blockFor(retryAfterMs);
     }
     if (!response.ok) {
+      const responseText = isTextResponse(response)
+        ? await response.text()
+        : undefined;
+
+      await this.#requestLog.append({
+        attempt,
+        durationMs: Date.now() - startedAt,
+        response,
+        ...(responseText === undefined ? {} : { responseText }),
+        startedAt,
+        url,
+      });
       throw new WikimediaRequestError(url, response.status, retryAfterMs);
     }
 
+    await this.#requestLog.append({
+      attempt,
+      durationMs: Date.now() - startedAt,
+      response,
+      startedAt,
+      url,
+    });
+
     return asRecord(await response.json());
   }
+}
+
+function isTextResponse(response: Response): boolean {
+  const contentType = response.headers.get("content-type");
+
+  if (contentType === null) {
+    return false;
+  }
+
+  return /(?:json|text|xml|javascript|html)/iu.test(contentType);
 }
 
 class WikimediaRequestError extends Error {

--- a/src/wikipage/wikimedia-client.ts
+++ b/src/wikipage/wikimedia-client.ts
@@ -1,5 +1,7 @@
 import { DomUtils, parseDocument } from "htmlparser2";
 
+import { getLogger } from "../common/logging.js";
+import { formatError } from "../utils/node-error.js";
 import type { WikipageFetchLog } from "./fetch-log.js";
 import { RateLimiter, parseRetryAfterMs } from "./rate-limiter.js";
 
@@ -246,7 +248,7 @@ export class WikimediaClient {
             },
       );
     } catch (error) {
-      await this.#requestLog.append({
+      await this.#appendFetchLog({
         attempt,
         durationMs: Date.now() - startedAt,
         error,
@@ -266,7 +268,7 @@ export class WikimediaClient {
         ? await response.text()
         : undefined;
 
-      await this.#requestLog.append({
+      await this.#appendFetchLog({
         attempt,
         durationMs: Date.now() - startedAt,
         response,
@@ -277,7 +279,7 @@ export class WikimediaClient {
       throw new WikimediaRequestError(url, response.status, retryAfterMs);
     }
 
-    await this.#requestLog.append({
+    await this.#appendFetchLog({
       attempt,
       durationMs: Date.now() - startedAt,
       response,
@@ -286,6 +288,18 @@ export class WikimediaClient {
     });
 
     return asRecord(await response.json());
+  }
+
+  async #appendFetchLog(
+    entry: Parameters<WikipageFetchLog["append"]>[0],
+  ): Promise<void> {
+    try {
+      await this.#requestLog.append(entry);
+    } catch (error) {
+      getLogger({ component: "wikipage" }).warn(
+        `Failed to write wikipage fetch log entry: ${formatError(error)}`,
+      );
+    }
   }
 }
 

--- a/test/common/logging.test.ts
+++ b/test/common/logging.test.ts
@@ -82,4 +82,25 @@ describe("common/logging", () => {
       return Promise.resolve();
     });
   });
+
+  it("can allocate numbered artifact names starting at one", async () => {
+    await withTempDir("spinedigest-logging-", (path) => {
+      const firstPath = allocateArtifactPath({
+        alwaysNumbered: true,
+        category: "llm",
+        logDirPath: path,
+        prefix: "request",
+      });
+      const secondPath = allocateArtifactPath({
+        alwaysNumbered: true,
+        category: "llm",
+        logDirPath: path,
+        prefix: "request",
+      });
+
+      expect(firstPath).toBe(`${path}/request-1.log`);
+      expect(secondPath).toBe(`${path}/request-2.log`);
+      return Promise.resolve();
+    });
+  });
 });

--- a/test/llm/client.test.ts
+++ b/test/llm/client.test.ts
@@ -217,6 +217,7 @@ describe("llm/client", () => {
         ]),
       ).resolves.toBe("generated response");
 
+      await expect(readdir(logDirPath)).resolves.toContain("request-1.log");
       await expect(readOnlyRequestLog(logDirPath)).resolves.toContain(
         "[[Usage]]:\ninput: 11\ncache: 3\noutput: 7\n\n",
       );

--- a/test/wikipage/resolver.test.ts
+++ b/test/wikipage/resolver.test.ts
@@ -1,5 +1,8 @@
+import { readdir, readFile } from "fs/promises";
+
 import { describe, expect, it } from "vitest";
 
+import { withLoggingContext } from "../../src/common/logging.js";
 import { Database } from "../../src/document/index.js";
 import { WikipageResolver } from "../../src/wikipage/index.js";
 import { withTempDir } from "../helpers/temp.js";
@@ -117,6 +120,119 @@ describe("wikipage/resolver", () => {
       } finally {
         await resolver.close();
       }
+    });
+  });
+
+  it("writes compact fetch logs when a log directory is configured", async () => {
+    await withTempDir("spinedigest-wikipage-", async (path) => {
+      const calls: string[] = [];
+
+      await withLoggingContext(
+        {
+          logDirPath: path,
+          operation: "wikipage-test",
+        },
+        async () => {
+          const resolver = await WikipageResolver.open({
+            cacheDatabasePath: `${path}/cache.sqlite`,
+            fetch: createMockFetch(calls),
+            language: "en",
+            logDirPath: path,
+            minRequestIntervalMs: 0,
+            retryBaseDelayMs: 0,
+          });
+
+          try {
+            await resolver.resolveQids(["Q1"]);
+          } finally {
+            await resolver.close();
+          }
+        },
+      );
+
+      const log = await readWikipageFetchLog(path);
+      const lines = log
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+      expect(lines).toHaveLength(3);
+      expect(lines[0]).toMatchObject({
+        action: "wbgetentities",
+        attempt: 1,
+        batch: {
+          count: 1,
+          kind: "qid",
+          sample: ["Q1"],
+        },
+        host: "www.wikidata.org",
+        ok: true,
+        status: 200,
+      });
+      expect(lines[0]).not.toHaveProperty("responseText");
+      expect(lines.slice(1)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            action: "query",
+            attempt: 1,
+            ok: true,
+            status: 200,
+          }),
+        ]),
+      );
+      expect(lines.slice(1).map(readBatchSample)).toEqual(
+        expect.arrayContaining([["Universe"], ["宇宙"]]),
+      );
+    });
+  });
+
+  it("includes response text for failed text responses", async () => {
+    await withTempDir("spinedigest-wikipage-", async (path) => {
+      const failingFetch: typeof globalThis.fetch = () =>
+        Promise.resolve(
+          new Response("service unavailable", {
+            headers: {
+              "content-type": "text/plain",
+            },
+            status: 503,
+          }),
+        );
+
+      await expect(
+        withLoggingContext(
+          {
+            logDirPath: path,
+            operation: "wikipage-test",
+          },
+          async () => {
+            const resolver = await WikipageResolver.open({
+              cacheDatabasePath: `${path}/cache.sqlite`,
+              fetch: failingFetch,
+              language: "en",
+              logDirPath: path,
+              minRequestIntervalMs: 0,
+              retryBaseDelayMs: 0,
+              retryTimes: 0,
+            });
+
+            try {
+              await resolver.resolveQids(["Q1"]);
+            } finally {
+              await resolver.close();
+            }
+          },
+        ),
+      ).rejects.toThrow("Wikimedia request failed with 503");
+
+      const [line] = (await readWikipageFetchLog(path)).trim().split("\n");
+      const entry = JSON.parse(line!) as Record<string, unknown>;
+
+      expect(entry).toMatchObject({
+        action: "wbgetentities",
+        ok: false,
+        responseText: "service unavailable",
+        status: 503,
+      });
     });
   });
 
@@ -388,6 +504,29 @@ function createMockFetch(calls: string[]): typeof fetch {
 
     return Promise.resolve(jsonResponse({}, 404));
   }) as typeof fetch;
+}
+
+async function readWikipageFetchLog(logDirPath: string): Promise<string> {
+  const entries = await readdir(logDirPath, { withFileTypes: true });
+  const runEntry = entries.find((entry) => entry.isDirectory());
+
+  expect(runEntry).toBeDefined();
+
+  return await readFile(
+    `${logDirPath}/${runEntry!.name}/artifacts/wikipage/wikipage-fetch.jsonl`,
+    "utf8",
+  );
+}
+
+function readBatchSample(entry: Record<string, unknown>): readonly unknown[] {
+  const batch = entry.batch;
+
+  expect(batch).toEqual(expect.any(Object));
+
+  const sample = (batch as Record<string, unknown>).sample;
+
+  expect(Array.isArray(sample)).toBe(true);
+  return sample as readonly unknown[];
 }
 
 function entity(

--- a/test/wikipage/resolver.test.ts
+++ b/test/wikipage/resolver.test.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile } from "fs/promises";
+import { mkdir, readdir, readFile } from "fs/promises";
 
 import { describe, expect, it } from "vitest";
 
@@ -233,6 +233,50 @@ describe("wikipage/resolver", () => {
         responseText: "service unavailable",
         status: 503,
       });
+    });
+  });
+
+  it("does not fail requests when fetch logging fails", async () => {
+    await withTempDir("spinedigest-wikipage-", async (path) => {
+      const calls: string[] = [];
+
+      await expect(
+        withLoggingContext(
+          {
+            logDirPath: path,
+            operation: "wikipage-test",
+          },
+          async () => {
+            const resolver = await WikipageResolver.open({
+              cacheDatabasePath: `${path}/cache.sqlite`,
+              fetch: createMockFetch(calls),
+              language: "en",
+              logDirPath: path,
+              minRequestIntervalMs: 0,
+              retryBaseDelayMs: 0,
+            });
+
+            try {
+              const runDirName = await readOnlyRunDirName(path);
+              await mkdir(
+                `${path}/${runDirName}/artifacts/wikipage/wikipage-fetch.jsonl`,
+              );
+
+              return await resolver.resolveQids(["Q1"]);
+            } finally {
+              await resolver.close();
+            }
+          },
+        ),
+      ).resolves.toMatchObject([
+        {
+          description: "totality of space and time",
+          label: "Universe",
+          qid: "Q1",
+        },
+      ]);
+
+      expect(calls.length).toBeGreaterThan(0);
     });
   });
 
@@ -507,15 +551,21 @@ function createMockFetch(calls: string[]): typeof fetch {
 }
 
 async function readWikipageFetchLog(logDirPath: string): Promise<string> {
-  const entries = await readdir(logDirPath, { withFileTypes: true });
-  const runEntry = entries.find((entry) => entry.isDirectory());
-
-  expect(runEntry).toBeDefined();
+  const runDirName = await readOnlyRunDirName(logDirPath);
 
   return await readFile(
-    `${logDirPath}/${runEntry!.name}/artifacts/wikipage/wikipage-fetch.jsonl`,
+    `${logDirPath}/${runDirName}/artifacts/wikipage/wikipage-fetch.jsonl`,
     "utf8",
   );
+}
+
+async function readOnlyRunDirName(logDirPath: string): Promise<string> {
+  const entries = await readdir(logDirPath, { withFileTypes: true });
+  const runEntries = entries.filter((entry) => entry.isDirectory());
+
+  expect(runEntries).toHaveLength(1);
+
+  return runEntries[0]!.name;
 }
 
 function readBatchSample(entry: Record<string, unknown>): readonly unknown[] {


### PR DESCRIPTION
## Summary
- add compact JSONL logging for wikipage fetches under job artifacts
- pass job log paths into knowledge-graph wikipage resolver sessions
- rename the first LLM request log from request.log to request-1.log for consistent numbering
- bump package version to 0.3.1

## Verification
- pnpm run format:check
- pnpm run lint
- pnpm run typecheck
- pnpm test:run
- pnpm run lint:fix
- manually confirmed new job logs include artifacts/wikipage/wikipage-fetch.jsonl and request-1.log naming