### PR TITLE
feat: add minimal library registry and URI management

### DIFF
--- a/packages/cli/src/app/main.ts
+++ b/packages/cli/src/app/main.ts
@@ -9,6 +9,7 @@ import {
   runConvertCommand,
   runGcCommand,
   runLegacyCommand,
+  runLibraryCommand,
   runLocalConfigCommand,
   runObjectMetadataCommand,
   runQueueCommand,
@@ -47,6 +48,9 @@ export async function main(): Promise<void> {
         return;
       case "object-metadata":
         await runObjectMetadataCommand(parsed.args);
+        return;
+      case "library":
+        await runLibraryCommand(parsed.args);
         return;
       case "chapter":
         await runArchiveChapterCommand(parsed.args);

--- a/packages/cli/src/args/helper/parse.ts
+++ b/packages/cli/src/args/helper/parse.ts
@@ -141,6 +141,7 @@ export function normalizeArchiveInlineOptions(
       case "--llm":
       case "--output":
       case "--output-format":
+      case "--path":
       case "--prompt":
       case "--stage":
       case "--to": {

--- a/packages/cli/src/args/parse.ts
+++ b/packages/cli/src/args/parse.ts
@@ -1,4 +1,5 @@
 import { parseArgs } from "util";
+import { isWikiGraphLibraryUri } from "wiki-graph-core";
 
 import { renderMainHelpText } from "./help.js";
 import { CLI_HELP_ROUTES, withHelpRoute } from "../support/index.js";
@@ -28,6 +29,7 @@ import {
   parseTransformArguments,
 } from "./root/index.js";
 import { parseArchiveUriFirstArguments } from "./uri/index.js";
+import { parseLibraryUriFirstArguments } from "./uri/library.js";
 export function parseCLIArguments(
   argv = process.argv.slice(2),
 ): ParsedCLIArguments {
@@ -140,6 +142,9 @@ export function parseCLIArguments(
         type: "string",
       },
       output: {
+        type: "string",
+      },
+      path: {
         type: "string",
       },
       "output-format": {
@@ -307,6 +312,10 @@ export function parseCLIArguments(
       "wg wikg://local/config --help",
     );
     return parseLocalConfigUriFirstArguments(positionals, values);
+  }
+
+  if (isWikiGraphLibraryUri(positionals[0])) {
+    return parseLibraryUriFirstArguments(positionals, values);
   }
 
   if (isWikiGraphUri(positionals[0])) {

--- a/packages/cli/src/args/types.ts
+++ b/packages/cli/src/args/types.ts
@@ -4,6 +4,7 @@ import type {
   ArchiveTriplePattern,
   BuildJobTarget,
   ChapterStage,
+  ParsedWikiGraphLibraryUri,
 } from "wiki-graph-core";
 
 export interface CLIArguments {
@@ -99,6 +100,27 @@ export interface CLIObjectMetadataArguments {
   readonly key?: string;
   readonly llmJSON?: string;
   readonly objectPath: string;
+}
+
+export type CLILibraryAction =
+  | "clear"
+  | "create"
+  | "delete"
+  | "get"
+  | "list"
+  | "put"
+  | "remove"
+  | "set";
+
+export interface CLILibraryArguments {
+  readonly action: CLILibraryAction;
+  readonly inputPath?: string | undefined;
+  readonly inputValue?: string | undefined;
+  readonly json?: boolean | undefined;
+  readonly jsonInputValue?: string | undefined;
+  readonly key?: string | undefined;
+  readonly path?: string | undefined;
+  readonly target: ParsedWikiGraphLibraryUri;
 }
 
 export type CLILocalConfigAction =
@@ -302,6 +324,7 @@ export interface ArchiveArgumentValues extends ArchiveMetaFlagValues {
   readonly output?: string;
   readonly "output-format"?: string;
   readonly parent?: string;
+  readonly path?: string;
   readonly predicate?: string;
   readonly prompt?: string;
   readonly query?: string;
@@ -363,6 +386,11 @@ export type ParsedCLIArguments =
       readonly args: CLIObjectMetadataArguments;
       readonly help: false;
       readonly kind: "object-metadata";
+    }
+  | {
+      readonly args: CLILibraryArguments;
+      readonly help: false;
+      readonly kind: "library";
     }
   | {
       readonly args: CLIArchiveArguments;

--- a/packages/cli/src/args/uri/library.ts
+++ b/packages/cli/src/args/uri/library.ts
@@ -1,0 +1,304 @@
+import {
+  parseWikiGraphLibraryUri,
+  type ParsedWikiGraphLibraryUri,
+} from "wiki-graph-core";
+
+import { withHelpRoute } from "../../support/index.js";
+import type {
+  ArchiveArgumentValues,
+  CLILibraryAction,
+  ParsedCLIArguments,
+} from "../types.js";
+import {
+  formatWikiGraphHelpCommand,
+  rejectArchiveBooleanFlag,
+  rejectArchiveFlag,
+} from "../helpers.js";
+
+const LIBRARY_METADATA_ACTIONS = new Set([
+  "clear",
+  "delete",
+  "get",
+  "put",
+  "set",
+]);
+const LIBRARY_SCOPE_ACTIONS = new Set(["create", "get", "list", "remove"]);
+
+export function parseLibraryUriFirstArguments(
+  positionals: readonly string[],
+  values: ArchiveArgumentValues,
+): ParsedCLIArguments {
+  const uri = positionals[0];
+  const explicitAction = positionals[1];
+
+  if (uri === undefined) {
+    throw new Error("Internal error: missing library URI.");
+  }
+
+  const target = parseWikiGraphLibraryUri(uri);
+  if (target === undefined) {
+    throw new Error(`Expected a Wiki Graph library URI: ${uri}`);
+  }
+
+  if (values.help === true) {
+    return {
+      help: true,
+      helpText: renderLibraryHelpText(uri, target),
+      kind: "help",
+    };
+  }
+
+  const action =
+    explicitAction ?? (target.kind === "metadata" ? "get" : "list");
+  if (!isLibraryAction(action)) {
+    throw new Error(
+      withHelpRoute(
+        `The library URI target ${uri} does not support \`${action}\`.`,
+        formatWikiGraphHelpCommand(uri),
+      ),
+    );
+  }
+
+  if (target.kind === "metadata") {
+    return parseLibraryMetadataArguments(
+      uri,
+      target,
+      action,
+      explicitAction === undefined ? [] : positionals.slice(2),
+      values,
+    );
+  }
+
+  return parseLibraryScopeArguments(
+    uri,
+    target,
+    action,
+    explicitAction === undefined ? [] : positionals.slice(2),
+    values,
+  );
+}
+
+function parseLibraryScopeArguments(
+  uri: string,
+  target: ParsedWikiGraphLibraryUri,
+  action: CLILibraryAction,
+  tail: readonly string[],
+  values: ArchiveArgumentValues,
+): ParsedCLIArguments {
+  const helpRoute = formatWikiGraphHelpCommand(uri, action);
+  if (!LIBRARY_SCOPE_ACTIONS.has(action)) {
+    throw new Error(
+      withHelpRoute(
+        `The library scope ${uri} does not support \`${action}\`.`,
+        helpRoute,
+      ),
+    );
+  }
+  rejectCommonLibraryFlags(action, values, helpRoute);
+  rejectArchiveBooleanFlag(action, "--jsonl", values.jsonl, helpRoute);
+  rejectArchiveFlag(action, "--input", values.input, helpRoute);
+  rejectArchiveFlag(action, "--json-input", values["json-input"], helpRoute);
+
+  switch (action) {
+    case "create":
+      if (!target.isDefault) {
+        throw new Error(
+          withHelpRoute("Create libraries from wikg://lib.", helpRoute),
+        );
+      }
+      rejectExtraPositionals(action, tail, 0, helpRoute);
+      if (values.path === undefined) {
+        throw new Error(withHelpRoute("Missing --path <folder>.", helpRoute));
+      }
+      return {
+        args: { action, json: values.json, path: values.path, target },
+        help: false,
+        kind: "library",
+      };
+    case "remove":
+      rejectExtraPositionals(action, tail, 0, helpRoute);
+      rejectArchiveFlag(action, "--path", values.path, helpRoute);
+      return {
+        args: { action, json: values.json, target },
+        help: false,
+        kind: "library",
+      };
+    case "get":
+    case "list":
+      rejectExtraPositionals(action, tail, 0, helpRoute);
+      rejectArchiveFlag(action, "--path", values.path, helpRoute);
+      return {
+        args: { action, json: values.json, target },
+        help: false,
+        kind: "library",
+      };
+    case "set":
+    case "put":
+    case "delete":
+    case "clear":
+      throw new Error(
+        "Internal error: metadata action routed to library scope.",
+      );
+  }
+}
+
+function parseLibraryMetadataArguments(
+  uri: string,
+  target: ParsedWikiGraphLibraryUri,
+  action: CLILibraryAction,
+  tail: readonly string[],
+  values: ArchiveArgumentValues,
+): ParsedCLIArguments {
+  const helpRoute = formatWikiGraphHelpCommand(uri, action);
+  if (!LIBRARY_METADATA_ACTIONS.has(action)) {
+    throw new Error(
+      withHelpRoute(
+        `The library metadata object ${uri} does not support \`${action}\`.`,
+        helpRoute,
+      ),
+    );
+  }
+  rejectCommonLibraryFlags(action, values, helpRoute);
+  rejectArchiveFlag(action, "--path", values.path, helpRoute);
+  rejectArchiveBooleanFlag(action, "--jsonl", values.jsonl, helpRoute);
+
+  switch (action) {
+    case "get":
+    case "clear":
+      rejectExtraPositionals(action, tail, 0, helpRoute);
+      return {
+        args: { action, json: values.json, target },
+        help: false,
+        kind: "library",
+      };
+    case "set":
+      rejectExtraPositionals(action, tail, 1, helpRoute);
+      return {
+        args: {
+          action,
+          inputPath: values.input,
+          inputValue: tail[0],
+          json: values.json,
+          jsonInputValue: values["json-input"],
+          target,
+        },
+        help: false,
+        kind: "library",
+      };
+    case "put":
+      rejectExtraPositionals(action, tail, 2, helpRoute);
+      return {
+        args: {
+          action,
+          inputPath: values.input,
+          inputValue: tail[1],
+          json: values.json,
+          jsonInputValue: values["json-input"],
+          key: tail[0],
+          target,
+        },
+        help: false,
+        kind: "library",
+      };
+    case "delete":
+      rejectExtraPositionals(action, tail, 1, helpRoute);
+      return {
+        args: { action, json: values.json, key: tail[0], target },
+        help: false,
+        kind: "library",
+      };
+    case "create":
+    case "list":
+    case "remove":
+      throw new Error(
+        "Internal error: scope action routed to library metadata.",
+      );
+  }
+}
+
+function rejectCommonLibraryFlags(
+  action: string,
+  values: ArchiveArgumentValues,
+  helpRoute: string,
+): void {
+  rejectArchiveFlag(action, "--query", values.query, helpRoute);
+  rejectArchiveFlag(action, "--limit", values.limit, helpRoute);
+  rejectArchiveFlag(action, "--cursor", values.cursor, helpRoute);
+  rejectArchiveFlag(action, "--context", values.context, helpRoute);
+  rejectArchiveFlag(action, "--evidence", values.evidence, helpRoute);
+  rejectArchiveFlag(action, "--llm", values.llm, helpRoute);
+  rejectArchiveFlag(action, "--output", values.output, helpRoute);
+  rejectArchiveFlag(
+    action,
+    "--output-format",
+    values["output-format"],
+    helpRoute,
+  );
+  rejectArchiveBooleanFlag(action, "--all", values.all, helpRoute);
+  rejectArchiveBooleanFlag(action, "--backlinks", values.backlinks, helpRoute);
+  rejectArchiveBooleanFlag(action, "--reverse", values.reverse, helpRoute);
+  rejectArchiveBooleanFlag(action, "--confirm", values.confirm, helpRoute);
+}
+
+function rejectExtraPositionals(
+  action: string,
+  positionals: readonly string[],
+  expected: number,
+  helpRoute: string,
+): void {
+  if (positionals.length > expected) {
+    throw new Error(
+      withHelpRoute(
+        `The \`${action}\` command received too many positional arguments.`,
+        helpRoute,
+      ),
+    );
+  }
+}
+
+function isLibraryAction(action: string): action is CLILibraryAction {
+  return (
+    action === "clear" ||
+    action === "create" ||
+    action === "delete" ||
+    action === "get" ||
+    action === "list" ||
+    action === "put" ||
+    action === "remove" ||
+    action === "set"
+  );
+}
+
+function renderLibraryHelpText(
+  uri: string,
+  target: ParsedWikiGraphLibraryUri,
+): string {
+  if (target.kind === "metadata") {
+    return [
+      "Help Type: command",
+      `Command: wg ${uri}`,
+      "",
+      "Library metadata object",
+      "",
+      "Usage:",
+      `  wg ${uri}`,
+      `  wg ${uri} set <json> [--json]`,
+      `  wg ${uri} put <key> <value> [--json]`,
+      `  wg ${uri} delete <key> [--json]`,
+      `  wg ${uri} clear [--json]`,
+    ].join("\n");
+  }
+  return [
+    "Help Type: command",
+    `Command: wg ${uri}`,
+    "",
+    "Library scope",
+    "",
+    "Usage:",
+    ...(target.isDefault
+      ? ["  wg wikg://lib create --path <folder> [--json]"]
+      : []),
+    `  wg ${uri}`,
+    ...(target.isDefault ? [] : [`  wg ${uri} remove [--json]`]),
+  ].join("\n");
+}

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -5,6 +5,7 @@ import type {
   CLIArchiveCoverArguments,
   CLIArchiveIndexArguments,
   CLIArchiveMetadataArguments,
+  CLILibraryArguments,
   CLIGcArguments,
   CLILegacyArguments,
   CLILocalConfigArguments,
@@ -78,6 +79,14 @@ export async function runLocalConfigCommand(
   const command = await import("./local-config.js");
 
   return command.runLocalConfigCommand(args);
+}
+
+export async function runLibraryCommand(
+  args: CLILibraryArguments,
+): Promise<void> {
+  const command = await import("./library.js");
+
+  return command.runLibraryCommand(args);
 }
 
 export async function runObjectMetadataCommand(

--- a/packages/cli/src/commands/library.ts
+++ b/packages/cli/src/commands/library.ts
@@ -128,7 +128,7 @@ async function readMetadataInput(
   options: { readonly jsonRequired: boolean },
 ): Promise<unknown> {
   const raw = await readRawInput(args);
-  if (args.json === true || options.jsonRequired) {
+  if (options.jsonRequired || args.jsonInputValue !== undefined) {
     return parseJSONInput(raw);
   }
   return raw;
@@ -206,6 +206,9 @@ function writeMetadataMap(
 function formatMetadataTextValue(value: unknown): string {
   if (Array.isArray(value)) {
     return value.map((item) => String(item)).join(" ");
+  }
+  if (value !== null && typeof value === "object") {
+    return JSON.stringify(value);
   }
   return String(value);
 }

--- a/packages/cli/src/commands/library.ts
+++ b/packages/cli/src/commands/library.ts
@@ -1,0 +1,211 @@
+import { readFile } from "fs/promises";
+
+import {
+  clearWikiGraphLibraryMetadata,
+  createWikiGraphLibrary,
+  deleteWikiGraphLibraryMetadataKey,
+  getWikiGraphLibraryMetadata,
+  listWikiGraphLibraryScope,
+  putWikiGraphLibraryMetadata,
+  removeWikiGraphLibrary,
+  replaceWikiGraphLibraryMetadata,
+  resolveWikiGraphLibrary,
+} from "wiki-graph-core";
+import type { CLILibraryArguments } from "../args/index.js";
+import {
+  formatCLIJSON,
+  readTextStreamFromStdin,
+  writeTextToStdout,
+} from "../support/index.js";
+
+export async function runLibraryCommand(
+  args: CLILibraryArguments,
+): Promise<void> {
+  switch (args.action) {
+    case "create": {
+      if (args.path === undefined) {
+        throw new Error("Missing --path <folder> for library create.");
+      }
+      const library = await createWikiGraphLibrary({ folderPath: args.path });
+      await writeLibrary(library, args.json ?? false);
+      return;
+    }
+    case "list": {
+      await listWikiGraphLibraryScope(args.target);
+      await writeTextToStdout(
+        args.json === true ? formatCLIJSON({ items: [] }) : "",
+      );
+      return;
+    }
+    case "remove": {
+      const library = await removeWikiGraphLibrary(args.target);
+      await writeTextToStdout(
+        args.json === true
+          ? formatCLIJSON({ removed: library.uri })
+          : `Removed library registry: ${library.uri}\n`,
+      );
+      return;
+    }
+    case "get": {
+      if (args.target.kind === "metadata") {
+        await writeMetadataMap(
+          await getWikiGraphLibraryMetadata(args.target),
+          args.json ?? false,
+        );
+        return;
+      }
+      await resolveWikiGraphLibrary(args.target);
+      await writeTextToStdout(
+        args.json === true ? formatCLIJSON({ items: [] }) : "",
+      );
+      return;
+    }
+    case "set": {
+      const value = await readMetadataInput(args, { jsonRequired: true });
+      await writeMetadataMap(
+        await replaceWikiGraphLibraryMetadata(
+          args.target,
+          parseMetadataMap(value),
+        ),
+        args.json ?? false,
+      );
+      return;
+    }
+    case "put": {
+      await writeMetadataMap(
+        await putWikiGraphLibraryMetadata(
+          args.target,
+          normalizeMetadataKey(args.key),
+          await readMetadataInput(args, { jsonRequired: false }),
+        ),
+        args.json ?? false,
+      );
+      return;
+    }
+    case "delete": {
+      await writeMetadataMap(
+        await deleteWikiGraphLibraryMetadataKey(
+          args.target,
+          normalizeMetadataKey(args.key),
+        ),
+        args.json ?? false,
+      );
+      return;
+    }
+    case "clear": {
+      await writeMetadataMap(
+        await clearWikiGraphLibraryMetadata(args.target),
+        args.json ?? false,
+      );
+      return;
+    }
+  }
+}
+
+async function writeLibrary(
+  library: Awaited<ReturnType<typeof createWikiGraphLibrary>>,
+  json: boolean,
+): Promise<void> {
+  if (json) {
+    await writeTextToStdout(
+      formatCLIJSON({
+        uri: library.uri,
+        id: library.publicId,
+        folderPath: library.folderPath,
+        isDefault: library.isDefault,
+        stagingPath: library.stagingPath,
+        createdAt: library.createdAt,
+        updatedAt: library.updatedAt,
+      }),
+    );
+    return;
+  }
+  await writeTextToStdout(`${library.uri}\n`);
+}
+
+async function readMetadataInput(
+  args: CLILibraryArguments,
+  options: { readonly jsonRequired: boolean },
+): Promise<unknown> {
+  const raw = await readRawInput(args);
+  if (args.json === true || options.jsonRequired) {
+    return parseJSONInput(raw);
+  }
+  return raw;
+}
+
+async function readRawInput(args: CLILibraryArguments): Promise<string> {
+  const sources = [
+    args.inputValue === undefined ? undefined : "positional value",
+    args.inputPath === undefined ? undefined : "--input",
+    args.jsonInputValue === undefined ? undefined : "--json value",
+  ].filter((source): source is string => source !== undefined);
+
+  if (sources.length > 1) {
+    throw new Error(`Choose only one input source: ${sources.join(", ")}.`);
+  }
+  if (args.jsonInputValue !== undefined) {
+    return args.jsonInputValue;
+  }
+  if (args.inputValue !== undefined) {
+    return args.inputValue;
+  }
+  if (args.inputPath === "-") {
+    let content = "";
+    for await (const chunk of readTextStreamFromStdin()) {
+      content += chunk;
+    }
+    return content;
+  }
+  if (args.inputPath !== undefined) {
+    return await readFile(args.inputPath, "utf8");
+  }
+  throw new Error(
+    "Missing input. Pass a value, use --input <path>, or use --input - for stdin.",
+  );
+}
+
+function parseMetadataMap(value: unknown): Readonly<Record<string, unknown>> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Metadata set requires a JSON object.");
+  }
+  return value as Readonly<Record<string, unknown>>;
+}
+
+function parseJSONInput(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `Invalid JSON input: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function normalizeMetadataKey(key: string | undefined): string {
+  const normalized = key?.trim() ?? "";
+  if (normalized === "") {
+    throw new Error("Metadata key cannot be empty.");
+  }
+  return normalized;
+}
+
+function writeMetadataMap(
+  map: Readonly<Record<string, unknown>>,
+  json: boolean,
+): Promise<void> {
+  if (json) {
+    return writeTextToStdout(formatCLIJSON(map));
+  }
+  const lines = Object.entries(map).map(
+    ([key, value]) => `${key}: ${formatMetadataTextValue(value)}`,
+  );
+  return writeTextToStdout(lines.length === 0 ? "" : `${lines.join("\n")}\n`);
+}
+
+function formatMetadataTextValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item)).join(" ");
+  }
+  return String(value);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,6 +38,27 @@ export {
 export { resolveDataDirPath } from "./runtime/common/data-dir.js";
 export { createEnv } from "./runtime/common/template.js";
 export {
+  clearWikiGraphLibraryMetadata,
+  createWikiGraphLibrary,
+  deleteWikiGraphLibraryMetadataKey,
+  ensureDefaultWikiGraphLibrary,
+  formatWikiGraphLibraryUri,
+  getWikiGraphLibraryMetadata,
+  isWikiGraphLibraryUri,
+  listWikiGraphLibraryScope,
+  parseWikiGraphLibraryUri,
+  putWikiGraphLibraryMetadata,
+  removeWikiGraphLibrary,
+  replaceWikiGraphLibraryMetadata,
+  resolveDefaultWikiGraphLibraryDirectoryPath,
+  resolveWikiGraphLibrary,
+  resolveWikiGraphLibraryStagingDirectoryPath,
+} from "./library/index.js";
+export type {
+  ParsedWikiGraphLibraryUri,
+  WikiGraphLibraryRecord,
+} from "./library/index.js";
+export {
   resolveWikiGraphCoreDatabasePath,
   resolveWikiGraphHomeDirectoryPath,
 } from "./runtime/common/wiki-graph/dir.js";

--- a/packages/core/src/library/index.ts
+++ b/packages/core/src/library/index.ts
@@ -1,0 +1,1 @@
+export * from "./registry.js";

--- a/packages/core/src/library/registry.ts
+++ b/packages/core/src/library/registry.ts
@@ -144,26 +144,29 @@ export function resolveWikiGraphLibraryStagingDirectoryPath(
 
 export async function ensureDefaultWikiGraphLibrary(): Promise<WikiGraphLibraryRecord> {
   return await withLibraryRegistryDatabase(async (database) => {
-    const existing = await readDefaultLibraryRecord(database);
-    if (existing !== undefined) {
-      await mkdir(existing.folderPath, { recursive: true });
-      return existing;
-    }
+    const library = await database.transaction(async () => {
+      const existing = await readDefaultLibraryRecord(database);
+      if (existing !== undefined) {
+        return existing;
+      }
 
-    const now = new Date().toISOString();
-    const publicId = await createUniqueLibraryPublicId(database);
-    const folderPath = resolveDefaultWikiGraphLibraryDirectoryPath();
+      const now = new Date().toISOString();
+      const publicId = await createUniqueLibraryPublicId(database);
+      const folderPath = resolveDefaultWikiGraphLibraryDirectoryPath();
 
-    await database.run(
-      `
-        INSERT INTO libraries (public_id, folder_path, is_default, created_at, updated_at)
-        VALUES (?, ?, 1, ?, ?)
-      `,
-      [publicId, folderPath, now, now],
-    );
-    await mkdir(folderPath, { recursive: true });
+      await database.run(
+        `
+          INSERT INTO libraries (public_id, folder_path, is_default, created_at, updated_at)
+          VALUES (?, ?, 1, ?, ?)
+        `,
+        [publicId, folderPath, now, now],
+      );
 
-    return await requireDefaultLibraryRecord(database);
+      return await requireDefaultLibraryRecord(database);
+    });
+
+    await mkdir(library.folderPath, { recursive: true });
+    return library;
   });
 }
 

--- a/packages/core/src/library/registry.ts
+++ b/packages/core/src/library/registry.ts
@@ -1,0 +1,466 @@
+import { randomBytes } from "crypto";
+import { mkdir, stat } from "fs/promises";
+import { join, resolve } from "path";
+
+import {
+  getNumber,
+  getString,
+  type Database,
+  type SqlRow,
+} from "../document/database.js";
+import { openSharedStateDatabase } from "../document/index.js";
+import {
+  resolveWikiGraphCoreDatabasePath,
+  resolveWikiGraphHomeDirectoryPath,
+  resolveWikiGraphStagingDirectoryPath,
+} from "../runtime/common/wiki-graph/dir.js";
+import { isNodeError } from "../utils/node-error.js";
+
+const DEFAULT_LIBRARY_FOLDER_NAME = "default-library";
+const PUBLIC_ID_BYTES = 6;
+const RESERVED_METADATA_KEYS = new Set([
+  "id",
+  "public_id",
+  "publicId",
+  "folder_path",
+  "folderPath",
+  "is_default",
+  "isDefault",
+  "staging_path",
+  "stagingPath",
+  "created_at",
+  "createdAt",
+  "updated_at",
+  "updatedAt",
+  "uri",
+]);
+
+const LIBRARY_REGISTRY_SCHEMA_SQL = `
+  PRAGMA journal_mode = WAL;
+
+  CREATE TABLE IF NOT EXISTS libraries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    public_id TEXT NOT NULL UNIQUE,
+    folder_path TEXT NOT NULL UNIQUE,
+    is_default INTEGER NOT NULL DEFAULT 0 CHECK (is_default IN (0, 1)),
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  );
+
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_libraries_single_default
+  ON libraries(is_default)
+  WHERE is_default = 1;
+
+  CREATE TABLE IF NOT EXISTS library_metadata (
+    library_id INTEGER NOT NULL,
+    key TEXT NOT NULL,
+    value_json TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (library_id, key)
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_library_metadata_library
+  ON library_metadata(library_id);
+`;
+
+export interface WikiGraphLibraryRecord {
+  readonly id: number;
+  readonly publicId: string;
+  readonly uri: string;
+  readonly folderPath: string;
+  readonly isDefault: boolean;
+  readonly stagingPath: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface ParsedWikiGraphLibraryUri {
+  readonly kind: "metadata" | "scope";
+  readonly publicId?: string;
+  readonly isDefault: boolean;
+}
+
+export function isWikiGraphLibraryUri(uri: string | undefined): uri is string {
+  if (uri === "wikg://lib") {
+    return true;
+  }
+  if (uri?.startsWith("wikg://lib/") !== true) {
+    return false;
+  }
+
+  return !uri
+    .slice("wikg://lib/".length)
+    .split("/")
+    .some((part) => part.endsWith(".wikg"));
+}
+
+export function parseWikiGraphLibraryUri(
+  uri: string,
+): ParsedWikiGraphLibraryUri | undefined {
+  if (uri === "wikg://lib") {
+    return { isDefault: true, kind: "scope" };
+  }
+  if (uri === "wikg://lib/meta") {
+    return { isDefault: true, kind: "metadata" };
+  }
+  if (!uri.startsWith("wikg://lib/")) {
+    return undefined;
+  }
+
+  const path = uri.slice("wikg://lib/".length);
+  const match = /^([^/]+)\.lib(?:\/(meta))?$/u.exec(path);
+  if (match?.[1] !== undefined) {
+    return {
+      isDefault: false,
+      kind: match[2] === "meta" ? "metadata" : "scope",
+      publicId: match[1],
+    };
+  }
+
+  if (/^[^/.][^/]*(?:\/meta)?$/u.test(path)) {
+    throw new Error(
+      "Specified library URIs must use the .lib suffix: wikg://lib/<lib-id>.lib",
+    );
+  }
+
+  throw new Error(
+    `Invalid Wiki Graph library URI: ${uri}. Expected wikg://lib, wikg://lib/meta, wikg://lib/<lib-id>.lib, or wikg://lib/<lib-id>.lib/meta.`,
+  );
+}
+
+export function formatWikiGraphLibraryUri(publicId?: string): string {
+  return publicId === undefined ? "wikg://lib" : `wikg://lib/${publicId}.lib`;
+}
+
+export function resolveDefaultWikiGraphLibraryDirectoryPath(): string {
+  return join(resolveWikiGraphHomeDirectoryPath(), DEFAULT_LIBRARY_FOLDER_NAME);
+}
+
+export function resolveWikiGraphLibraryStagingDirectoryPath(
+  id: number,
+): string {
+  return join(resolveWikiGraphStagingDirectoryPath(), "library", String(id));
+}
+
+export async function ensureDefaultWikiGraphLibrary(): Promise<WikiGraphLibraryRecord> {
+  return await withLibraryRegistryDatabase(async (database) => {
+    const existing = await readDefaultLibraryRecord(database);
+    if (existing !== undefined) {
+      await mkdir(existing.folderPath, { recursive: true });
+      return existing;
+    }
+
+    const now = new Date().toISOString();
+    const publicId = await createUniqueLibraryPublicId(database);
+    const folderPath = resolveDefaultWikiGraphLibraryDirectoryPath();
+
+    await database.run(
+      `
+        INSERT INTO libraries (public_id, folder_path, is_default, created_at, updated_at)
+        VALUES (?, ?, 1, ?, ?)
+      `,
+      [publicId, folderPath, now, now],
+    );
+    await mkdir(folderPath, { recursive: true });
+
+    return await requireDefaultLibraryRecord(database);
+  });
+}
+
+export async function createWikiGraphLibrary(input: {
+  readonly folderPath: string;
+}): Promise<WikiGraphLibraryRecord> {
+  const folderPath = resolve(input.folderPath);
+  if (await pathExists(folderPath)) {
+    throw new Error(`Library folder already exists: ${folderPath}`);
+  }
+
+  return await withLibraryRegistryDatabase(async (database) => {
+    return await database.transaction(async () => {
+      const now = new Date().toISOString();
+      const publicId = await createUniqueLibraryPublicId(database);
+
+      await database.run(
+        `
+          INSERT INTO libraries (public_id, folder_path, is_default, created_at, updated_at)
+          VALUES (?, ?, 0, ?, ?)
+        `,
+        [publicId, folderPath, now, now],
+      );
+      await mkdir(folderPath);
+
+      return await requireLibraryRecordByPublicId(database, publicId);
+    });
+  });
+}
+
+export async function resolveWikiGraphLibrary(
+  target: ParsedWikiGraphLibraryUri,
+): Promise<WikiGraphLibraryRecord> {
+  if (target.isDefault) {
+    return await ensureDefaultWikiGraphLibrary();
+  }
+  if (target.publicId === undefined) {
+    throw new Error("Missing library id.");
+  }
+
+  return await withLibraryRegistryDatabase(
+    async (database) =>
+      await requireLibraryRecordByPublicId(database, target.publicId!),
+  );
+}
+
+export async function listWikiGraphLibraryScope(
+  target: ParsedWikiGraphLibraryUri,
+): Promise<readonly []> {
+  await resolveWikiGraphLibrary(target);
+  return [];
+}
+
+export async function removeWikiGraphLibrary(
+  target: ParsedWikiGraphLibraryUri,
+): Promise<WikiGraphLibraryRecord> {
+  const library = await resolveWikiGraphLibrary(target);
+  if (library.isDefault) {
+    throw new Error(
+      "The default library is managed by the system and cannot be removed.",
+    );
+  }
+
+  await withLibraryRegistryDatabase(async (database) => {
+    await database.transaction(async () => {
+      await database.run("DELETE FROM library_metadata WHERE library_id = ?", [
+        library.id,
+      ]);
+      await database.run("DELETE FROM libraries WHERE id = ?", [library.id]);
+    });
+  });
+
+  return library;
+}
+
+export async function getWikiGraphLibraryMetadata(
+  target: ParsedWikiGraphLibraryUri,
+): Promise<Readonly<Record<string, unknown>>> {
+  const library = await resolveWikiGraphLibrary(target);
+
+  return await withLibraryRegistryDatabase(
+    async (database) => await readLibraryMetadataMap(database, library.id),
+  );
+}
+
+export async function replaceWikiGraphLibraryMetadata(
+  target: ParsedWikiGraphLibraryUri,
+  map: Readonly<Record<string, unknown>>,
+): Promise<Readonly<Record<string, unknown>>> {
+  rejectReservedMetadataKeys(Object.keys(map));
+  const library = await resolveWikiGraphLibrary(target);
+
+  return await withLibraryRegistryDatabase(async (database) => {
+    await database.transaction(async () => {
+      await database.run("DELETE FROM library_metadata WHERE library_id = ?", [
+        library.id,
+      ]);
+      for (const [key, value] of Object.entries(map)) {
+        await putLibraryMetadata(database, library.id, key, value);
+      }
+    });
+    return await readLibraryMetadataMap(database, library.id);
+  });
+}
+
+export async function putWikiGraphLibraryMetadata(
+  target: ParsedWikiGraphLibraryUri,
+  key: string,
+  value: unknown,
+): Promise<Readonly<Record<string, unknown>>> {
+  rejectReservedMetadataKeys([key]);
+  const library = await resolveWikiGraphLibrary(target);
+
+  return await withLibraryRegistryDatabase(async (database) => {
+    await putLibraryMetadata(database, library.id, key, value);
+    return await readLibraryMetadataMap(database, library.id);
+  });
+}
+
+export async function deleteWikiGraphLibraryMetadataKey(
+  target: ParsedWikiGraphLibraryUri,
+  key: string,
+): Promise<Readonly<Record<string, unknown>>> {
+  const library = await resolveWikiGraphLibrary(target);
+
+  return await withLibraryRegistryDatabase(async (database) => {
+    await database.run(
+      "DELETE FROM library_metadata WHERE library_id = ? AND key = ?",
+      [library.id, key],
+    );
+    return await readLibraryMetadataMap(database, library.id);
+  });
+}
+
+export async function clearWikiGraphLibraryMetadata(
+  target: ParsedWikiGraphLibraryUri,
+): Promise<Readonly<Record<string, unknown>>> {
+  const library = await resolveWikiGraphLibrary(target);
+
+  return await withLibraryRegistryDatabase(async (database) => {
+    await database.run("DELETE FROM library_metadata WHERE library_id = ?", [
+      library.id,
+    ]);
+    return await readLibraryMetadataMap(database, library.id);
+  });
+}
+
+async function withLibraryRegistryDatabase<T>(
+  operation: (database: Database) => Promise<T>,
+): Promise<T> {
+  const database = await openSharedStateDatabase(
+    resolveWikiGraphCoreDatabasePath(),
+    LIBRARY_REGISTRY_SCHEMA_SQL,
+  );
+
+  try {
+    return await operation(database);
+  } finally {
+    await database.close();
+  }
+}
+
+async function readDefaultLibraryRecord(
+  database: Database,
+): Promise<WikiGraphLibraryRecord | undefined> {
+  return await database.queryOne(
+    `
+      SELECT id, public_id, folder_path, is_default, created_at, updated_at
+      FROM libraries
+      WHERE is_default = 1
+    `,
+    undefined,
+    mapLibraryRecord,
+  );
+}
+
+async function requireDefaultLibraryRecord(
+  database: Database,
+): Promise<WikiGraphLibraryRecord> {
+  const record = await readDefaultLibraryRecord(database);
+  if (record === undefined) {
+    throw new Error("Default library registry record is missing.");
+  }
+  return record;
+}
+
+async function requireLibraryRecordByPublicId(
+  database: Database,
+  publicId: string,
+): Promise<WikiGraphLibraryRecord> {
+  const record = await database.queryOne(
+    `
+      SELECT id, public_id, folder_path, is_default, created_at, updated_at
+      FROM libraries
+      WHERE public_id = ?
+    `,
+    [publicId],
+    mapLibraryRecord,
+  );
+
+  if (record === undefined) {
+    throw new Error(`Unknown Wiki Graph library: ${publicId}`);
+  }
+  return record;
+}
+
+function mapLibraryRecord(row: SqlRow): WikiGraphLibraryRecord {
+  const id = getNumber(row, "id");
+  const publicId = getString(row, "public_id");
+  return {
+    createdAt: getString(row, "created_at"),
+    folderPath: getString(row, "folder_path"),
+    id,
+    isDefault: getNumber(row, "is_default") === 1,
+    publicId,
+    stagingPath: resolveWikiGraphLibraryStagingDirectoryPath(id),
+    updatedAt: getString(row, "updated_at"),
+    uri: formatWikiGraphLibraryUri(
+      getNumber(row, "is_default") === 1 ? undefined : publicId,
+    ),
+  };
+}
+
+async function readLibraryMetadataMap(
+  database: Database,
+  libraryId: number,
+): Promise<Readonly<Record<string, unknown>>> {
+  const rows = await database.queryAll(
+    `
+      SELECT key, value_json
+      FROM library_metadata
+      WHERE library_id = ?
+      ORDER BY key
+    `,
+    [libraryId],
+    (row) => ({
+      key: getString(row, "key"),
+      value: JSON.parse(getString(row, "value_json")) as unknown,
+    }),
+  );
+  const map: Record<string, unknown> = {};
+  for (const row of rows) {
+    map[row.key] = row.value;
+  }
+  return map;
+}
+
+async function putLibraryMetadata(
+  database: Database,
+  libraryId: number,
+  key: string,
+  value: unknown,
+): Promise<void> {
+  await database.run(
+    `
+      INSERT INTO library_metadata (library_id, key, value_json, updated_at)
+      VALUES (?, ?, ?, ?)
+      ON CONFLICT(library_id, key) DO UPDATE SET
+        value_json = excluded.value_json,
+        updated_at = excluded.updated_at
+    `,
+    [libraryId, key, JSON.stringify(value), new Date().toISOString()],
+  );
+}
+
+async function createUniqueLibraryPublicId(
+  database: Database,
+): Promise<string> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const publicId = randomBytes(PUBLIC_ID_BYTES).toString("hex");
+    const existing = await database.queryOne(
+      "SELECT public_id FROM libraries WHERE public_id = ?",
+      [publicId],
+      (row) => getString(row, "public_id"),
+    );
+    if (existing === undefined) {
+      return publicId;
+    }
+  }
+  throw new Error("Could not generate a unique library id.");
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function rejectReservedMetadataKeys(keys: readonly string[]): void {
+  const reserved = keys.find((key) => RESERVED_METADATA_KEYS.has(key));
+  if (reserved !== undefined) {
+    throw new Error(`Library metadata cannot modify system field: ${reserved}`);
+  }
+}

--- a/test/cli/library.test.ts
+++ b/test/cli/library.test.ts
@@ -1,8 +1,51 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type * as CLISupport from "../../packages/cli/src/support/index.js";
+import type * as WikiGraphCore from "wiki-graph-core";
+
+const libraryMockState = vi.hoisted(() => ({
+  metadata: {} as Record<string, unknown>,
+  putCalls: [] as unknown[],
+  textWrites: [] as string[],
+}));
+
+vi.mock("wiki-graph-core", async (importOriginal) => {
+  const actual = await importOriginal<typeof WikiGraphCore>();
+
+  return {
+    ...actual,
+    putWikiGraphLibraryMetadata: vi.fn(
+      (_target: unknown, key: string, value: unknown) => {
+        libraryMockState.putCalls.push({ key, value });
+        libraryMockState.metadata[key] = value;
+        return Promise.resolve({ ...libraryMockState.metadata });
+      },
+    ),
+  };
+});
+
+vi.mock("../../packages/cli/src/support/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof CLISupport>();
+
+  return {
+    ...actual,
+    writeTextToStdout: vi.fn((text: string) => {
+      libraryMockState.textWrites.push(text);
+      return Promise.resolve();
+    }),
+  };
+});
 
 import { parseCLIArguments } from "../../packages/cli/src/args/index.js";
+import { runLibraryCommand } from "../../packages/cli/src/commands/index.js";
 
 describe("cli/library args", () => {
+  beforeEach(() => {
+    libraryMockState.metadata = {};
+    libraryMockState.putCalls.length = 0;
+    libraryMockState.textWrites.length = 0;
+  });
+
   it("parses library create, scope, remove, and metadata commands", () => {
     expect(
       parseCLIArguments([
@@ -75,5 +118,38 @@ describe("cli/library args", () => {
       },
       kind: "archive",
     });
+  });
+
+  it("keeps --json as output formatting for library metadata put", async () => {
+    await runLibraryCommand({
+      action: "put",
+      inputValue: "42",
+      json: true,
+      key: "title",
+      target: { isDefault: true, kind: "metadata" },
+    });
+
+    expect(libraryMockState.putCalls).toStrictEqual([
+      { key: "title", value: "42" },
+    ]);
+    expect(JSON.parse(libraryMockState.textWrites[0]!)).toStrictEqual({
+      title: "42",
+    });
+  });
+
+  it("renders object metadata values as JSON in text output", async () => {
+    await runLibraryCommand({
+      action: "put",
+      jsonInputValue: '{"nested":true}',
+      key: "details",
+      target: { isDefault: true, kind: "metadata" },
+    });
+
+    expect(libraryMockState.putCalls).toStrictEqual([
+      { key: "details", value: { nested: true } },
+    ]);
+    expect(libraryMockState.textWrites).toStrictEqual([
+      'details: {"nested":true}\n',
+    ]);
   });
 });

--- a/test/cli/library.test.ts
+++ b/test/cli/library.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { parseCLIArguments } from "../../packages/cli/src/args/index.js";
+
+describe("cli/library args", () => {
+  it("parses library create, scope, remove, and metadata commands", () => {
+    expect(
+      parseCLIArguments([
+        "wikg://lib",
+        "create",
+        "--path",
+        "/tmp/research",
+        "--json",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "create",
+        json: true,
+        path: "/tmp/research",
+        target: { isDefault: true, kind: "scope" },
+      },
+      help: false,
+      kind: "library",
+    });
+
+    expect(parseCLIArguments(["wikg://lib/abc123abc123.lib"])).toStrictEqual({
+      args: {
+        action: "list",
+        json: undefined,
+        target: { isDefault: false, kind: "scope", publicId: "abc123abc123" },
+      },
+      help: false,
+      kind: "library",
+    });
+
+    expect(
+      parseCLIArguments(["wikg://lib/abc123abc123.lib", "remove", "--json"]),
+    ).toMatchObject({
+      args: {
+        action: "remove",
+        json: true,
+        target: { publicId: "abc123abc123" },
+      },
+      kind: "library",
+    });
+
+    expect(
+      parseCLIArguments(["wikg://lib/meta", "put", "title", "Default"]),
+    ).toMatchObject({
+      args: {
+        action: "put",
+        inputValue: "Default",
+        key: "title",
+        target: { isDefault: true, kind: "metadata" },
+      },
+      help: false,
+      kind: "library",
+    });
+  });
+
+  it("rejects unsupported specified library URI and inspect", () => {
+    expect(() => parseCLIArguments(["wikg://lib/abc123abc123"])).toThrow(
+      ".lib suffix",
+    );
+    expect(() =>
+      parseCLIArguments(["wikg://lib/abc123abc123.lib", "inspect"]),
+    ).toThrow("does not support `inspect`");
+  });
+
+  it("does not steal archive URIs below a lib path segment", () => {
+    expect(parseCLIArguments(["wikg://lib/book.wikg"])).toMatchObject({
+      args: {
+        action: "list",
+        archivePath: expect.stringContaining("lib/book.wikg") as string,
+      },
+      kind: "archive",
+    });
+  });
+});

--- a/test/core/library/registry.test.ts
+++ b/test/core/library/registry.test.ts
@@ -49,6 +49,19 @@ describe("wiki graph library registry", () => {
     ).toStrictEqual({});
   });
 
+  it("reuses one default library across concurrent first-run callers", async () => {
+    const libraries = await Promise.all(
+      Array.from(
+        { length: 8 },
+        async () => await ensureDefaultWikiGraphLibrary(),
+      ),
+    );
+
+    expect(new Set(libraries.map((library) => library.id)).size).toBe(1);
+    expect(new Set(libraries.map((library) => library.publicId)).size).toBe(1);
+    expect((await stat(libraries[0]!.folderPath)).isDirectory()).toBe(true);
+  });
+
   it("creates non-default libraries with public .lib URIs and refuses existing folders", async () => {
     const folderPath = join(stateDir, "research");
     const library = await createWikiGraphLibrary({ folderPath });

--- a/test/core/library/registry.test.ts
+++ b/test/core/library/registry.test.ts
@@ -1,0 +1,131 @@
+import { mkdtemp, rm, stat } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  clearWikiGraphLibraryMetadata,
+  createWikiGraphLibrary,
+  deleteWikiGraphLibraryMetadataKey,
+  ensureDefaultWikiGraphLibrary,
+  formatWikiGraphLibraryUri,
+  getWikiGraphLibraryMetadata,
+  listWikiGraphLibraryScope,
+  parseLocatedWikiGraphUri,
+  parseWikiGraphLibraryUri,
+  putWikiGraphLibraryMetadata,
+  removeWikiGraphLibrary,
+  replaceWikiGraphLibraryMetadata,
+} from "../../../packages/core/src/index.js";
+
+describe("wiki graph library registry", () => {
+  const originalStateDir = process.env.WIKIGRAPH_STATE_DIR;
+  let stateDir: string;
+
+  beforeEach(async () => {
+    stateDir = await mkdtemp(join(tmpdir(), "wikg-library-"));
+    process.env.WIKIGRAPH_STATE_DIR = stateDir;
+  });
+
+  afterEach(async () => {
+    if (originalStateDir === undefined) {
+      delete process.env.WIKIGRAPH_STATE_DIR;
+    } else {
+      process.env.WIKIGRAPH_STATE_DIR = originalStateDir;
+    }
+    await rm(stateDir, { force: true, recursive: true });
+  });
+
+  it("auto-creates the default library with empty metadata", async () => {
+    const library = await ensureDefaultWikiGraphLibrary();
+
+    expect(library.id).toEqual(expect.any(Number));
+    expect(library.isDefault).toBe(true);
+    expect(library.uri).toBe("wikg://lib");
+    expect(library.folderPath).toBe(join(stateDir, "default-library"));
+    expect((await stat(library.folderPath)).isDirectory()).toBe(true);
+    expect(
+      await getWikiGraphLibraryMetadata({ isDefault: true, kind: "metadata" }),
+    ).toStrictEqual({});
+  });
+
+  it("creates non-default libraries with public .lib URIs and refuses existing folders", async () => {
+    const folderPath = join(stateDir, "research");
+    const library = await createWikiGraphLibrary({ folderPath });
+
+    expect(library.id).toEqual(expect.any(Number));
+    expect(Number.isInteger(library.id)).toBe(true);
+    expect(library.publicId).toMatch(/^[0-9a-f]{12}$/u);
+    expect(library.uri).toBe(`wikg://lib/${library.publicId}.lib`);
+    expect(formatWikiGraphLibraryUri(library.publicId)).toBe(library.uri);
+    expect((await stat(folderPath)).isDirectory()).toBe(true);
+    await expect(createWikiGraphLibrary({ folderPath })).rejects.toThrow(
+      "Library folder already exists",
+    );
+  });
+
+  it("parses library URIs without stealing .wikg archive URIs", () => {
+    expect(parseWikiGraphLibraryUri("wikg://lib")).toStrictEqual({
+      isDefault: true,
+      kind: "scope",
+    });
+    expect(
+      parseWikiGraphLibraryUri("wikg://lib/abc123abc123.lib/meta"),
+    ).toStrictEqual({
+      isDefault: false,
+      kind: "metadata",
+      publicId: "abc123abc123",
+    });
+    expect(() => parseWikiGraphLibraryUri("wikg://lib/abc123abc123")).toThrow(
+      ".lib suffix",
+    );
+    const parsed = parseLocatedWikiGraphUri(
+      "wikg://tmp/lib/book.wikg/entity/Q42",
+    );
+    expect(parsed.archivePath).toContain("tmp/lib/book.wikg");
+    expect(parsed.objectUri).toBe("wikg://entity/Q42");
+  });
+
+  it("supports metadata put, set, delete, and clear while rejecting system fields", async () => {
+    const library = await createWikiGraphLibrary({
+      folderPath: join(stateDir, "metadata-library"),
+    });
+    const target = parseWikiGraphLibraryUri(`${library.uri}/meta`)!;
+
+    expect(
+      await putWikiGraphLibraryMetadata(target, "title", "Research"),
+    ).toStrictEqual({
+      title: "Research",
+    });
+    expect(
+      await putWikiGraphLibraryMetadata(target, "description", "Notes"),
+    ).toStrictEqual({ description: "Notes", title: "Research" });
+    expect(
+      await replaceWikiGraphLibraryMetadata(target, { title: "Only title" }),
+    ).toStrictEqual({ title: "Only title" });
+    await expect(
+      putWikiGraphLibraryMetadata(target, "folder_path", "/tmp"),
+    ).rejects.toThrow("system field");
+    expect(
+      await deleteWikiGraphLibraryMetadataKey(target, "title"),
+    ).toStrictEqual({});
+    expect(await clearWikiGraphLibraryMetadata(target)).toStrictEqual({});
+  });
+
+  it("removes only registry records and keeps folders; default removal is rejected", async () => {
+    const library = await createWikiGraphLibrary({
+      folderPath: join(stateDir, "kept"),
+    });
+    const target = parseWikiGraphLibraryUri(library.uri)!;
+
+    expect(await listWikiGraphLibraryScope(target)).toStrictEqual([]);
+    expect((await removeWikiGraphLibrary(target)).uri).toBe(library.uri);
+    await expect(stat(library.folderPath)).resolves.toBeTruthy();
+    await expect(
+      removeWikiGraphLibrary({ isDefault: true, kind: "scope" }),
+    ).rejects.toThrow("default library");
+    await expect(listWikiGraphLibraryScope(target)).rejects.toThrow(
+      "Unknown Wiki Graph library",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add core library registry in the global Wiki Graph core DB with default library auto-creation, public short-id URIs, staging-path derivation, create/remove, and metadata storage.
- Add CLI routing for `wikg://lib`, `wikg://lib/<id>.lib`, and `/meta` operations, including create path validation, metadata input handling, scope empty listing, and default-remove rejection.
- Add focused core and CLI tests for URI parsing, archive-boundary precedence, metadata behavior, directory semantics, and registry-only removal.

Closes #128

## Test Plan
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm run build`
- `pnpm run test -- --run`
- Built CLI smoke test for library create/meta/scope/remove with isolated `WIKIGRAPH_STATE_DIR`
