### PR TITLE
fix: enforce structured compressor output

### DIFF
--- a/packages/core/data/editor/text_compressor.jinja
+++ b/packages/core/data/editor/text_compressor.jinja
@@ -46,6 +46,18 @@ Your compressed text must fall within the acceptable range. Going over the maxim
 
 ---
 
+## Response Protocol (MUST FOLLOW)
+
+Return exactly one JSON object and nothing else:
+
+```json
+{"compressedText":"..."}
+```
+
+The `compressedText` value is the only user-visible compressed content. Do not put your reasoning, approach, analysis, trade-offs, Markdown fences, or any extra fields before or after the JSON object.
+
+---
+
 ## Format Requirements (MUST FOLLOW)
 
 ### 1. Remove ALL `<chunk>` tags from your output
@@ -61,9 +73,9 @@ The input text contains `<chunk>` markup tags like this:
 - ❌ WRONG: `<chunk retention="detailed">比如刮风啊...</chunk>`
 - ✅ CORRECT: `比如刮风啊...`
 
-### 2. Output plain text only
+### 2. `compressedText` must be plain text only
 
-Do NOT add:
+Inside the `compressedText` string, do NOT add:
 - Section headers (like "## Compressed Text")
 - XML/HTML markup of any kind
 - Explanatory comments mixed with the content
@@ -120,8 +132,8 @@ You are compressing a **segment** of a larger work (like part of a book chapter)
 
 ## Output Format
 
-[Optional: If you face difficult trade-offs, write 1-2 sentences about your approach. Keep this brief.]
+Return exactly this JSON shape:
 
----
-
-[Your compressed text - plain text only, no headers, no tags, written as continuous prose]
+```json
+{"compressedText":"Your compressed text - plain text only, no headers, no tags, written as continuous prose"}
+```

--- a/packages/core/src/text/editor/compressor.test.ts
+++ b/packages/core/src/text/editor/compressor.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  LLMessage,
+  LLM,
+  LLMRequestOptions,
+} from "../../external/llm/index.js";
+import { CompressionRequester } from "./compressor.js";
+
+interface RequestCall<S extends string> {
+  readonly messages: readonly LLMessage[];
+  readonly options: LLMRequestOptions<S> | undefined;
+}
+
+describe("editor/compressor", () => {
+  it("returns only structured compressed text after self-talk derailment", async () => {
+    const calls: RequestCall<"compress">[] = [];
+    const llm = createFakeLlm<"compress">({
+      calls,
+      responses: [
+        [
+          "My approach is to keep the highlighted facts and remove filler.",
+          "---",
+          "只保留正文。",
+        ].join("\n"),
+        JSON.stringify({ compressedText: "只保留正文。" }),
+      ],
+    });
+    const requester = new CompressionRequester(llm, "compress", 0.2);
+
+    await expect(
+      requester.request({
+        markedText: '<chunk retention="detailed">只保留正文。</chunk>',
+        targetLength: 12,
+      }),
+    ).resolves.toBe("只保留正文。");
+
+    expect(calls).toHaveLength(2);
+    const retryMessages = calls[1]?.messages;
+
+    expect(retryMessages?.[retryMessages.length - 1]?.content).toContain(
+      "Regenerate",
+    );
+  });
+
+  it("keeps revision history in the same JSON protocol", async () => {
+    const calls: RequestCall<"compress">[] = [];
+    const llm = createFakeLlm<"compress">({
+      calls,
+      responses: [JSON.stringify({ compressedText: "修订后的正文。" })],
+    });
+    const requester = new CompressionRequester(llm, "compress", 0.2);
+
+    await requester.request({
+      markedText: "原文",
+      previousCompressedText: "上一版正文。",
+      revisionFeedback: "补充缺失信息。",
+      targetLength: 10,
+    });
+
+    const initialMessages = calls[0]?.messages;
+
+    expect(initialMessages?.[2]).toMatchObject({
+      content: JSON.stringify({ compressedText: "上一版正文。" }),
+      role: "assistant",
+    });
+    expect(initialMessages?.[3]).toMatchObject({
+      content: "补充缺失信息。",
+      role: "user",
+    });
+  });
+});
+
+function createFakeLlm<S extends string>(input: {
+  readonly calls: RequestCall<S>[];
+  readonly responses: string[];
+}): LLM<S> {
+  const request = vi.fn(
+    async (
+      messagesOrOperation:
+        | readonly LLMessage[]
+        | ((
+            request: (
+              messages: readonly LLMessage[],
+              options?: LLMRequestOptions<S>,
+            ) => Promise<string>,
+          ) => Promise<string>),
+      options?: LLMRequestOptions<S>,
+    ) => {
+      if (typeof messagesOrOperation === "function") {
+        return await messagesOrOperation(async (messages, requestOptions) => {
+          input.calls.push({ messages, options: requestOptions });
+          const response = input.responses.shift();
+
+          if (response === undefined) {
+            throw new Error("Unexpected LLM request");
+          }
+
+          return await Promise.resolve(response);
+        });
+      }
+
+      input.calls.push({ messages: messagesOrOperation, options });
+      const response = input.responses.shift();
+
+      if (response === undefined) {
+        throw new Error("Unexpected LLM request");
+      }
+
+      return response;
+    },
+  );
+
+  return {
+    loadSystemPrompt: vi.fn((templateName: string) => templateName),
+    request,
+  } as unknown as LLM<S>;
+}

