### PR TITLE
fix(search-index): refactor archive index projection

### DIFF
--- a/packages/core/src/document/directory/search-index.ts
+++ b/packages/core/src/document/directory/search-index.ts
@@ -1,5 +1,7 @@
+import { stat } from "fs/promises";
 import { join } from "path";
 
+import { isNodeError } from "../../utils/node-error.js";
 import { Database } from "../database.js";
 import { SEARCH_INDEX_SCHEMA_SQL } from "../schema.js";
 import type { DocumentFileStore } from "./types.js";
@@ -16,9 +18,11 @@ export async function openSearchIndexDatabase<T>(input: {
       : await input.fileStore.resolveSearchIndexDatabasePath(
           input.documentPath,
         );
+  const shouldInitialize =
+    !input.readonly && (await isMissingOrEmptyFile(databasePath));
   const database = await Database.open(
     databasePath,
-    input.readonly ? "" : SEARCH_INDEX_SCHEMA_SQL,
+    shouldInitialize ? SEARCH_INDEX_SCHEMA_SQL : "",
     {
       onWrite: () => {
         input.fileStore.markSearchIndexDatabaseDirty?.();
@@ -38,6 +42,18 @@ export async function openSearchIndexDatabase<T>(input: {
   }
 }
 
+async function isMissingOrEmptyFile(path: string): Promise<boolean> {
+  const stats = await stat(path).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  });
+
+  return stats === undefined || stats.size === 0;
+}
+
 async function migrateSearchIndexSchema(database: Database): Promise<void> {
   await ensureColumn(
     database,
@@ -45,6 +61,16 @@ async function migrateSearchIndexSchema(database: Database): Promise<void> {
     "archive_id",
     "INTEGER NOT NULL DEFAULT 0",
   );
+  if (
+    !(await hasUniqueIndex(database, "text_sentence_records", [
+      "archive_id",
+      "kind",
+      "chapter_id",
+      "sentence_index",
+    ]))
+  ) {
+    await rebuildTextSentenceRecordsTable(database);
+  }
   await ensureColumn(
     database,
     "search_object_properties_records",
@@ -59,23 +85,99 @@ async function migrateSearchIndexSchema(database: Database): Promise<void> {
       PRIMARY KEY (archive_id, chapter_id)
     )
   `);
-  await database.run(`
-    CREATE INDEX IF NOT EXISTS idx_text_sentence_records_archive_chapter
-    ON text_sentence_records(archive_id, kind, chapter_id, sentence_index)
-  `);
-  await database.run(`
-    CREATE INDEX IF NOT EXISTS idx_search_object_properties_records_archive_owner
-    ON search_object_properties_records(archive_id, owner_kind, owner_id)
-  `);
-  await database.run(`
-    CREATE INDEX IF NOT EXISTS idx_search_object_properties_records_archive_chapter
-    ON search_object_properties_records(
-      archive_id,
-      chapter_id,
-      owner_kind,
-      owner_id
-    )
-  `);
+}
+
+async function rebuildTextSentenceRecordsTable(
+  database: Database,
+): Promise<void> {
+  await database.transaction(async () => {
+    await database.run(`
+      CREATE TABLE text_sentence_records_next (
+        id INTEGER PRIMARY KEY,
+        archive_id INTEGER NOT NULL,
+        kind INTEGER NOT NULL,
+        chapter_id INTEGER NOT NULL,
+        sentence_index INTEGER NOT NULL,
+        words_count INTEGER NOT NULL DEFAULT 0,
+        byte_offset INTEGER NOT NULL DEFAULT 0,
+        byte_length INTEGER NOT NULL DEFAULT 0,
+        UNIQUE(archive_id, kind, chapter_id, sentence_index)
+      )
+    `);
+    await database.run(`
+      INSERT INTO text_sentence_records_next (
+        id,
+        archive_id,
+        kind,
+        chapter_id,
+        sentence_index,
+        words_count,
+        byte_offset,
+        byte_length
+      )
+      SELECT
+        id,
+        archive_id,
+        kind,
+        chapter_id,
+        sentence_index,
+        words_count,
+        byte_offset,
+        byte_length
+      FROM text_sentence_records
+    `);
+    await database.run("DROP TABLE text_sentence_records");
+    await database.run(`
+      ALTER TABLE text_sentence_records_next
+      RENAME TO text_sentence_records
+    `);
+    await database.run(`
+      CREATE INDEX IF NOT EXISTS idx_text_sentence_records_chapter
+      ON text_sentence_records(archive_id, kind, chapter_id, sentence_index)
+    `);
+  });
+}
+
+async function hasUniqueIndex(
+  database: Database,
+  table: string,
+  columns: readonly string[],
+): Promise<boolean> {
+  const indexes = await database.queryAll(
+    `PRAGMA index_list(${table})`,
+    undefined,
+    (row) => ({
+      name: String(row.name),
+      unique: Number(row.unique) === 1,
+    }),
+  );
+
+  for (const index of indexes) {
+    if (!index.unique) {
+      continue;
+    }
+
+    const indexColumns = await database.queryAll(
+      `PRAGMA index_info(${index.name})`,
+      undefined,
+      (row) => ({
+        name: String(row.name),
+        seqno: Number(row.seqno),
+      }),
+    );
+    const orderedColumns = indexColumns
+      .sort((left, right) => left.seqno - right.seqno)
+      .map((column) => column.name);
+
+    if (
+      orderedColumns.length === columns.length &&
+      orderedColumns.every((column, index) => column === columns[index])
+    ) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 async function ensureColumn(

--- a/packages/core/src/document/directory/search-index.ts
+++ b/packages/core/src/document/directory/search-index.ts
@@ -27,9 +27,72 @@ export async function openSearchIndexDatabase<T>(input: {
     },
   );
 
+  if (!input.readonly) {
+    await migrateSearchIndexSchema(database);
+  }
+
   try {
     return await input.operation(database);
   } finally {
     await database.close();
   }
+}
+
+async function migrateSearchIndexSchema(database: Database): Promise<void> {
+  await ensureColumn(
+    database,
+    "text_sentence_records",
+    "archive_id",
+    "INTEGER NOT NULL DEFAULT 0",
+  );
+  await ensureColumn(
+    database,
+    "search_object_properties_records",
+    "archive_id",
+    "INTEGER NOT NULL DEFAULT 0",
+  );
+  await database.run(`
+    CREATE TABLE IF NOT EXISTS index_dirty_chapters (
+      archive_id INTEGER NOT NULL,
+      chapter_id INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (archive_id, chapter_id)
+    )
+  `);
+  await database.run(`
+    CREATE INDEX IF NOT EXISTS idx_text_sentence_records_archive_chapter
+    ON text_sentence_records(archive_id, kind, chapter_id, sentence_index)
+  `);
+  await database.run(`
+    CREATE INDEX IF NOT EXISTS idx_search_object_properties_records_archive_owner
+    ON search_object_properties_records(archive_id, owner_kind, owner_id)
+  `);
+  await database.run(`
+    CREATE INDEX IF NOT EXISTS idx_search_object_properties_records_archive_chapter
+    ON search_object_properties_records(
+      archive_id,
+      chapter_id,
+      owner_kind,
+      owner_id
+    )
+  `);
+}
+
+async function ensureColumn(
+  database: Database,
+  table: string,
+  column: string,
+  definition: string,
+): Promise<void> {
+  const columns = await database.queryAll(
+    `PRAGMA table_info(${table})`,
+    undefined,
+    (row) => String(row.name),
+  );
+
+  if (columns.includes(column)) {
+    return;
+  }
+
+  await database.run(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
 }

--- a/packages/core/src/document/directory/search-index.ts
+++ b/packages/core/src/document/directory/search-index.ts
@@ -3,7 +3,10 @@ import { join } from "path";
 
 import { isNodeError } from "../../utils/node-error.js";
 import { Database } from "../database.js";
-import { SEARCH_INDEX_SCHEMA_SQL } from "../schema.js";
+import {
+  SEARCH_INDEX_SCHEMA_SQL,
+  SEARCH_INDEX_TEXT_SENTENCE_RECORDS_COLUMNS_SQL,
+} from "../schema.js";
 import type { DocumentFileStore } from "./types.js";
 
 export async function openSearchIndexDatabase<T>(input: {
@@ -93,15 +96,7 @@ async function rebuildTextSentenceRecordsTable(
   await database.transaction(async () => {
     await database.run(`
       CREATE TABLE text_sentence_records_next (
-        id INTEGER PRIMARY KEY,
-        archive_id INTEGER NOT NULL,
-        kind INTEGER NOT NULL,
-        chapter_id INTEGER NOT NULL,
-        sentence_index INTEGER NOT NULL,
-        words_count INTEGER NOT NULL DEFAULT 0,
-        byte_offset INTEGER NOT NULL DEFAULT 0,
-        byte_length INTEGER NOT NULL DEFAULT 0,
-        UNIQUE(archive_id, kind, chapter_id, sentence_index)
+${SEARCH_INDEX_TEXT_SENTENCE_RECORDS_COLUMNS_SQL}
       )
     `);
     await database.run(`

--- a/packages/core/src/document/schema.ts
+++ b/packages/core/src/document/schema.ts
@@ -299,17 +299,18 @@ export const SEARCH_INDEX_SCHEMA_SQL = `
 
   CREATE TABLE IF NOT EXISTS text_sentence_records (
     id INTEGER PRIMARY KEY,
+    archive_id INTEGER NOT NULL,
     kind INTEGER NOT NULL,
     chapter_id INTEGER NOT NULL,
     sentence_index INTEGER NOT NULL,
     words_count INTEGER NOT NULL DEFAULT 0,
     byte_offset INTEGER NOT NULL DEFAULT 0,
     byte_length INTEGER NOT NULL DEFAULT 0,
-    UNIQUE(kind, chapter_id, sentence_index)
+    UNIQUE(archive_id, kind, chapter_id, sentence_index)
   );
 
   CREATE INDEX IF NOT EXISTS idx_text_sentence_records_chapter
-  ON text_sentence_records(kind, chapter_id, sentence_index);
+  ON text_sentence_records(archive_id, kind, chapter_id, sentence_index);
 
   CREATE VIRTUAL TABLE IF NOT EXISTS text_sentence_fts USING fts5(
     tier1,
@@ -320,6 +321,7 @@ export const SEARCH_INDEX_SCHEMA_SQL = `
 
   CREATE TABLE IF NOT EXISTS search_object_properties_records (
     id INTEGER PRIMARY KEY,
+    archive_id INTEGER NOT NULL,
     owner_kind INTEGER NOT NULL,
     owner_id TEXT NOT NULL,
     property_kind INTEGER NOT NULL,
@@ -327,16 +329,23 @@ export const SEARCH_INDEX_SCHEMA_SQL = `
   );
 
   CREATE INDEX IF NOT EXISTS idx_search_object_properties_records_owner
-  ON search_object_properties_records(owner_kind, owner_id);
+  ON search_object_properties_records(archive_id, owner_kind, owner_id);
 
   CREATE INDEX IF NOT EXISTS idx_search_object_properties_records_chapter
-  ON search_object_properties_records(chapter_id, owner_kind, owner_id);
+  ON search_object_properties_records(archive_id, chapter_id, owner_kind, owner_id);
 
   CREATE VIRTUAL TABLE IF NOT EXISTS search_object_properties_fts USING fts5(
     tier1,
     tier2,
     tier3,
     tokenize='ascii'
+  );
+
+  CREATE TABLE IF NOT EXISTS index_dirty_chapters (
+    archive_id INTEGER NOT NULL,
+    chapter_id INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (archive_id, chapter_id)
   );
 `;
 

--- a/packages/core/src/document/schema.ts
+++ b/packages/core/src/document/schema.ts
@@ -291,6 +291,18 @@ export const SCHEMA_SQL = `
   );
 `;
 
+export const SEARCH_INDEX_TEXT_SENTENCE_RECORDS_COLUMNS_SQL = `
+  id INTEGER PRIMARY KEY,
+  archive_id INTEGER NOT NULL,
+  kind INTEGER NOT NULL,
+  chapter_id INTEGER NOT NULL,
+  sentence_index INTEGER NOT NULL,
+  words_count INTEGER NOT NULL DEFAULT 0,
+  byte_offset INTEGER NOT NULL DEFAULT 0,
+  byte_length INTEGER NOT NULL DEFAULT 0,
+  UNIQUE(archive_id, kind, chapter_id, sentence_index)
+`;
+
 export const SEARCH_INDEX_SCHEMA_SQL = `
   CREATE TABLE IF NOT EXISTS search_index_state (
     key TEXT PRIMARY KEY,
@@ -298,15 +310,7 @@ export const SEARCH_INDEX_SCHEMA_SQL = `
   );
 
   CREATE TABLE IF NOT EXISTS text_sentence_records (
-    id INTEGER PRIMARY KEY,
-    archive_id INTEGER NOT NULL,
-    kind INTEGER NOT NULL,
-    chapter_id INTEGER NOT NULL,
-    sentence_index INTEGER NOT NULL,
-    words_count INTEGER NOT NULL DEFAULT 0,
-    byte_offset INTEGER NOT NULL DEFAULT 0,
-    byte_length INTEGER NOT NULL DEFAULT 0,
-    UNIQUE(archive_id, kind, chapter_id, sentence_index)
+${SEARCH_INDEX_TEXT_SENTENCE_RECORDS_COLUMNS_SQL}
   );
 
   CREATE INDEX IF NOT EXISTS idx_text_sentence_records_chapter

--- a/packages/core/src/retrieval/query/archive-view/index-state.ts
+++ b/packages/core/src/retrieval/query/archive-view/index-state.ts
@@ -15,17 +15,40 @@ import {
 import { createTextStreamIndex } from "./text-streams.js";
 import type { ArchiveTextStreamKind } from "./types.js";
 
+const SEARCH_INDEX_REBUILD_ATTEMPTS = 2;
+
 export async function rebuildArchiveSearchIndex(
   document: Document,
   progress?: SearchIndexProgressReporter,
 ): Promise<void> {
-  const input = await buildArchiveIndexProjection(document, progress);
+  for (let attempt = 0; attempt < SEARCH_INDEX_REBUILD_ATTEMPTS; attempt += 1) {
+    const input = await buildArchiveIndexProjection(document, progress);
+    const fingerprint = createSearchIndexFingerprint(input);
 
-  if ((await readSearchIndexStatus(document, input)) === "dirty") {
+    if ((await readSearchIndexStatus(document, input)) === "dirty") {
+      const beforeDeleteInput = await buildArchiveIndexProjection(document);
+
+      if (createSearchIndexFingerprint(beforeDeleteInput) !== fingerprint) {
+        continue;
+      }
+
+      await document.deleteSearchIndexDatabase();
+    }
+
+    await writeArchiveIndexProjection(document, input, progress);
+
+    const verifiedInput = await buildArchiveIndexProjection(document);
+    if (
+      createSearchIndexFingerprint(verifiedInput) === fingerprint &&
+      (await readSearchIndexStatus(document, verifiedInput)) === "current"
+    ) {
+      return;
+    }
+
     await document.deleteSearchIndexDatabase();
   }
 
-  await writeArchiveIndexProjection(document, input, progress);
+  throw new Error("Archive changed while rebuilding search index; retry.");
 }
 
 export async function isArchiveSearchIndexCurrent(

--- a/packages/core/src/retrieval/query/archive-view/index-state.ts
+++ b/packages/core/src/retrieval/query/archive-view/index-state.ts
@@ -2,13 +2,14 @@ import type { Document, ReadonlyDocument } from "../../../document/index.js";
 import { listChapters } from "../../../document/chapter/index.js";
 import {
   createSearchIndexFingerprint,
-  ensureSearchIndex,
   readSearchIndexStatus,
   SEARCH_OBJECT_PROPERTY_KIND,
   SEARCH_OBJECT_PROPERTY_OWNER_KIND,
+  SINGLE_ARCHIVE_INDEX_ID,
   TEXT_SENTENCE_KIND,
   type SearchIndexInput,
   type SearchIndexProgressReporter,
+  writeArchiveIndexProjection,
 } from "../../search-index/search/index.js";
 
 import { createTextStreamIndex } from "./text-streams.js";
@@ -18,13 +19,13 @@ export async function rebuildArchiveSearchIndex(
   document: Document,
   progress?: SearchIndexProgressReporter,
 ): Promise<void> {
-  const input = await createSearchIndexRecords(document, progress);
+  const input = await buildArchiveIndexProjection(document, progress);
 
   if ((await readSearchIndexStatus(document, input)) === "dirty") {
     await document.deleteSearchIndexDatabase();
   }
 
-  await ensureSearchIndex(document, input, progress);
+  await writeArchiveIndexProjection(document, input, progress);
 }
 
 export async function isArchiveSearchIndexCurrent(
@@ -38,7 +39,7 @@ export async function readArchiveSearchIndexStatus(
 ): Promise<"current" | "dirty" | "missing"> {
   return await readSearchIndexStatus(
     document,
-    await createSearchIndexRecords(document),
+    await buildArchiveIndexProjection(document),
   );
 }
 
@@ -53,10 +54,12 @@ export async function clearDirtyArchiveSearchIndex(
 export async function createArchiveSearchIndexFingerprint(
   document: ReadonlyDocument,
 ): Promise<string> {
-  return createSearchIndexFingerprint(await createSearchIndexRecords(document));
+  return createSearchIndexFingerprint(
+    await buildArchiveIndexProjection(document),
+  );
 }
 
-async function createSearchIndexRecords(
+export async function buildArchiveIndexProjection(
   document: ReadonlyDocument,
   progress?: SearchIndexProgressReporter,
 ): Promise<SearchIndexInput> {
@@ -69,6 +72,7 @@ async function createSearchIndexRecords(
     const title = chapter.title ?? `[chapter ${chapter.chapterId}]`;
 
     objectProperties.push({
+      archiveId: SINGLE_ARCHIVE_INDEX_ID,
       chapterId: chapter.chapterId,
       ownerId: String(chapter.chapterId),
       ownerKind: SEARCH_OBJECT_PROPERTY_OWNER_KIND.chapter,
@@ -103,6 +107,7 @@ async function createSearchIndexRecords(
 
   for (const node of await document.chunks.listAll()) {
     objectProperties.push({
+      archiveId: SINGLE_ARCHIVE_INDEX_ID,
       chapterId: node.sentenceId[0],
       ownerId: String(node.id),
       ownerKind: SEARCH_OBJECT_PROPERTY_OWNER_KIND.chunk,
@@ -110,6 +115,7 @@ async function createSearchIndexRecords(
       text: node.label,
     });
     objectProperties.push({
+      archiveId: SINGLE_ARCHIVE_INDEX_ID,
       chapterId: node.sentenceId[0],
       ownerId: String(node.id),
       ownerKind: SEARCH_OBJECT_PROPERTY_OWNER_KIND.chunk,
@@ -120,6 +126,7 @@ async function createSearchIndexRecords(
 
   for (const mention of await document.mentions.listAll()) {
     objectProperties.push({
+      archiveId: SINGLE_ARCHIVE_INDEX_ID,
       chapterId: mention.chapterId,
       ownerId: mention.qid,
       ownerKind: SEARCH_OBJECT_PROPERTY_OWNER_KIND.entity,
@@ -140,6 +147,7 @@ async function createTextStreamSearchIndexRecords(
   const index = await createTextStreamIndex(document, chapterId, stream);
 
   return index.sentences.map((sentence) => ({
+    archiveId: SINGLE_ARCHIVE_INDEX_ID,
     chapterId,
     kind:
       stream === "source"

--- a/packages/core/src/retrieval/query/archive-view/search/bucket-order.ts
+++ b/packages/core/src/retrieval/query/archive-view/search/bucket-order.ts
@@ -66,6 +66,7 @@ export function isAfterTextKey(
   return (
     compareTextIndexHits(
       {
+        archiveId: 0,
         chapterId: key.chapterId,
         kind: key.kind as SearchIndexTextHit["kind"],
         rank: key.rank,

--- a/packages/core/src/retrieval/search-index/index.ts
+++ b/packages/core/src/retrieval/search-index/index.ts
@@ -2,6 +2,7 @@ export {
   createSearchIndexFingerprint,
   ensureSearchIndex,
   isSearchIndexCurrent,
+  markDirtySearchIndexChapters,
   querySearchIndex,
   readArchiveIndexSettings,
   readSearchIndexFingerprintFromDatabase,
@@ -9,6 +10,7 @@ export {
   SEARCH_INDEX_FTS_HIT_LIMIT,
   SEARCH_OBJECT_PROPERTY_KIND,
   SEARCH_OBJECT_PROPERTY_OWNER_KIND,
+  SINGLE_ARCHIVE_INDEX_ID,
   setFtsIndexEmbedded,
   TEXT_SENTENCE_KIND,
 } from "./search/index.js";

--- a/packages/core/src/retrieval/search-index/search/build.ts
+++ b/packages/core/src/retrieval/search-index/search/build.ts
@@ -12,6 +12,16 @@ import {
 import type { SearchIndexInput, SearchIndexProgressReporter } from "./types.js";
 import { SEARCH_INDEX_VERSION } from "./types.js";
 
+export type ArchiveIndexProjection = SearchIndexInput;
+
+export async function writeArchiveIndexProjection(
+  document: Document,
+  projection: ArchiveIndexProjection,
+  progress?: SearchIndexProgressReporter,
+): Promise<void> {
+  await ensureSearchIndex(document, projection, progress);
+}
+
 export async function ensureSearchIndex(
   document: Document,
   input: SearchIndexInput,
@@ -32,7 +42,9 @@ export async function ensureSearchIndex(
       await progress?.({ phase: "clearing" });
       await database.run("DELETE FROM text_sentence_fts");
       await database.run("DELETE FROM search_object_properties_fts");
+      await database.run("DELETE FROM text_sentence_records");
       await database.run("DELETE FROM search_object_properties_records");
+      await database.run("DELETE FROM index_dirty_chapters");
       await database.run("DELETE FROM search_index_state");
 
       let textDone = 0;

--- a/packages/core/src/retrieval/search-index/search/core.ts
+++ b/packages/core/src/retrieval/search-index/search/core.ts
@@ -1,4 +1,5 @@
 export * from "./build.js";
+export * from "./dirty.js";
 export * from "./fingerprint.js";
 export * from "./query.js";
 export * from "./settings.js";

--- a/packages/core/src/retrieval/search-index/search/dirty.ts
+++ b/packages/core/src/retrieval/search-index/search/dirty.ts
@@ -1,0 +1,32 @@
+import type { Document } from "../../../document/index.js";
+import { SINGLE_ARCHIVE_INDEX_ID } from "./types.js";
+
+export async function markDirtySearchIndexChapters(
+  document: Document,
+  chapterIds: readonly number[],
+  options: { readonly archiveId?: number; readonly updatedAt?: number } = {},
+): Promise<void> {
+  if (chapterIds.length === 0) {
+    return;
+  }
+
+  const archiveId = options.archiveId ?? SINGLE_ARCHIVE_INDEX_ID;
+  const updatedAt = options.updatedAt ?? Date.now();
+  const uniqueChapterIds = [...new Set(chapterIds)];
+
+  await document.writeSearchIndexDatabase(async (database) => {
+    await database.transaction(async () => {
+      for (const chapterId of uniqueChapterIds) {
+        await database.run(
+          `
+            INSERT INTO index_dirty_chapters(archive_id, chapter_id, updated_at)
+            VALUES (?, ?, ?)
+            ON CONFLICT(archive_id, chapter_id) DO UPDATE SET
+              updated_at = excluded.updated_at
+          `,
+          [archiveId, chapterId, updatedAt],
+        );
+      }
+    });
+  });
+}

--- a/packages/core/src/retrieval/search-index/search/fingerprint.ts
+++ b/packages/core/src/retrieval/search-index/search/fingerprint.ts
@@ -8,6 +8,8 @@ export function createSearchIndexFingerprint(input: SearchIndexInput): string {
   for (const record of input.textSentences) {
     hash.update("text");
     hash.update("\0");
+    hash.update(String(record.archiveId));
+    hash.update("\0");
     hash.update(String(record.kind));
     hash.update("\0");
     hash.update(String(record.chapterId));
@@ -20,6 +22,8 @@ export function createSearchIndexFingerprint(input: SearchIndexInput): string {
 
   for (const record of input.objectProperties) {
     hash.update("object-property");
+    hash.update("\0");
+    hash.update(String(record.archiveId));
     hash.update("\0");
     hash.update(String(record.ownerKind));
     hash.update("\0");

--- a/packages/core/src/retrieval/search-index/search/helpers.ts
+++ b/packages/core/src/retrieval/search-index/search/helpers.ts
@@ -80,6 +80,7 @@ export function rankToScore(rank: number): number {
 
 export function createObjectHitKey(hit: SearchIndexObjectHit): string {
   return [
+    hit.archiveId,
     hit.ownerKind,
     hit.ownerId,
     hit.propertyKind,
@@ -88,5 +89,5 @@ export function createObjectHitKey(hit: SearchIndexObjectHit): string {
 }
 
 export function createTextHitKey(hit: SearchIndexTextHit): string {
-  return [hit.kind, hit.chapterId, hit.sentenceIndex].join(":");
+  return [hit.archiveId, hit.kind, hit.chapterId, hit.sentenceIndex].join(":");
 }

--- a/packages/core/src/retrieval/search-index/search/query.ts
+++ b/packages/core/src/retrieval/search-index/search/query.ts
@@ -30,6 +30,7 @@ import type {
   TextSentenceKind,
 } from "./types.js";
 import { SEARCH_INDEX_FTS_HIT_LIMIT, TIER_WEIGHTS } from "./types.js";
+import { assertSearchIndexNotDirty } from "./status.js";
 
 export async function querySearchIndex(
   document: ReadonlyDocument,
@@ -57,6 +58,7 @@ export async function querySearchIndex(
   const terms = listSearchPlanTerms(plan);
 
   return await document.readSearchIndexDatabase(async (database) => {
+    await assertSearchIndexNotDirty(database);
     const tierQueries = createTierQueries(query, plan, options.match ?? "any");
     const objectHitLimit = options.objectHitLimit ?? SEARCH_INDEX_FTS_HIT_LIMIT;
     const textHitLimit = options.textHitLimit ?? SEARCH_INDEX_FTS_HIT_LIMIT;
@@ -143,6 +145,7 @@ async function queryObjectRows(
         r.owner_kind AS owner_kind,
         r.owner_id AS owner_id,
         r.property_kind AS property_kind,
+        r.archive_id AS archive_id,
         r.chapter_id AS chapter_id,
         bm25(search_object_properties_fts, ?, ?, ?) AS rank
       FROM search_object_properties_fts
@@ -161,6 +164,7 @@ async function queryObjectRows(
     ],
     (row) => ({
       ownerId: String(row.owner_id),
+      archiveId: getNumber(row, "archive_id"),
       ownerKind: getNumber(row, "owner_kind") as SearchObjectPropertyOwnerKind,
       propertyKind: getNumber(row, "property_kind") as SearchObjectPropertyKind,
       score: rankToScore(getNumber(row, "rank")),
@@ -201,6 +205,7 @@ async function queryTextRows(
     `
       SELECT
         kind,
+        archive_id,
         chapter_id,
         sentence_index,
         words_count,
@@ -208,6 +213,7 @@ async function queryTextRows(
       FROM (
         SELECT
           r.kind AS kind,
+          r.archive_id AS archive_id,
           r.chapter_id AS chapter_id,
           r.sentence_index AS sentence_index,
           r.words_count AS words_count,
@@ -265,6 +271,7 @@ async function queryTextRows(
 
       return {
         chapterId: getNumber(row, "chapter_id"),
+        archiveId: getNumber(row, "archive_id"),
         kind: getNumber(row, "kind") as TextSentenceKind,
         rank,
         score: rankToScore(rank),

--- a/packages/core/src/retrieval/search-index/search/status.ts
+++ b/packages/core/src/retrieval/search-index/search/status.ts
@@ -50,27 +50,34 @@ export async function readSearchIndexStatus(
 export async function hasDirtySearchIndexChapters(
   database: Database,
 ): Promise<boolean> {
-  const count = await database
-    .queryOne(
-      `
-        SELECT COUNT(*) AS count
-        FROM index_dirty_chapters
-      `,
-      undefined,
-      (row) => getNumber(row, "count"),
-    )
-    .catch((error: unknown) => {
-      if (
-        error instanceof Error &&
-        error.message.includes("no such table: index_dirty_chapters")
-      ) {
-        return undefined;
-      }
+  if (!(await hasTable(database, "index_dirty_chapters"))) {
+    return false;
+  }
 
-      throw error;
-    });
+  const count = await database.queryOne(
+    `
+      SELECT COUNT(*) AS count
+      FROM index_dirty_chapters
+    `,
+    undefined,
+    (row) => getNumber(row, "count"),
+  );
 
   return (count ?? 0) > 0;
+}
+
+async function hasTable(database: Database, table: string): Promise<boolean> {
+  const row = await database.queryOne(
+    `
+      SELECT 1 AS found
+      FROM sqlite_master
+      WHERE type = 'table' AND name = ?
+    `,
+    [table],
+    (value) => getNumber(value, "found"),
+  );
+
+  return row === 1;
 }
 
 export async function assertSearchIndexNotDirty(

--- a/packages/core/src/retrieval/search-index/search/status.ts
+++ b/packages/core/src/retrieval/search-index/search/status.ts
@@ -1,3 +1,4 @@
+import { getNumber, type Database } from "../../../document/database.js";
 import type { ReadonlyDocument } from "../../../document/index.js";
 import { isMissingSearchIndexError } from "./errors.js";
 import {
@@ -22,6 +23,10 @@ export async function readSearchIndexStatus(
 
   try {
     return await document.readSearchIndexDatabase(async (database) => {
+      if (await hasDirtySearchIndexChapters(database)) {
+        return "dirty";
+      }
+
       const indexedFingerprint =
         await readSearchIndexFingerprintFromDatabase(database);
 
@@ -39,5 +44,41 @@ export async function readSearchIndexStatus(
     }
 
     throw error;
+  }
+}
+
+export async function hasDirtySearchIndexChapters(
+  database: Database,
+): Promise<boolean> {
+  const count = await database
+    .queryOne(
+      `
+        SELECT COUNT(*) AS count
+        FROM index_dirty_chapters
+      `,
+      undefined,
+      (row) => getNumber(row, "count"),
+    )
+    .catch((error: unknown) => {
+      if (
+        error instanceof Error &&
+        error.message.includes("no such table: index_dirty_chapters")
+      ) {
+        return undefined;
+      }
+
+      throw error;
+    });
+
+  return (count ?? 0) > 0;
+}
+
+export async function assertSearchIndexNotDirty(
+  database: Database,
+): Promise<void> {
+  if (await hasDirtySearchIndexChapters(database)) {
+    throw new Error(
+      "Archive search index is dirty; rebuild the index before querying.",
+    );
   }
 }

--- a/packages/core/src/retrieval/search-index/search/status.ts
+++ b/packages/core/src/retrieval/search-index/search/status.ts
@@ -54,16 +54,17 @@ export async function hasDirtySearchIndexChapters(
     return false;
   }
 
-  const count = await database.queryOne(
+  const dirty = await database.queryOne(
     `
-      SELECT COUNT(*) AS count
+      SELECT 1 AS found
       FROM index_dirty_chapters
+      LIMIT 1
     `,
     undefined,
-    (row) => getNumber(row, "count"),
+    (row) => getNumber(row, "found"),
   );
 
-  return (count ?? 0) > 0;
+  return dirty === 1;
 }
 
 async function hasTable(database: Database, table: string): Promise<boolean> {

--- a/packages/core/src/retrieval/search-index/search/types.ts
+++ b/packages/core/src/retrieval/search-index/search/types.ts
@@ -3,6 +3,8 @@ export const TEXT_SENTENCE_KIND = {
   summary: 2,
 } as const;
 
+export const SINGLE_ARCHIVE_INDEX_ID = 0;
+
 export type TextSentenceKind =
   (typeof TEXT_SENTENCE_KIND)[keyof typeof TEXT_SENTENCE_KIND];
 
@@ -26,6 +28,7 @@ export type SearchObjectPropertyKind =
   (typeof SEARCH_OBJECT_PROPERTY_KIND)[keyof typeof SEARCH_OBJECT_PROPERTY_KIND];
 
 export interface TextSentenceRecordInput {
+  readonly archiveId: number;
   readonly chapterId: number;
   readonly kind: TextSentenceKind;
   readonly sentenceIndex: number;
@@ -34,6 +37,7 @@ export interface TextSentenceRecordInput {
 }
 
 export interface SearchObjectPropertyRecordInput {
+  readonly archiveId: number;
   readonly chapterId?: number;
   readonly ownerId: string;
   readonly ownerKind: SearchObjectPropertyOwnerKind;
@@ -68,6 +72,7 @@ export type SearchIndexProgressReporter = (
 export type SearchIndexStatus = "current" | "dirty" | "missing";
 
 export interface SearchIndexTextHit {
+  readonly archiveId: number;
   readonly chapterId: number;
   readonly kind: TextSentenceKind;
   readonly rank: number;
@@ -77,6 +82,7 @@ export interface SearchIndexTextHit {
 }
 
 export interface SearchIndexObjectHit {
+  readonly archiveId: number;
   readonly chapterId?: number;
   readonly ownerId: string;
   readonly ownerKind: SearchObjectPropertyOwnerKind;
@@ -90,7 +96,7 @@ export interface SearchIndexQueryResult {
   readonly textHits: readonly SearchIndexTextHit[];
 }
 
-export const SEARCH_INDEX_VERSION = "3";
+export const SEARCH_INDEX_VERSION = "4";
 export const SEARCH_INDEX_FTS_HIT_LIMIT = 32_000;
 export const FTS5_RANK_SCORE_SCALE = 1_000_000;
 export const TIER_WEIGHTS = [1, 0.45, 0.08] as const;

--- a/packages/core/src/retrieval/search-index/search/write.ts
+++ b/packages/core/src/retrieval/search-index/search/write.ts
@@ -14,9 +14,9 @@ export async function insertTextSentenceRecord(
     `
       SELECT id
       FROM text_sentence_records
-      WHERE kind = ? AND chapter_id = ? AND sentence_index = ?
+      WHERE archive_id = ? AND kind = ? AND chapter_id = ? AND sentence_index = ?
     `,
-    [record.kind, record.chapterId, record.sentenceIndex],
+    [record.archiveId, record.kind, record.chapterId, record.sentenceIndex],
     (row) => getNumber(row, "id"),
   );
 
@@ -27,11 +27,17 @@ export async function insertTextSentenceRecord(
   await database.run(
     `
       INSERT INTO text_sentence_records (
-        kind, chapter_id, sentence_index, words_count, byte_offset, byte_length
+        archive_id, kind, chapter_id, sentence_index, words_count, byte_offset, byte_length
       )
-      VALUES (?, ?, ?, ?, 0, 0)
+      VALUES (?, ?, ?, ?, ?, 0, 0)
     `,
-    [record.kind, record.chapterId, record.sentenceIndex, record.wordsCount],
+    [
+      record.archiveId,
+      record.kind,
+      record.chapterId,
+      record.sentenceIndex,
+      record.wordsCount,
+    ],
   );
 
   return await database.getLastInsertRowId();
@@ -44,11 +50,12 @@ export async function insertSearchObjectPropertyRecord(
   await database.run(
     `
       INSERT INTO search_object_properties_records (
-        owner_kind, owner_id, property_kind, chapter_id
+        archive_id, owner_kind, owner_id, property_kind, chapter_id
       )
-      VALUES (?, ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?)
     `,
     [
+      record.archiveId,
       record.ownerKind,
       record.ownerId,
       record.propertyKind,

--- a/test/core/retrieval/query/archive-view/helpers.ts
+++ b/test/core/retrieval/query/archive-view/helpers.ts
@@ -21,6 +21,7 @@ import {
 } from "../../../../../packages/core/src/retrieval/query/view.js";
 import {
   isSearchIndexCurrent,
+  markDirtySearchIndexChapters,
   querySearchIndex,
   readArchiveIndexSettings,
   SEARCH_INDEX_FTS_HIT_LIMIT,
@@ -56,6 +57,7 @@ export {
   listArchiveEvidence,
   listArchiveObjects,
   listRelatedArchiveObjects,
+  markDirtySearchIndexChapters,
   packArchiveContext,
   querySearchIndex,
   readArchiveIndexSettings,

--- a/test/core/retrieval/query/archive-view/index.test.ts
+++ b/test/core/retrieval/query/archive-view/index.test.ts
@@ -1,5 +1,9 @@
+import { mkdir } from "fs/promises";
+import { join } from "path";
+
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  Database,
   DirectoryDocument,
   countSearchIndexRows,
   findArchiveObjects,
@@ -117,6 +121,97 @@ describe("archive/query/archive-view/index", () => {
 
         await expect(isSearchIndexCurrent(document)).resolves.toBe(true);
         await expect(countSearchIndexRows(document)).resolves.toBe(0);
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("migrates legacy search index uniqueness to include archive_id", async () => {
+    await withTempDir("wikigraph-archive-view-", async (path) => {
+      const documentPath = `${path}/document`;
+      await mkdir(documentPath, { recursive: true });
+      const legacyDatabase = await Database.open(
+        join(documentPath, "fts.db"),
+        `
+          CREATE TABLE text_sentence_records (
+            id INTEGER PRIMARY KEY,
+            kind INTEGER NOT NULL,
+            chapter_id INTEGER NOT NULL,
+            sentence_index INTEGER NOT NULL,
+            words_count INTEGER NOT NULL DEFAULT 0,
+            byte_offset INTEGER NOT NULL DEFAULT 0,
+            byte_length INTEGER NOT NULL DEFAULT 0,
+            UNIQUE(kind, chapter_id, sentence_index)
+          );
+          CREATE TABLE search_object_properties_records (
+            id INTEGER PRIMARY KEY,
+            owner_kind INTEGER NOT NULL,
+            owner_id TEXT NOT NULL,
+            property_kind INTEGER NOT NULL,
+            chapter_id INTEGER
+          );
+        `,
+      );
+
+      try {
+        await legacyDatabase.run(`
+          INSERT INTO text_sentence_records (
+            kind, chapter_id, sentence_index, words_count
+          )
+          VALUES (1, 1, 0, 3)
+        `);
+      } finally {
+        await legacyDatabase.close();
+      }
+
+      const document = await DirectoryDocument.open(documentPath);
+
+      try {
+        await document.writeSearchIndexDatabase(async (database) => {
+          await database.run(
+            `
+              INSERT INTO text_sentence_records (
+                archive_id, kind, chapter_id, sentence_index, words_count
+              )
+              VALUES (?, ?, ?, ?, ?)
+            `,
+            [1, 1, 1, 0, 4],
+          );
+
+          const rows = await database.queryAll(
+            `
+              SELECT archive_id, kind, chapter_id, sentence_index, words_count
+              FROM text_sentence_records
+              ORDER BY archive_id
+            `,
+            undefined,
+            (row) => ({
+              archiveId: Number(row.archive_id),
+              chapterId: Number(row.chapter_id),
+              kind: Number(row.kind),
+              sentenceIndex: Number(row.sentence_index),
+              wordsCount: Number(row.words_count),
+            }),
+          );
+
+          expect(rows).toStrictEqual([
+            {
+              archiveId: 0,
+              chapterId: 1,
+              kind: 1,
+              sentenceIndex: 0,
+              wordsCount: 3,
+            },
+            {
+              archiveId: 1,
+              chapterId: 1,
+              kind: 1,
+              sentenceIndex: 0,
+              wordsCount: 4,
+            },
+          ]);
+        });
       } finally {
         await document.release();
       }

--- a/test/core/retrieval/query/archive-view/index.test.ts
+++ b/test/core/retrieval/query/archive-view/index.test.ts
@@ -7,8 +7,11 @@ import {
   isSearchIndexCurrent,
   listArchiveEvidence,
   listRelatedArchiveObjects,
+  markDirtySearchIndexChapters,
+  querySearchIndex,
   readArchiveIndexSettings,
   rebuildArchiveSearchIndex,
+  seedSourcedDocument,
   setupArchiveViewTestState,
   teardownArchiveViewTestState,
   withTempDir,
@@ -18,6 +21,86 @@ beforeEach(setupArchiveViewTestState);
 afterEach(teardownArchiveViewTestState);
 
 describe("archive/query/archive-view/index", () => {
+  it("projects single-archive search rows with archive_id 0", async () => {
+    await withTempDir("wikigraph-archive-view-", async (path) => {
+      const document = await DirectoryDocument.open(`${path}/document`);
+
+      try {
+        await seedSourcedDocument(document);
+
+        await expect(
+          document.readSearchIndexDatabase(async (database) => {
+            const textArchiveIds = await database.queryAll(
+              `
+                SELECT DISTINCT archive_id
+                FROM text_sentence_records
+                ORDER BY archive_id
+              `,
+              undefined,
+              (row) => Number(row.archive_id),
+            );
+            const objectArchiveIds = await database.queryAll(
+              `
+                SELECT DISTINCT archive_id
+                FROM search_object_properties_records
+                ORDER BY archive_id
+              `,
+              undefined,
+              (row) => Number(row.archive_id),
+            );
+
+            return { objectArchiveIds, textArchiveIds };
+          }),
+        ).resolves.toStrictEqual({
+          objectArchiveIds: [0],
+          textArchiveIds: [0],
+        });
+
+        const result = await querySearchIndex(document, "Wiki");
+
+        expect(result?.textHits[0]).toMatchObject({ archiveId: 0 });
+        expect(result?.objectHits[0]).toMatchObject({ archiveId: 0 });
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("treats dirty chapter projection rows as an index-backed read blocker", async () => {
+    await withTempDir("wikigraph-archive-view-", async (path) => {
+      const document = await DirectoryDocument.open(`${path}/document`);
+
+      try {
+        await seedSourcedDocument(document);
+        await expect(isArchiveSearchIndexCurrent(document)).resolves.toBe(true);
+
+        await markDirtySearchIndexChapters(document, [1]);
+
+        await expect(isArchiveSearchIndexCurrent(document)).resolves.toBe(
+          false,
+        );
+        await expect(findArchiveObjects(document, "Wiki")).rejects.toThrow(
+          "Wiki Graph search index is missing or outdated. Run `<archive-uri>/index enable` before searching.",
+        );
+        await expect(querySearchIndex(document, "Wiki")).rejects.toThrow(
+          "Archive search index is dirty; rebuild the index before querying.",
+        );
+        await expect(document.readSummary(1)).resolves.toContain("Summary");
+
+        await rebuildArchiveSearchIndex(document);
+
+        await expect(isArchiveSearchIndexCurrent(document)).resolves.toBe(true);
+        await expect(
+          findArchiveObjects(document, "Wiki"),
+        ).resolves.toMatchObject({
+          query: "Wiki",
+        });
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
   it("distinguishes a missing index from a current empty index", async () => {
     await withTempDir("wikigraph-archive-view-", async (path) => {
       const document = await DirectoryDocument.open(`${path}/document`);


### PR DESCRIPTION
Closes #122

## Summary
- Scope search index projection rows and query hits with `archive_id`, using `0` as the single-archive sentinel.
- Add an explicit `index_dirty_chapters` read blocker and a helper to mark chapter-level projection dirtiness without writing canonical archive IDs into `data.db`.
- Introduce projection builder/writer naming around archive index rebuilds while keeping hydration and external CLI/SDK behavior unchanged.
- Add migration guards for existing external FTS/search-index SQLite caches.

## Tests
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm vitest run test/core/retrieval/query/archive-view/index.test.ts test/core/retrieval/query/archive-view/text-search.test.ts --passWithNoTests`
- `pnpm run test:run`
- `pnpm run build`

## Known risks
- This PR prepares the current FTS/search-index projection layer for archive scoping and dirty-set blocking; it does not implement user-facing library features.
- Existing public archive-view errors still collapse dirty/missing/outdated index state to the current user-facing rebuild message, while the lower-level index-backed read path rejects dirty projection rows explicitly.
