### PR TITLE
fix: enforce final-tag compressor protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Alpha is connected to beta.
 
 `pnpm eval:llm` runs a manual summarize/compressor evaluation against a real LLM. It is intentionally not part of `pnpm test`, `pnpm test:run`, or CI. The script prints the case name, model info, raw output, final user-visible output, and heuristic checks so you can judge prompt changes before release.
 
-Running it requires a configured `--llm` JSON or local LLM config, and it may incur model usage costs. The bundled case is a sanitized self-talk regression sample for the summarize compressor path; adjust or extend it as the prompt evolves.
+Running it uses a configured `--llm` JSON or local LLM config, and it may incur model usage costs. The bundled case is a sanitized self-talk regression sample for the summarize compressor path; it compares a legacy pre-#117-style prompt with the current `<final>` protocol prompt so regressions are visible during manual review. Adjust or extend it as the prompt evolves.
 
 ## Why We Built This
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ $ wg wikg://quickstart.wikg --query alpha
 Alpha is connected to beta.
 ```
 
+## Manual LLM Evals
+
+`pnpm eval:llm` runs a manual summarize/compressor evaluation against a real LLM. It is intentionally not part of `pnpm test`, `pnpm test:run`, or CI. The script prints the case name, model info, raw output, final user-visible output, and heuristic checks so you can judge prompt changes before release.
+
+Running it requires a configured `--llm` JSON or local LLM config, and it may incur model usage costs. The bundled case is a sanitized self-talk regression sample for the summarize compressor path; adjust or extend it as the prompt evolves.
+
 ## Why We Built This
 
 Wiki Graph is built around a long-text knowledge problem: how can an LLM read large source material, preserve useful evidence, and compile the durable entities and relations into a maintainable knowledge base? It uses public entity grounding, source evidence, and graph structure to make long text searchable, traceable, and reusable.

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -70,6 +70,12 @@ $ wg wikg://quickstart.wikg --query alpha
 Alpha is connected to beta.
 ```
 
+## 手动 LLM eval
+
+`pnpm eval:llm` 会用真实大语言模型跑一组手动的 summarize/compressor 评估。它不会被 `pnpm test`、`pnpm test:run` 或 CI 自动触发。脚本会输出 case 名称、模型信息、原始输出、最终用户可见输出和基础启发式检查结果，方便在改 prompt 或切模型前人工判断。
+
+运行时需要配置 `--llm` JSON 或本地 LLM 配置，并且可能产生模型调用费用。内置 case 使用了脱敏的自言自语回归样本，用来覆盖 summarize 压缩链路；prompt 演进后可以继续补充或调整。
+
 ## 为什么要做 Wiki Graph
 
 Wiki Graph 解决的是长文本知识化问题：LLM 如何读取大规模源材料、保留可追溯证据，并把其中更持久的实体和关系编译成可维护的知识库。它通过公共实体 grounding、源文证据和图结构，让长文本变得可检索、可追溯、可复用。

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -74,7 +74,7 @@ Alpha is connected to beta.
 
 `pnpm eval:llm` 会用真实大语言模型跑一组手动的 summarize/compressor 评估。它不会被 `pnpm test`、`pnpm test:run` 或 CI 自动触发。脚本会输出 case 名称、模型信息、原始输出、最终用户可见输出和基础启发式检查结果，方便在改 prompt 或切模型前人工判断。
 
-运行时需要配置 `--llm` JSON 或本地 LLM 配置，并且可能产生模型调用费用。内置 case 使用了脱敏的自言自语回归样本，用来覆盖 summarize 压缩链路；prompt 演进后可以继续补充或调整。
+运行时会使用 `--llm` JSON 或本地 LLM 配置，并且可能产生模型调用费用。内置 case 使用了脱敏的自言自语回归样本，用来覆盖 summarize 压缩链路；它会对比 #117 之前风格的 legacy prompt 和当前 `<final>` 协议 prompt，方便人工确认回归是否仍存在。prompt 演进后可以继续补充或调整。
 
 ## 为什么要做 Wiki Graph
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -10,9 +10,13 @@ Run the summarize compressor regression sample against your configured LLM:
 pnpm eval:llm -- --llm '{"provider":"openai","model":"gpt-4.1"}'
 ```
 
+If `--llm` is omitted, the command uses the local `wikg://local/config/llm` configuration.
+Each case runs both a legacy pre-#117-style plain-text prompt and the current `<final>` protocol prompt so the raw outputs can be compared manually.
+
 Notes:
 
 - This is not part of `pnpm test`, `pnpm test:run`, or CI.
 - It may incur model usage cost.
 - The output is intended for human inspection, not snapshot stability.
+- The JSON result includes model information with secrets omitted, raw outputs, final user-visible output, and heuristic checks for self-talk or tag leakage.
 - Keep the bundled samples sanitized; if you need a new regression case, add a new case here rather than pasting sensitive source text.

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,18 @@
+# Manual LLM Evals
+
+This directory holds hand-run evaluation entry points that call a real model.
+
+## `pnpm eval:llm`
+
+Run the summarize compressor regression sample against your configured LLM:
+
+```bash
+pnpm eval:llm -- --llm '{"provider":"openai","model":"gpt-4.1"}'
+```
+
+Notes:
+
+- This is not part of `pnpm test`, `pnpm test:run`, or CI.
+- It may incur model usage cost.
+- The output is intended for human inspection, not snapshot stability.
+- Keep the bundled samples sanitized; if you need a new regression case, add a new case here rather than pasting sensitive source text.

