### PR TITLE
Default build prompts in core

### DIFF
--- a/packages/cli/src/cli/stage-runtime.ts
+++ b/packages/cli/src/cli/stage-runtime.ts
@@ -1,4 +1,10 @@
 import { resolveDataDirPath } from "wiki-graph-core";
+export {
+  DEFAULT_EXTRACTION_PROMPT,
+  DEFAULT_KNOWLEDGE_GRAPH_RECALL_PROMPT,
+  resolveExtractionPrompt,
+  resolveKnowledgeGraphRecallPrompt,
+} from "wiki-graph-core";
 import type { WikiGraphScope } from "wiki-graph-core";
 import { createDefaultWikiGraphSampling } from "wiki-graph-core";
 import { LLM } from "wiki-graph-core";
@@ -10,19 +16,6 @@ import type {
 import { loadCLIConfig, type CLIConfig } from "./config.js";
 import { CLI_HELP_ROUTES, withHelpRoute } from "./errors.js";
 import { buildLLMOptions } from "./llm.js";
-
-export const DEFAULT_EXTRACTION_PROMPT =
-  "Focus on the main storyline and key character developments. Preserve important dialogues and critical plot points. Background descriptions and minor details can be compressed significantly.";
-
-export const DEFAULT_KNOWLEDGE_GRAPH_RECALL_PROMPT = [
-  "Recall only source mentions that should become stable searchable knowledge graph objects.",
-  "Prefer named entities: historical persons, places, organizations, dynasties, political entities, named works, named events, battles, titles, and explicitly named domain concepts.",
-  "Recall a non-named common concept only when it is a central recurring topic of the chapter and would be useful as an entity search result across multiple evidence passages.",
-  "Do not recall a surface merely because it is useful for summarizing the story or explaining a detail.",
-  "Do not recall pure numbers, standalone dates without a named event role, units of measurement, dimensions, ordinal labels, chapter numbers, punctuation fragments, common function words, generic verbs, generic adjectives, generic roles, generic objects, or incidental attributes.",
-  "Measurements, quantities, dimensions, tactical details, and descriptive attributes should remain evidence text, not entity mentions.",
-  "When uncertain, skip the mention rather than creating a noisy knowledge graph object.",
-].join(" ");
 
 export function createStageLLM(
   config: CLIConfig,
@@ -76,22 +69,4 @@ export async function loadRequiredStageConfig(options: {
   }
 
   return config;
-}
-
-export function resolveExtractionPrompt(prompt: string | undefined): string {
-  const normalizedPrompt = prompt?.trim();
-
-  return normalizedPrompt === undefined || normalizedPrompt === ""
-    ? DEFAULT_EXTRACTION_PROMPT
-    : normalizedPrompt;
-}
-
-export function resolveKnowledgeGraphRecallPrompt(
-  prompt: string | undefined,
-): string {
-  const normalizedPrompt = prompt?.trim();
-
-  return normalizedPrompt === undefined || normalizedPrompt === ""
-    ? DEFAULT_KNOWLEDGE_GRAPH_RECALL_PROMPT
-    : normalizedPrompt;
 }

--- a/packages/core/src/facade/app.ts
+++ b/packages/core/src/facade/app.ts
@@ -29,11 +29,9 @@ import { createDefaultWikiGraphSampling } from "./llm-sampling.js";
 import { WikiGraphArchiveFile } from "../wikg/index.js";
 import type { WikiGraphArchive } from "./wiki-graph-archive.js";
 import type { ChapterStage } from "./chapter.js";
+import { resolveExtractionPrompt } from "./prompts.js";
 
 const DATA_DIR_PATH = resolveDataDirPath();
-
-const DEFAULT_EXTRACTION_PROMPT =
-  "Focus on the main storyline and key character developments. Preserve important dialogues and critical plot points. Background descriptions and minor details can be compressed significantly.";
 
 export interface WikiGraphLLMOptions {
   readonly cacheDirPath?: string;
@@ -283,12 +281,4 @@ function isWikiGraphLLMOptions(
   llm: NonNullable<WikiGraphOptions["llm"]>,
 ): llm is WikiGraphLLMOptions {
   return typeof llm === "object" && llm !== null && "model" in llm;
-}
-
-function resolveExtractionPrompt(prompt: string | undefined): string {
-  const normalizedPrompt = prompt?.trim();
-
-  return normalizedPrompt === undefined || normalizedPrompt === ""
-    ? DEFAULT_EXTRACTION_PROMPT
-    : normalizedPrompt;
 }

--- a/packages/core/src/facade/chapter-build.ts
+++ b/packages/core/src/facade/chapter-build.ts
@@ -46,6 +46,7 @@ import {
   type GenerateChapterGraphOptions,
   type GenerateChapterSummaryOptions,
 } from "./chapter.js";
+import { resolveExtractionPrompt } from "./prompts.js";
 
 export interface ChapterGraphBuildArtifact {
   readonly documentPath: string;
@@ -1356,31 +1357,27 @@ async function requireStage(
   }
 }
 
-function createTopologyOptions(
-  options: Pick<
-    BuildSerialTopologyOptions,
-    "extractionPrompt" | "userLanguage"
-  >,
-): BuildSerialTopologyOptions {
+function createTopologyOptions(options: {
+  readonly extractionPrompt?: string;
+  readonly userLanguage?: BuildSerialTopologyOptions["userLanguage"];
+}): BuildSerialTopologyOptions {
   return {
-    extractionPrompt: options.extractionPrompt,
+    extractionPrompt: resolveExtractionPrompt(options.extractionPrompt),
     ...(options.userLanguage === undefined
       ? {}
       : { userLanguage: options.userLanguage }),
   };
 }
 
-function createGraphBuildParameterInput(
-  options: Pick<
-    BuildSerialTopologyOptions,
-    "extractionPrompt" | "userLanguage"
-  >,
-): GraphBuildParameterInput {
+function createGraphBuildParameterInput(options: {
+  readonly extractionPrompt?: string;
+  readonly userLanguage?: BuildSerialTopologyOptions["userLanguage"];
+}): GraphBuildParameterInput {
   const language = normalizeLanguageCode(options.userLanguage);
 
   return {
     ...(language === undefined ? {} : { language }),
-    prompt: options.extractionPrompt,
+    prompt: resolveExtractionPrompt(options.extractionPrompt),
   };
 }
 

--- a/packages/core/src/facade/chapter.ts
+++ b/packages/core/src/facade/chapter.ts
@@ -11,6 +11,7 @@ import {
   type BuildSerialTopologyOptions,
 } from "../serial.js";
 import { TOC_FILE_VERSION, type TocItem } from "../source/index.js";
+import { resolveExtractionPrompt } from "./prompts.js";
 
 export const CHAPTER_STAGES = [
   "planned",
@@ -93,7 +94,7 @@ export interface MoveChapterOptions {
 
 export interface AdvanceChapterStagesOptions {
   readonly chapterId?: number;
-  readonly extractionPrompt: string;
+  readonly extractionPrompt?: string;
   readonly llm: LLM<WikiGraphScope>;
   readonly logDirPath?: string;
   readonly onProgress?: AdvanceChapterStagesProgressCallback;
@@ -179,7 +180,7 @@ export function parseChapterTreeInput(input: unknown): ChapterTreeInput {
 }
 
 export interface GenerateChapterGraphOptions {
-  readonly extractionPrompt: string;
+  readonly extractionPrompt?: string;
   readonly llm: LLM<WikiGraphScope>;
   readonly logDirPath?: string;
   readonly progressTracker?: SerialProgressSink;
@@ -307,7 +308,7 @@ export async function generateChapterGraph(
     );
     const language = normalizeLanguageCode(options.userLanguage);
     const parameter = await openedDocument.graphBuildParameters.save({
-      prompt: options.extractionPrompt,
+      prompt: resolveExtractionPrompt(options.extractionPrompt),
       ...(language === undefined ? {} : { language }),
     });
     await openedDocument.serials.setTopologyReady(
@@ -774,7 +775,7 @@ async function advanceEntriesToGraphed(
       type: "started",
     });
     await generateChapterGraph(document, entry.chapterId, {
-      extractionPrompt: options.extractionPrompt,
+      extractionPrompt: resolveExtractionPrompt(options.extractionPrompt),
       llm: options.llm,
       ...(options.logDirPath === undefined
         ? {}
@@ -1426,7 +1427,7 @@ function createTopologyOptions(
   options: GenerateChapterGraphOptions,
 ): BuildSerialTopologyOptions {
   return {
-    extractionPrompt: options.extractionPrompt,
+    extractionPrompt: resolveExtractionPrompt(options.extractionPrompt),
     ...(options.userLanguage === undefined
       ? {}
       : { userLanguage: options.userLanguage }),

--- a/packages/core/src/facade/index.ts
+++ b/packages/core/src/facade/index.ts
@@ -88,6 +88,12 @@ export {
   createContinuationCursor,
   readContinuationCursor,
 } from "../archive/query/index.js";
+export {
+  DEFAULT_EXTRACTION_PROMPT,
+  DEFAULT_KNOWLEDGE_GRAPH_RECALL_PROMPT,
+  resolveExtractionPrompt,
+  resolveKnowledgeGraphRecallPrompt,
+} from "./prompts.js";
 export type { ContinuationCursor } from "../archive/query/index.js";
 export type {
   BuildChapterGraphArtifactOptions,

--- a/packages/core/src/facade/knowledge-graph-build.ts
+++ b/packages/core/src/facade/knowledge-graph-build.ts
@@ -43,6 +43,7 @@ import {
 
 import { getChapterDetails, type ChapterDetails } from "./chapter.js";
 import type { BuildJobProgressReporter } from "./build-queue.js";
+import { resolveKnowledgeGraphRecallPrompt } from "./prompts.js";
 
 export interface ChapterKnowledgeGraphBuildArtifact {
   readonly chapterId: number;
@@ -72,7 +73,7 @@ export interface BuildChapterKnowledgeGraphArtifactOptions {
 }
 
 export interface GenerateChapterKnowledgeGraphArtifactOptions {
-  readonly policyPrompt: string;
+  readonly policyPrompt?: string;
   readonly progressTracker?: Pick<
     BuildJobProgressReporter,
     "throwIfStopped" | "updatePhase"
@@ -169,6 +170,7 @@ export async function generateChapterKnowledgeGraphArtifactFromSnapshot(
   const fragments = snapshot.fragments;
   const text = joinFragmentText(fragments);
   const sentences = createWikimatchSentences(fragments);
+  const policyPrompt = resolveKnowledgeGraphRecallPrompt(options.policyPrompt);
   await options.progressTracker?.updatePhase({
     done: 0,
     phase: "matching",
@@ -201,7 +203,7 @@ export async function generateChapterKnowledgeGraphArtifactFromSnapshot(
   });
   const screenedCandidates = await screenCandidates({
     candidates: rawCandidates,
-    policyPrompt: options.policyPrompt,
+    policyPrompt,
     ...(options.progressTracker === undefined
       ? {}
       : { progressTracker: options.progressTracker }),
@@ -240,7 +242,7 @@ export async function generateChapterKnowledgeGraphArtifactFromSnapshot(
     candidates: enrichedCandidates,
     chapterId,
     fragments,
-    policyPrompt: options.policyPrompt,
+    policyPrompt,
     ...(options.progressTracker === undefined
       ? {}
       : { progressTracker: options.progressTracker }),
@@ -260,7 +262,12 @@ export async function generateChapterKnowledgeGraphArtifactFromSnapshot(
   const artifact = await buildChapterKnowledgeGraphArtifact(chapterId, {
     mentionLinks,
     mentions,
-    parameter: createKnowledgeGraphParameterInput(options),
+    parameter: createKnowledgeGraphParameterInput({
+      policyPrompt,
+      ...(options.resolverOptions === undefined
+        ? {}
+        : { resolverOptions: options.resolverOptions }),
+    }),
     workspacePath: options.workspacePath,
   });
 
@@ -304,7 +311,7 @@ function createKnowledgeGraphParameterInput(
   options: Pick<
     GenerateChapterKnowledgeGraphArtifactOptions,
     "policyPrompt" | "resolverOptions"
-  >,
+  > & { readonly policyPrompt: string },
 ): GraphBuildParameterInput {
   return {
     language:

--- a/packages/core/src/facade/prompts.test.ts
+++ b/packages/core/src/facade/prompts.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  DEFAULT_EXTRACTION_PROMPT,
+  DEFAULT_KNOWLEDGE_GRAPH_RECALL_PROMPT,
+  resolveExtractionPrompt,
+  resolveKnowledgeGraphRecallPrompt,
+} from "./prompts.js";
+
+describe("prompt defaults", () => {
+  test("resolves empty extraction prompts to the SDK default", () => {
+    expect(resolveExtractionPrompt(undefined)).toBe(DEFAULT_EXTRACTION_PROMPT);
+    expect(resolveExtractionPrompt("   ")).toBe(DEFAULT_EXTRACTION_PROMPT);
+  });
+
+  test("resolves empty Knowledge Graph recall prompts to the SDK default", () => {
+    expect(resolveKnowledgeGraphRecallPrompt(undefined)).toBe(
+      DEFAULT_KNOWLEDGE_GRAPH_RECALL_PROMPT,
+    );
+    expect(resolveKnowledgeGraphRecallPrompt("   ")).toBe(
+      DEFAULT_KNOWLEDGE_GRAPH_RECALL_PROMPT,
+    );
+  });
+
+  test("trims caller-provided prompts", () => {
+    expect(resolveExtractionPrompt(" custom extraction ")).toBe(
+      "custom extraction",
+    );
+    expect(resolveKnowledgeGraphRecallPrompt(" custom recall ")).toBe(
+      "custom recall",
+    );
+  });
+});

--- a/packages/core/src/facade/prompts.ts
+++ b/packages/core/src/facade/prompts.ts
@@ -1,0 +1,30 @@
+export const DEFAULT_EXTRACTION_PROMPT =
+  "Focus on the main storyline and key character developments. Preserve important dialogues and critical plot points. Background descriptions and minor details can be compressed significantly.";
+
+export const DEFAULT_KNOWLEDGE_GRAPH_RECALL_PROMPT = [
+  "Recall only source mentions that should become stable searchable knowledge graph objects.",
+  "Prefer named entities: historical persons, places, organizations, dynasties, political entities, named works, named events, battles, titles, and explicitly named domain concepts.",
+  "Recall a non-named common concept only when it is a central recurring topic of the chapter and would be useful as an entity search result across multiple evidence passages.",
+  "Do not recall a surface merely because it is useful for summarizing the story or explaining a detail.",
+  "Do not recall pure numbers, standalone dates without a named event role, units of measurement, dimensions, ordinal labels, chapter numbers, punctuation fragments, common function words, generic verbs, generic adjectives, generic roles, generic objects, or incidental attributes.",
+  "Measurements, quantities, dimensions, tactical details, and descriptive attributes should remain evidence text, not entity mentions.",
+  "When uncertain, skip the mention rather than creating a noisy knowledge graph object.",
+].join(" ");
+
+export function resolveExtractionPrompt(prompt: string | undefined): string {
+  const normalizedPrompt = prompt?.trim();
+
+  return normalizedPrompt === undefined || normalizedPrompt === ""
+    ? DEFAULT_EXTRACTION_PROMPT
+    : normalizedPrompt;
+}
+
+export function resolveKnowledgeGraphRecallPrompt(
+  prompt: string | undefined,
+): string {
+  const normalizedPrompt = prompt?.trim();
+
+  return normalizedPrompt === undefined || normalizedPrompt === ""
+    ? DEFAULT_KNOWLEDGE_GRAPH_RECALL_PROMPT
+    : normalizedPrompt;
+}


### PR DESCRIPTION
## Summary
- move build prompt defaults and prompt resolvers into wiki-graph-core facade
- allow SDK build APIs to omit extraction/policy prompts and fall back to core defaults
- re-export core prompt defaults from the CLI runtime instead of duplicating text there
- add prompt resolver unit coverage

## Verification
- `pnpm verify`
- `pnpm test:run packages/core/src/facade/prompts.test.ts`