### PR TITLE
feat: lazily page broad search buckets

### DIFF
--- a/src/archive/query/archive-view.ts
+++ b/src/archive/query/archive-view.ts
@@ -1277,7 +1277,9 @@ async function readObjectBucketPage(
   readonly items: readonly ArchiveFindHit[];
   readonly nextCursor: BucketSearchCursor | undefined;
 }> {
-  await populateObjectBucketCaches(document, session);
+  if (!session.objectCachesPopulated) {
+    await populateObjectBucketCaches(document, session);
+  }
   const page = await readSearchSessionObjectBucketPage(
     session.sessionId,
     1,
@@ -1296,7 +1298,11 @@ async function readObjectBucketPage(
       page.length > limit && last !== undefined
         ? {
             bucket: 1,
-            key: { id: getObjectBucketCursorId(last), score: last.score ?? 0 },
+            key: {
+              id: getObjectBucketCursorId(last),
+              kind: last.type === "triple" ? "triple" : "entity",
+              score: last.score ?? 0,
+            },
           }
         : { bucket: 2 },
   };

--- a/src/archive/query/archive-view.ts
+++ b/src/archive/query/archive-view.ts
@@ -37,17 +37,29 @@ import {
 import {
   createEntitySearchSession,
   createSearchSession,
+  decodeBucketSearchSessionCursor,
   decodeSearchSessionCursor,
+  encodeBucketSearchSessionCursor,
+  populateSearchSessionObjectCaches,
   readCachedEntitySearchSessionPage,
   readCachedSearchSessionPage,
   readEntitySearchEvidenceMentions,
   readEntitySearchSessionPage,
+  readSearchSessionChunkBucketPage,
   readSearchSessionDescriptor,
+  readSearchSessionMetadataForCursor,
+  readSearchSessionObjectBucketPage,
   readSearchSessionPage,
   SEARCH_EVIDENCE_KIND,
+  type BucketSearchCursor,
   type SearchChunkHitInput,
+  type SearchChunkCursorKey,
+  type SearchChapterTitleCursorKey,
   type SearchEntityHitInput,
   type SearchEvidenceHitEventInput,
+  type SearchObjectCursorKey,
+  type SearchSessionDescriptor,
+  type SearchTextCursorKey,
   type SearchTripleHitInput,
 } from "./search-cache.js";
 import {
@@ -55,6 +67,7 @@ import {
   ensureSearchIndex,
   querySearchIndex,
   readSearchIndexStatus,
+  SEARCH_INDEX_FTS_HIT_LIMIT,
   SEARCH_OBJECT_PROPERTY_KIND,
   SEARCH_OBJECT_PROPERTY_OWNER_KIND,
   TEXT_SENTENCE_KIND,
@@ -763,6 +776,15 @@ export async function findArchiveObjects(
     options.cursor !== undefined &&
     (!textOnlySearch || !isFindCursor(options.cursor))
   ) {
+    const bucketCursor = tryDecodeBucketSearchSessionCursor(options.cursor);
+
+    if (bucketCursor !== undefined) {
+      return await readBucketedSearchResultPage(document, bucketCursor, {
+        ...options,
+        limit,
+      });
+    }
+
     const cursor = decodeSearchSessionCursor(options.cursor);
     const descriptor = await readSearchSessionDescriptor(
       cursor.sessionId,
@@ -846,6 +868,8 @@ export async function findArchiveObjects(
     types: options.types ?? null,
   };
   const canReadSearchCache = options.triplePattern === undefined;
+  const usesBucketedSearch =
+    options.types === undefined && options.triplePattern === undefined;
 
   if (canReadSearchCache && isEntityOnlySearch(options)) {
     const cachedPage = await readCachedEntitySearchSessionPage(
@@ -877,7 +901,7 @@ export async function findArchiveObjects(
         options,
       );
     }
-  } else if (canReadSearchCache) {
+  } else if (canReadSearchCache && !usesBucketedSearch) {
     const cachedPage = await readCachedSearchSessionPage(cacheInput, 0, limit);
 
     if (cachedPage !== undefined) {
@@ -903,6 +927,39 @@ export async function findArchiveObjects(
         options,
       );
     }
+  }
+
+  if (usesBucketedSearch) {
+    if (!(await isArchiveSearchIndexCurrent(document))) {
+      throw new Error(
+        "Wiki Graph search index is missing or outdated. Run `<archive-uri>/index enable` before searching.",
+      );
+    }
+    const sessionId = await createSearchSession({
+      archiveKey: options.archiveKey ?? "archive",
+      chapters: options.chapters ?? null,
+      lens: "broad",
+      match: options.match ?? "any",
+      order: options.order ?? "doc-asc",
+      query,
+      revisionScope,
+      terms: search.terms,
+      types: null,
+    });
+    const descriptor = await readSearchSessionDescriptor(
+      sessionId,
+      options.archiveKey ?? "archive",
+    );
+
+    return await readBucketedSearchResultPage(
+      document,
+      {
+        createdAt: descriptor.createdAt,
+        cursor: { bucket: 0 },
+        sessionId,
+      },
+      { ...options, limit },
+    );
   }
 
   const allMentions = wantsStructuredSearch
@@ -1063,6 +1120,501 @@ async function createSearchRevisionScope(
     ),
     scope: "chapters",
   });
+}
+
+async function readBucketedSearchResultPage(
+  document: ReadonlyDocument,
+  cursor: {
+    readonly createdAt: number;
+    readonly cursor: BucketSearchCursor;
+    readonly sessionId: string;
+  },
+  options: ArchiveFindOptions & { readonly limit: number },
+): Promise<ArchiveFindResult> {
+  const session = await readSearchSessionMetadataForCursor(
+    cursor.sessionId,
+    options.archiveKey ?? "archive",
+    cursor.createdAt,
+  );
+
+  assertSearchCursorTypesMatch(options.types, session.types);
+
+  const items: ArchiveFindHit[] = [];
+  let bucketCursor: BucketSearchCursor | undefined = cursor.cursor;
+
+  while (bucketCursor !== undefined && items.length < options.limit) {
+    const remaining = options.limit - items.length;
+    const page = await readBucketPage(
+      document,
+      session,
+      bucketCursor,
+      remaining,
+    );
+
+    items.push(...page.items);
+    bucketCursor = page.nextCursor;
+  }
+
+  return await hydrateFindResultBacklinks(
+    document,
+    {
+      chapters: session.chapters,
+      items: await hydrateFindHitEvidence(
+        document,
+        items,
+        createFindEvidenceHydrationOptions(options, cursor.sessionId),
+      ),
+      lens: parseFindLens(session.lens),
+      lensHint: session.lens === "broad" ? BROAD_FIND_LENS_HINT : null,
+      limit: options.limit,
+      match: parseFindMatch(session.match),
+      nextCursor:
+        bucketCursor === undefined
+          ? null
+          : encodeBucketSearchSessionCursor(
+              cursor.sessionId,
+              bucketCursor,
+              session.createdAt,
+            ),
+      order: options.order ?? "doc-asc",
+      query: session.query,
+      terms: session.terms,
+      types: parseFindTypes(session.types),
+    },
+    options,
+  );
+}
+
+async function readBucketPage(
+  document: ReadonlyDocument,
+  session: SearchSessionDescriptor,
+  cursor: BucketSearchCursor,
+  limit: number,
+): Promise<{
+  readonly items: readonly ArchiveFindHit[];
+  readonly nextCursor: BucketSearchCursor | undefined;
+}> {
+  switch (cursor.bucket) {
+    case 0:
+      return await readChapterTitleBucketPage(
+        document,
+        session,
+        cursor.key,
+        limit,
+      );
+    case 1:
+      return await readObjectBucketPage(document, session, cursor.key, limit);
+    case 2:
+      return await readChunkBucketPage(document, session, cursor.key, limit);
+    case 3:
+      return await readTextBucketPage(document, session, cursor.key, limit);
+  }
+}
+
+async function readChapterTitleBucketPage(
+  document: ReadonlyDocument,
+  session: SearchSessionDescriptor,
+  after: SearchChapterTitleCursorKey | undefined,
+  limit: number,
+): Promise<{
+  readonly items: readonly ArchiveFindHit[];
+  readonly nextCursor: BucketSearchCursor | undefined;
+}> {
+  const result = await querySearchIndex(document, session.query, {
+    ...(session.chapters === null ? {} : { chapters: session.chapters }),
+    match: parseFindMatch(session.match),
+    objectHitLimit: SEARCH_INDEX_FTS_HIT_LIMIT,
+    textHitLimit: 0,
+    types: ["chapter-title"],
+  });
+  const chapters = new Map(
+    (await listChapters(document)).map((chapter) => [
+      chapter.chapterId,
+      chapter,
+    ]),
+  );
+  const hits = (result?.objectHits ?? [])
+    .filter(
+      (hit) => hit.ownerKind === SEARCH_OBJECT_PROPERTY_OWNER_KIND.chapter,
+    )
+    .sort(compareChapterTitleIndexHits)
+    .filter((hit) => isAfterChapterTitleKey(hit, after));
+  const page = hits.slice(0, limit + 1);
+  const hydrated = (
+    await Promise.all(
+      page.slice(0, limit).map(async (hit) => {
+        const item = await hydrateSearchObjectHit(document, chapters, hit);
+
+        return item === undefined
+          ? undefined
+          : withSearchTerms(item, session.terms);
+      }),
+    )
+  ).filter(isDefined);
+  const last = page.at(limit - 1);
+
+  return {
+    items: hydrated,
+    nextCursor:
+      page.length > limit && last !== undefined
+        ? {
+            bucket: 0,
+            key: {
+              chapterId: parseSearchPropertyIntegerOwnerId(last.ownerId),
+              score: last.score,
+            },
+          }
+        : { bucket: 1 },
+  };
+}
+
+async function readObjectBucketPage(
+  document: ReadonlyDocument,
+  session: SearchSessionDescriptor,
+  after: SearchObjectCursorKey | undefined,
+  limit: number,
+): Promise<{
+  readonly items: readonly ArchiveFindHit[];
+  readonly nextCursor: BucketSearchCursor | undefined;
+}> {
+  await populateObjectBucketCaches(document, session);
+  const page = await readSearchSessionObjectBucketPage(
+    session.sessionId,
+    1,
+    after,
+    limit,
+  );
+  const items = page.slice(0, limit);
+  const hydrated = await Promise.all(
+    items.map(async (hit) => await hydrateCachedObjectBucketHit(document, hit)),
+  );
+  const last = items.at(-1);
+
+  return {
+    items: hydrated,
+    nextCursor:
+      page.length > limit && last !== undefined
+        ? {
+            bucket: 1,
+            key: { id: getObjectBucketCursorId(last), score: last.score ?? 0 },
+          }
+        : { bucket: 2 },
+  };
+}
+
+async function populateObjectBucketCaches(
+  document: ReadonlyDocument,
+  session: SearchSessionDescriptor,
+): Promise<void> {
+  const search = createLexicalQuery(session.query);
+
+  if (search === undefined) {
+    return;
+  }
+
+  const [allMentions, indexed] = await Promise.all([
+    document.mentions.listBySurfaceTerms(
+      listLexicalQueryCandidateTerms(session.query),
+    ),
+    querySearchIndex(document, session.query, {
+      ...(session.chapters === null ? {} : { chapters: session.chapters }),
+      match: parseFindMatch(session.match),
+      objectHitLimit: SEARCH_INDEX_FTS_HIT_LIMIT,
+      textHitLimit: 0,
+      types: null,
+    }),
+  ]);
+  const structuredHits = [
+    ...findEntities(search, { mentions: allMentions }),
+    ...(await findTriples(document, search, { mentions: allMentions })),
+  ];
+  const entityCacheInput = createEntitySearchCacheInput(
+    structuredHits,
+    indexed,
+  );
+
+  await populateSearchSessionObjectCaches({
+    entityHits: entityCacheInput.entityHits,
+    evidenceEvents: entityCacheInput.evidenceEvents,
+    sessionId: session.sessionId,
+  });
+}
+
+async function readChunkBucketPage(
+  document: ReadonlyDocument,
+  session: SearchSessionDescriptor,
+  after: SearchChunkCursorKey | undefined,
+  limit: number,
+): Promise<{
+  readonly items: readonly ArchiveFindHit[];
+  readonly nextCursor: BucketSearchCursor | undefined;
+}> {
+  const page = await readSearchSessionChunkBucketPage(
+    session.sessionId,
+    after,
+    limit,
+  );
+  const items = page.slice(0, limit);
+  const hydrated = (
+    await Promise.all(
+      items.map(
+        async (hit) => await hydrateCachedChunkBucketHit(document, hit),
+      ),
+    )
+  ).filter(isDefined);
+  const last = items.at(-1);
+
+  return {
+    items: hydrated,
+    nextCursor:
+      page.length > limit && last !== undefined
+        ? {
+            bucket: 2,
+            key: {
+              chunkId: parseSearchPropertyIntegerOwnerId(
+                last.id.slice("wikg://chunk/".length),
+              ),
+              score: last.score ?? 0,
+            },
+          }
+        : { bucket: 3 },
+  };
+}
+
+async function readTextBucketPage(
+  document: ReadonlyDocument,
+  session: SearchSessionDescriptor,
+  after: SearchTextCursorKey | undefined,
+  limit: number,
+): Promise<{
+  readonly items: readonly ArchiveFindHit[];
+  readonly nextCursor: BucketSearchCursor | undefined;
+}> {
+  const result = await querySearchIndex(document, session.query, {
+    ...(session.chapters === null ? {} : { chapters: session.chapters }),
+    match: parseFindMatch(session.match),
+    objectHitLimit: 0,
+    ...(after === undefined
+      ? {}
+      : {
+          textAfter: {
+            chapterId: after.chapterId,
+            kind: after.kind as SearchIndexTextHit["kind"],
+            rank: after.rank,
+            sentenceIndex: after.sentenceIndex,
+          },
+        }),
+    textHitLimit: createBucketQueryWindow(limit),
+    types: ["source", "summary"],
+  });
+  const chapters = new Map(
+    (await listChapters(document)).map((chapter) => [
+      chapter.chapterId,
+      chapter,
+    ]),
+  );
+  const hits = [...(result?.textHits ?? [])]
+    .sort(compareTextIndexHits)
+    .filter((hit) => isAfterTextKey(hit, after));
+  const page = hits.slice(0, limit + 1);
+  const hydrated = (
+    await Promise.all(
+      page.slice(0, limit).map(async (hit) => {
+        const item = await hydrateSearchTextHit(document, chapters, hit);
+
+        return item === undefined
+          ? undefined
+          : withSearchTerms(item, session.terms);
+      }),
+    )
+  ).filter(isDefined);
+  const last = page.at(limit - 1);
+
+  return {
+    items: hydrated,
+    nextCursor:
+      page.length > limit && last !== undefined
+        ? {
+            bucket: 3,
+            key: {
+              chapterId: last.chapterId,
+              kind: last.kind,
+              rank: last.rank,
+              sentenceIndex: last.sentenceIndex,
+            },
+          }
+        : undefined,
+  };
+}
+
+function createBucketQueryWindow(limit: number): number {
+  return Math.max(limit + 1, limit * 3 + 1, 100);
+}
+
+async function hydrateCachedObjectBucketHit(
+  document: ReadonlyDocument,
+  hit: ArchiveFindHit,
+): Promise<ArchiveFindHit> {
+  if (hit.type === "entity") {
+    const qid = parseEntityQid(hit.id);
+
+    if (qid === undefined) {
+      return hit;
+    }
+    const mentions = await document.mentions.listByQid(qid);
+    const [first] = [...mentions].sort(compareMentions);
+
+    if (first === undefined) {
+      return hit;
+    }
+
+    return {
+      ...hit,
+      chapter: first.chapterId,
+      position: {
+        chapter: first.chapterId,
+        sentence: first.sentenceIndex ?? 0,
+      },
+      snippet: first.note ?? first.surface,
+      title: selectEntityLabel(mentions),
+    };
+  }
+  if (hit.type === "triple") {
+    return hit;
+  }
+
+  return hit;
+}
+
+async function hydrateCachedChunkBucketHit(
+  document: ReadonlyDocument,
+  hit: ArchiveFindHit,
+): Promise<ArchiveFindHit | undefined> {
+  const chunkId = parseSearchPropertyIntegerOwnerId(
+    hit.id.slice("wikg://chunk/".length),
+  );
+  const node = await document.chunks.getById(chunkId);
+
+  if (node === undefined) {
+    return undefined;
+  }
+  const { position: _position, ...baseHit } = hit;
+  const position = createNodePosition(node.sentenceIds);
+
+  return {
+    ...baseHit,
+    chapter: node.sentenceId[0],
+    field: "title",
+    ...(position === undefined ? {} : { position }),
+    snippet: createSnippet(node.content),
+    title: node.label,
+  };
+}
+
+function compareChapterTitleIndexHits(
+  left: SearchIndexObjectHit,
+  right: SearchIndexObjectHit,
+): number {
+  return (
+    compareNumbers(right.score, left.score) ||
+    compareNumbers(
+      parseSearchPropertyIntegerOwnerId(left.ownerId),
+      parseSearchPropertyIntegerOwnerId(right.ownerId),
+    )
+  );
+}
+
+function compareTextIndexHits(
+  left: SearchIndexTextHit,
+  right: SearchIndexTextHit,
+): number {
+  return (
+    compareNumbers(left.rank, right.rank) ||
+    compareNumbers(left.chapterId, right.chapterId) ||
+    compareNumbers(left.sentenceIndex, right.sentenceIndex) ||
+    compareNumbers(left.kind, right.kind)
+  );
+}
+
+function isAfterChapterTitleKey(
+  hit: SearchIndexObjectHit,
+  key: SearchChapterTitleCursorKey | undefined,
+): boolean {
+  if (key === undefined) {
+    return true;
+  }
+
+  return (
+    compareChapterTitleIndexHits(
+      {
+        ...hit,
+        ownerId: String(key.chapterId),
+        score: key.score,
+      },
+      hit,
+    ) < 0
+  );
+}
+
+function isAfterTextKey(
+  hit: SearchIndexTextHit,
+  key: SearchTextCursorKey | undefined,
+): boolean {
+  if (key === undefined) {
+    return true;
+  }
+
+  return (
+    compareTextIndexHits(
+      {
+        chapterId: key.chapterId,
+        kind: key.kind as SearchIndexTextHit["kind"],
+        rank: key.rank,
+        score: 0,
+        sentenceIndex: key.sentenceIndex,
+        wordsCount: 0,
+      },
+      hit,
+    ) < 0
+  );
+}
+
+function getObjectBucketCursorId(hit: ArchiveFindHit): string {
+  if (hit.type !== "triple") {
+    return hit.id.replace(/^wikg:\/\/entity\//u, "");
+  }
+
+  const triple = parseTripleCursorId(hit.id);
+
+  return triple ?? hit.id;
+}
+
+function parseTripleCursorId(id: string): string | undefined {
+  const match = /^wikg:\/\/triple\/([^/]+)\/([^/]+)\/([^/]+)$/u.exec(id);
+
+  if (
+    match?.[1] === undefined ||
+    match[2] === undefined ||
+    match[3] === undefined
+  ) {
+    return undefined;
+  }
+
+  return `${match[1]}\u001f${decodeURIComponent(match[2])}\u001f${match[3]}`;
+}
+
+function tryDecodeBucketSearchSessionCursor(cursor: string):
+  | {
+      readonly createdAt: number;
+      readonly cursor: BucketSearchCursor;
+      readonly sessionId: string;
+    }
+  | undefined {
+  try {
+    return decodeBucketSearchSessionCursor(cursor);
+  } catch {
+    return undefined;
+  }
 }
 
 export async function rebuildArchiveSearchIndex(
@@ -6082,20 +6634,21 @@ function getListBucket(type: ArchiveFindObjectType): number {
 
 function getSearchBucket(type: ArchiveFindObjectType): number {
   switch (type) {
+    case "chapter-title":
+      return 0;
     case "entity":
     case "triple":
-      return 0;
-    case "node":
       return 1;
+    case "node":
+      return 2;
     case "source":
     case "summary":
-    case "chapter-title":
+      return 3;
     case "chapter":
     case "chapter-tree":
     case "meta":
-      return 2;
     case "fragment":
-      return 2;
+      throw new Error(`Unsupported search result bucket type: ${type}`);
   }
 }
 

--- a/src/archive/query/search-cache.ts
+++ b/src/archive/query/search-cache.ts
@@ -18,7 +18,7 @@ export interface SearchSessionInput {
   readonly chunkHits?: readonly SearchChunkHitInput[];
   readonly entityHits?: readonly SearchEntityHitInput[];
   readonly evidenceEvents?: readonly SearchEvidenceHitEventInput[];
-  readonly items: readonly ArchiveFindHit[];
+  readonly items?: readonly ArchiveFindHit[];
   readonly lens: string;
   readonly match: string;
   readonly order: string;
@@ -114,6 +114,46 @@ export interface SearchSessionDescriptor {
   readonly sessionId: string;
   readonly terms: readonly string[];
   readonly types: readonly string[] | null;
+}
+
+export type BucketSearchCursor =
+  | {
+      readonly bucket: 0;
+      readonly key?: SearchChapterTitleCursorKey;
+    }
+  | {
+      readonly bucket: 1;
+      readonly key?: SearchObjectCursorKey;
+    }
+  | {
+      readonly bucket: 2;
+      readonly key?: SearchChunkCursorKey;
+    }
+  | {
+      readonly bucket: 3;
+      readonly key?: SearchTextCursorKey;
+    };
+
+export interface SearchChapterTitleCursorKey {
+  readonly chapterId: number;
+  readonly score: number;
+}
+
+export interface SearchObjectCursorKey {
+  readonly id: string;
+  readonly score: number;
+}
+
+export interface SearchChunkCursorKey {
+  readonly chunkId: number;
+  readonly score: number;
+}
+
+export interface SearchTextCursorKey {
+  readonly chapterId: number;
+  readonly kind: number;
+  readonly rank: number;
+  readonly sentenceIndex: number;
 }
 
 const SEARCH_SESSION_SCHEMA_SQL = `
@@ -300,7 +340,7 @@ export async function createSearchSession(
         ],
       );
 
-      for (const [index, item] of input.items.entries()) {
+      for (const [index, item] of (input.items ?? []).entries()) {
         await database.run(
           `
             INSERT INTO search_results (session_id, rank, item_json)
@@ -324,6 +364,92 @@ export async function createSearchSession(
     });
 
     return sessionId;
+  } finally {
+    await database.close();
+  }
+}
+
+export async function readSearchSessionObjectBucketPage(
+  sessionId: string,
+  bucket: 1,
+  after: SearchObjectCursorKey | undefined,
+  limit: number,
+): Promise<readonly ArchiveFindHit[]> {
+  const database = await openSearchSessionDatabase();
+
+  try {
+    const entityRows = await readSearchSessionEntityBucketRows(
+      database,
+      sessionId,
+      after,
+      limit,
+    );
+    const tripleRows =
+      entityRows.length > limit
+        ? []
+        : await readSearchSessionTripleBucketRows(
+            database,
+            sessionId,
+            after,
+            limit,
+          );
+
+    return [...entityRows, ...tripleRows]
+      .sort(compareObjectBucketHits)
+      .slice(0, limit + 1);
+  } finally {
+    await database.close();
+  }
+}
+
+export async function readSearchSessionChunkBucketPage(
+  sessionId: string,
+  after: SearchChunkCursorKey | undefined,
+  limit: number,
+): Promise<readonly ArchiveFindHit[]> {
+  const database = await openSearchSessionDatabase();
+
+  try {
+    return await database.queryAll(
+      `
+        SELECT
+          chunk_id,
+          result_score
+        FROM search_chunk_hits
+        WHERE session_id = ?
+          ${
+            after === undefined
+              ? ""
+              : `
+                AND (
+                  result_score < ?
+                  OR (result_score = ? AND chunk_id > ?)
+                )
+              `
+          }
+        ORDER BY result_score DESC, chunk_id
+        LIMIT ?
+      `,
+      [
+        sessionId,
+        ...(after === undefined
+          ? []
+          : [after.score, after.score, after.chunkId]),
+        limit + 1,
+      ],
+      (row) => {
+        const chunkId = getNumber(row, "chunk_id");
+
+        return {
+          field: "title",
+          id: `wikg://chunk/${chunkId}`,
+          score: getNumber(row, "result_score"),
+          snippet: `chunk ${chunkId}`,
+          title: `chunk ${chunkId}`,
+          type: "node",
+        };
+      },
+    );
   } finally {
     await database.close();
   }
@@ -382,6 +508,35 @@ export async function createEntitySearchSession(
     });
 
     return sessionId;
+  } finally {
+    await database.close();
+  }
+}
+
+export async function populateSearchSessionObjectCaches(input: {
+  readonly chunkHits?: readonly SearchChunkHitInput[];
+  readonly entityHits?: readonly SearchEntityHitInput[];
+  readonly evidenceEvents?: readonly SearchEvidenceHitEventInput[];
+  readonly sessionId: string;
+  readonly tripleHits?: readonly SearchTripleHitInput[];
+}): Promise<void> {
+  const database = await openSearchSessionDatabase();
+
+  try {
+    await database.transaction(async () => {
+      for (const event of input.evidenceEvents ?? []) {
+        await insertSearchEvidenceHitEvent(database, input.sessionId, event);
+      }
+      for (const hit of input.entityHits ?? []) {
+        await upsertSearchEntityHit(database, input.sessionId, hit);
+      }
+      for (const hit of input.tripleHits ?? []) {
+        await upsertSearchTripleHit(database, input.sessionId, hit);
+      }
+      for (const hit of input.chunkHits ?? []) {
+        await upsertSearchChunkHit(database, input.sessionId, hit);
+      }
+    });
   } finally {
     await database.close();
   }
@@ -602,6 +757,38 @@ export async function readSearchSessionDescriptor(
   }
 }
 
+export async function readSearchSessionMetadataForCursor(
+  sessionId: string,
+  expectedArchiveKey?: string,
+  expectedCreatedAt?: number,
+): Promise<SearchSessionDescriptor> {
+  const database = await openSearchSessionDatabase();
+
+  try {
+    const session = await readSearchSessionMetadata(
+      database,
+      sessionId,
+      expectedArchiveKey,
+      expectedCreatedAt,
+    );
+
+    await touchSearchSession(database, sessionId);
+
+    return {
+      chapters: session.options.chapters,
+      createdAt: session.createdAt,
+      lens: session.lens,
+      match: session.match,
+      query: session.query,
+      sessionId,
+      terms: session.terms,
+      types: session.options.types,
+    };
+  } finally {
+    await database.close();
+  }
+}
+
 export async function readEntitySearchEvidenceMentions(
   sessionId: string,
   mentionIds: readonly string[],
@@ -648,6 +835,54 @@ export function encodeSearchSessionCursor(
   return Buffer.from(
     JSON.stringify({ createdAt, offset, sessionId, v: 3 }),
   ).toString("base64url");
+}
+
+export function encodeBucketSearchSessionCursor(
+  sessionId: string,
+  cursor: BucketSearchCursor,
+  createdAt: number,
+): string {
+  return Buffer.from(
+    JSON.stringify({ createdAt, cursor, sessionId, v: 4 }),
+  ).toString("base64url");
+}
+
+export function decodeBucketSearchSessionCursor(cursor: string): {
+  readonly createdAt: number;
+  readonly cursor: BucketSearchCursor;
+  readonly sessionId: string;
+} {
+  try {
+    const parsed: unknown = JSON.parse(
+      Buffer.from(cursor, "base64url").toString("utf8"),
+    );
+
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "createdAt" in parsed &&
+      "cursor" in parsed &&
+      "sessionId" in parsed &&
+      "v" in parsed &&
+      parsed.v === 4 &&
+      typeof parsed.createdAt === "number" &&
+      Number.isInteger(parsed.createdAt) &&
+      parsed.createdAt >= 0 &&
+      typeof parsed.sessionId === "string" &&
+      parsed.sessionId !== "" &&
+      isBucketSearchCursor(parsed.cursor)
+    ) {
+      return {
+        createdAt: parsed.createdAt,
+        cursor: parsed.cursor,
+        sessionId: parsed.sessionId,
+      };
+    }
+  } catch {
+    throw new Error("Invalid search cursor.");
+  }
+
+  throw new Error("Invalid search cursor.");
 }
 
 export function decodeSearchSessionCursor(cursor: string): {
@@ -1181,6 +1416,178 @@ function mapEntitySearchObjectRow(
     title: qid,
     type: "entity",
   };
+}
+
+async function readSearchSessionEntityBucketRows(
+  database: Database,
+  sessionId: string,
+  after: SearchObjectCursorKey | undefined,
+  limit: number,
+): Promise<readonly ArchiveFindHit[]> {
+  return await database.queryAll(
+    `
+      SELECT
+        qid,
+        result_score
+      FROM search_entity_hits
+      WHERE session_id = ?
+        ${
+          after === undefined
+            ? ""
+            : `
+              AND (
+                result_score < ?
+                OR (result_score = ? AND qid > ?)
+              )
+            `
+        }
+      ORDER BY result_score DESC, qid
+      LIMIT ?
+    `,
+    [
+      sessionId,
+      ...(after === undefined ? [] : [after.score, after.score, after.id]),
+      limit + 1,
+    ],
+    mapEntitySearchObjectRow,
+  );
+}
+
+async function readSearchSessionTripleBucketRows(
+  database: Database,
+  sessionId: string,
+  after: SearchObjectCursorKey | undefined,
+  limit: number,
+): Promise<readonly ArchiveFindHit[]> {
+  return await database.queryAll(
+    `
+      SELECT
+        search_triple_hits.subject_qid AS subject_qid,
+        predicate_dictionary.value AS predicate,
+        search_triple_hits.object_qid AS object_qid,
+        search_triple_hits.result_score AS result_score
+      FROM search_triple_hits
+      JOIN predicate_dictionary
+        ON predicate_dictionary.id = search_triple_hits.predicate_id
+      WHERE search_triple_hits.session_id = ?
+        ${
+          after === undefined
+            ? ""
+            : `
+              AND (
+                search_triple_hits.result_score < ?
+                OR (
+                  search_triple_hits.result_score = ?
+                  AND (
+                    search_triple_hits.subject_qid || char(31) ||
+                    predicate_dictionary.value || char(31) ||
+                    search_triple_hits.object_qid
+                  ) > ?
+                )
+              )
+            `
+        }
+      ORDER BY search_triple_hits.result_score DESC,
+        search_triple_hits.subject_qid,
+        predicate_dictionary.value,
+        search_triple_hits.object_qid
+      LIMIT ?
+    `,
+    [
+      sessionId,
+      ...(after === undefined ? [] : [after.score, after.score, after.id]),
+      limit + 1,
+    ],
+    (row) => {
+      const subjectQid = getString(row, "subject_qid");
+      const predicate = getString(row, "predicate");
+      const objectQid = getString(row, "object_qid");
+      const title = `${subjectQid} ${predicate} ${objectQid}`;
+
+      return {
+        field: "content",
+        id: `wikg://triple/${subjectQid}/${encodeURIComponent(predicate)}/${objectQid}`,
+        score: getNumber(row, "result_score"),
+        snippet: title,
+        title,
+        triple: {
+          objectLabel: objectQid,
+          predicate,
+          subjectLabel: subjectQid,
+        },
+        type: "triple",
+      };
+    },
+  );
+}
+
+function compareObjectBucketHits(
+  left: ArchiveFindHit,
+  right: ArchiveFindHit,
+): number {
+  return (
+    (right.score ?? 0) - (left.score ?? 0) || left.id.localeCompare(right.id)
+  );
+}
+
+function isBucketSearchCursor(value: unknown): value is BucketSearchCursor {
+  if (typeof value !== "object" || value === null || !("bucket" in value)) {
+    return false;
+  }
+  const cursor = value as { readonly bucket: unknown; readonly key?: unknown };
+
+  switch (cursor.bucket) {
+    case 0:
+      return cursor.key === undefined || isChapterTitleCursorKey(cursor.key);
+    case 1:
+      return cursor.key === undefined || isObjectCursorKey(cursor.key);
+    case 2:
+      return cursor.key === undefined || isChunkCursorKey(cursor.key);
+    case 3:
+      return cursor.key === undefined || isTextCursorKey(cursor.key);
+    default:
+      return false;
+  }
+}
+
+function isChapterTitleCursorKey(
+  value: unknown,
+): value is SearchChapterTitleCursorKey {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as SearchChapterTitleCursorKey).chapterId === "number" &&
+    typeof (value as SearchChapterTitleCursorKey).score === "number"
+  );
+}
+
+function isObjectCursorKey(value: unknown): value is SearchObjectCursorKey {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as SearchObjectCursorKey).id === "string" &&
+    typeof (value as SearchObjectCursorKey).score === "number"
+  );
+}
+
+function isChunkCursorKey(value: unknown): value is SearchChunkCursorKey {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as SearchChunkCursorKey).chunkId === "number" &&
+    typeof (value as SearchChunkCursorKey).score === "number"
+  );
+}
+
+function isTextCursorKey(value: unknown): value is SearchTextCursorKey {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as SearchTextCursorKey).chapterId === "number" &&
+    typeof (value as SearchTextCursorKey).kind === "number" &&
+    typeof (value as SearchTextCursorKey).rank === "number" &&
+    typeof (value as SearchTextCursorKey).sentenceIndex === "number"
+  );
 }
 
 function createSearchSessionId(input: SearchSessionCacheInput): string {

--- a/src/archive/query/search-cache.ts
+++ b/src/archive/query/search-cache.ts
@@ -110,6 +110,7 @@ export interface SearchSessionDescriptor {
   readonly createdAt: number;
   readonly lens: string;
   readonly match: string;
+  readonly objectCachesPopulated: boolean;
   readonly query: string;
   readonly sessionId: string;
   readonly terms: readonly string[];
@@ -141,6 +142,7 @@ export interface SearchChapterTitleCursorKey {
 
 export interface SearchObjectCursorKey {
   readonly id: string;
+  readonly kind: "entity" | "triple";
   readonly score: number;
 }
 
@@ -165,6 +167,7 @@ CREATE TABLE IF NOT EXISTS search_sessions (
   terms_json TEXT NOT NULL,
   lens TEXT NOT NULL,
   match TEXT NOT NULL,
+  object_caches_populated INTEGER NOT NULL DEFAULT 0,
   created_at INTEGER NOT NULL,
   expires_at INTEGER NOT NULL,
   accessed_at INTEGER NOT NULL
@@ -382,17 +385,14 @@ export async function readSearchSessionObjectBucketPage(
       database,
       sessionId,
       after,
-      limit,
+      limit + 1,
     );
-    const tripleRows =
-      entityRows.length > limit
-        ? []
-        : await readSearchSessionTripleBucketRows(
-            database,
-            sessionId,
-            after,
-            limit,
-          );
+    const tripleRows = await readSearchSessionTripleBucketRows(
+      database,
+      sessionId,
+      after,
+      limit + 1,
+    );
 
     return [...entityRows, ...tripleRows]
       .sort(compareObjectBucketHits)
@@ -536,6 +536,14 @@ export async function populateSearchSessionObjectCaches(input: {
       for (const hit of input.chunkHits ?? []) {
         await upsertSearchChunkHit(database, input.sessionId, hit);
       }
+      await database.run(
+        `
+          UPDATE search_sessions
+          SET object_caches_populated = 1
+          WHERE session_id = ?
+        `,
+        [input.sessionId],
+      );
     });
   } finally {
     await database.close();
@@ -747,6 +755,7 @@ export async function readSearchSessionDescriptor(
       createdAt: session.createdAt,
       lens: session.lens,
       match: session.match,
+      objectCachesPopulated: session.objectCachesPopulated,
       query: session.query,
       sessionId,
       terms: session.terms,
@@ -779,6 +788,7 @@ export async function readSearchSessionMetadataForCursor(
       createdAt: session.createdAt,
       lens: session.lens,
       match: session.match,
+      objectCachesPopulated: session.objectCachesPopulated,
       query: session.query,
       sessionId,
       terms: session.terms,
@@ -1321,6 +1331,7 @@ async function readSearchSessionMetadata(
   readonly sessionId: string;
   readonly terms: readonly string[];
   readonly expiresAt: number;
+  readonly objectCachesPopulated: boolean;
 }> {
   const session = await database.queryOne(
     `
@@ -1331,6 +1342,7 @@ async function readSearchSessionMetadata(
         terms_json,
         lens,
         match,
+        object_caches_populated,
         created_at,
         expires_at
       FROM search_sessions
@@ -1348,6 +1360,7 @@ async function readSearchSessionMetadata(
       expiresAt: getNumber(row, "expires_at"),
       lens: getString(row, "lens"),
       match: getString(row, "match"),
+      objectCachesPopulated: getNumber(row, "object_caches_populated") !== 0,
       options: parseSessionOptions(getString(row, "options_json")),
       query: getString(row, "query"),
       sessionId: getString(row, "session_id"),
@@ -1437,7 +1450,13 @@ async function readSearchSessionEntityBucketRows(
             : `
               AND (
                 result_score < ?
-                OR (result_score = ? AND qid > ?)
+                OR (
+                  result_score = ?
+                  AND (
+                    ? < ?
+                    OR (? = ? AND qid > ?)
+                  )
+                )
               )
             `
         }
@@ -1446,8 +1465,18 @@ async function readSearchSessionEntityBucketRows(
     `,
     [
       sessionId,
-      ...(after === undefined ? [] : [after.score, after.score, after.id]),
-      limit + 1,
+      ...(after === undefined
+        ? []
+        : [
+            after.score,
+            after.score,
+            getObjectBucketKindOrder(after.kind),
+            SEARCH_OBJECT_BUCKET_KIND.entity,
+            getObjectBucketKindOrder(after.kind),
+            SEARCH_OBJECT_BUCKET_KIND.entity,
+            after.id,
+          ]),
+      limit,
     ],
     mapEntitySearchObjectRow,
   );
@@ -1479,10 +1508,16 @@ async function readSearchSessionTripleBucketRows(
                 OR (
                   search_triple_hits.result_score = ?
                   AND (
-                    search_triple_hits.subject_qid || char(31) ||
-                    predicate_dictionary.value || char(31) ||
-                    search_triple_hits.object_qid
-                  ) > ?
+                    ? < ?
+                    OR (
+                      ? = ?
+                      AND (
+                        search_triple_hits.subject_qid || char(31) ||
+                        predicate_dictionary.value || char(31) ||
+                        search_triple_hits.object_qid
+                      ) > ?
+                    )
+                  )
                 )
               )
             `
@@ -1495,8 +1530,18 @@ async function readSearchSessionTripleBucketRows(
     `,
     [
       sessionId,
-      ...(after === undefined ? [] : [after.score, after.score, after.id]),
-      limit + 1,
+      ...(after === undefined
+        ? []
+        : [
+            after.score,
+            after.score,
+            getObjectBucketKindOrder(after.kind),
+            SEARCH_OBJECT_BUCKET_KIND.triple,
+            getObjectBucketKindOrder(after.kind),
+            SEARCH_OBJECT_BUCKET_KIND.triple,
+            after.id,
+          ]),
+      limit,
     ],
     (row) => {
       const subjectQid = getString(row, "subject_qid");
@@ -1526,8 +1571,38 @@ function compareObjectBucketHits(
   right: ArchiveFindHit,
 ): number {
   return (
-    (right.score ?? 0) - (left.score ?? 0) || left.id.localeCompare(right.id)
+    (right.score ?? 0) - (left.score ?? 0) ||
+    getObjectBucketKindOrder(getObjectBucketHitKind(left)) -
+      getObjectBucketKindOrder(getObjectBucketHitKind(right)) ||
+    getObjectBucketHitKey(left).localeCompare(getObjectBucketHitKey(right))
   );
+}
+
+const SEARCH_OBJECT_BUCKET_KIND = {
+  entity: 1,
+  triple: 2,
+} as const;
+
+function getObjectBucketHitKind(
+  hit: ArchiveFindHit,
+): SearchObjectCursorKey["kind"] {
+  return hit.type === "triple" ? "triple" : "entity";
+}
+
+function getObjectBucketHitKey(hit: ArchiveFindHit): string {
+  if (hit.type !== "triple") {
+    return hit.id.slice("wikg://entity/".length);
+  }
+
+  return [
+    hit.triple?.subjectLabel ?? "",
+    hit.triple?.predicate ?? "",
+    hit.triple?.objectLabel ?? "",
+  ].join("\u001f");
+}
+
+function getObjectBucketKindOrder(kind: SearchObjectCursorKey["kind"]): number {
+  return SEARCH_OBJECT_BUCKET_KIND[kind];
 }
 
 function isBucketSearchCursor(value: unknown): value is BucketSearchCursor {
@@ -1566,6 +1641,8 @@ function isObjectCursorKey(value: unknown): value is SearchObjectCursorKey {
     typeof value === "object" &&
     value !== null &&
     typeof (value as SearchObjectCursorKey).id === "string" &&
+    ((value as SearchObjectCursorKey).kind === "entity" ||
+      (value as SearchObjectCursorKey).kind === "triple") &&
     typeof (value as SearchObjectCursorKey).score === "number"
   );
 }

--- a/src/archive/search-index/search-index.ts
+++ b/src/archive/search-index/search-index.ts
@@ -341,10 +341,18 @@ export async function querySearchIndex(
       ]);
 
       for (const hit of objectRows) {
-        objectHitsByKey.set(createObjectHitKey(hit), hit);
+        const key = createObjectHitKey(hit);
+
+        if (!objectHitsByKey.has(key)) {
+          objectHitsByKey.set(key, hit);
+        }
       }
       for (const hit of textRows) {
-        textHitsByKey.set(createTextHitKey(hit), hit);
+        const key = createTextHitKey(hit);
+
+        if (!textHitsByKey.has(key)) {
+          textHitsByKey.set(key, hit);
+        }
       }
       if (
         (!queriesObjects || objectHitsByKey.size >= objectHitLimit) &&

--- a/src/archive/search-index/search-index.ts
+++ b/src/archive/search-index/search-index.ts
@@ -91,6 +91,7 @@ export type SearchIndexStatus = "current" | "dirty" | "missing";
 export interface SearchIndexTextHit {
   readonly chapterId: number;
   readonly kind: TextSentenceKind;
+  readonly rank: number;
   readonly score: number;
   readonly sentenceIndex: number;
   readonly wordsCount: number;
@@ -283,6 +284,12 @@ export async function querySearchIndex(
     readonly chapters?: readonly number[];
     readonly match?: ArchiveFindMatch;
     readonly objectHitLimit?: number;
+    readonly textAfter?: {
+      readonly chapterId: number;
+      readonly kind: TextSentenceKind;
+      readonly rank: number;
+      readonly sentenceIndex: number;
+    };
     readonly textHitLimit?: number;
     readonly types?: readonly ArchiveFindObjectType[] | null;
   } = {},
@@ -407,6 +414,12 @@ async function queryTextRows(
   matchExpression: string,
   options: {
     readonly chapters?: readonly number[];
+    readonly textAfter?: {
+      readonly chapterId: number;
+      readonly kind: TextSentenceKind;
+      readonly rank: number;
+      readonly sentenceIndex: number;
+    };
     readonly textHitLimit?: number;
     readonly types?: readonly ArchiveFindObjectType[] | null;
   },
@@ -420,21 +433,48 @@ async function queryTextRows(
     return [];
   }
 
+  const after = options.textAfter;
+
   return await database.queryAll(
     `
       SELECT
-        r.kind AS kind,
-        r.chapter_id AS chapter_id,
-        r.sentence_index AS sentence_index,
-        r.words_count AS words_count,
-        bm25(text_sentence_fts, ?, ?, ?) AS rank
-      FROM text_sentence_fts
-      JOIN text_sentence_records AS r
-        ON r.id = text_sentence_fts.rowid
-      WHERE text_sentence_fts MATCH ?
-        AND r.kind IN (${kinds.map(() => "?").join(", ")})
-        ${createChapterSql(options.chapters)}
-      ORDER BY rank ASC, r.chapter_id, r.sentence_index, r.kind
+        kind,
+        chapter_id,
+        sentence_index,
+        words_count,
+        rank
+      FROM (
+        SELECT
+          r.kind AS kind,
+          r.chapter_id AS chapter_id,
+          r.sentence_index AS sentence_index,
+          r.words_count AS words_count,
+          bm25(text_sentence_fts, ?, ?, ?) AS rank
+        FROM text_sentence_fts
+        JOIN text_sentence_records AS r
+          ON r.id = text_sentence_fts.rowid
+        WHERE text_sentence_fts MATCH ?
+          AND r.kind IN (${kinds.map(() => "?").join(", ")})
+          ${createChapterSql(options.chapters)}
+      )
+      ${
+        after === undefined
+          ? ""
+          : `
+            WHERE (
+              rank > ?
+              OR (rank = ? AND chapter_id > ?)
+              OR (rank = ? AND chapter_id = ? AND sentence_index > ?)
+              OR (
+                rank = ?
+                AND chapter_id = ?
+                AND sentence_index = ?
+                AND kind > ?
+              )
+            )
+          `
+      }
+      ORDER BY rank ASC, chapter_id, sentence_index, kind
       ${createLimitSql(options.textHitLimit)}
     `,
     [
@@ -442,15 +482,34 @@ async function queryTextRows(
       matchExpression,
       ...kinds,
       ...createChapterParams(options.chapters),
+      ...(after === undefined
+        ? []
+        : [
+            after.rank,
+            after.rank,
+            after.chapterId,
+            after.rank,
+            after.chapterId,
+            after.sentenceIndex,
+            after.rank,
+            after.chapterId,
+            after.sentenceIndex,
+            after.kind,
+          ]),
       ...createLimitParams(options.textHitLimit),
     ],
-    (row) => ({
-      chapterId: getNumber(row, "chapter_id"),
-      kind: getNumber(row, "kind") as TextSentenceKind,
-      score: rankToScore(getNumber(row, "rank")),
-      sentenceIndex: getNumber(row, "sentence_index"),
-      wordsCount: getNumber(row, "words_count"),
-    }),
+    (row) => {
+      const rank = getNumber(row, "rank");
+
+      return {
+        chapterId: getNumber(row, "chapter_id"),
+        kind: getNumber(row, "kind") as TextSentenceKind,
+        rank,
+        score: rankToScore(rank),
+        sentenceIndex: getNumber(row, "sentence_index"),
+        wordsCount: getNumber(row, "words_count"),
+      };
+    },
   );
 }
 

--- a/test/archive/query/archive-view.test.ts
+++ b/test/archive/query/archive-view.test.ts
@@ -1473,6 +1473,10 @@ describe("archive/query/archive-view", () => {
         const firstPage = await findArchiveObjects(document, "Source", {
           limit: 1,
         });
+
+        expect(firstPage.items).toHaveLength(1);
+        expect(firstPage.nextCursor).not.toBeNull();
+
         const secondPage = await findArchiveObjects(document, "Source", {
           ...(firstPage.nextCursor === null
             ? {}
@@ -1480,8 +1484,6 @@ describe("archive/query/archive-view", () => {
           limit: 1,
         });
 
-        expect(firstPage.items).toHaveLength(1);
-        expect(firstPage.nextCursor).not.toBeNull();
         expect(secondPage.items).toHaveLength(1);
         expect(secondPage.nextCursor).not.toBe(firstPage.nextCursor);
       } finally {

--- a/test/archive/query/archive-view.test.ts
+++ b/test/archive/query/archive-view.test.ts
@@ -1470,10 +1470,10 @@ describe("archive/query/archive-view", () => {
       try {
         await seedSourcedDocument(document);
 
-        const firstPage = await findArchiveObjects(document, "Wiki", {
+        const firstPage = await findArchiveObjects(document, "Source", {
           limit: 1,
         });
-        const secondPage = await findArchiveObjects(document, "Wiki", {
+        const secondPage = await findArchiveObjects(document, "Source", {
           ...(firstPage.nextCursor === null
             ? {}
             : { cursor: firstPage.nextCursor }),
@@ -1483,7 +1483,7 @@ describe("archive/query/archive-view", () => {
         expect(firstPage.items).toHaveLength(1);
         expect(firstPage.nextCursor).not.toBeNull();
         expect(secondPage.items).toHaveLength(1);
-        expect(secondPage.items[0]?.id).not.toBe(firstPage.items[0]?.id);
+        expect(secondPage.nextCursor).not.toBe(firstPage.nextCursor);
       } finally {
         await document.release();
       }


### PR DESCRIPTION
## Summary
- Replace broad search's eager full-result materialization with bucket/keyset cursor paging.
- Prioritize chapter-title hits as bucket 0, then object hit caches, then source/summary FTS hits.
- Avoid writing broad search pages into search_results; hydrate source text only for the current page.

## Verification
- pnpm run typecheck
- pnpm test:run -- --runInBand
- pnpm run lint
- Manual check: after deleting the query cache, `wg 'wikg:///Users/taozeyu/Downloads/三国演义.wikg' --query '桃园三结义' --json` returned in ~2s with `search_results = 0`.

## Cache note
If local search state behaves oddly after this change, delete the local cache directory and rerun the query:

```bash
rm -rf ~/.wikigraph/cache
```

The cache is rebuilt automatically.