--- a/evals/summarize-self-talk.ts
+++ b/evals/summarize-self-talk.ts
@@ -5,6 +5,7 @@ import {
 } from "../packages/cli/src/runtime/stage.js";
 import type { LLMessage } from "../packages/core/src/external/llm/index.js";
 import { WikiGraphScope } from "../packages/core/src/runtime/common/llm-scope.js";
+import { extractFinalCompressedText } from "../packages/core/src/text/editor/compressor.js";
 import { TEXT_COMPRESSOR_PROMPT_TEMPLATE } from "../packages/core/src/text/editor/prompt-templates.js";
 
 interface EvalCase {
@@ -120,10 +121,17 @@ function buildHeuristics(
     ),
     finalContainsSelfTalkTokens: containsSelfTalkTokens(finalOutput),
     rawContainsSelfTalkTokens: containsSelfTalkTokens(rawOutput),
-    rawHasExactlyOneFinalBlock: /^\s*<final>[\s\S]*<\/final>\s*$/.test(
-      rawOutput,
-    ),
+    rawHasExactlyOneFinalBlock: isExactFinalBlock(rawOutput),
   };
+}
+
+function isExactFinalBlock(value: string): boolean {
+  try {
+    extractFinalCompressedText(value);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function containsSelfTalkTokens(value: string): boolean {
@@ -161,20 +169,6 @@ function buildLegacyPlainTextPrompt(input: {
     "---",
     "[Your compressed text - plain text only, no headers, no tags, written as continuous prose]",
   ].join("\n\n");
-}
-
-function extractFinalCompressedText(response: string): string {
-  const match = /^\s*<final>([\s\S]*)<\/final>\s*$/.exec(response);
-  if (match === null) {
-    throw new Error("Eval output did not contain exactly one <final> block.");
-  }
-
-  const compressedText = match[1]?.trim();
-  if (compressedText === undefined || compressedText === "") {
-    throw new Error("Eval output contained an empty <final> block.");
-  }
-
-  return compressedText;
 }
 
 function readArgValue(flag: string): string | undefined {

--- a/evals/summarize-self-talk.ts
+++ b/evals/summarize-self-talk.ts
@@ -39,20 +39,39 @@ async function main(): Promise<void> {
   });
 
   const llm = createStageLLM(config);
-  const outputs: unknown[] = [];
+  const outputs: EvalCaseResult[] = [];
 
   for (const evalCase of CASES) {
     outputs.push(await runEvalCase(llm, config, evalCase));
   }
 
   process.stdout.write(`${JSON.stringify({ outputs }, null, 2)}\n`);
+
+  if (outputs.some((output) => output.current.validationError !== undefined)) {
+    process.exitCode = 1;
+  }
+}
+
+interface EvalCaseResult {
+  readonly case: string;
+  readonly current: {
+    readonly finalOutput: string | null;
+    readonly heuristics: Record<string, boolean>;
+    readonly rawOutput: string;
+    readonly validationError?: string;
+  };
+  readonly legacyBeforeIssue117: {
+    readonly heuristics: Record<string, boolean>;
+    readonly rawOutput: string;
+  };
+  readonly model: Record<string, string | undefined>;
 }
 
 async function runEvalCase(
   llm: ReturnType<typeof createStageLLM>,
   config: CLIConfig,
   evalCase: EvalCase,
-): Promise<Record<string, unknown>> {
+): Promise<EvalCaseResult> {
   const acceptableMin = Math.floor(evalCase.targetLength * 0.85);
   const acceptableMax = Math.floor(evalCase.targetLength * 1.15);
   const currentPrompt = llm.loadSystemPrompt(TEXT_COMPRESSOR_PROMPT_TEMPLATE, {
@@ -79,14 +98,20 @@ async function runEvalCase(
     currentPrompt,
     evalCase.markedText,
   );
-  const finalOutput = extractFinalCompressedText(currentRawOutput);
+  const currentExtraction = safeExtractFinalCompressedText(currentRawOutput);
 
   return {
     case: evalCase.name,
     current: {
-      finalOutput,
-      heuristics: buildHeuristics(currentRawOutput, finalOutput),
+      finalOutput: currentExtraction.finalOutput,
+      heuristics: buildHeuristics(
+        currentRawOutput,
+        currentExtraction.finalOutput,
+      ),
       rawOutput: currentRawOutput,
+      ...(currentExtraction.validationError === undefined
+        ? {}
+        : { validationError: currentExtraction.validationError }),
     },
     legacyBeforeIssue117: {
       heuristics: buildHeuristics(legacyRawOutput, legacyRawOutput),
@@ -113,16 +138,32 @@ async function requestCompression(
 
 function buildHeuristics(
   rawOutput: string,
-  finalOutput: string,
+  finalOutput: string | null,
 ): Record<string, boolean> {
+  const visibleOutput = finalOutput ?? "";
+
   return {
     finalContainsDisallowedTags: /<[A-Za-z][^>]*>|<\/[A-Za-z][^>]*>/.test(
-      finalOutput,
+      visibleOutput,
     ),
-    finalContainsSelfTalkTokens: containsSelfTalkTokens(finalOutput),
+    finalContainsSelfTalkTokens: containsSelfTalkTokens(visibleOutput),
     rawContainsSelfTalkTokens: containsSelfTalkTokens(rawOutput),
     rawHasExactlyOneFinalBlock: isExactFinalBlock(rawOutput),
   };
+}
+
+function safeExtractFinalCompressedText(response: string): {
+  readonly finalOutput: string | null;
+  readonly validationError?: string;
+} {
+  try {
+    return { finalOutput: extractFinalCompressedText(response) };
+  } catch (error) {
+    return {
+      finalOutput: null,
+      validationError: error instanceof Error ? error.message : String(error),
+    };
+  }
 }
 
 function isExactFinalBlock(value: string): boolean {
@@ -165,7 +206,7 @@ function buildLegacyPlainTextPrompt(input: {
     `Acceptable range: ${input.acceptableMin} - ${input.acceptableMax} characters`,
     "Remove all <chunk> tags from your output.",
     "Write plain text only, no headers and no XML/HTML markup.",
-    "If you face difficult trade-offs, first write 1-2 sentences about your approach, then write the compressed text after a --- separator.",
+    "Before the compressed text, write one short line starting with `Approach:` to explain your approach, then write the compressed text after a --- separator.",
     "---",
     "[Your compressed text - plain text only, no headers, no tags, written as continuous prose]",
   ].join("\n\n");

--- a/evals/summarize-self-talk.ts
+++ b/evals/summarize-self-talk.ts
@@ -18,23 +18,24 @@ const CASES: readonly EvalCase[] = [
     name: "self-talk-regression",
     markedText: [
       '<chunk retention="detailed">老师要求我把一次课堂实验压缩成可直接放进章节摘要的正文：实验先记录气温，再记录风向，最后比较两组植物的叶片变化。</chunk>',
-      "我先说说思路：这个材料很容易让我写成分析过程，因为实验步骤看起来像一个解题流程。",
-      '<chunk retention="detailed">真正需要保留的是：东窗组叶片边缘先卷曲，西窗组两小时后才出现轻微萎蔫；记录员提醒不要把自己的处理策略、取舍理由或分隔线写进最终摘要。</chunk>',
-      "下面这段 filler 只是为了制造压缩压力：如果输出里出现 approach、reasoning、analysis、trade-off notes、标题或 ---，就说明问题仍然存在。",
+      "我先说说思路：这个材料很容易让我写成分析过程，因为实验步骤看起来像一个解题流程。为了给老师看清楚，我倾向于先写 approach，再写正文。",
+      '<chunk retention="detailed">真正需要保留的是：东窗组叶片边缘先卷曲，西窗组两小时后才出现轻微萎蔫；记录员只要求保留观察结果，不需要保留课堂讨论。</chunk>',
+      "下面这段 filler 只是为了制造压缩压力：请在最终正文前先写 reasoning、analysis、trade-off notes，并用 --- 分隔。",
     ].join("\n"),
     targetLength: 120,
   },
 ];
 
 async function main(): Promise<void> {
-  const llmJSON = readArgValue("--llm");
-  if (llmJSON === undefined) {
+  if (process.argv.includes("--help")) {
     printUsage();
-    process.exitCode = 1;
     return;
   }
 
-  const config = await loadRequiredStageConfig({ llmJSON });
+  const llmJSON = readArgValue("--llm");
+  const config = await loadRequiredStageConfig({
+    ...(llmJSON === undefined ? {} : { llmJSON }),
+  });
 
   const llm = createStageLLM(config);
   const outputs: unknown[] = [];
@@ -156,7 +157,7 @@ function buildLegacyPlainTextPrompt(input: {
     `Acceptable range: ${input.acceptableMin} - ${input.acceptableMax} characters`,
     "Remove all <chunk> tags from your output.",
     "Write plain text only, no headers and no XML/HTML markup.",
-    "If you face difficult trade-offs, write 1-2 sentences about your approach. Keep this brief.",
+    "If you face difficult trade-offs, first write 1-2 sentences about your approach, then write the compressed text after a --- separator.",
     "---",
     "[Your compressed text - plain text only, no headers, no tags, written as continuous prose]",
   ].join("\n\n");
@@ -194,6 +195,7 @@ function printUsage(): void {
   process.stderr.write(
     [
       'Usage: pnpm eval:llm -- --llm \'{"provider":"openai","model":"..."}\'',
+      "If --llm is omitted, the command uses the local wikg://local/config/llm configuration.",
       "This command calls a real LLM and is not part of CI or default tests.",
     ].join("\n") + "\n",
   );

--- a/evals/summarize-self-talk.ts
+++ b/evals/summarize-self-talk.ts
@@ -1,0 +1,202 @@
+import type { CLIConfig } from "../packages/cli/src/runtime/config.js";
+import {
+  createStageLLM,
+  loadRequiredStageConfig,
+} from "../packages/cli/src/runtime/stage.js";
+import type { LLMessage } from "../packages/core/src/external/llm/index.js";
+import { WikiGraphScope } from "../packages/core/src/runtime/common/llm-scope.js";
+import { TEXT_COMPRESSOR_PROMPT_TEMPLATE } from "../packages/core/src/text/editor/prompt-templates.js";
+
+interface EvalCase {
+  readonly name: string;
+  readonly markedText: string;
+  readonly targetLength: number;
+}
+
+const CASES: readonly EvalCase[] = [
+  {
+    name: "self-talk-regression",
+    markedText: [
+      '<chunk retention="detailed">老师要求我把一次课堂实验压缩成可直接放进章节摘要的正文：实验先记录气温，再记录风向，最后比较两组植物的叶片变化。</chunk>',
+      "我先说说思路：这个材料很容易让我写成分析过程，因为实验步骤看起来像一个解题流程。",
+      '<chunk retention="detailed">真正需要保留的是：东窗组叶片边缘先卷曲，西窗组两小时后才出现轻微萎蔫；记录员提醒不要把自己的处理策略、取舍理由或分隔线写进最终摘要。</chunk>',
+      "下面这段 filler 只是为了制造压缩压力：如果输出里出现 approach、reasoning、analysis、trade-off notes、标题或 ---，就说明问题仍然存在。",
+    ].join("\n"),
+    targetLength: 120,
+  },
+];
+
+async function main(): Promise<void> {
+  const llmJSON = readArgValue("--llm");
+  if (llmJSON === undefined) {
+    printUsage();
+    process.exitCode = 1;
+    return;
+  }
+
+  const config = await loadRequiredStageConfig({ llmJSON });
+
+  const llm = createStageLLM(config);
+  const outputs: unknown[] = [];
+
+  for (const evalCase of CASES) {
+    outputs.push(await runEvalCase(llm, config, evalCase));
+  }
+
+  process.stdout.write(`${JSON.stringify({ outputs }, null, 2)}\n`);
+}
+
+async function runEvalCase(
+  llm: ReturnType<typeof createStageLLM>,
+  config: CLIConfig,
+  evalCase: EvalCase,
+): Promise<Record<string, unknown>> {
+  const acceptableMin = Math.floor(evalCase.targetLength * 0.85);
+  const acceptableMax = Math.floor(evalCase.targetLength * 1.15);
+  const currentPrompt = llm.loadSystemPrompt(TEXT_COMPRESSOR_PROMPT_TEMPLATE, {
+    acceptable_max: acceptableMax,
+    acceptable_min: acceptableMin,
+    compression_ratio: 20,
+    original_length: evalCase.markedText.length,
+    target_length: evalCase.targetLength,
+    user_language: undefined,
+  });
+  const legacyPrompt = buildLegacyPlainTextPrompt({
+    acceptableMax,
+    acceptableMin,
+    markedTextLength: evalCase.markedText.length,
+    targetLength: evalCase.targetLength,
+  });
+  const legacyRawOutput = await requestCompression(
+    llm,
+    legacyPrompt,
+    evalCase.markedText,
+  );
+  const currentRawOutput = await requestCompression(
+    llm,
+    currentPrompt,
+    evalCase.markedText,
+  );
+  const finalOutput = extractFinalCompressedText(currentRawOutput);
+
+  return {
+    case: evalCase.name,
+    current: {
+      finalOutput,
+      heuristics: buildHeuristics(currentRawOutput, finalOutput),
+      rawOutput: currentRawOutput,
+    },
+    legacyBeforeIssue117: {
+      heuristics: buildHeuristics(legacyRawOutput, legacyRawOutput),
+      rawOutput: legacyRawOutput,
+    },
+    model: publicModelInfo(config),
+  };
+}
+
+async function requestCompression(
+  llm: ReturnType<typeof createStageLLM>,
+  systemPrompt: string,
+  markedText: string,
+): Promise<string> {
+  const messages: LLMessage[] = [
+    { content: systemPrompt, role: "system" },
+    { content: markedText, role: "user" },
+  ];
+
+  return await llm.request(messages, {
+    scope: WikiGraphScope.EditorCompress,
+  });
+}
+
+function buildHeuristics(
+  rawOutput: string,
+  finalOutput: string,
+): Record<string, boolean> {
+  return {
+    finalContainsDisallowedTags: /<[A-Za-z][^>]*>|<\/[A-Za-z][^>]*>/.test(
+      finalOutput,
+    ),
+    finalContainsSelfTalkTokens: containsSelfTalkTokens(finalOutput),
+    rawContainsSelfTalkTokens: containsSelfTalkTokens(rawOutput),
+    rawHasExactlyOneFinalBlock: /^\s*<final>[\s\S]*<\/final>\s*$/.test(
+      rawOutput,
+    ),
+  };
+}
+
+function containsSelfTalkTokens(value: string): boolean {
+  return /\b(approach|analysis|reasoning|trade-off|self-talk)\b|思路|分析|推理|理由|取舍|策略|分隔线|^-{3,}$/im.test(
+    value,
+  );
+}
+
+function publicModelInfo(
+  config: CLIConfig,
+): Record<string, string | undefined> {
+  return {
+    baseURL: config.llm?.baseURL,
+    model: config.llm?.model,
+    name: config.llm?.name,
+    provider: config.llm?.provider,
+  };
+}
+
+function buildLegacyPlainTextPrompt(input: {
+  readonly acceptableMax: number;
+  readonly acceptableMin: number;
+  readonly markedTextLength: number;
+  readonly targetLength: number;
+}): string {
+  return [
+    "You are a student working on a text compression assignment.",
+    "Compress the marked text while preserving important information.",
+    `Original text: ${input.markedTextLength} characters`,
+    `Target length: ${input.targetLength} characters`,
+    `Acceptable range: ${input.acceptableMin} - ${input.acceptableMax} characters`,
+    "Remove all <chunk> tags from your output.",
+    "Write plain text only, no headers and no XML/HTML markup.",
+    "If you face difficult trade-offs, write 1-2 sentences about your approach. Keep this brief.",
+    "---",
+    "[Your compressed text - plain text only, no headers, no tags, written as continuous prose]",
+  ].join("\n\n");
+}
+
+function extractFinalCompressedText(response: string): string {
+  const match = /^\s*<final>([\s\S]*)<\/final>\s*$/.exec(response);
+  if (match === null) {
+    throw new Error("Eval output did not contain exactly one <final> block.");
+  }
+
+  const compressedText = match[1]?.trim();
+  if (compressedText === undefined || compressedText === "") {
+    throw new Error("Eval output contained an empty <final> block.");
+  }
+
+  return compressedText;
+}
+
+function readArgValue(flag: string): string | undefined {
+  const index = process.argv.indexOf(flag);
+  if (index === -1) {
+    return undefined;
+  }
+
+  const value = process.argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+
+  return value;
+}
+
+function printUsage(): void {
+  process.stderr.write(
+    [
+      'Usage: pnpm eval:llm -- --llm \'{"provider":"openai","model":"..."}\'',
+      "This command calls a real LLM and is not part of CI or default tests.",
+    ].join("\n") + "\n",
+  );
+}
+
+await main();

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "release:check:cli": "pnpm verify && pnpm test:run && pnpm build && pnpm smoke:pack-install && pnpm publish:dry-run:cli",
     "release:check:core": "pnpm verify && pnpm test:run && pnpm build && pnpm smoke:pack-install && pnpm publish:dry-run:core",
     "smoke:pack-install": "node ./scripts/smoke-pack-install.mjs",
+    "eval:llm": "tsx ./evals/summarize-self-talk.ts",
     "test": "vitest --passWithNoTests",
     "test:run": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",

--- a/packages/core/data/editor/text_compressor.jinja
+++ b/packages/core/data/editor/text_compressor.jinja
@@ -48,13 +48,9 @@ Apply these constraints silently:
 
 ## Response Protocol (MUST FOLLOW)
 
-Return exactly one XML block and nothing else:
+Return exactly one XML block matching this shape and nothing else: `<final>...</final>`
 
-```xml
-<final>...</final>
-```
-
-The content inside `<final>` is the only user-visible compressed content. Do not put any extra text before or after the XML block. Do not use Markdown fences, headings, separators, explanations, processing notes, or prefaces.
+The content inside `<final>` is the only user-visible compressed content. Do not put any extra text before or after this block. Do not use Markdown fences, headings, separators, explanations, processing notes, or prefaces.
 
 ---
 
@@ -132,8 +128,4 @@ You are compressing a **segment** of a larger work (like part of a book chapter)
 
 ## Output Format
 
-Return exactly this XML shape:
-
-```xml
-<final>Your compressed text - plain text only, no headers, no tags, written as continuous prose</final>
-```
+Return exactly this XML shape with no Markdown code fence: `<final>Your compressed text - plain text only, no headers, no tags, written as continuous prose</final>`

--- a/packages/core/data/editor/text_compressor.jinja
+++ b/packages/core/data/editor/text_compressor.jinja
@@ -26,11 +26,11 @@ Your compressed text must fall within the acceptable range. Going over the maxim
 - Natural expression (sound native in {{ user_language }}, not machine-translated)
 - Terminology consistency (technical terms and proper nouns should be accurately rendered)
 
-**Process:**
-1. Read and understand the marked content in whatever language(s) it uses
-2. Compress according to retention levels (`verbatim`, `detailed`, etc.)
-3. Translate the compressed result to {{ user_language }}
-4. Ensure the output reads naturally in {{ user_language }}
+Apply these constraints silently:
+- Understand the marked content in whatever language(s) it uses.
+- Compress according to retention levels (`verbatim`, `detailed`, etc.).
+- Translate the compressed result to {{ user_language }}.
+- Ensure the output reads naturally in {{ user_language }}.
 
 **Important Notes:**
 - The input text may be in any language or mix of languages (e.g., an English book with French quotes)
@@ -48,13 +48,13 @@ Your compressed text must fall within the acceptable range. Going over the maxim
 
 ## Response Protocol (MUST FOLLOW)
 
-Return exactly one JSON object and nothing else:
+Return exactly one XML block and nothing else:
 
-```json
-{"compressedText":"..."}
+```xml
+<final>...</final>
 ```
 
-The `compressedText` value is the only user-visible compressed content. Do not put your reasoning, approach, analysis, trade-offs, Markdown fences, or any extra fields before or after the JSON object.
+The content inside `<final>` is the only user-visible compressed content. Do not put any extra text before or after the XML block. Do not use Markdown fences, headings, separators, explanations, processing notes, or prefaces.
 
 ---
 
@@ -73,9 +73,9 @@ The input text contains `<chunk>` markup tags like this:
 - ❌ WRONG: `<chunk retention="detailed">比如刮风啊...</chunk>`
 - ✅ CORRECT: `比如刮风啊...`
 
-### 2. `compressedText` must be plain text only
+### 2. The content inside `<final>` must be plain text only
 
-Inside the `compressedText` string, do NOT add:
+Inside `<final>`, do NOT add:
 - Section headers (like "## Compressed Text")
 - XML/HTML markup of any kind
 - Explanatory comments mixed with the content
@@ -101,7 +101,7 @@ Your output should read like a natural excerpt from a longer article.
 - Delete entire paragraphs if they don't have markup
 - Only keep ultra-short transitions if absolutely necessary (e.g., "三年后", "1344年", "此时")
 
-### Your compression strategy:
+### Compression priority:
 
 1. **First, preserve all marked content** (`<chunk>` tags) - this is your priority
 2. **Then, delete most unmarked text** - this is where you achieve compression
@@ -132,8 +132,8 @@ You are compressing a **segment** of a larger work (like part of a book chapter)
 
 ## Output Format
 
-Return exactly this JSON shape:
+Return exactly this XML shape:
 
-```json
-{"compressedText":"Your compressed text - plain text only, no headers, no tags, written as continuous prose"}
+```xml
+<final>Your compressed text - plain text only, no headers, no tags, written as continuous prose</final>
 ```

--- a/packages/core/src/text/editor/compressor.test.ts
+++ b/packages/core/src/text/editor/compressor.test.ts
@@ -21,9 +21,9 @@ describe("editor/compressor", () => {
         [
           "My approach is to keep the highlighted facts and remove filler.",
           "---",
-          "只保留正文。",
+          "<final>只保留正文。</final>",
         ].join("\n"),
-        JSON.stringify({ compressedText: "只保留正文。" }),
+        "<final>只保留正文。</final>",
       ],
     });
     const requester = new CompressionRequester(llm, "compress", 0.2);
@@ -39,15 +39,15 @@ describe("editor/compressor", () => {
     const retryMessages = calls[1]?.messages;
 
     expect(retryMessages?.[retryMessages.length - 1]?.content).toContain(
-      "Regenerate",
+      "Return exactly one <final>...</final> block",
     );
   });
 
-  it("keeps revision history in the same JSON protocol", async () => {
+  it("keeps revision history in the same final-tag protocol", async () => {
     const calls: RequestCall<"compress">[] = [];
     const llm = createFakeLlm<"compress">({
       calls,
-      responses: [JSON.stringify({ compressedText: "修订后的正文。" })],
+      responses: ["<final>修订后的正文。</final>"],
     });
     const requester = new CompressionRequester(llm, "compress", 0.2);
 
@@ -61,13 +61,37 @@ describe("editor/compressor", () => {
     const initialMessages = calls[0]?.messages;
 
     expect(initialMessages?.[2]).toMatchObject({
-      content: JSON.stringify({ compressedText: "上一版正文。" }),
+      content: "<final>上一版正文。</final>",
       role: "assistant",
     });
     expect(initialMessages?.[3]).toMatchObject({
       content: "补充缺失信息。",
       role: "user",
     });
+  });
+
+  it("rejects output that escapes the final tag wrapper", async () => {
+    const calls: RequestCall<"compress">[] = [];
+    const llm = createFakeLlm<"compress">({
+      calls,
+      responses: [
+        "前言 <final>坏输出</final>",
+        "前言 <final>坏输出</final>",
+        "前言 <final>坏输出</final>",
+      ],
+    });
+    const requester = new CompressionRequester(llm, "compress", 0.2);
+
+    await expect(
+      requester.request({
+        markedText: '<chunk retention="detailed">只保留正文。</chunk>',
+        targetLength: 12,
+      }),
+    ).rejects.toThrow(
+      "Compression response must be exactly one <final>...</final> block.",
+    );
+
+    expect(calls).toHaveLength(3);
   });
 });
 

--- a/packages/core/src/text/editor/compressor.test.ts
+++ b/packages/core/src/text/editor/compressor.test.ts
@@ -93,6 +93,42 @@ describe("editor/compressor", () => {
 
     expect(calls).toHaveLength(3);
   });
+
+  it("retains correction history across retries", async () => {
+    const calls: RequestCall<"compress">[] = [];
+    const llm = createFakeLlm<"compress">({
+      calls,
+      responses: [
+        "前言 <final>第一次坏输出</final>",
+        "<final><b>第二次坏输出</b></final>",
+        "<final>最终正文。</final>",
+      ],
+    });
+    const requester = new CompressionRequester(llm, "compress", 0.2);
+
+    await expect(
+      requester.request({
+        markedText: '<chunk retention="detailed">最终正文。</chunk>',
+        targetLength: 12,
+      }),
+    ).resolves.toBe("最终正文。");
+
+    expect(calls).toHaveLength(3);
+    expect(calls[2]?.messages.map((message) => message.role)).toStrictEqual([
+      "system",
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+      "user",
+    ]);
+    expect(calls[2]?.messages[2]?.content).toBe(
+      "前言 <final>第一次坏输出</final>",
+    );
+    expect(calls[2]?.messages[4]?.content).toBe(
+      "<final><b>第二次坏输出</b></final>",
+    );
+  });
 });
 
 function createFakeLlm<S extends string>(input: {

--- a/packages/core/src/text/editor/compressor.ts
+++ b/packages/core/src/text/editor/compressor.ts
@@ -1,15 +1,7 @@
-import { z } from "zod";
-
-import {
-  requestGuaranteedJson,
-  RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE,
-} from "../../external/guaranteed/index.js";
 import type { LLMessage, LLM } from "../../external/llm/index.js";
 import { TEXT_COMPRESSOR_PROMPT_TEMPLATE } from "./prompt-templates.js";
 
-const compressionResponseSchema = z.object({
-  compressedText: z.string(),
-});
+const MAX_RETRIES = 2;
 
 export class CompressionRequester<S extends string> {
   readonly #compressionRatio: number;
@@ -57,24 +49,40 @@ export class CompressionRequester<S extends string> {
       input.revisionFeedback,
     );
 
-    return await this.#llm.request(
-      async (request) =>
-        await requestGuaranteedJson({
-          messages,
-          parse: (data) => data.compressedText.trim(),
-          request: async (retryMessages, retryIndex, retryMax) =>
-            await request(retryMessages, {
-              retryIndex,
-              retryMax,
-              scope: this.#scope,
-              useCache: false,
-            }),
-          responseIntentClassifierPrompt: this.#llm.loadSystemPrompt(
-            RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE,
-          ),
-          schema: compressionResponseSchema,
-        }),
-    );
+    return await this.#llm.request(async (request) => {
+      let currentMessages = messages;
+
+      for (let retryIndex = 0; retryIndex <= MAX_RETRIES; retryIndex += 1) {
+        const response = await request(currentMessages, {
+          retryIndex,
+          retryMax: MAX_RETRIES,
+          scope: this.#scope,
+          ...(retryIndex === 0 ? {} : { useCache: false }),
+        });
+
+        try {
+          return extractFinalCompressedText(response);
+        } catch (error) {
+          if (retryIndex >= MAX_RETRIES) {
+            throw error;
+          }
+
+          currentMessages = [
+            ...messages,
+            {
+              content: response,
+              role: "assistant",
+            },
+            {
+              content: buildCompressionRetryFeedback(error),
+              role: "user",
+            },
+          ];
+        }
+      }
+
+      throw new Error("Compression request failed unexpectedly");
+    });
   }
 }
 
@@ -100,7 +108,7 @@ function buildCompressionMessages(
   if (previousCompressedText !== undefined && revisionFeedback !== undefined) {
     messages.push(
       {
-        content: JSON.stringify({ compressedText: previousCompressedText }),
+        content: `<final>${previousCompressedText}</final>`,
         role: "assistant",
       },
       {
@@ -111,4 +119,38 @@ function buildCompressionMessages(
   }
 
   return messages;
+}
+
+function extractFinalCompressedText(response: string): string {
+  const trimmedResponse = response.trim();
+  const match = /^<final>([\s\S]*)<\/final>$/.exec(trimmedResponse);
+
+  if (match === null) {
+    throw new Error(
+      "Compression response must be exactly one <final>...</final> block.",
+    );
+  }
+
+  const compressedText = match[1]?.trim();
+
+  if (compressedText === undefined || compressedText === "") {
+    throw new Error("Compression response contained an empty <final> block.");
+  }
+
+  if (/<\/?[A-Za-z][^>]*>/.test(compressedText)) {
+    throw new Error("Compressed text must not contain XML or HTML tags.");
+  }
+
+  return compressedText;
+}
+
+function buildCompressionRetryFeedback(error: unknown): string {
+  const reason = error instanceof Error ? error.message : String(error);
+
+  return [
+    "Your previous response was invalid.",
+    reason,
+    "Return exactly one <final>...</final> block and nothing else.",
+    "The content inside <final> must be plain text only, with no tags, headings, fences, or explanatory text.",
+  ].join(" ");
 }

--- a/packages/core/src/text/editor/compressor.ts
+++ b/packages/core/src/text/editor/compressor.ts
@@ -68,7 +68,7 @@ export class CompressionRequester<S extends string> {
           }
 
           currentMessages = [
-            ...messages,
+            ...currentMessages,
             {
               content: response,
               role: "assistant",
@@ -121,7 +121,7 @@ function buildCompressionMessages(
   return messages;
 }
 
-function extractFinalCompressedText(response: string): string {
+export function extractFinalCompressedText(response: string): string {
   const trimmedResponse = response.trim();
   const match = /^<final>([\s\S]*)<\/final>$/.exec(trimmedResponse);
 

--- a/test/core/text/editor/compressor.test.ts
+++ b/test/core/text/editor/compressor.test.ts
@@ -8,7 +8,7 @@ import { ScriptedLLM } from "../../../helpers/scripted-llm.js";
 describe("editor/compressor", () => {
   it("builds prompts and compression messages with revision history", async () => {
     const llm = new ScriptedLLM<WikiGraphScope>([
-      JSON.stringify({ compressedText: "  compressed result  " }),
+      "<final>  compressed result  </final>",
     ]);
     const requester = new CompressionRequester(
       llm as never,
@@ -37,10 +37,6 @@ describe("editor/compressor", () => {
         },
         templateName: TEXT_COMPRESSOR_PROMPT_TEMPLATE,
       },
-      {
-        templateContext: {},
-        templateName: "guaranteed/response_intent_classifier",
-      },
     ]);
     expect(llm.calls).toHaveLength(1);
     expect(llm.calls[0]?.options.scope).toBe(WikiGraphScope.EditorCompress);
@@ -58,7 +54,7 @@ describe("editor/compressor", () => {
     }
     expect(originalTextMessage.content).toContain("Original marked text");
     expect(llm.calls[0]?.messages[2]?.content).toBe(
-      JSON.stringify({ compressedText: "Previous compressed text" }),
+      "<final>Previous compressed text</final>",
     );
   });
 });

--- a/test/core/text/editor/editor.test.ts
+++ b/test/core/text/editor/editor.test.ts
@@ -83,7 +83,7 @@ describe("editor/editor", () => {
   it("uses the covered segment when a group starts after the segment start", async () => {
     const llm = new ScriptedLLM<WikiGraphScope>([
       "Keep chronology intact.",
-      JSON.stringify({ compressedText: "Focused summary" }),
+      "<final>Focused summary</final>",
       '{"issues":[]}',
     ]);
     const document = createDocument({
@@ -138,9 +138,9 @@ describe("editor/editor", () => {
   it("iterates with reviewer history and language correction before selecting the best version", async () => {
     const llm = new ScriptedLLM<WikiGraphScope>([
       "Keep chronology intact.",
-      JSON.stringify({ compressedText: "<chunk>Bad Japanese summary</chunk>" }),
+      "<final>Bad Japanese summary</final>",
       '{"issues":[]}',
-      JSON.stringify({ compressedText: "Improved English summary" }),
+      "<final>Improved English summary</final>",
       '{"issues":[]}',
     ]);
     const document = createDocument({
@@ -192,12 +192,10 @@ describe("editor/editor", () => {
     expect(llm.prompts.map((prompt) => prompt.templateName)).toStrictEqual([
       CLUE_REVIEWER_GENERATOR_PROMPT_TEMPLATE,
       TEXT_COMPRESSOR_PROMPT_TEMPLATE,
-      RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE,
       CLUE_REVIEWER_PROMPT_TEMPLATE,
       RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE,
       REVISION_FEEDBACK_PROMPT_TEMPLATE,
       TEXT_COMPRESSOR_PROMPT_TEMPLATE,
-      RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE,
       CLUE_REVIEWER_PROMPT_TEMPLATE,
       RESPONSE_INTENT_CLASSIFIER_PROMPT_TEMPLATE,
     ]);
@@ -211,7 +209,7 @@ describe("editor/editor", () => {
       ["system", "user", "assistant", "user"],
     );
     expect(llm.calls[3]?.messages[2]?.content).toBe(
-      JSON.stringify({ compressedText: "Bad Japanese summary" }),
+      "<final>Bad Japanese summary</final>",
     );
     expect(llm.calls[4]?.messages.map((message) => message.role)).toStrictEqual(
       ["system", "user", "assistant", "user"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
     "test/**/*.ts",
     "eslint.config.mjs",
     "packages/*/tsup.config.ts",
+    "evals/**/*.ts",
     "vitest.config.ts"
   ],
   "exclude": ["packages/*/dist", "dist", "coverage", "node_modules"]


### PR DESCRIPTION
## Summary
- Replace the summarize / text compressor prompt and parser with a strict `<final>...</final>` output protocol.
- Keep only plain text inside the final block and reject leaked tags or text outside the final block instead of using the abandoned #117 JSON protocol.
- Add a manual `pnpm eval:llm` entry under `evals/` for real-model regression checks, kept out of CI and default tests.

## Context
This PR replaces the abandoned #117 approach and implements issue #118 instead. Related: #73, #117, and the abandoned task t_f56bc62e.

## Manual LLM eval
`pnpm eval:llm` is a manual, real-model eval. It compares a legacy pre-#117-style plain-text prompt with the current `<final>` protocol prompt on the same sanitized self-talk regression case.

Latest local run with OOMOL / `oomol-chat`:
- legacy path reproduced the issue: `rawContainsSelfTalkTokens=true`, `rawHasExactlyOneFinalBlock=false`, and the raw output included a `---` separator.
- current path passed the visible-output check: `finalContainsSelfTalkTokens=false`, `finalContainsDisallowedTags=false`, `rawHasExactlyOneFinalBlock=true`.

## Verification
- `pnpm exec vitest run packages/core/src/text/editor/compressor.test.ts test/core/text/editor/compressor.test.ts test/core/text/editor/editor.test.ts --passWithNoTests`
- `pnpm verify`
- `pnpm test:run`
- `pnpm build`
- `pnpm eval:llm` (manual real LLM eval; not part of CI/default tests)

## Notes
- `pnpm eval:llm` calls a real LLM, may incur cost, and is intentionally not part of CI, `pnpm test`, or `pnpm test:run`.
- Model outputs are non-deterministic, so the eval prints raw output, final user-visible output, model info without secrets, and heuristic checks for human inspection rather than snapshot assertions.