--- a/packages/core/src/text/editor/compressor.ts
+++ b/packages/core/src/text/editor/compressor.ts
@@ -1,5 +1,15 @@
+import { z } from "zod";
+
+import {
+  requestGuaranteedJson,
+  RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE,
+} from "../../external/guaranteed/index.js";
 import type { LLMessage, LLM } from "../../external/llm/index.js";
 import { TEXT_COMPRESSOR_PROMPT_TEMPLATE } from "./prompt-templates.js";
+
+const compressionResponseSchema = z.object({
+  compressedText: z.string(),
+});
 
 export class CompressionRequester<S extends string> {
   readonly #compressionRatio: number;
@@ -47,11 +57,24 @@ export class CompressionRequester<S extends string> {
       input.revisionFeedback,
     );
 
-    return (
-      await this.#llm.request(messages, {
-        scope: this.#scope,
-      })
-    ).trim();
+    return await this.#llm.request(
+      async (request) =>
+        await requestGuaranteedJson({
+          messages,
+          parse: (data) => data.compressedText.trim(),
+          request: async (retryMessages, retryIndex, retryMax) =>
+            await request(retryMessages, {
+              retryIndex,
+              retryMax,
+              scope: this.#scope,
+              useCache: false,
+            }),
+          responseIntentClassifierPrompt: this.#llm.loadSystemPrompt(
+            RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE,
+          ),
+          schema: compressionResponseSchema,
+        }),
+    );
   }
 }
 
