### PR TITLE
fix: route library help through templates

### DIFF
--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -454,6 +454,20 @@ describe("cli/args/help", () => {
     expect(metadataHelpText).toContain("Metadata keys are free-form");
     expect(createHelpText).toContain("Library Predicate Command");
     expect(createHelpText).toContain("Create a non-default library registry");
+    expect(
+      renderLibraryPredicateHelpText(
+        "wikg://lib",
+        { isDefault: true, kind: "scope" },
+        "list",
+      ),
+    ).toContain("Enumerate objects in this library scope");
+    expect(
+      renderLibraryPredicateHelpText(
+        "wikg://lib/meta",
+        { isDefault: true, kind: "metadata" },
+        "get",
+      ),
+    ).toContain("Read this library metadata map");
   });
 
   it("supports a first-contact recovery chain from root help to parse failures", () => {

--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -4,6 +4,8 @@ import {
   renderArchiveMaintenanceChapterActionHelpText,
   renderArchiveMaintenanceCommandHelpText,
   renderHelpTopicText,
+  renderLibraryPredicateHelpText,
+  renderLibraryUriHelpText,
   renderMainHelpText,
   renderUriHelpText,
   renderUriPredicateHelpText,
@@ -178,6 +180,7 @@ describe("cli/args/help", () => {
     expect(rootHelpText).toContain("wg help uri");
     expect(rootHelpText).toContain("wg <archive-uri> inspect");
     expect(rootHelpText).toContain("wg transform");
+    expect(rootHelpText).toContain("wg wikg://lib --help");
     expect(rootHelpText).not.toContain("wg import");
     expect(rootHelpText).not.toContain("wg wikg://local/job add");
     expect(rootHelpText).not.toContain("wg <archive-uri>/index build");
@@ -427,6 +430,30 @@ describe("cli/args/help", () => {
     expect(renderArchiveMaintenanceCommandHelpText("meta")).toContain(
       "<object-uri>/meta put <key>",
     );
+  });
+
+  it("renders library help through templates", () => {
+    const scopeHelpText = renderLibraryUriHelpText("wikg://lib", {
+      isDefault: true,
+      kind: "scope",
+    });
+    const metadataHelpText = renderLibraryUriHelpText("wikg://lib/meta", {
+      isDefault: true,
+      kind: "metadata",
+    });
+    const createHelpText = renderLibraryPredicateHelpText(
+      "wikg://lib",
+      { isDefault: true, kind: "scope" },
+      "create",
+    );
+
+    expect(scopeHelpText).toContain("Library scope");
+    expect(scopeHelpText).toContain("wg wikg://lib create --path <folder>");
+    expect(scopeHelpText).toContain(".lib` suffix");
+    expect(metadataHelpText).toContain("Library metadata object");
+    expect(metadataHelpText).toContain("Metadata keys are free-form");
+    expect(createHelpText).toContain("Library Predicate Command");
+    expect(createHelpText).toContain("Create a non-default library registry");
   });
 
   it("supports a first-contact recovery chain from root help to parse failures", () => {

--- a/packages/cli/src/args/help.ts
+++ b/packages/cli/src/args/help.ts
@@ -2,6 +2,7 @@ import { resolveDataDirPath } from "wiki-graph-core";
 import { createEnv } from "wiki-graph-core";
 
 import { CLI_FULL_COMMAND, CLI_PRIMARY_COMMAND } from "wiki-graph-core";
+import type { ParsedWikiGraphLibraryUri } from "wiki-graph-core";
 import { CLI_FORMATS } from "../support/index.js";
 import { CLI_HELP_ROUTES, withHelpRoute } from "../support/index.js";
 import { formatCliCommand } from "../support/index.js";
@@ -9,6 +10,7 @@ import type {
   CLIArchiveAction,
   CLIArchiveChapterAction,
   CLIArchiveMaintenanceCommand,
+  CLILibraryAction,
 } from "./types.js";
 
 export const HELP_TOPICS = [
@@ -262,6 +264,25 @@ export function renderUriPredicateHelpText(
   }
 
   return renderHelpTemplate("help/commands/predicate", {
+    predicate,
+    target,
+    uri,
+  });
+}
+
+export function renderLibraryUriHelpText(
+  uri: string,
+  target: ParsedWikiGraphLibraryUri,
+): string {
+  return renderHelpTemplate("help/commands/library", { target, uri });
+}
+
+export function renderLibraryPredicateHelpText(
+  uri: string,
+  target: ParsedWikiGraphLibraryUri,
+  predicate: CLILibraryAction,
+): string {
+  return renderHelpTemplate("help/commands/library-predicate", {
     predicate,
     target,
     uri,

--- a/packages/cli/src/args/uri/library.ts
+++ b/packages/cli/src/args/uri/library.ts
@@ -4,6 +4,10 @@ import {
 } from "wiki-graph-core";
 
 import { withHelpRoute } from "../../support/index.js";
+import {
+  renderLibraryPredicateHelpText,
+  renderLibraryUriHelpText,
+} from "../help.js";
 import type {
   ArchiveArgumentValues,
   CLILibraryAction,
@@ -40,10 +44,10 @@ export function parseLibraryUriFirstArguments(
     throw new Error(`Expected a Wiki Graph library URI: ${uri}`);
   }
 
-  if (values.help === true) {
+  if (values.help === true && explicitAction === undefined) {
     return {
       help: true,
-      helpText: renderLibraryHelpText(uri, target),
+      helpText: renderLibraryUriHelpText(uri, target),
       kind: "help",
     };
   }
@@ -57,6 +61,15 @@ export function parseLibraryUriFirstArguments(
         formatWikiGraphHelpCommand(uri),
       ),
     );
+  }
+
+  if (values.help === true) {
+    validateLibraryActionForTarget(uri, target, action);
+    return {
+      help: true,
+      helpText: renderLibraryPredicateHelpText(uri, target, action),
+      kind: "help",
+    };
   }
 
   if (target.kind === "metadata") {
@@ -269,36 +282,35 @@ function isLibraryAction(action: string): action is CLILibraryAction {
   );
 }
 
-function renderLibraryHelpText(
+function validateLibraryActionForTarget(
   uri: string,
   target: ParsedWikiGraphLibraryUri,
-): string {
+  action: CLILibraryAction,
+): void {
+  const helpRoute = formatWikiGraphHelpCommand(uri);
   if (target.kind === "metadata") {
-    return [
-      "Help Type: command",
-      `Command: wg ${uri}`,
-      "",
-      "Library metadata object",
-      "",
-      "Usage:",
-      `  wg ${uri}`,
-      `  wg ${uri} set <json> [--json]`,
-      `  wg ${uri} put <key> <value> [--json]`,
-      `  wg ${uri} delete <key> [--json]`,
-      `  wg ${uri} clear [--json]`,
-    ].join("\n");
+    if (!LIBRARY_METADATA_ACTIONS.has(action)) {
+      throw new Error(
+        withHelpRoute(
+          `The library metadata object ${uri} does not support \`${action}\`.`,
+          helpRoute,
+        ),
+      );
+    }
+    return;
   }
-  return [
-    "Help Type: command",
-    `Command: wg ${uri}`,
-    "",
-    "Library scope",
-    "",
-    "Usage:",
-    ...(target.isDefault
-      ? ["  wg wikg://lib create --path <folder> [--json]"]
-      : []),
-    `  wg ${uri}`,
-    ...(target.isDefault ? [] : [`  wg ${uri} remove [--json]`]),
-  ].join("\n");
+
+  if (!LIBRARY_SCOPE_ACTIONS.has(action)) {
+    throw new Error(
+      withHelpRoute(
+        `The library scope ${uri} does not support \`${action}\`.`,
+        helpRoute,
+      ),
+    );
+  }
+  if (action === "create" && !target.isDefault) {
+    throw new Error(
+      withHelpRoute("Create libraries from wikg://lib.", helpRoute),
+    );
+  }
 }

--- a/packages/core/data/help/commands/library-predicate.jinja
+++ b/packages/core/data/help/commands/library-predicate.jinja
@@ -26,6 +26,26 @@ Notes:
 Examples:
   {{ commandName }} wikg://lib create --path ./research-library
   {{ commandName }} wikg://lib create --path ./research-library --json
+{% elif target.kind == "scope" and predicate == "get" %}
+Purpose:
+  Read a specific object in this library scope.
+
+Usage:
+  {{ commandName }} {{ uri }} get [--json]
+
+Notes:
+  - This follows the normal URI scope contract.
+  - First-stage library support does not yet enumerate library members, so the help page is present even if the command currently returns an empty scope result.
+{% elif target.kind == "scope" and predicate == "list" %}
+Purpose:
+  Enumerate objects in this library scope.
+
+Usage:
+  {{ commandName }} {{ uri }} list [--json]
+
+Notes:
+  - This follows the normal URI scope contract.
+  - First-stage library support does not yet enumerate library members, so the help page is present even if the command currently returns an empty scope result.
 {% elif target.kind == "scope" and predicate == "remove" %}
 Purpose:
   Remove this non-default library registry.
@@ -52,6 +72,17 @@ Notes:
   - Metadata keys are free-form user fields.
   - System registry fields such as id, public id, folder path, default marker, and staging path cannot be modified through metadata.
   - With `--json`, success output is the resulting metadata map.
+{% elif target.kind == "metadata" and predicate == "get" %}
+Purpose:
+  Read this library metadata map.
+
+Usage:
+  {{ commandName }} {{ uri }} get [--json]
+
+Notes:
+  - This reads the whole metadata map.
+  - Metadata keys are free-form user fields.
+  - System registry fields such as id, public id, folder path, default marker, and staging path cannot be modified through metadata.
 {% elif target.kind == "metadata" and predicate == "put" %}
 Purpose:
   Write one library metadata key.

--- a/packages/core/data/help/commands/library-predicate.jinja
+++ b/packages/core/data/help/commands/library-predicate.jinja
@@ -1,0 +1,96 @@
+Help Type: command
+Command: {{ commandName }} {{ uri }} {{ predicate }}
+
+Library Predicate Command
+
+Target:
+  {{ uri }}
+
+Predicate:
+  {{ predicate }}
+
+{% if target.kind == "scope" and predicate == "create" %}
+Purpose:
+  Create a non-default library registry and create its empty library folder.
+
+Usage:
+  {{ commandName }} wikg://lib create --path <folder> [--json]
+
+Notes:
+  - Libraries are created from the default library scope, `wikg://lib`.
+  - `<folder>` must not already exist; the command creates it as an empty directory.
+  - The folder is not scanned, and contained `.wikg` files are not registered in this stage.
+  - Registry data is stored in the global core database, not in the library folder.
+  - Text output is the new public library URI. With `--json`, output includes the public id, URI, folder path, default marker, staging path, and timestamps.
+
+Examples:
+  {{ commandName }} wikg://lib create --path ./research-library
+  {{ commandName }} wikg://lib create --path ./research-library --json
+{% elif target.kind == "scope" and predicate == "remove" %}
+Purpose:
+  Remove this non-default library registry.
+
+Usage:
+  {{ commandName }} {{ uri }} remove [--json]
+
+Notes:
+  - The default library is system-managed and cannot be removed.
+  - Removing a library deletes the core registry record and library metadata.
+  - Removing a library does not delete, inspect, scan, or clean the library folder.
+  - First-stage library support does not remove library index or archive membership because those are not created yet.
+{% elif target.kind == "metadata" and predicate == "set" %}
+Purpose:
+  Replace the whole library metadata map.
+
+Usage:
+  {{ commandName }} {{ uri }} set <json> [--json]
+  {{ commandName }} {{ uri }} set --json-input <json> [--json]
+  {{ commandName }} {{ uri }} set --json --input <path|-> [--json]
+
+Notes:
+  - `set` requires a JSON object.
+  - Metadata keys are free-form user fields.
+  - System registry fields such as id, public id, folder path, default marker, and staging path cannot be modified through metadata.
+  - With `--json`, success output is the resulting metadata map.
+{% elif target.kind == "metadata" and predicate == "put" %}
+Purpose:
+  Write one library metadata key.
+
+Usage:
+  {{ commandName }} {{ uri }} put <key> <value> [--json]
+  {{ commandName }} {{ uri }} put <key> --json <value>
+  {{ commandName }} {{ uri }} put <key> --json-input <value> [--json]
+  {{ commandName }} {{ uri }} put <key> --input <path|-> [--json]
+
+Notes:
+  - Without JSON input, the value is stored as a string.
+  - With JSON input, the value is parsed as JSON.
+  - Metadata keys are command arguments, not URI segments.
+  - System registry fields such as id, public id, folder path, default marker, and staging path cannot be modified through metadata.
+{% elif target.kind == "metadata" and predicate == "delete" %}
+Purpose:
+  Delete one library metadata key.
+
+Usage:
+  {{ commandName }} {{ uri }} delete <key> [--json]
+
+Notes:
+  - Missing keys are ignored.
+  - With `--json`, success output is the resulting metadata map.
+{% elif target.kind == "metadata" and predicate == "clear" %}
+Purpose:
+  Clear this library metadata map.
+
+Usage:
+  {{ commandName }} {{ uri }} clear [--json]
+
+Notes:
+  - This clears user metadata only.
+  - It does not remove the library registry or change the library folder.
+{% else %}
+This library target does not support `{{ predicate }}`.
+{% endif %}
+
+Related help:
+  - {{ commandName }} {{ uri }} --help
+  - {{ commandName }} help uri

--- a/packages/core/data/help/commands/library.jinja
+++ b/packages/core/data/help/commands/library.jinja
@@ -1,0 +1,69 @@
+Help Type: command
+Command: {{ commandName }} {{ uri }}
+
+{% if target.kind == "metadata" %}
+Library metadata object
+
+Default behavior:
+  - `{{ commandName }} {{ uri }}` reads this library metadata map.
+  - Metadata keys are free-form user fields.
+  - System registry fields such as id, public id, folder path, default marker, and staging path are not metadata.
+
+Use when:
+  - You need to read or edit user metadata attached to a library scope.
+
+Usage:
+  {{ commandName }} {{ uri }} [--json]
+  {{ commandName }} {{ uri }} set <json> [--json]
+  {{ commandName }} {{ uri }} set --json-input <json> [--json]
+  {{ commandName }} {{ uri }} set --json --input <path|->
+  {{ commandName }} {{ uri }} put <key> <value> [--json]
+  {{ commandName }} {{ uri }} put <key> --json <value>
+  {{ commandName }} {{ uri }} put <key> --json-input <value> [--json]
+  {{ commandName }} {{ uri }} put <key> --input <path|-> [--json]
+  {{ commandName }} {{ uri }} delete <key> [--json]
+  {{ commandName }} {{ uri }} clear [--json]
+
+Predicate commands:
+  - set: replace the whole metadata map. Help: {{ commandName }} {{ uri }} set --help
+  - put: write one metadata key. Help: {{ commandName }} {{ uri }} put --help
+  - delete: delete one metadata key. Help: {{ commandName }} {{ uri }} delete --help
+  - clear: clear the metadata map. Help: {{ commandName }} {{ uri }} clear --help
+{% else %}
+Library scope
+
+Default behavior:
+  - `{{ commandName }} {{ uri }}` enumerates objects in this library scope.
+  - First-stage library support does not scan the library folder, so the scope can be empty even when the folder contains `.wikg` files.
+
+Use when:
+  - You need the library entry point before future library-level archive enumeration or search.
+{% if target.isDefault %}
+  - You need to create another library registry.
+{% else %}
+  - You need to address a specific non-default library.
+{% endif %}
+
+URI forms:
+  - `{{ commandName }} wikg://lib` addresses the default library.
+  - `{{ commandName }} wikg://lib/<lib-id>.lib` addresses a non-default library.
+  - Non-default library URIs require the `.lib` suffix so future `wikg://lib/<archive-id>/` archive shortcuts remain unambiguous.
+
+Usage:
+{% if target.isDefault %}
+  {{ commandName }} wikg://lib
+  {{ commandName }} wikg://lib create --path <folder> [--json]
+  {{ commandName }} wikg://lib/meta [--json]
+{% else %}
+  {{ commandName }} {{ uri }}
+  {{ commandName }} {{ uri }} remove [--json]
+  {{ commandName }} {{ uri }}/meta [--json]
+{% endif %}
+
+Predicate commands:
+{% if target.isDefault %}
+  - create: create a non-default library registry and an empty folder. Help: {{ commandName }} wikg://lib create --help
+{% else %}
+  - remove: remove this library registry without deleting its folder. Help: {{ commandName }} {{ uri }} remove --help
+{% endif %}
+{% endif %}

--- a/packages/core/data/help/commands/root.jinja
+++ b/packages/core/data/help/commands/root.jinja
@@ -41,7 +41,7 @@ Core concepts:
   - Cursor: a continuation token consumed by `{{ commandName }} next`.
 
 Important object families:
-  chapter, chunk, entity, triple, summary, index, job, config, meta.
+  chapter, chunk, entity, triple, summary, index, library, job, config, meta.
 
 What to learn where:
   - Normal workflow, object choice, and practical Agent behavior:
@@ -72,6 +72,9 @@ Non-predicate command entry points:
   {{ commandName }} gc --help
   {{ commandName }} legacy --help
   {{ commandName }} help [topic] [--help|-h]
+
+Library entry point:
+  {{ commandName }} wikg://lib --help
 
 Help topics:
 {% for topic in helpTopics %}

--- a/test/cli/library.test.ts
+++ b/test/cli/library.test.ts
@@ -88,12 +88,12 @@ describe("cli/library args", () => {
     });
 
     expect(
-      parseCLIArguments(["wikg://lib/meta", "put", "title", "Default"]),
+      parseCLIArguments(["wikg://lib/meta", "put", "note", "Default"]),
     ).toMatchObject({
       args: {
         action: "put",
         inputValue: "Default",
-        key: "title",
+        key: "note",
         target: { isDefault: true, kind: "metadata" },
       },
       help: false,
@@ -108,6 +108,28 @@ describe("cli/library args", () => {
     expect(() =>
       parseCLIArguments(["wikg://lib/abc123abc123.lib", "inspect"]),
     ).toThrow("does not support `inspect`");
+  });
+
+  it("routes library URI and predicate help through command pages", () => {
+    const scopeHelp = parseCLIArguments(["wikg://lib", "--help"]);
+    const createHelp = parseCLIArguments(["wikg://lib", "create", "--help"]);
+    const putHelp = parseCLIArguments(["wikg://lib/meta", "put", "--help"]);
+
+    expect(scopeHelp).toMatchObject({
+      help: true,
+      kind: "help",
+    });
+    if (!scopeHelp.help || !createHelp.help || !putHelp.help) {
+      throw new Error("Expected help output.");
+    }
+    expect(scopeHelp.helpText).toContain("Library scope");
+    expect(createHelp.helpText).toContain(
+      "Create a non-default library registry",
+    );
+    expect(putHelp.helpText).toContain("Write one library metadata key");
+    expect(() =>
+      parseCLIArguments(["wikg://lib/abc123abc123.lib", "create", "--help"]),
+    ).toThrow("Create libraries from wikg://lib.");
   });
 
   it("does not steal archive URIs below a lib path segment", () => {


### PR DESCRIPTION
## Summary

- move library URI and predicate help text into `packages/core/data/help/commands/` templates
- route `wikg://lib --help` and `wikg://lib <predicate> --help` through the template renderer
- add root help discoverability for the library entry point
- cover template rendering and library predicate help routing in tests

Follow-up to #128 / #129.

## Verification

- `pnpm test:run packages/cli/src/args/help.test.ts test/cli/library.test.ts`
- `pnpm typecheck`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec eslint packages/cli/src/args/help.ts packages/cli/src/args/uri/library.ts packages/cli/src/args/help.test.ts test/cli/library.test.ts`
- `git diff --check`

Note: full `pnpm lint` currently traverses untracked `.worktrees/` in this local checkout and reports generated/worktree files, so this PR used targeted eslint on the touched TypeScript files.
