### PR TITLE
fix: resolve library archive URI scope

### DIFF
--- a/packages/cli/src/args/archive.test.ts
+++ b/packages/cli/src/args/archive.test.ts
@@ -97,6 +97,42 @@ describe("cli/args/archive", () => {
       kind: "archive",
     });
 
+    expect(parseCLIArguments(["wikg://lib/archive123/chapter"])).toStrictEqual({
+      args: {
+        action: "list",
+        archivePath: "wikg://lib/archive123/chapter",
+        format: "text",
+        kinds: ["chapter"],
+      },
+      help: false,
+      kind: "archive",
+    });
+    expect(
+      parseCLIArguments(["wikg://lib/team.lib/archive123/entity/Q23"]),
+    ).toStrictEqual({
+      args: {
+        action: "get",
+        archivePath: "wikg://lib/team.lib/archive123/entity/Q23",
+        format: "text",
+        objectId: "wikg://lib/team.lib/archive123/entity/Q23",
+      },
+      help: false,
+      kind: "archive",
+    });
+    expect(parseCLIArguments(["wikg://lib/entity/Q23"])).toStrictEqual({
+      args: {
+        action: "list",
+        json: undefined,
+        target: {
+          isDefault: true,
+          kind: "scope",
+          objectUri: "wikg://entity/Q23",
+        },
+      },
+      help: false,
+      kind: "library",
+    });
+
     expect(
       parseCLIArguments([
         "wikg://book.wikg/entity/Q1",

--- a/packages/cli/src/commands/archive-command/index.ts
+++ b/packages/cli/src/commands/archive-command/index.ts
@@ -36,6 +36,7 @@ import {
   getSingleObjectEvidenceLimit,
   isArchiveRootGet,
   readArchiveDocument,
+  resolveArchiveCommandRuntimeArguments,
   runNextArchivePage,
   writeArchiveRoot,
 } from "./run/index.js";
@@ -44,6 +45,8 @@ import { resolveArchiveChapterScope } from "./run/scope.js";
 export async function runArchiveCommand(
   args: CLIArchiveArguments,
 ): Promise<void> {
+  args = await resolveArchiveCommandRuntimeArguments(args);
+
   switch (args.action) {
     case "create":
       await createArchive(args);

--- a/packages/cli/src/commands/archive-command/index.ts
+++ b/packages/cli/src/commands/archive-command/index.ts
@@ -37,6 +37,7 @@ import {
   isArchiveRootGet,
   readArchiveDocument,
   resolveArchiveCommandRuntimeArguments,
+  resolveArchiveRuntimeLocation,
   runNextArchivePage,
   writeArchiveRoot,
 } from "./run/index.js";
@@ -67,9 +68,12 @@ export async function runArchiveCommand(
       });
       return;
     case "inspect":
-      await readArchiveDocument(args.archivePath, async (document) => {
-        await writeArchiveInspectReport(document, args);
-      });
+      await readArchiveDocument(
+        (await resolveArchiveRuntimeLocation(args.archivePath)).archivePath,
+        async (document) => {
+          await writeArchiveInspectReport(document, args);
+        },
+      );
       return;
     case "search":
       await readArchiveDocument(

--- a/packages/cli/src/commands/archive-command/run/next.ts
+++ b/packages/cli/src/commands/archive-command/run/next.ts
@@ -17,7 +17,7 @@ import {
 import { readArchiveDocument } from "./document.js";
 import { createCollectionFindResult } from "./options.js";
 import { DEFAULT_OUTPUT_LIMIT } from "./types.js";
-import { getArchivePath } from "./uri.js";
+import { resolveArchiveRuntimeLocation } from "./uri.js";
 
 export async function runNextArchivePage(
   args: CLIArchiveArguments,
@@ -28,16 +28,18 @@ export async function runNextArchivePage(
   const cursor = await readContinuationCursor(cursorId);
 
   if (explicitArchivePath !== undefined) {
-    const archivePath = getArchivePath(explicitArchivePath);
+    const { archivePath } =
+      await resolveArchiveRuntimeLocation(explicitArchivePath);
+    const cursorArchivePath = getCursorArchivePath(cursor);
 
-    if (archivePath !== cursor.archivePath) {
+    if (archivePath !== cursorArchivePath) {
       throw new Error(
-        `Continuation cursor ${cursorId} belongs to ${cursor.archivePath}, not ${archivePath}.`,
+        `Continuation cursor ${cursorId} belongs to ${cursorArchivePath}, not ${archivePath}.`,
       );
     }
   }
 
-  await readArchiveDocument(cursor.archivePath, async (document) => {
+  await readArchiveDocument(getCursorArchivePath(cursor), async (document) => {
     const format = args.format ?? cursor.format;
     const limit = args.limit ?? DEFAULT_OUTPUT_LIMIT;
 
@@ -85,6 +87,7 @@ export async function runNextArchivePage(
               ? {}
               : { evidenceLimit: cursor.evidenceLimit }),
             format,
+            indexScope: cursor.indexScope,
             ...(cursor.ids === null ? {} : { ids: cursor.ids }),
             limit,
             order: cursor.order,
@@ -139,6 +142,7 @@ export async function runNextArchivePage(
               ? {}
               : { evidenceLimit: cursor.evidenceLimit }),
             format,
+            indexScope: cursor.indexScope,
             limit,
             ...(cursor.sourceContext === undefined
               ? {}
@@ -168,6 +172,7 @@ export async function runNextArchivePage(
             archivePath: cursor.archivePath,
             continuationKind: "evidence",
             format,
+            indexScope: cursor.indexScope,
             limit,
             order: cursor.order,
             ...(cursor.query === undefined ? {} : { query: cursor.query }),
@@ -203,6 +208,7 @@ export async function runNextArchivePage(
               ? {}
               : { evidenceLimit: cursor.evidenceLimit }),
             format,
+            indexScope: cursor.indexScope,
             limit,
             order: cursor.order,
             ...(cursor.query === undefined ? {} : { query: cursor.query }),
@@ -218,4 +224,16 @@ export async function runNextArchivePage(
         return;
     }
   });
+}
+
+function getCursorArchivePath(
+  cursor: Awaited<ReturnType<typeof readContinuationCursor>>,
+): string {
+  if (cursor.indexScope === undefined) {
+    return cursor.archivePath;
+  }
+  if (cursor.indexScope.kind === "archive-index") {
+    return cursor.indexScope.archivePath;
+  }
+  return cursor.archivePath;
 }

--- a/packages/cli/src/commands/archive-command/run/options.ts
+++ b/packages/cli/src/commands/archive-command/run/options.ts
@@ -12,7 +12,11 @@ import {
   DEFAULT_OUTPUT_LIMIT,
   type ArchiveOutputContext,
 } from "./types.js";
-import { getArchivePath, parseChapterScope } from "./uri.js";
+import {
+  getArchiveIndexScope,
+  getArchivePath,
+  parseChapterScope,
+} from "./uri.js";
 
 export function createFindOptions(
   args: CLIArchiveArguments,
@@ -57,6 +61,7 @@ export function createArchiveOutputContext(
   return {
     archiveKey: getArchivePath(args.archivePath),
     archivePath: getArchivePath(args.archivePath),
+    indexScope: getArchiveIndexScope(args.archivePath),
     ...(args.backlinks === undefined ? {} : { backlinks: args.backlinks }),
     ...(isEvidenceDisabled(args.evidenceLimit)
       ? { evidenceDisabled: true }

--- a/packages/cli/src/commands/archive-command/run/types.ts
+++ b/packages/cli/src/commands/archive-command/run/types.ts
@@ -1,4 +1,4 @@
-import type { ArchiveCollectionResult } from "wiki-graph-core";
+import type { ArchiveCollectionResult, QueryIndexScope } from "wiki-graph-core";
 
 import type { CLIArchiveArguments } from "../../../args/index.js";
 
@@ -18,6 +18,7 @@ export interface ArchiveOutputContext {
   readonly evidenceLimit?: number;
   readonly format: ResultFormat;
   readonly ids?: readonly string[];
+  readonly indexScope: QueryIndexScope;
   readonly limit: number;
   readonly order?: ArchiveCollectionResult["order"];
   readonly query?: string;

--- a/packages/cli/src/commands/archive-command/run/uri.test.ts
+++ b/packages/cli/src/commands/archive-command/run/uri.test.ts
@@ -1,0 +1,56 @@
+import { mkdtemp, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  addWikiGraphLibraryArchive,
+  parseWikiGraphLibraryUri,
+} from "wiki-graph-core";
+import { resolveArchiveCommandRuntimeArguments } from "./uri.js";
+
+let previousStateDir: string | undefined;
+let tempDir: string;
+
+beforeEach(async () => {
+  previousStateDir = process.env.WIKIGRAPH_STATE_DIR;
+  tempDir = await mkdtemp(join(tmpdir(), "wikigraph-cli-uri-test-"));
+  process.env.WIKIGRAPH_STATE_DIR = join(tempDir, "state");
+});
+
+afterEach(async () => {
+  if (previousStateDir === undefined) {
+    delete process.env.WIKIGRAPH_STATE_DIR;
+  } else {
+    process.env.WIKIGRAPH_STATE_DIR = previousStateDir;
+  }
+  await rm(tempDir, { force: true, recursive: true });
+});
+
+describe("archive-command URI runtime resolution", () => {
+  it("resolves library archive object URIs before running archive commands", async () => {
+    const target = parseWikiGraphLibraryUri("wikg://lib");
+    expect(target).toBeDefined();
+    const source = join(tempDir, "book.wikg");
+    await writeFile(source, "content");
+    const archive = await addWikiGraphLibraryArchive({
+      inputPath: source,
+      target: target!,
+      to: "books/book.wikg",
+    });
+
+    await expect(
+      resolveArchiveCommandRuntimeArguments({
+        action: "get",
+        archivePath: `${archive.uri}/entity/Q23`,
+        format: "json",
+        objectId: `${archive.uri}/entity/Q23`,
+      }),
+    ).resolves.toStrictEqual({
+      action: "get",
+      archivePath: `wikg://${archive.path}/entity/Q23`,
+      format: "json",
+      objectId: `wikg://${archive.path}/entity/Q23`,
+    });
+  });
+});

--- a/packages/cli/src/commands/archive-command/run/uri.ts
+++ b/packages/cli/src/commands/archive-command/run/uri.ts
@@ -1,9 +1,81 @@
-import { requireLocatedObjectOrArchiveUri } from "wiki-graph-core";
+import {
+  formatLocatedWikiGraphUri,
+  parseLocatedWikiGraphUri,
+  requireLocatedObjectOrArchiveUri,
+  resolveWikiGraphLibraryArchivePath,
+  type QueryIndexScope,
+} from "wiki-graph-core";
 
 import type { CLIArchiveArguments } from "../../../args/index.js";
 
+export interface ArchiveRuntimeLocation {
+  readonly archiveKey: string;
+  readonly archivePath: string;
+  readonly indexScope: QueryIndexScope;
+  readonly locatedUri: string;
+}
+
+export async function resolveArchiveRuntimeLocation(
+  uriOrPath: string,
+): Promise<ArchiveRuntimeLocation> {
+  if (!uriOrPath.startsWith("wikg://")) {
+    return {
+      archiveKey: uriOrPath,
+      archivePath: uriOrPath,
+      indexScope: {
+        archiveKey: uriOrPath,
+        archivePath: uriOrPath,
+        kind: "archive-index",
+      },
+      locatedUri: formatLocatedWikiGraphUri(uriOrPath),
+    };
+  }
+
+  const parsed = parseLocatedWikiGraphUri(uriOrPath);
+  const archiveLocator = parsed.archivePath ?? uriOrPath;
+  const archivePath = archiveLocator.startsWith("wikg://lib/")
+    ? await resolveWikiGraphLibraryArchivePath(archiveLocator)
+    : archiveLocator;
+
+  return {
+    archiveKey: archivePath,
+    archivePath,
+    indexScope: { archiveKey: archivePath, archivePath, kind: "archive-index" },
+    locatedUri: formatLocatedWikiGraphUri(archivePath, parsed.objectUri),
+  };
+}
+
+export async function resolveArchiveCommandRuntimeArguments(
+  args: CLIArchiveArguments,
+): Promise<CLIArchiveArguments> {
+  if (
+    args.action === "create" ||
+    args.action === "export" ||
+    args.action === "next"
+  ) {
+    return args;
+  }
+  if (!args.archivePath.startsWith("wikg://lib/")) {
+    return args;
+  }
+
+  const location = await resolveArchiveRuntimeLocation(args.archivePath);
+  return {
+    ...args,
+    archivePath: location.locatedUri,
+    ...(args.objectId === args.archivePath
+      ? { objectId: location.locatedUri }
+      : {}),
+  };
+}
+
 export function getArchivePath(uri: string): string {
   return requireLocatedObjectOrArchiveUri(uri).archivePath;
+}
+
+export function getArchiveIndexScope(uri: string): QueryIndexScope {
+  const archivePath = getArchivePath(uri);
+  return { archiveKey: archivePath, archivePath, kind: "archive-index" };
 }
 
 export function getObjectUri(uri: string): string {

--- a/packages/cli/src/commands/archive-output/object/cursor.ts
+++ b/packages/cli/src/commands/archive-output/object/cursor.ts
@@ -25,7 +25,7 @@ export async function createOutputContinuationCursor(
       archivePath: context.archivePath,
       cursor,
       format: context.format,
-      indexScope: createArchiveIndexScope(context),
+      indexScope: context.indexScope,
       kind: "evidence",
       order: context.order ?? "doc-asc",
       ...(context.query === undefined ? {} : { query: context.query }),
@@ -47,7 +47,7 @@ export async function createOutputContinuationCursor(
         ? {}
         : { evidenceLimit: context.evidenceLimit }),
       format: context.format,
-      indexScope: createArchiveIndexScope(context),
+      indexScope: context.indexScope,
       kind: "related",
       order: context.order ?? "doc-asc",
       ...(context.query === undefined ? {} : { query: context.query }),
@@ -71,7 +71,7 @@ export async function createOutputContinuationCursor(
         : { evidenceLimit: context.evidenceLimit }),
       format: context.format,
       ids: context.ids ?? null,
-      indexScope: createArchiveIndexScope(context),
+      indexScope: context.indexScope,
       kind: "collection",
       order: context.order ?? "doc-asc",
       ...(context.sourceContext === undefined
@@ -94,7 +94,7 @@ export async function createOutputContinuationCursor(
         ? {}
         : { evidenceLimit: context.evidenceLimit }),
       format: context.format,
-      indexScope: createArchiveIndexScope(context),
+      indexScope: context.indexScope,
       kind: "search",
       ...(context.chapters === undefined ? {} : { chapters: context.chapters }),
       ...(context.query === undefined ? {} : { query: context.query }),
@@ -109,12 +109,4 @@ export async function createOutputContinuationCursor(
   }
 
   return await createContinuationCursor(input);
-}
-
-function createArchiveIndexScope(context: ArchiveOutputContext) {
-  return {
-    archiveKey: context.archiveKey,
-    archivePath: context.archivePath,
-    kind: "archive-index" as const,
-  };
 }

--- a/packages/cli/src/commands/archive-output/object/types.ts
+++ b/packages/cli/src/commands/archive-output/object/types.ts
@@ -1,3 +1,4 @@
+import type { QueryIndexScope } from "wiki-graph-core";
 import type { CLIArchiveArguments } from "../../../args/index.js";
 
 export type ResultFormat = "json" | "jsonl" | "text";
@@ -69,6 +70,7 @@ export interface ArchiveOutputContext {
   readonly evidenceLimit?: number;
   readonly format: ResultFormat;
   readonly ids?: readonly string[];
+  readonly indexScope: QueryIndexScope;
   readonly limit: number;
   readonly order?: "doc-asc" | "doc-desc";
   readonly query?: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,6 +56,7 @@ export {
   removeWikiGraphLibrary,
   replaceWikiGraphLibraryMetadata,
   resolveDefaultWikiGraphLibraryDirectoryPath,
+  resolveWikiGraphLibraryArchivePath,
   resolveWikiGraphLibrary,
   resolveWikiGraphLibraryStagingDirectoryPath,
   scanWikiGraphLibrary,

--- a/packages/core/src/library/membership.test.ts
+++ b/packages/core/src/library/membership.test.ts
@@ -14,10 +14,12 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   addWikiGraphLibraryArchive,
   ensureDefaultWikiGraphLibrary,
+  isWikiGraphLibraryUri,
   moveWikiGraphLibraryArchive,
   parseLocatedWikiGraphUri,
   parseWikiGraphLibraryUri,
   removeWikiGraphLibraryArchive,
+  resolveWikiGraphLibraryArchivePath,
   scanWikiGraphLibrary,
 } from "../index.js";
 import { writeWikgArchive } from "../storage/wikg/index.js";
@@ -183,6 +185,14 @@ describe("library archive membership", () => {
 
 describe("library URI locators", () => {
   it("separates library archives from library scopes", () => {
+    expect(isWikiGraphLibraryUri("wikg://lib")).toBe(true);
+    expect(isWikiGraphLibraryUri("wikg://lib/team.lib")).toBe(true);
+    expect(isWikiGraphLibraryUri("wikg://lib/entity/Q23")).toBe(true);
+    expect(isWikiGraphLibraryUri("wikg://lib/archive123/chapter")).toBe(false);
+    expect(
+      isWikiGraphLibraryUri("wikg://lib/team.lib/archive123/chapter"),
+    ).toBe(false);
+
     expect(
       parseLocatedWikiGraphUri("wikg://lib/archive123/chapter"),
     ).toStrictEqual({
@@ -202,6 +212,26 @@ describe("library URI locators", () => {
       objectUri: "wikg://entity",
       publicId: "team",
     });
+  });
+
+  it("resolves a library archive locator to the managed .wikg file", async () => {
+    const target = parseWikiGraphLibraryUri("wikg://lib");
+    expect(target).toBeDefined();
+    const source = join(tempDir, "source.wikg");
+    await writeFile(source, "content");
+
+    const added = await addWikiGraphLibraryArchive({
+      inputPath: source,
+      target: target!,
+      to: "nested/book.wikg",
+    });
+
+    await expect(resolveWikiGraphLibraryArchivePath(added.uri)).resolves.toBe(
+      added.path,
+    );
+    await expect(
+      resolveWikiGraphLibraryArchivePath(`${added.uri}-missing`),
+    ).rejects.toThrow("Unknown Wiki Graph library archive");
   });
 });
 

--- a/packages/core/src/library/membership.ts
+++ b/packages/core/src/library/membership.ts
@@ -24,6 +24,7 @@ import { WIKI_GRAPH_ARCHIVE_EXTENSION } from "../runtime/common/wiki-graph/uri.j
 import { readWikgArchiveMutationToken } from "../storage/wikg/index.js";
 import { isNodeError } from "../utils/node-error.js";
 import {
+  parseWikiGraphLibraryUri,
   resolveWikiGraphLibrary,
   type ParsedWikiGraphLibraryUri,
   type WikiGraphLibraryRecord,
@@ -187,6 +188,29 @@ export async function getWikiGraphLibraryArchive(
 ): Promise<WikiGraphLibraryArchiveRecord> {
   const library = await resolveWikiGraphLibrary(target);
   return await resolveLibraryArchiveTarget(target, library);
+}
+
+export async function resolveWikiGraphLibraryArchivePath(
+  archiveLocator: string,
+): Promise<string> {
+  const target = parseWikiGraphLibraryUri(archiveLocator);
+  if (target === undefined || target.kind !== "archive") {
+    throw new Error(
+      `Expected a Wiki Graph library archive locator: ${archiveLocator}`,
+    );
+  }
+
+  const archive = await getWikiGraphLibraryArchive(target);
+  if (!archive.exists || archive.status === "missing") {
+    throw new Error(`Wiki Graph library archive is missing: ${archiveLocator}`);
+  }
+  if (archive.status === "conflict") {
+    throw new Error(
+      `Wiki Graph library archive has a conflict and cannot be resolved: ${archiveLocator}`,
+    );
+  }
+
+  return archive.path;
 }
 
 export async function addWikiGraphLibraryArchive(input: {

--- a/packages/core/src/library/registry.ts
+++ b/packages/core/src/library/registry.ts
@@ -14,6 +14,7 @@ import {
   resolveWikiGraphHomeDirectoryPath,
   resolveWikiGraphStagingDirectoryPath,
 } from "../runtime/common/wiki-graph/dir.js";
+import { WIKI_GRAPH_ARCHIVE_EXTENSION } from "../runtime/common/wiki-graph/uri.js";
 import { isNodeError } from "../utils/node-error.js";
 
 const DEFAULT_LIBRARY_FOLDER_NAME = "default-library";
@@ -83,16 +84,18 @@ export interface ParsedWikiGraphLibraryUri {
 }
 
 export function isWikiGraphLibraryUri(uri: string | undefined): uri is string {
-  if (uri === "wikg://lib") {
-    return true;
-  }
-  if (uri?.startsWith("wikg://lib/") !== true) {
+  if (uri?.startsWith("wikg://lib") !== true) {
     return false;
   }
-  return !uri
-    .slice("wikg://lib/".length)
-    .split("/")
-    .some((part) => part.endsWith(".wikg"));
+  try {
+    const target = parseWikiGraphLibraryUri(uri);
+    return (
+      target !== undefined &&
+      (target.kind !== "archive" || target.objectUri === undefined)
+    );
+  } catch {
+    return false;
+  }
 }
 
 export function parseWikiGraphLibraryUri(
@@ -109,6 +112,11 @@ export function parseWikiGraphLibraryUri(
   }
 
   const path = uri.slice("wikg://lib/".length).replace(/\/+$/u, "");
+  if (
+    path.split("/").some((part) => part.endsWith(WIKI_GRAPH_ARCHIVE_EXTENSION))
+  ) {
+    return undefined;
+  }
   const explicitLibraryArchiveMatch =
     /^([^/]+)\.lib\/(?!meta(?:\/|$)|chapter(?:\/|$)|chunk(?:\/|$)|entity(?:\/|$)|triple(?:\/|$))([^/]+)(?:\/(.*))?$/u.exec(
       path,

--- a/packages/core/src/runtime/common/wiki-graph/uri.ts
+++ b/packages/core/src/runtime/common/wiki-graph/uri.ts
@@ -71,7 +71,11 @@ function parseLibraryArchiveLocatorBody(
     );
   const groups = match?.groups;
   const archive = groups?.archive;
-  if (archive === undefined || isLibraryScopeSegment(archive)) {
+  if (
+    archive === undefined ||
+    archive.endsWith(WIKI_GRAPH_ARCHIVE_EXTENSION) ||
+    isLibraryScopeSegment(archive)
+  ) {
     return undefined;
   }
   const library = groups?.library;

--- a/test/cli/archive/object.test.ts
+++ b/test/cli/archive/object.test.ts
@@ -239,6 +239,18 @@ describe("cli/archive/object", () => {
     expect(archiveMockState.textWrites[0]).not.toContain("Cost: $");
   });
 
+  it("inspects a resolved located archive URI via its filesystem path", async () => {
+    await runArchiveCommand({
+      action: "inspect",
+      archivePath: "wikg:///tmp/library/book.wikg",
+    });
+
+    expect(archiveMockState.readCalls).toStrictEqual([
+      "/tmp/library/book.wikg",
+    ]);
+    expect(archiveMockState.textWrites[0]).toContain("Archive Inspect");
+  });
+
   it("prints request and job performance hints for multi-chapter generation", async () => {
     archiveMockState.inspectChapters = [
       {


### PR DESCRIPTION
## Summary

This PR completes the #137 follow-up on top of #133/#135 by closing the URI/runtime gaps left after the initial library archive membership merge:

- routes `wikg://lib/<archive-id>/chapter` and `wikg://lib/<lib-id>.lib/<archive-id>/...` through the archive URI/object parser instead of the library management parser
- keeps `wikg://lib`, `wikg://lib/<lib-id>.lib`, `wikg://lib/meta`, and library scope/object URIs such as `wikg://lib/entity/Q23` on the library side
- adds a centralized library archive resolver that maps a library archive locator to the managed `.wikg` file path before archive commands open `WikiGraphArchiveFile`
- threads cursor `QueryIndexScope` through archive output contexts and makes `next` use the cursor index scope when resolving the continuation source

## #133/#135 follow-up and lock points

- URI classification remains centralized in `packages/core/src/runtime/common/wiki-graph/uri.ts` and `packages/core/src/library/registry.ts`:
  - `.wikg` segments stay file archive locators
  - library archive object locators are excluded from `isWikiGraphLibraryUri()` so CLI top-level routing sends them to archive URI parsing
  - library scope/meta/object URIs remain library targets
- Library archive locator -> real file path resolve is centralized in `resolveWikiGraphLibraryArchivePath()` (`packages/core/src/library/membership.ts`) and consumed by archive command runtime resolution (`packages/cli/src/commands/archive-command/run/uri.ts`). Individual `list/search/evidence/related/pack/get` actions do not query the registry themselves.
- Query/index scope handling is centralized at the archive output/runtime boundary:
  - `ArchiveOutputContext` carries `QueryIndexScope`
  - cursor creation reuses `context.indexScope`
  - `next` validates explicit URI arguments after runtime resolution and reads from the cursor index scope path.

## Tests

- `pnpm exec vitest run packages/core/src/library/membership.test.ts packages/core/src/retrieval/query/continuation-cursor/payload.test.ts packages/cli/src/args/archive.test.ts packages/cli/src/commands/archive-command/run/uri.test.ts --passWithNoTests`
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run test`
- `pnpm run build`

Closes #137.