@@ -77,7 +100,7 @@ function buildCompressionMessages(
   if (previousCompressedText !== undefined && revisionFeedback !== undefined) {
     messages.push(
       {
-        content: previousCompressedText,
+        content: JSON.stringify({ compressedText: previousCompressedText }),
         role: "assistant",
       },
       {

--- a/test/core/text/editor/compressor.test.ts
+++ b/test/core/text/editor/compressor.test.ts
@@ -7,7 +7,9 @@ import { ScriptedLLM } from "../../../helpers/scripted-llm.js";
 
 describe("editor/compressor", () => {
   it("builds prompts and compression messages with revision history", async () => {
-    const llm = new ScriptedLLM<WikiGraphScope>(["  compressed result  "]);
+    const llm = new ScriptedLLM<WikiGraphScope>([
+      JSON.stringify({ compressedText: "  compressed result  " }),
+    ]);
     const requester = new CompressionRequester(
       llm as never,
       WikiGraphScope.EditorCompress,
@@ -35,6 +37,10 @@ describe("editor/compressor", () => {
         },
         templateName: TEXT_COMPRESSOR_PROMPT_TEMPLATE,
       },
+      {
+        templateContext: {},
+        templateName: "guaranteed/response_intent_classifier",
+      },
     ]);
     expect(llm.calls).toHaveLength(1);
     expect(llm.calls[0]?.options.scope).toBe(WikiGraphScope.EditorCompress);
@@ -51,5 +57,8 @@ describe("editor/compressor", () => {
       );
     }
     expect(originalTextMessage.content).toContain("Original marked text");
+    expect(llm.calls[0]?.messages[2]?.content).toBe(
+      JSON.stringify({ compressedText: "Previous compressed text" }),
+    );
   });
 });

--- a/test/core/text/editor/editor.test.ts
+++ b/test/core/text/editor/editor.test.ts
@@ -83,7 +83,7 @@ describe("editor/editor", () => {
   it("uses the covered segment when a group starts after the segment start", async () => {
     const llm = new ScriptedLLM<WikiGraphScope>([
       "Keep chronology intact.",
-      ["## Compressed Text", "Focused summary"].join("\n"),
+      JSON.stringify({ compressedText: "Focused summary" }),
       '{"issues":[]}',
     ]);
     const document = createDocument({
@@ -138,16 +138,9 @@ describe("editor/editor", () => {
   it("iterates with reviewer history and language correction before selecting the best version", async () => {
     const llm = new ScriptedLLM<WikiGraphScope>([
       "Keep chronology intact.",
-      [
-        "Planning notes",
-        "",
-        "## Compressed Text",
-        "<chunk>Bad Japanese summary</chunk>",
-      ].join("\n"),
+      JSON.stringify({ compressedText: "<chunk>Bad Japanese summary</chunk>" }),
       '{"issues":[]}',
-      ["## Compressed Text", "```text", "Improved English summary", "```"].join(
-        "\n",
-      ),
+      JSON.stringify({ compressedText: "Improved English summary" }),
       '{"issues":[]}',
     ]);
     const document = createDocument({
@@ -199,10 +192,12 @@ describe("editor/editor", () => {
     expect(llm.prompts.map((prompt) => prompt.templateName)).toStrictEqual([
       CLUE_REVIEWER_GENERATOR_PROMPT_TEMPLATE,
       TEXT_COMPRESSOR_PROMPT_TEMPLATE,
+      RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE,
       CLUE_REVIEWER_PROMPT_TEMPLATE,
       RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE,
       REVISION_FEEDBACK_PROMPT_TEMPLATE,
       TEXT_COMPRESSOR_PROMPT_TEMPLATE,
+      RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE,
       CLUE_REVIEWER_PROMPT_TEMPLATE,
       RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE,
     ]);
@@ -215,7 +210,9 @@ describe("editor/editor", () => {
     expect(llm.calls[3]?.messages.map((message) => message.role)).toStrictEqual(
       ["system", "user", "assistant", "user"],
     );
-    expect(llm.calls[3]?.messages[2]?.content).toBe("Bad Japanese summary");
+    expect(llm.calls[3]?.messages[2]?.content).toBe(
+      JSON.stringify({ compressedText: "Bad Japanese summary" }),
+    );
     expect(llm.calls[4]?.messages.map((message) => message.role)).toStrictEqual(
       ["system", "user", "assistant", "user"],
     );


### PR DESCRIPTION
## Summary
- Fixes #73 by requiring the text compressor to return a structured JSON object instead of free-form prose.
- Routes compressor requests through `requestGuaranteedJson` so self-talk, Markdown separators, and other malformed responses are rejected and retried before user-visible output is returned.
- Keeps compressor revision history in the same JSON protocol and adds regression coverage for self-talk derailment and retry recovery.

## Problem
When the compressor model returned internal self-talk / approach notes followed by `---` and then user-facing compressed text, the previous free-form parsing path could treat the entire response as the final summary if the expected `## Compressed Text` heading was missing. That allowed model-internal narration to leak into user-visible summary output.

## Root Cause
The compressor prompt and parser protocol were inconsistent: the prompt allowed approach/self-talk-style output and did not require a heading, while `extractCompressedText` fell back to returning the whole response when the heading was absent. Because the compressor request was not using the repository's structured guaranteed JSON protocol, malformed prose could bypass validation instead of being rejected and retried.

## Fix
- Change text compression to request structured JSON with a required `compressedText` field.
- Use `requestGuaranteedJson` / retry validation so malformed or self-talk responses are regenerated before returning output.
- Keep revision-history compression on the same JSON protocol.
- Add targeted regression tests covering first-response self-talk derailment, retry recovery, compressor unit behavior, and editor integration paths.

## Reproduction Conditions
The original bug reproduces when the model's first compressor response contains internal narration such as an approach/self-talk section plus a Markdown separator before the intended compressed text, and omits the `## Compressed Text` heading. The verification script simulates that production compressor path and confirms the first malformed response is rejected, retried, and does not leak.

## Verification
- `corepack pnpm tsx /tmp/wiki-graph-issue-73-verify.mts` — passed; `leakedSelfTalk=false`, `requestCount=2`, retry prompt contains `Regenerate`.
- `corepack pnpm vitest run packages/core/src/text/editor/compressor.test.ts test/core/text/editor/compressor.test.ts test/core/text/editor/editor.test.ts packages/core/src/external/guaranteed/request.test.ts` — passed; 4 files / 15 tests.
- `pnpm --version && pnpm verify` — passed with pnpm 10.33.2; lint / typecheck / format:check passed.
- `pnpm test:run` — passed; 113 files / 687 tests.
- `pnpm build` — passed; only the existing tsup CJS/import.meta warning was observed.
- GitHub PR checks — Code Quality SUCCESS, Package Readiness SUCCESS, CodeRabbit SUCCESS; `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN`.

Note: `corepack pnpm verify` on this machine first failed because nested scripts resolved to a local pnpm v11.9.0 wrapper/version check. Re-running through the project-selected `pnpm` 10.33.2 passed and is the result recorded above.

## Impact / Risk
The change is scoped to text compressor request/response handling and its tests. It should reduce user-visible malformed output by rejecting invalid compressor responses before return. Adjacent coverage includes guaranteed request retry behavior, compressor unit tests, root editor/compressor integration tests, the full test suite, build, and PR checks.

Fixes #73
