### PR TITLE
feat: manage library archive membership

### DIFF
--- a/packages/cli/src/args/types.ts
+++ b/packages/cli/src/args/types.ts
@@ -103,17 +103,21 @@ export interface CLIObjectMetadataArguments {
 }
 
 export type CLILibraryAction =
+  | "add"
   | "clear"
   | "create"
   | "delete"
   | "get"
   | "list"
+  | "move"
   | "put"
   | "remove"
+  | "scan"
   | "set";
 
 export interface CLILibraryArguments {
   readonly action: CLILibraryAction;
+  readonly confirm?: boolean | undefined;
   readonly inputPath?: string | undefined;
   readonly inputValue?: string | undefined;
   readonly json?: boolean | undefined;
@@ -121,6 +125,7 @@ export interface CLILibraryArguments {
   readonly key?: string | undefined;
   readonly path?: string | undefined;
   readonly target: ParsedWikiGraphLibraryUri;
+  readonly to?: string | undefined;
 }
 
 export type CLILocalConfigAction =

--- a/packages/cli/src/args/uri/library.ts
+++ b/packages/cli/src/args/uri/library.ts
@@ -26,7 +26,15 @@ const LIBRARY_METADATA_ACTIONS = new Set([
   "put",
   "set",
 ]);
-const LIBRARY_SCOPE_ACTIONS = new Set(["create", "get", "list", "remove"]);
+const LIBRARY_SCOPE_ACTIONS = new Set([
+  "add",
+  "create",
+  "get",
+  "list",
+  "remove",
+  "scan",
+]);
+const LIBRARY_ARCHIVE_ACTIONS = new Set(["move", "remove"]);
 
 export function parseLibraryUriFirstArguments(
   positionals: readonly string[],
@@ -81,6 +89,15 @@ export function parseLibraryUriFirstArguments(
       values,
     );
   }
+  if (target.kind === "archive") {
+    return parseLibraryArchiveArguments(
+      uri,
+      target,
+      action,
+      explicitAction === undefined ? [] : positionals.slice(2),
+      values,
+    );
+  }
 
   return parseLibraryScopeArguments(
     uri,
@@ -109,7 +126,6 @@ function parseLibraryScopeArguments(
   }
   rejectCommonLibraryFlags(action, values, helpRoute);
   rejectArchiveBooleanFlag(action, "--jsonl", values.jsonl, helpRoute);
-  rejectArchiveFlag(action, "--input", values.input, helpRoute);
   rejectArchiveFlag(action, "--json-input", values["json-input"], helpRoute);
 
   switch (action) {
@@ -120,6 +136,8 @@ function parseLibraryScopeArguments(
         );
       }
       rejectExtraPositionals(action, tail, 0, helpRoute);
+      rejectArchiveFlag(action, "--input", values.input, helpRoute);
+      rejectArchiveFlag(action, "--to", values.to, helpRoute);
       if (values.path === undefined) {
         throw new Error(withHelpRoute("Missing --path <folder>.", helpRoute));
       }
@@ -128,9 +146,38 @@ function parseLibraryScopeArguments(
         help: false,
         kind: "library",
       };
-    case "remove":
+    case "add":
       rejectExtraPositionals(action, tail, 0, helpRoute);
       rejectArchiveFlag(action, "--path", values.path, helpRoute);
+      if (values.input === undefined) {
+        throw new Error(withHelpRoute("Missing --input <path>.", helpRoute));
+      }
+      return {
+        args: {
+          action,
+          inputPath: values.input,
+          json: values.json,
+          target,
+          to: values.to,
+        },
+        help: false,
+        kind: "library",
+      };
+    case "scan":
+      rejectExtraPositionals(action, tail, 0, helpRoute);
+      rejectArchiveFlag(action, "--input", values.input, helpRoute);
+      rejectArchiveFlag(action, "--path", values.path, helpRoute);
+      rejectArchiveFlag(action, "--to", values.to, helpRoute);
+      return {
+        args: { action, json: values.json, target },
+        help: false,
+        kind: "library",
+      };
+    case "remove":
+      rejectExtraPositionals(action, tail, 0, helpRoute);
+      rejectArchiveFlag(action, "--input", values.input, helpRoute);
+      rejectArchiveFlag(action, "--path", values.path, helpRoute);
+      rejectArchiveFlag(action, "--to", values.to, helpRoute);
       return {
         args: { action, json: values.json, target },
         help: false,
@@ -139,20 +186,67 @@ function parseLibraryScopeArguments(
     case "get":
     case "list":
       rejectExtraPositionals(action, tail, 0, helpRoute);
+      rejectArchiveFlag(action, "--input", values.input, helpRoute);
       rejectArchiveFlag(action, "--path", values.path, helpRoute);
+      rejectArchiveFlag(action, "--to", values.to, helpRoute);
       return {
         args: { action, json: values.json, target },
         help: false,
         kind: "library",
       };
+    case "move":
     case "set":
     case "put":
     case "delete":
     case "clear":
       throw new Error(
-        "Internal error: metadata action routed to library scope.",
+        "Internal error: non-scope action routed to library scope.",
       );
   }
+}
+
+function parseLibraryArchiveArguments(
+  uri: string,
+  target: ParsedWikiGraphLibraryUri,
+  action: CLILibraryAction,
+  tail: readonly string[],
+  values: ArchiveArgumentValues,
+): ParsedCLIArguments {
+  const helpRoute = formatWikiGraphHelpCommand(uri, action);
+  if (!LIBRARY_ARCHIVE_ACTIONS.has(action)) {
+    throw new Error(
+      withHelpRoute(
+        `The library archive ${uri} does not support \`${action}\`.`,
+        helpRoute,
+      ),
+    );
+  }
+  rejectCommonLibraryFlags(action, values, helpRoute);
+  rejectArchiveFlag(action, "--input", values.input, helpRoute);
+  rejectArchiveFlag(action, "--json-input", values["json-input"], helpRoute);
+  rejectArchiveFlag(action, "--path", values.path, helpRoute);
+  rejectArchiveBooleanFlag(action, "--jsonl", values.jsonl, helpRoute);
+  rejectExtraPositionals(action, tail, 0, helpRoute);
+
+  if (action === "remove") {
+    rejectArchiveFlag(action, "--to", values.to, helpRoute);
+    return {
+      args: { action, confirm: values.confirm, json: values.json, target },
+      help: false,
+      kind: "library",
+    };
+  }
+  if (values.to === undefined) {
+    throw new Error(
+      withHelpRoute("Missing --to <relative-wikg-path>.", helpRoute),
+    );
+  }
+  rejectArchiveBooleanFlag(action, "--confirm", values.confirm, helpRoute);
+  return {
+    args: { action, json: values.json, target, to: values.to },
+    help: false,
+    kind: "library",
+  };
 }
 
 function parseLibraryMetadataArguments(
@@ -173,6 +267,7 @@ function parseLibraryMetadataArguments(
   }
   rejectCommonLibraryFlags(action, values, helpRoute);
   rejectArchiveFlag(action, "--path", values.path, helpRoute);
+  rejectArchiveFlag(action, "--to", values.to, helpRoute);
   rejectArchiveBooleanFlag(action, "--jsonl", values.jsonl, helpRoute);
 
   switch (action) {
@@ -220,9 +315,12 @@ function parseLibraryMetadataArguments(
         help: false,
         kind: "library",
       };
+    case "add":
     case "create":
     case "list":
+    case "move":
     case "remove":
+    case "scan":
       throw new Error(
         "Internal error: scope action routed to library metadata.",
       );
@@ -250,7 +348,6 @@ function rejectCommonLibraryFlags(
   rejectArchiveBooleanFlag(action, "--all", values.all, helpRoute);
   rejectArchiveBooleanFlag(action, "--backlinks", values.backlinks, helpRoute);
   rejectArchiveBooleanFlag(action, "--reverse", values.reverse, helpRoute);
-  rejectArchiveBooleanFlag(action, "--confirm", values.confirm, helpRoute);
 }
 
 function rejectExtraPositionals(
@@ -271,13 +368,16 @@ function rejectExtraPositionals(
 
 function isLibraryAction(action: string): action is CLILibraryAction {
   return (
+    action === "add" ||
     action === "clear" ||
     action === "create" ||
     action === "delete" ||
     action === "get" ||
     action === "list" ||
+    action === "move" ||
     action === "put" ||
     action === "remove" ||
+    action === "scan" ||
     action === "set"
   );
 }
@@ -293,6 +393,18 @@ function validateLibraryActionForTarget(
       throw new Error(
         withHelpRoute(
           `The library metadata object ${uri} does not support \`${action}\`.`,
+          helpRoute,
+        ),
+      );
+    }
+    return;
+  }
+
+  if (target.kind === "archive") {
+    if (!LIBRARY_ARCHIVE_ACTIONS.has(action)) {
+      throw new Error(
+        withHelpRoute(
+          `The library archive ${uri} does not support \`${action}\`.`,
           helpRoute,
         ),
       );

--- a/packages/cli/src/commands/library.ts
+++ b/packages/cli/src/commands/library.ts
@@ -1,15 +1,21 @@
 import { readFile } from "fs/promises";
 
 import {
+  addWikiGraphArchiveToLibrary,
   clearWikiGraphLibraryMetadata,
   createWikiGraphLibrary,
   deleteWikiGraphLibraryMetadataKey,
   getWikiGraphLibraryMetadata,
   listWikiGraphLibraryScope,
+  moveWikiGraphLibraryArchive,
   putWikiGraphLibraryMetadata,
   removeWikiGraphLibrary,
+  removeWikiGraphLibraryArchive,
   replaceWikiGraphLibraryMetadata,
   resolveWikiGraphLibrary,
+  scanWikiGraphLibraryArchives,
+  type WikiGraphLibraryArchiveRecord,
+  type WikiGraphLibraryRecord,
 } from "wiki-graph-core";
 import type { CLILibraryArguments } from "../args/index.js";
 import {
@@ -30,19 +36,64 @@ export async function runLibraryCommand(
       await writeLibrary(library, args.json ?? false);
       return;
     }
+    case "scan": {
+      await writeLibraryArchiveList(
+        (await scanWikiGraphLibraryArchives(args.target)).items,
+        args.json ?? false,
+      );
+      return;
+    }
+    case "add": {
+      if (args.inputPath === undefined) {
+        throw new Error("Missing --input <path> for library add.");
+      }
+      await writeLibraryArchive(
+        (
+          await addWikiGraphArchiveToLibrary({
+            inputPath: args.inputPath,
+            target: args.target,
+            ...(args.to === undefined ? {} : { to: args.to }),
+          })
+        ).archive,
+        args.json ?? false,
+      );
+      return;
+    }
     case "list": {
-      await listWikiGraphLibraryScope(args.target);
-      await writeTextToStdout(
-        args.json === true ? formatCLIJSON({ items: [] }) : "",
+      await writeLibraryArchiveList(
+        await listWikiGraphLibraryScope(args.target),
+        args.json ?? false,
       );
       return;
     }
     case "remove": {
+      if (args.target.kind === "archive") {
+        if (args.confirm !== true) {
+          throw new Error("Library archive remove requires --confirm.");
+        }
+        await writeLibraryArchiveMutation(
+          await removeWikiGraphLibraryArchive(args.target),
+          args.json ?? false,
+          "removed",
+        );
+        return;
+      }
       const library = await removeWikiGraphLibrary(args.target);
       await writeTextToStdout(
         args.json === true
           ? formatCLIJSON({ removed: library.uri })
           : `Removed library registry: ${library.uri}\n`,
+      );
+      return;
+    }
+    case "move": {
+      if (args.to === undefined) {
+        throw new Error("Missing --to <relative-wikg-path> for library move.");
+      }
+      await writeLibraryArchiveMutation(
+        await moveWikiGraphLibraryArchive({ target: args.target, to: args.to }),
+        args.json ?? false,
+        "moved",
       );
       return;
     }
@@ -54,9 +105,22 @@ export async function runLibraryCommand(
         );
         return;
       }
+      if (args.target.kind === "archive") {
+        await writeLibraryArchive(
+          (await listWikiGraphLibraryScope(args.target)).find(
+            (item) => item.publicId === args.target.archivePublicId,
+          ) ??
+            (() => {
+              throw new Error("Unknown Wiki Graph library archive.");
+            })(),
+          args.json ?? false,
+        );
+        return;
+      }
       await resolveWikiGraphLibrary(args.target);
-      await writeTextToStdout(
-        args.json === true ? formatCLIJSON({ items: [] }) : "",
+      await writeLibraryArchiveList(
+        await listWikiGraphLibraryScope(args.target),
+        args.json ?? false,
       );
       return;
     }
@@ -103,7 +167,7 @@ export async function runLibraryCommand(
 }
 
 async function writeLibrary(
-  library: Awaited<ReturnType<typeof createWikiGraphLibrary>>,
+  library: WikiGraphLibraryRecord,
   json: boolean,
 ): Promise<void> {
   if (json) {
@@ -121,6 +185,74 @@ async function writeLibrary(
     return;
   }
   await writeTextToStdout(`${library.uri}\n`);
+}
+
+async function writeLibraryArchiveList(
+  archives: readonly WikiGraphLibraryArchiveRecord[],
+  json: boolean,
+): Promise<void> {
+  if (json) {
+    await writeTextToStdout(
+      formatCLIJSON({ items: archives.map(formatArchiveJSON) }),
+    );
+    return;
+  }
+  await writeTextToStdout(
+    archives
+      .map(
+        (archive) =>
+          `${archive.uri}\t${archive.relativePath}\t${archive.status}`,
+      )
+      .join("\n") + (archives.length === 0 ? "" : "\n"),
+  );
+}
+
+async function writeLibraryArchive(
+  archive: WikiGraphLibraryArchiveRecord,
+  json: boolean,
+): Promise<void> {
+  if (json) {
+    await writeTextToStdout(formatCLIJSON(formatArchiveJSON(archive)));
+    return;
+  }
+  await writeTextToStdout(
+    `${archive.uri}\t${archive.relativePath}\t${archive.status}\n`,
+  );
+}
+
+async function writeLibraryArchiveMutation(
+  result: {
+    readonly archive: WikiGraphLibraryArchiveRecord;
+    readonly missing?: boolean;
+  },
+  json: boolean,
+  action: "moved" | "removed",
+): Promise<void> {
+  if (json) {
+    await writeTextToStdout(
+      formatCLIJSON({
+        [action]: formatArchiveJSON(result.archive),
+        ...(result.missing === true ? { missing: true } : {}),
+      }),
+    );
+    return;
+  }
+  await writeTextToStdout(
+    `${action}: ${result.archive.uri}\t${result.archive.relativePath}${result.missing === true ? " (file missing)" : ""}\n`,
+  );
+}
+
+function formatArchiveJSON(archive: WikiGraphLibraryArchiveRecord): object {
+  return {
+    uri: archive.uri,
+    id: archive.publicId,
+    libraryUri: archive.libraryUri,
+    relativePath: archive.relativePath,
+    archivePath: archive.archivePath,
+    status: archive.status,
+    createdAt: archive.createdAt,
+    updatedAt: archive.updatedAt,
+  };
 }
 
 async function readMetadataInput(

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -86,7 +86,9 @@ export {
   snapshotChapterKnowledgeGraphInput,
 } from "./knowledge-graph-build/index.js";
 export {
+  createArchiveQueryIndexScope,
   createContinuationCursor,
+  createLibraryQueryIndexScope,
   deleteArchiveSearchSessions,
   readContinuationCursor,
 } from "../retrieval/query/index.js";
@@ -96,7 +98,11 @@ export {
   resolveExtractionPrompt,
   resolveKnowledgeGraphRecallPrompt,
 } from "./prompts.js";
-export type { ContinuationCursor } from "../retrieval/query/index.js";
+export type {
+  ContinuationCursor,
+  QueryIndexScope,
+  QueryScope,
+} from "../retrieval/query/index.js";
 export type {
   BuildChapterGraphArtifactOptions,
   BuildChapterSummaryArtifactOptions,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,7 @@ export { resolveDataDirPath } from "./runtime/common/data-dir.js";
 export { createEnv } from "./runtime/common/template.js";
 export {
   clearWikiGraphLibraryMetadata,
+  addWikiGraphArchiveToLibrary,
   createWikiGraphLibrary,
   deleteWikiGraphLibraryMetadataKey,
   ensureDefaultWikiGraphLibrary,
@@ -46,17 +47,24 @@ export {
   getWikiGraphLibraryMetadata,
   isWikiGraphLibraryUri,
   listWikiGraphLibraryScope,
+  moveWikiGraphLibraryArchive,
   parseWikiGraphLibraryUri,
   putWikiGraphLibraryMetadata,
   removeWikiGraphLibrary,
+  removeWikiGraphLibraryArchive,
   replaceWikiGraphLibraryMetadata,
   resolveDefaultWikiGraphLibraryDirectoryPath,
+  resolveWikiGraphLibraryArchive,
   resolveWikiGraphLibrary,
   resolveWikiGraphLibraryStagingDirectoryPath,
+  scanWikiGraphLibraryArchives,
 } from "./library/index.js";
 export type {
   ParsedWikiGraphLibraryUri,
+  WikiGraphLibraryArchiveMutationResult,
+  WikiGraphLibraryArchiveRecord,
   WikiGraphLibraryRecord,
+  WikiGraphLibraryScanResult,
 } from "./library/index.js";
 export {
   resolveWikiGraphCoreDatabasePath,
@@ -189,6 +197,8 @@ export type {
 export { formatError } from "./utils/node-error.js";
 export {
   createContinuationCursor,
+  createArchiveQueryIndexScope,
+  createLibraryQueryIndexScope,
   deleteArchiveSearchSessions,
   findArchiveObjects,
   formatChapterId,
@@ -237,6 +247,8 @@ export type {
   ArchiveRelatedResult,
   ArchiveTriplePattern,
   ContinuationCursor,
+  QueryIndexScope,
+  QueryScope,
 } from "./api/index.js";
 export { setFtsIndexEmbedded } from "./retrieval/search-index/index.js";
 export {

--- a/packages/core/src/library/registry.ts
+++ b/packages/core/src/library/registry.ts
@@ -1,6 +1,23 @@
 import { randomBytes } from "crypto";
-import { mkdir, stat } from "fs/promises";
-import { join, resolve } from "path";
+import {
+  copyFile,
+  lstat,
+  mkdir,
+  readdir,
+  realpath,
+  rename,
+  rm,
+  stat,
+} from "fs/promises";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from "path";
 
 import {
   getNumber,
@@ -14,6 +31,7 @@ import {
   resolveWikiGraphHomeDirectoryPath,
   resolveWikiGraphStagingDirectoryPath,
 } from "../runtime/common/wiki-graph/dir.js";
+import { WIKI_GRAPH_ARCHIVE_EXTENSION } from "../runtime/common/wiki-graph/uri.js";
 import { isNodeError } from "../utils/node-error.js";
 
 const DEFAULT_LIBRARY_FOLDER_NAME = "default-library";
@@ -33,6 +51,14 @@ const RESERVED_METADATA_KEYS = new Set([
   "updated_at",
   "updatedAt",
   "uri",
+]);
+const LIBRARY_SCOPE_HEADS = new Set([
+  "chapter",
+  "chunk",
+  "entity",
+  "source",
+  "summary",
+  "triple",
 ]);
 
 const LIBRARY_REGISTRY_SCHEMA_SQL = `
@@ -61,6 +87,20 @@ const LIBRARY_REGISTRY_SCHEMA_SQL = `
 
   CREATE INDEX IF NOT EXISTS idx_library_metadata_library
   ON library_metadata(library_id);
+
+  CREATE TABLE IF NOT EXISTS library_archives (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    library_id INTEGER NOT NULL,
+    public_id TEXT NOT NULL,
+    relative_path TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE(library_id, public_id),
+    UNIQUE(library_id, relative_path)
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_library_archives_library
+  ON library_archives(library_id);
 `;
 
 export interface WikiGraphLibraryRecord {
@@ -75,9 +115,35 @@ export interface WikiGraphLibraryRecord {
 }
 
 export interface ParsedWikiGraphLibraryUri {
-  readonly kind: "metadata" | "scope";
+  readonly archivePublicId?: string;
+  readonly kind: "archive" | "metadata" | "scope";
+  readonly objectUri?: string;
   readonly publicId?: string;
   readonly isDefault: boolean;
+}
+
+export interface WikiGraphLibraryArchiveRecord {
+  readonly id: number;
+  readonly publicId: string;
+  readonly uri: string;
+  readonly libraryId: number;
+  readonly libraryPublicId: string;
+  readonly libraryUri: string;
+  readonly relativePath: string;
+  readonly archivePath: string;
+  readonly status: "present" | "missing";
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface WikiGraphLibraryScanResult {
+  readonly library: WikiGraphLibraryRecord;
+  readonly items: readonly WikiGraphLibraryArchiveRecord[];
+}
+
+export interface WikiGraphLibraryArchiveMutationResult {
+  readonly archive: WikiGraphLibraryArchiveRecord;
+  readonly missing?: boolean;
 }
 
 export function isWikiGraphLibraryUri(uri: string | undefined): uri is string {
@@ -91,7 +157,7 @@ export function isWikiGraphLibraryUri(uri: string | undefined): uri is string {
   return !uri
     .slice("wikg://lib/".length)
     .split("/")
-    .some((part) => part.endsWith(".wikg"));
+    .some((part) => part.endsWith(WIKI_GRAPH_ARCHIVE_EXTENSION));
 }
 
 export function parseWikiGraphLibraryUri(
@@ -107,13 +173,49 @@ export function parseWikiGraphLibraryUri(
     return undefined;
   }
 
-  const path = uri.slice("wikg://lib/".length);
-  const match = /^([^/]+)\.lib(?:\/(meta))?$/u.exec(path);
-  if (match?.[1] !== undefined) {
+  const path = uri.slice("wikg://lib/".length).replace(/\/+$/u, "");
+  const parts = path.split("/").filter((part) => part !== "");
+  const explicitLibraryMatch = /^([^/]+)\.lib$/u.exec(parts[0] ?? "");
+  if (explicitLibraryMatch?.[1] !== undefined) {
+    const publicId = explicitLibraryMatch[1];
+    const tail = parts.slice(1);
+    if (tail.length === 0 || (tail.length === 1 && tail[0] === "meta")) {
+      return {
+        isDefault: false,
+        kind: tail[0] === "meta" ? "metadata" : "scope",
+        publicId,
+      };
+    }
+    if (isLibraryScopeTail(tail)) {
+      return {
+        isDefault: false,
+        kind: "scope",
+        objectUri: formatWikiGraphObjectUri(tail.join("/")),
+        publicId,
+      };
+    }
     return {
+      archivePublicId: tail[0]!,
       isDefault: false,
-      kind: match[2] === "meta" ? "metadata" : "scope",
-      publicId: match[1],
+      kind: "archive",
+      ...formatOptionalObjectUriProperty(tail.slice(1)),
+      publicId,
+    };
+  }
+
+  if (isLibraryScopeTail(parts)) {
+    return {
+      isDefault: true,
+      kind: "scope",
+      objectUri: formatWikiGraphObjectUri(parts.join("/")),
+    };
+  }
+  if (parts.length > 0) {
+    return {
+      archivePublicId: parts[0]!,
+      isDefault: true,
+      kind: "archive",
+      ...formatOptionalObjectUriProperty(parts.slice(1)),
     };
   }
 
@@ -124,7 +226,7 @@ export function parseWikiGraphLibraryUri(
   }
 
   throw new Error(
-    `Invalid Wiki Graph library URI: ${uri}. Expected wikg://lib, wikg://lib/meta, wikg://lib/<lib-id>.lib, or wikg://lib/<lib-id>.lib/meta.`,
+    `Invalid Wiki Graph library URI: ${uri}. Expected wikg://lib, wikg://lib/meta, wikg://lib/<lib-id>.lib, wikg://lib/<lib-id>.lib/meta, or a library archive/scope URI.`,
   );
 }
 
@@ -215,9 +317,164 @@ export async function resolveWikiGraphLibrary(
 
 export async function listWikiGraphLibraryScope(
   target: ParsedWikiGraphLibraryUri,
-): Promise<readonly []> {
-  await resolveWikiGraphLibrary(target);
-  return [];
+): Promise<readonly WikiGraphLibraryArchiveRecord[]> {
+  const library = await resolveWikiGraphLibrary(target);
+  return await withLibraryRegistryDatabase(
+    async (database) => await readLibraryArchiveRecords(database, library),
+  );
+}
+
+export async function scanWikiGraphLibraryArchives(
+  target: ParsedWikiGraphLibraryUri,
+): Promise<WikiGraphLibraryScanResult> {
+  const library = await resolveWikiGraphLibrary(target);
+  await mkdir(library.folderPath, { recursive: true });
+  const relativePaths = await listWikgFiles(library.folderPath);
+  const now = new Date().toISOString();
+  const items = await withLibraryRegistryDatabase(async (database) => {
+    await database.transaction(async () => {
+      for (const relativePath of relativePaths) {
+        const existing = await readLibraryArchiveRecordByRelativePath(
+          database,
+          library,
+          relativePath,
+        );
+        if (existing === undefined) {
+          await database.run(
+            `
+              INSERT INTO library_archives (library_id, public_id, relative_path, created_at, updated_at)
+              VALUES (?, ?, ?, ?, ?)
+            `,
+            [
+              library.id,
+              await createUniqueLibraryArchivePublicId(database, library.id),
+              relativePath,
+              now,
+              now,
+            ],
+          );
+        } else {
+          await database.run(
+            "UPDATE library_archives SET updated_at = ? WHERE id = ?",
+            [now, existing.id],
+          );
+        }
+      }
+    });
+    return await readLibraryArchiveRecords(database, library);
+  });
+  return { items, library };
+}
+
+export async function addWikiGraphArchiveToLibrary(input: {
+  readonly target: ParsedWikiGraphLibraryUri;
+  readonly inputPath: string;
+  readonly to?: string;
+  readonly cwd?: string;
+}): Promise<WikiGraphLibraryArchiveMutationResult> {
+  if (input.inputPath.startsWith("wikg://")) {
+    throw new Error(
+      "Library add --input accepts a file path, not a wikg:// URI.",
+    );
+  }
+  if (/^[a-z][a-z0-9+.-]*:\/\//iu.test(input.inputPath)) {
+    throw new Error("Library add does not support URL inputs yet.");
+  }
+  const library = await resolveWikiGraphLibrary(input.target);
+  const cwd = input.cwd ?? process.cwd();
+  const sourcePath = isAbsolute(input.inputPath)
+    ? resolve(input.inputPath)
+    : resolve(cwd, input.inputPath);
+  await assertReadableWikgFile(sourcePath, "Library add input");
+  const relativePath = assertSafeLibraryArchiveRelativePath(
+    input.to ?? basename(sourcePath),
+  );
+  const archivePath = await resolveSafeLibraryArchivePath(
+    library,
+    relativePath,
+    {
+      mustNotExist: true,
+    },
+  );
+  await mkdir(dirname(archivePath), { recursive: true });
+  await copyFile(sourcePath, archivePath);
+  assertInsideLibrary(
+    await realpath(archivePath),
+    await realpath(library.folderPath),
+  );
+  const archive = await registerLibraryArchivePath(library, relativePath);
+  return { archive };
+}
+
+export async function removeWikiGraphLibraryArchive(
+  target: ParsedWikiGraphLibraryUri,
+): Promise<WikiGraphLibraryArchiveMutationResult> {
+  const { archive } = await resolveWikiGraphLibraryArchive(target);
+  const missing = !(await pathExists(archive.archivePath));
+  if (!missing) {
+    await rm(archive.archivePath);
+  }
+  await withLibraryRegistryDatabase(async (database) => {
+    await database.run("DELETE FROM library_archives WHERE id = ?", [
+      archive.id,
+    ]);
+  });
+  return {
+    archive: { ...archive, status: missing ? "missing" : archive.status },
+    ...(missing ? { missing: true } : {}),
+  };
+}
+
+export async function moveWikiGraphLibraryArchive(input: {
+  readonly target: ParsedWikiGraphLibraryUri;
+  readonly to: string;
+}): Promise<WikiGraphLibraryArchiveMutationResult> {
+  const { archive, library } = await resolveWikiGraphLibraryArchive(
+    input.target,
+  );
+  if (!(await pathExists(archive.archivePath))) {
+    throw new Error(`Library archive file is missing: ${archive.relativePath}`);
+  }
+  const relativePath = assertSafeLibraryArchiveRelativePath(input.to);
+  const toPath = await resolveSafeLibraryArchivePath(library, relativePath, {
+    mustNotExist: true,
+  });
+  await mkdir(dirname(toPath), { recursive: true });
+  await rename(archive.archivePath, toPath);
+  const updated = await withLibraryRegistryDatabase(async (database) => {
+    const now = new Date().toISOString();
+    await database.run(
+      "UPDATE library_archives SET relative_path = ?, updated_at = ? WHERE id = ?",
+      [relativePath, now, archive.id],
+    );
+    return await requireLibraryArchiveRecordByPublicId(
+      database,
+      library,
+      archive.publicId,
+    );
+  });
+  return { archive: updated };
+}
+
+export async function resolveWikiGraphLibraryArchive(
+  target: ParsedWikiGraphLibraryUri,
+): Promise<{
+  readonly library: WikiGraphLibraryRecord;
+  readonly archive: WikiGraphLibraryArchiveRecord;
+}> {
+  if (target.kind !== "archive" || target.archivePublicId === undefined) {
+    throw new Error("Expected a library archive URI.");
+  }
+  const library = await resolveWikiGraphLibrary(target);
+  const archive = await withLibraryRegistryDatabase(
+    async (database) =>
+      await requireLibraryArchiveRecordByPublicId(
+        database,
+        library,
+        target.archivePublicId!,
+      ),
+  );
+  return { archive, library };
 }
 
 export async function removeWikiGraphLibrary(
@@ -233,6 +490,9 @@ export async function removeWikiGraphLibrary(
   await withLibraryRegistryDatabase(async (database) => {
     await database.transaction(async () => {
       await database.run("DELETE FROM library_metadata WHERE library_id = ?", [
+        library.id,
+      ]);
+      await database.run("DELETE FROM library_archives WHERE library_id = ?", [
         library.id,
       ]);
       await database.run("DELETE FROM libraries WHERE id = ?", [library.id]);
@@ -390,6 +650,124 @@ function mapLibraryRecord(row: SqlRow): WikiGraphLibraryRecord {
   };
 }
 
+async function readLibraryArchiveRecords(
+  database: Database,
+  library: WikiGraphLibraryRecord,
+): Promise<readonly WikiGraphLibraryArchiveRecord[]> {
+  const records = await database.queryAll(
+    `
+      SELECT id, library_id, public_id, relative_path, created_at, updated_at
+      FROM library_archives
+      WHERE library_id = ?
+      ORDER BY relative_path
+    `,
+    [library.id],
+    (row) => mapLibraryArchiveRecord(row, library),
+  );
+  return await Promise.all(records.map(withLibraryArchiveStatus));
+}
+
+async function readLibraryArchiveRecordByRelativePath(
+  database: Database,
+  library: WikiGraphLibraryRecord,
+  relativePath: string,
+): Promise<WikiGraphLibraryArchiveRecord | undefined> {
+  const record = await database.queryOne(
+    `
+      SELECT id, library_id, public_id, relative_path, created_at, updated_at
+      FROM library_archives
+      WHERE library_id = ? AND relative_path = ?
+    `,
+    [library.id, relativePath],
+    (row) => mapLibraryArchiveRecord(row, library),
+  );
+  return record === undefined
+    ? undefined
+    : await withLibraryArchiveStatus(record);
+}
+
+async function requireLibraryArchiveRecordByPublicId(
+  database: Database,
+  library: WikiGraphLibraryRecord,
+  publicId: string,
+): Promise<WikiGraphLibraryArchiveRecord> {
+  const record = await database.queryOne(
+    `
+      SELECT id, library_id, public_id, relative_path, created_at, updated_at
+      FROM library_archives
+      WHERE library_id = ? AND public_id = ?
+    `,
+    [library.id, publicId],
+    (row) => mapLibraryArchiveRecord(row, library),
+  );
+  if (record === undefined) {
+    throw new Error(`Unknown Wiki Graph library archive: ${publicId}`);
+  }
+  return await withLibraryArchiveStatus(record);
+}
+
+function mapLibraryArchiveRecord(
+  row: SqlRow,
+  library: WikiGraphLibraryRecord,
+): WikiGraphLibraryArchiveRecord {
+  const publicId = getString(row, "public_id");
+  const relativePath = getString(row, "relative_path");
+  const archivePath = join(library.folderPath, relativePath);
+  return {
+    archivePath,
+    createdAt: getString(row, "created_at"),
+    id: getNumber(row, "id"),
+    libraryId: getNumber(row, "library_id"),
+    libraryPublicId: library.publicId,
+    libraryUri: library.uri,
+    publicId,
+    relativePath,
+    status: "present",
+    updatedAt: getString(row, "updated_at"),
+    uri: `${library.uri}/${publicId}`,
+  };
+}
+
+async function withLibraryArchiveStatus(
+  archive: WikiGraphLibraryArchiveRecord,
+): Promise<WikiGraphLibraryArchiveRecord> {
+  return {
+    ...archive,
+    status: (await pathExists(archive.archivePath)) ? "present" : "missing",
+  };
+}
+
+async function registerLibraryArchivePath(
+  library: WikiGraphLibraryRecord,
+  relativePath: string,
+): Promise<WikiGraphLibraryArchiveRecord> {
+  return await withLibraryRegistryDatabase(async (database) => {
+    const now = new Date().toISOString();
+    await database.run(
+      `
+        INSERT INTO library_archives (library_id, public_id, relative_path, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+      `,
+      [
+        library.id,
+        await createUniqueLibraryArchivePublicId(database, library.id),
+        relativePath,
+        now,
+        now,
+      ],
+    );
+    const record = await readLibraryArchiveRecordByRelativePath(
+      database,
+      library,
+      relativePath,
+    );
+    if (record === undefined) {
+      throw new Error("Library archive registry insert failed.");
+    }
+    return record;
+  });
+}
+
 async function readLibraryMetadataMap(
   database: Database,
   libraryId: number,
@@ -449,6 +827,24 @@ async function createUniqueLibraryPublicId(
   throw new Error("Could not generate a unique library id.");
 }
 
+async function createUniqueLibraryArchivePublicId(
+  database: Database,
+  libraryId: number,
+): Promise<string> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const publicId = randomBytes(PUBLIC_ID_BYTES).toString("hex");
+    const existing = await database.queryOne(
+      "SELECT public_id FROM library_archives WHERE library_id = ? AND public_id = ?",
+      [libraryId, publicId],
+      (row) => getString(row, "public_id"),
+    );
+    if (existing === undefined) {
+      return publicId;
+    }
+  }
+  throw new Error("Could not generate a unique library archive id.");
+}
+
 async function pathExists(path: string): Promise<boolean> {
   try {
     await stat(path);
@@ -466,4 +862,113 @@ function rejectReservedMetadataKeys(keys: readonly string[]): void {
   if (reserved !== undefined) {
     throw new Error(`Library metadata cannot modify system field: ${reserved}`);
   }
+}
+
+function isLibraryScopeTail(parts: readonly string[]): boolean {
+  return parts.length > 0 && LIBRARY_SCOPE_HEADS.has(parts[0]!);
+}
+
+function formatOptionalObjectUri(parts: readonly string[]): string | undefined {
+  return parts.length === 0
+    ? undefined
+    : formatWikiGraphObjectUri(parts.join("/"));
+}
+
+function formatOptionalObjectUriProperty(parts: readonly string[]): {
+  readonly objectUri?: string;
+} {
+  const objectUri = formatOptionalObjectUri(parts);
+  return objectUri === undefined ? {} : { objectUri };
+}
+
+function formatWikiGraphObjectUri(path: string): string {
+  return `wikg://${path.replace(/^\/+|\/+$/gu, "")}`;
+}
+
+async function listWikgFiles(rootPath: string): Promise<readonly string[]> {
+  const rootRealPath = await realpath(rootPath);
+  const results: string[] = [];
+  await walkLibraryDirectory(rootRealPath, rootRealPath, results);
+  return results.sort((a, b) => a.localeCompare(b));
+}
+
+async function walkLibraryDirectory(
+  rootRealPath: string,
+  directoryPath: string,
+  results: string[],
+): Promise<void> {
+  const entries = await readdir(directoryPath, { withFileTypes: true });
+  for (const entry of entries) {
+    const path = join(directoryPath, entry.name);
+    if (entry.isDirectory()) {
+      const childRealPath = await realpath(path);
+      assertInsideLibrary(childRealPath, rootRealPath);
+      await walkLibraryDirectory(rootRealPath, childRealPath, results);
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(WIKI_GRAPH_ARCHIVE_EXTENSION)) {
+      results.push(toLibraryRelativePath(rootRealPath, path));
+    }
+  }
+}
+
+async function assertReadableWikgFile(
+  path: string,
+  label: string,
+): Promise<void> {
+  if (!path.endsWith(WIKI_GRAPH_ARCHIVE_EXTENSION)) {
+    throw new Error(`${label} must be a .wikg file.`);
+  }
+  const stats = await lstat(path);
+  if (!stats.isFile()) {
+    throw new Error(`${label} must be a regular .wikg file.`);
+  }
+}
+
+function assertSafeLibraryArchiveRelativePath(path: string): string {
+  const normalized = path.replace(/\\/gu, "/").replace(/^\/+|\/+$/gu, "");
+  if (normalized === "") {
+    throw new Error("Library archive path cannot be empty.");
+  }
+  if (isAbsolute(path) || normalized.split("/").includes("..")) {
+    throw new Error(
+      "Library archive path must stay inside the library folder.",
+    );
+  }
+  if (!normalized.endsWith(WIKI_GRAPH_ARCHIVE_EXTENSION)) {
+    throw new Error("Library archive path must end with .wikg.");
+  }
+  return normalized;
+}
+
+async function resolveSafeLibraryArchivePath(
+  library: WikiGraphLibraryRecord,
+  relativePath: string,
+  options: { readonly mustNotExist: boolean },
+): Promise<string> {
+  const rootRealPath = await realpath(library.folderPath);
+  const archivePath = resolve(rootRealPath, relativePath);
+  assertInsideLibrary(archivePath, rootRealPath);
+  const parent = dirname(archivePath);
+  if (await pathExists(parent)) {
+    assertInsideLibrary(await realpath(parent), rootRealPath);
+  }
+  if (options.mustNotExist && (await pathExists(archivePath))) {
+    throw new Error(`Library archive already exists: ${relativePath}`);
+  }
+  return archivePath;
+}
+
+function assertInsideLibrary(path: string, rootPath: string): void {
+  const resolvedRoot = resolve(rootPath);
+  const resolvedPath = resolve(path);
+  const rel = relative(resolvedRoot, resolvedPath);
+  if (rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))) {
+    return;
+  }
+  throw new Error("Library archive path must stay inside the library folder.");
+}
+
+function toLibraryRelativePath(rootPath: string, path: string): string {
+  return relative(rootPath, path).split(sep).join("/");
 }

--- a/packages/core/src/retrieval/query/continuation-cursor/types.ts
+++ b/packages/core/src/retrieval/query/continuation-cursor/types.ts
@@ -1,3 +1,5 @@
+import type { QueryIndexScope } from "../scope.js";
+
 export type ContinuationCursor =
   | {
       readonly archiveKey: string;
@@ -8,6 +10,7 @@ export type ContinuationCursor =
       readonly evidenceLimit?: number;
       readonly format: "json" | "jsonl" | "text";
       readonly ids: readonly string[] | null;
+      readonly indexScope?: QueryIndexScope;
       readonly kind: "collection";
       readonly order: "doc-asc" | "doc-desc";
       readonly sourceContext?: number;
@@ -26,6 +29,7 @@ export type ContinuationCursor =
       readonly cursor: string;
       readonly evidenceLimit?: number;
       readonly format: "json" | "jsonl" | "text";
+      readonly indexScope?: QueryIndexScope;
       readonly kind: "search";
       readonly query?: string;
       readonly sourceContext?: number;
@@ -41,6 +45,7 @@ export type ContinuationCursor =
       readonly archivePath: string;
       readonly cursor: string;
       readonly format: "json" | "jsonl" | "text";
+      readonly indexScope?: QueryIndexScope;
       readonly kind: "evidence";
       readonly order: "doc-asc" | "doc-desc";
       readonly query?: string;
@@ -53,6 +58,7 @@ export type ContinuationCursor =
       readonly cursor: string;
       readonly evidenceLimit?: number;
       readonly format: "json" | "jsonl" | "text";
+      readonly indexScope?: QueryIndexScope;
       readonly kind: "related";
       readonly order: "doc-asc" | "doc-desc";
       readonly query?: string;

--- a/packages/core/src/retrieval/query/index.ts
+++ b/packages/core/src/retrieval/query/index.ts
@@ -55,6 +55,11 @@ export {
 } from "./continuation-cursor/index.js";
 export type { ContinuationCursor } from "./continuation-cursor/index.js";
 export {
+  createArchiveQueryIndexScope,
+  createLibraryQueryIndexScope,
+} from "./scope.js";
+export type { QueryIndexScope, QueryScope } from "./scope.js";
+export {
   createSearchSession,
   deleteArchiveSearchSessions,
   readCachedSearchSessionPage,

--- a/packages/core/src/retrieval/query/scope.ts
+++ b/packages/core/src/retrieval/query/scope.ts
@@ -1,0 +1,29 @@
+export type QueryScope =
+  | { readonly kind: "archive"; readonly archiveId: number }
+  | { readonly kind: "library"; readonly libraryId: number }
+  | {
+      readonly archiveId: number;
+      readonly kind: "library-archive";
+      readonly libraryId: number;
+    };
+
+export type QueryIndexScope =
+  | {
+      readonly archiveKey: string;
+      readonly archivePath: string;
+      readonly kind: "archive-index";
+    }
+  | { readonly kind: "library-index"; readonly libraryId: number };
+
+export function createArchiveQueryIndexScope(input: {
+  readonly archiveKey: string;
+  readonly archivePath: string;
+}): QueryIndexScope {
+  return { ...input, kind: "archive-index" };
+}
+
+export function createLibraryQueryIndexScope(
+  libraryId: number,
+): QueryIndexScope {
+  return { kind: "library-index", libraryId };
+}

--- a/packages/core/src/runtime/common/wiki-graph/uri.ts
+++ b/packages/core/src/runtime/common/wiki-graph/uri.ts
@@ -7,6 +7,10 @@ export const WIKI_GRAPH_ARCHIVE_EXTENSION = ".wikg";
 
 export interface LocatedWikiGraphUri {
   readonly archivePath?: string;
+  readonly libraryArchive?: {
+    readonly archivePublicId: string;
+    readonly libraryPublicId?: string;
+  };
   readonly objectUri?: string;
 }
 
@@ -30,6 +34,12 @@ export function parseLocatedWikiGraphUri(uri: string): LocatedWikiGraphUri {
   const path = split[0] ?? "";
   const hash = split[1] ?? "";
   const parts = path.split("/");
+
+  const libraryArchive = parseLibraryArchiveLocator(parts, hash);
+  if (libraryArchive !== undefined) {
+    return libraryArchive;
+  }
+
   const archiveIndex = parts.findIndex((part) =>
     part.endsWith(WIKI_GRAPH_ARCHIVE_EXTENSION),
   );
@@ -56,6 +66,47 @@ export function parseLocatedWikiGraphUri(uri: string): LocatedWikiGraphUri {
           ),
         }),
   };
+}
+
+function parseLibraryArchiveLocator(
+  parts: readonly string[],
+  hash: string,
+): LocatedWikiGraphUri | undefined {
+  if (parts[0] !== "lib") {
+    return undefined;
+  }
+  const explicitLibrary = /^([^/]+)\.lib$/u.exec(parts[1] ?? "");
+  const archivePublicId = explicitLibrary === null ? parts[1] : parts[2];
+  if (archivePublicId === undefined || archivePublicId === "") {
+    return undefined;
+  }
+  if (archivePublicId.endsWith(WIKI_GRAPH_ARCHIVE_EXTENSION)) {
+    return undefined;
+  }
+  if (isLibraryScopeHead(archivePublicId)) {
+    return undefined;
+  }
+  const objectParts = parts.slice(explicitLibrary === null ? 2 : 3);
+  return {
+    libraryArchive: {
+      archivePublicId,
+      ...(explicitLibrary?.[1] === undefined
+        ? {}
+        : { libraryPublicId: explicitLibrary[1] }),
+    },
+    ...(objectParts.length === 0
+      ? {}
+      : {
+          objectUri: formatWikiGraphObjectUri(
+            objectParts.join("/"),
+            hash === "" ? undefined : hash,
+          ),
+        }),
+  };
+}
+
+function isLibraryScopeHead(value: string): boolean {
+  return /^(?:chapter|chunk|entity|source|summary|triple)$/u.test(value);
 }
 
 function resolveArchivePath(archivePath: string): string {

--- a/test/cli/library.test.ts
+++ b/test/cli/library.test.ts
@@ -101,10 +101,24 @@ describe("cli/library args", () => {
     });
   });
 
-  it("rejects unsupported specified library URI and inspect", () => {
-    expect(() => parseCLIArguments(["wikg://lib/abc123abc123"])).toThrow(
-      ".lib suffix",
-    );
+  it("parses library archive URI actions and rejects inspect", () => {
+    expect(
+      parseCLIArguments(["wikg://lib/abc123abc123", "remove", "--confirm"]),
+    ).toMatchObject({
+      args: {
+        action: "remove",
+        confirm: true,
+        target: { archivePublicId: "abc123abc123", kind: "archive" },
+      },
+      kind: "library",
+    });
+    expect(parseCLIArguments(["wikg://lib/entity/Q23"])).toMatchObject({
+      args: {
+        action: "list",
+        target: { kind: "scope", objectUri: "wikg://entity/Q23" },
+      },
+      kind: "library",
+    });
     expect(() =>
       parseCLIArguments(["wikg://lib/abc123abc123.lib", "inspect"]),
     ).toThrow("does not support `inspect`");

--- a/test/core/library/registry.test.ts
+++ b/test/core/library/registry.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, stat } from "fs/promises";
+import { mkdir, mkdtemp, rm, stat, writeFile } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -10,12 +10,16 @@ import {
   ensureDefaultWikiGraphLibrary,
   formatWikiGraphLibraryUri,
   getWikiGraphLibraryMetadata,
+  addWikiGraphArchiveToLibrary,
   listWikiGraphLibraryScope,
+  moveWikiGraphLibraryArchive,
   parseLocatedWikiGraphUri,
   parseWikiGraphLibraryUri,
   putWikiGraphLibraryMetadata,
+  removeWikiGraphLibraryArchive,
   removeWikiGraphLibrary,
   replaceWikiGraphLibraryMetadata,
+  scanWikiGraphLibraryArchives,
 } from "../../../packages/core/src/index.js";
 
 describe("wiki graph library registry", () => {
@@ -89,9 +93,25 @@ describe("wiki graph library registry", () => {
       kind: "metadata",
       publicId: "abc123abc123",
     });
-    expect(() => parseWikiGraphLibraryUri("wikg://lib/abc123abc123")).toThrow(
-      ".lib suffix",
-    );
+    expect(parseWikiGraphLibraryUri("wikg://lib/entity/Q23")).toStrictEqual({
+      isDefault: true,
+      kind: "scope",
+      objectUri: "wikg://entity/Q23",
+    });
+    expect(
+      parseWikiGraphLibraryUri("wikg://lib/abc123abc123/chapter"),
+    ).toStrictEqual({
+      archivePublicId: "abc123abc123",
+      isDefault: true,
+      kind: "archive",
+      objectUri: "wikg://chapter",
+    });
+    expect(
+      parseLocatedWikiGraphUri("wikg://lib/abc123abc123/chapter"),
+    ).toMatchObject({
+      libraryArchive: { archivePublicId: "abc123abc123" },
+      objectUri: "wikg://chapter",
+    });
     const parsed = parseLocatedWikiGraphUri(
       "wikg://tmp/lib/book.wikg/entity/Q42",
     );
@@ -140,5 +160,70 @@ describe("wiki graph library registry", () => {
     await expect(listWikiGraphLibraryScope(target)).rejects.toThrow(
       "Unknown Wiki Graph library",
     );
+  });
+
+  it("scans, adds, moves, and removes managed library archive files", async () => {
+    const library = await ensureDefaultWikiGraphLibrary();
+    await mkdir(join(library.folderPath, "nested"), { recursive: true });
+    await writeFile(join(library.folderPath, "nested", "book.wikg"), "archive");
+
+    const scan = await scanWikiGraphLibraryArchives({
+      isDefault: true,
+      kind: "scope",
+    });
+    expect(scan.items).toHaveLength(1);
+    expect(scan.items[0]!.relativePath).toBe("nested/book.wikg");
+    await rm(join(library.folderPath, "nested", "book.wikg"));
+    expect(
+      (
+        await scanWikiGraphLibraryArchives({
+          isDefault: true,
+          kind: "scope",
+        })
+      ).items.find((item) => item.relativePath === "nested/book.wikg")?.status,
+    ).toBe("missing");
+
+    const inputPath = join(stateDir, "external.wikg");
+    await writeFile(inputPath, "external");
+    const added = await addWikiGraphArchiveToLibrary({
+      inputPath,
+      target: { isDefault: true, kind: "scope" },
+      to: "imported/book.wikg",
+    });
+    expect(added.archive.relativePath).toBe("imported/book.wikg");
+    await expect(
+      stat(join(library.folderPath, "imported", "book.wikg")),
+    ).resolves.toBeTruthy();
+    await expect(
+      addWikiGraphArchiveToLibrary({
+        inputPath,
+        target: { isDefault: true, kind: "scope" },
+        to: "../escape.wikg",
+      }),
+    ).rejects.toThrow("inside the library folder");
+
+    const moved = await moveWikiGraphLibraryArchive({
+      target: {
+        archivePublicId: added.archive.publicId,
+        isDefault: true,
+        kind: "archive",
+      },
+      to: "renamed/book.wikg",
+    });
+    expect(moved.archive.publicId).toBe(added.archive.publicId);
+    expect(moved.archive.relativePath).toBe("renamed/book.wikg");
+    await expect(
+      stat(join(library.folderPath, "renamed", "book.wikg")),
+    ).resolves.toBeTruthy();
+
+    const removed = await removeWikiGraphLibraryArchive({
+      archivePublicId: moved.archive.publicId,
+      isDefault: true,
+      kind: "archive",
+    });
+    expect(removed.archive.publicId).toBe(added.archive.publicId);
+    await expect(
+      stat(join(library.folderPath, "renamed", "book.wikg")),
+    ).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- add library archive membership registry with recursive scan, add/import, archive remove, and in-library move support
- route library archive and library scope URIs through centralized parsing without stealing .wikg file archive URIs
- add query/index scope types for archive-index and library-index cursor groundwork

## Verification
- pnpm run format:check
- pnpm run lint
- pnpm run typecheck
- pnpm run test:run
- pnpm run build