### PR TITLE
docs: document local CLI development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ web_modules/
 # TypeScript cache
 *.tsbuildinfo
 .spinedigest/
+.wikigraph/
 test/.reports/
 
 # Optional npm cache directory

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ $ wg wikg://quickstart.wikg --query alpha
 Alpha is connected to beta.
 ```
 
+## Local Development
+
+When developing Wiki Graph itself, see [Local CLI Development](./docs/local-cli-development.md) for how to install the current branch as `wg` or run the current checkout through pnpm without a global install.
+
 ## Manual LLM Evals
 
 `pnpm eval:llm` runs a manual summarize/compressor evaluation against a real LLM. It is intentionally not part of `pnpm test`, `pnpm test:run`, or CI. The script prints the case name, model info, raw output, final user-visible output, and heuristic checks so you can judge prompt changes before release.

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -70,6 +70,10 @@ $ wg wikg://quickstart.wikg --query alpha
 Alpha is connected to beta.
 ```
 
+## 本地开发
+
+开发 Wiki Graph 本身时，可阅读 [Local CLI Development](./docs/local-cli-development.md)，了解如何把当前 branch 安装成本机 `wg`，或如何通过 pnpm 直接运行当前 checkout 而不做全局安装。
+
 ## 手动 LLM eval
 
 `pnpm eval:llm` 会用真实大语言模型跑一组手动的 summarize/compressor 评估。它不会被 `pnpm test`、`pnpm test:run` 或 CI 自动触发。脚本会输出 case 名称、模型信息、原始输出、最终用户可见输出和基础启发式检查结果，方便在改 prompt 或切模型前人工判断。

--- a/docs/local-cli-development.md
+++ b/docs/local-cli-development.md
@@ -70,10 +70,10 @@ The extra `--` is passed to the CLI and changes the parsed command.
 
 The installed CLI stores local runtime state under `~/.wikigraph`. The
 development CLI entry point is compiled to use the repository-level
-`project/.wikigraph/state` directory instead, so users cannot change CLI state
+`.wikigraph/state` directory instead, so users cannot change CLI state
 location through environment variables.
 
-Use `project/.wikigraph/` for local development data:
+Use repository-root `.wikigraph/` for local development data:
 
 ```bash
 mkdir -p .wikigraph/state .wikigraph/out .wikigraph/input
@@ -95,14 +95,15 @@ Recommended subdirectories:
 - `.wikigraph/out/`: generated `.wikg` archives and exported regression output;
 - `.wikigraph/input/`: private or temporary local input files.
 
-Remove all local development state and generated regression output with:
+Remove all local development data with:
 
 ```bash
 pnpm cli:clean-dev-state
 ```
 
-This deletes only `project/.wikigraph/`. It does not affect the installed CLI's
-machine-level `~/.wikigraph` directory.
+This deletes repository-root `.wikigraph/`, including `.wikigraph/state/`,
+`.wikigraph/out/`, and `.wikigraph/input/`. It does not affect the installed
+CLI's machine-level `~/.wikigraph` directory.
 
 For repeated shell use, define a local helper from the repository root:
 

--- a/docs/local-cli-development.md
+++ b/docs/local-cli-development.md
@@ -1,0 +1,120 @@
+# Local CLI Development
+
+This document explains how to run the current checkout as the Wiki Graph CLI
+during development.
+
+It covers two different workflows:
+
+- install the current branch as the machine-level `wg` command;
+- run the current branch through pnpm without installing it.
+
+Use the pnpm workflow for day-to-day development and regression checks. Use the
+install workflow only when you explicitly need to preview the packaged CLI as a
+global command.
+
+## Install The Current Branch
+
+Use this workflow when you want the current branch to behave like an installed
+release:
+
+```bash
+pnpm cli:install-local
+```
+
+The script builds and packs the workspace, then installs the generated
+`wiki-graph` package through npm as a global package. After it finishes, `wg`
+and `wikigraph` resolve through the machine-level npm installation.
+
+This workflow is useful for:
+
+- previewing an unreleased version outside the repository;
+- checking package contents, `dist` output, shebangs, and `bin` entries;
+- testing how a normal user will experience the CLI after installation.
+
+It is not the default regression workflow for agents or parallel worktrees. A
+global install is shared by all shells and worktrees on the same machine, so one
+checkout can replace the `wg` command used by another checkout.
+
+Remove the global preview install with:
+
+```bash
+pnpm cli:uninstall-local
+```
+
+## Run Without Installing
+
+Use this workflow for normal development, local regression checks, and agent
+worktree runs:
+
+```bash
+pnpm --filter wiki-graph dev --help
+pnpm --filter wiki-graph dev wikg://book.wikg --help
+pnpm --filter wiki-graph dev help uri
+```
+
+Do not add an extra argument separator after `dev`. For this package, write:
+
+```bash
+pnpm --filter wiki-graph dev wikg://book.wikg --help
+```
+
+Do not write:
+
+```bash
+pnpm --filter wiki-graph dev -- wikg://book.wikg --help
+```
+
+The extra `--` is passed to the CLI and changes the parsed command.
+
+## Development State Directory
+
+Wiki Graph stores local runtime state under `~/.wikigraph` unless
+`WIKIGRAPH_STATE_DIR` is set. The `pnpm --filter wiki-graph dev` script sets
+`WIKIGRAPH_STATE_DIR=../../.wikigraph/state` from `packages/cli`, which resolves
+to the repository-level `project/.wikigraph/state` directory.
+
+Use `project/.wikigraph/` for local development data:
+
+```bash
+mkdir -p .wikigraph/state .wikigraph/out .wikigraph/input
+pnpm --filter wiki-graph dev --help
+```
+
+`pnpm --filter wiki-graph dev` runs the package script from
+`packages/cli`. When you want an archive under the repository-level
+`.wikigraph/out/` directory, pass an absolute `wikg://` URI based on the
+repository root:
+
+```bash
+pnpm --filter wiki-graph dev "wikg://$PWD/.wikigraph/out/regression.wikg" --help
+```
+
+Recommended subdirectories:
+
+- `.wikigraph/state/`: runtime state, cache, queue, logs, and temporary files;
+- `.wikigraph/out/`: generated `.wikg` archives and exported regression output;
+- `.wikigraph/input/`: private or temporary local input files.
+
+For repeated shell use, define a local helper from the repository root:
+
+```bash
+wg-dev() {
+  pnpm --filter wiki-graph dev "$@"
+}
+```
+
+Then run:
+
+```bash
+wg-dev --help
+wg-dev "wikg://$PWD/.wikigraph/out/regression.wikg" inspect
+```
+
+## Choosing The Workflow
+
+Use pnpm without installing when validating source changes, CLI behavior, help
+text, archive operations, state handling, or bug fixes in the current checkout.
+
+Use the install workflow only when the question is about the packaged command
+itself: global `wg` resolution, npm package layout, `dist` artifacts, executable
+metadata, or previewing an unreleased branch outside this repository.

--- a/docs/local-cli-development.md
+++ b/docs/local-cli-development.md
@@ -68,10 +68,10 @@ The extra `--` is passed to the CLI and changes the parsed command.
 
 ## Development State Directory
 
-Wiki Graph stores local runtime state under `~/.wikigraph` unless
-`WIKIGRAPH_STATE_DIR` is set. The `pnpm --filter wiki-graph dev` script sets
-`WIKIGRAPH_STATE_DIR=../../.wikigraph/state` from `packages/cli`, which resolves
-to the repository-level `project/.wikigraph/state` directory.
+The installed CLI stores local runtime state under `~/.wikigraph`. The
+development CLI entry point is compiled to use the repository-level
+`project/.wikigraph/state` directory instead, so users cannot change CLI state
+location through environment variables.
 
 Use `project/.wikigraph/` for local development data:
 

--- a/docs/local-cli-development.md
+++ b/docs/local-cli-development.md
@@ -95,6 +95,15 @@ Recommended subdirectories:
 - `.wikigraph/out/`: generated `.wikg` archives and exported regression output;
 - `.wikigraph/input/`: private or temporary local input files.
 
+Remove all local development state and generated regression output with:
+
+```bash
+pnpm cli:clean-dev-state
+```
+
+This deletes only `project/.wikigraph/`. It does not affect the installed CLI's
+machine-level `~/.wikigraph` directory.
+
 For repeated shell use, define a local helper from the repository root:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "NODE_OPTIONS=--max-old-space-size=8192 pnpm -r --sort run build",
     "coverage:report": "node ./scripts/coverage-report.mjs",
+    "cli:clean-dev-state": "rimraf .wikigraph",
     "cli:install-local": "node ./scripts/install-local-cli.mjs",
     "cli:uninstall-local": "npm uninstall -g wiki-graph",
     "dev": "pnpm --filter wiki-graph dev",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,7 +47,7 @@
   },
   "scripts": {
     "build": "rimraf dist && tsup --config tsup.config.ts && node ../../scripts/copy-package-data.mjs ../core/data dist/data",
-    "dev": "tsx src/bin/cli.ts"
+    "dev": "WIKIGRAPH_STATE_DIR=../../.wikigraph/state tsx src/bin/cli.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.68",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,7 +47,7 @@
   },
   "scripts": {
     "build": "rimraf dist && tsup --config tsup.config.ts && node ../../scripts/copy-package-data.mjs ../core/data dist/data",
-    "dev": "WIKIGRAPH_STATE_DIR=../../.wikigraph/state tsx src/bin/cli.ts"
+    "dev": "tsx src/bin/dev-cli.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.68",

--- a/packages/cli/src/bin/dev-cli.ts
+++ b/packages/cli/src/bin/dev-cli.ts
@@ -6,7 +6,7 @@ declare global {
 
 globalThis.__WIKIGRAPH_STATE_DIR__ = resolve(
   import.meta.dirname,
-  "../../../.wikigraph/state",
+  "../../../../.wikigraph/state",
 );
 
 const { main } = await import("../app/index.js");

--- a/packages/cli/src/bin/dev-cli.ts
+++ b/packages/cli/src/bin/dev-cli.ts
@@ -1,0 +1,14 @@
+import { resolve } from "path";
+
+declare global {
+  var __WIKIGRAPH_STATE_DIR__: string | undefined;
+}
+
+globalThis.__WIKIGRAPH_STATE_DIR__ = resolve(
+  import.meta.dirname,
+  "../../../.wikigraph/state",
+);
+
+const { main } = await import("../app/index.js");
+
+void main();

--- a/packages/cli/src/commands/archive-command/run/uri.test.ts
+++ b/packages/cli/src/commands/archive-command/run/uri.test.ts
@@ -7,23 +7,23 @@ import {
   addWikiGraphLibraryArchive,
   parseWikiGraphLibraryUri,
 } from "wiki-graph-core";
+import {
+  getWikiGraphStateDirectoryPathForTesting,
+  setWikiGraphStateDirectoryPathForTesting,
+} from "../../../../../core/src/runtime/common/wiki-graph/dir.js";
 import { resolveArchiveCommandRuntimeArguments } from "./uri.js";
 
 let previousStateDir: string | undefined;
 let tempDir: string;
 
 beforeEach(async () => {
-  previousStateDir = process.env.WIKIGRAPH_STATE_DIR;
+  previousStateDir = getWikiGraphStateDirectoryPathForTesting();
   tempDir = await mkdtemp(join(tmpdir(), "wikigraph-cli-uri-test-"));
-  process.env.WIKIGRAPH_STATE_DIR = join(tempDir, "state");
+  setWikiGraphStateDirectoryPathForTesting(join(tempDir, "state"));
 });
 
 afterEach(async () => {
-  if (previousStateDir === undefined) {
-    delete process.env.WIKIGRAPH_STATE_DIR;
-  } else {
-    process.env.WIKIGRAPH_STATE_DIR = previousStateDir;
-  }
+  setWikiGraphStateDirectoryPathForTesting(previousStateDir);
   await rm(tempDir, { force: true, recursive: true });
 });
 

--- a/packages/core/src/library/membership.test.ts
+++ b/packages/core/src/library/membership.test.ts
@@ -22,23 +22,23 @@ import {
   resolveWikiGraphLibraryArchivePath,
   scanWikiGraphLibrary,
 } from "../index.js";
+import {
+  getWikiGraphStateDirectoryPathForTesting,
+  setWikiGraphStateDirectoryPathForTesting,
+} from "../runtime/common/wiki-graph/dir.js";
 import { writeWikgArchive } from "../storage/wikg/index.js";
 
 let previousStateDir: string | undefined;
 let tempDir: string;
 
 beforeEach(async () => {
-  previousStateDir = process.env.WIKIGRAPH_STATE_DIR;
+  previousStateDir = getWikiGraphStateDirectoryPathForTesting();
   tempDir = await mkdtemp(join(tmpdir(), "wikigraph-library-test-"));
-  process.env.WIKIGRAPH_STATE_DIR = join(tempDir, "state");
+  setWikiGraphStateDirectoryPathForTesting(join(tempDir, "state"));
 });
 
 afterEach(async () => {
-  if (previousStateDir === undefined) {
-    delete process.env.WIKIGRAPH_STATE_DIR;
-  } else {
-    process.env.WIKIGRAPH_STATE_DIR = previousStateDir;
-  }
+  setWikiGraphStateDirectoryPathForTesting(previousStateDir);
   await rm(tempDir, { force: true, recursive: true });
 });
 

--- a/packages/core/src/runtime/common/wiki-graph/dir.ts
+++ b/packages/core/src/runtime/common/wiki-graph/dir.ts
@@ -24,9 +24,7 @@ export function setWikiGraphStateDirectoryPathForTesting(
   globalThis.__WIKIGRAPH_STATE_DIR__ = path;
 }
 
-export function getWikiGraphStateDirectoryPathForTesting():
-  | string
-  | undefined {
+export function getWikiGraphStateDirectoryPathForTesting(): string | undefined {
   return globalThis.__WIKIGRAPH_STATE_DIR__;
 }
 

--- a/packages/core/src/runtime/common/wiki-graph/dir.ts
+++ b/packages/core/src/runtime/common/wiki-graph/dir.ts
@@ -1,14 +1,33 @@
 import { homedir } from "os";
 import { join, resolve } from "path";
 
-export function resolveWikiGraphHomeDirectoryPath(): string {
-  const localDataRootPath = process.env.WIKIGRAPH_STATE_DIR;
+declare global {
+  var __WIKIGRAPH_STATE_DIR__: string | undefined;
+}
 
-  if (localDataRootPath !== undefined && localDataRootPath.trim() !== "") {
-    return resolve(localDataRootPath);
+export function resolveWikiGraphHomeDirectoryPath(): string {
+  const injectedStateDirPath = globalThis.__WIKIGRAPH_STATE_DIR__;
+
+  if (
+    injectedStateDirPath !== undefined &&
+    injectedStateDirPath.trim() !== ""
+  ) {
+    return resolve(injectedStateDirPath);
   }
 
   return join(homedir(), ".wikigraph");
+}
+
+export function setWikiGraphStateDirectoryPathForTesting(
+  path: string | undefined,
+): void {
+  globalThis.__WIKIGRAPH_STATE_DIR__ = path;
+}
+
+export function getWikiGraphStateDirectoryPathForTesting():
+  | string
+  | undefined {
+  return globalThis.__WIKIGRAPH_STATE_DIR__;
 }
 
 export function resolveWikiGraphCoreDatabasePath(): string {

--- a/test/core/api/app.test.ts
+++ b/test/core/api/app.test.ts
@@ -48,6 +48,10 @@ vi.mock("../../../packages/core/src/api/digest.js", () => ({
 }));
 
 import { WikiGraphScope } from "../../../packages/core/src/runtime/common/llm-scope.js";
+import {
+  getWikiGraphStateDirectoryPathForTesting,
+  setWikiGraphStateDirectoryPathForTesting,
+} from "../../../packages/core/src/runtime/common/wiki-graph/dir.js";
 import { DirectoryDocument } from "../../../packages/core/src/document/index.js";
 import { WikiGraphArchive } from "../../../packages/core/src/api/wiki-graph-archive.js";
 import { Language, WikiGraph } from "../../../packages/core/src/index.js";
@@ -221,9 +225,9 @@ describe("facade/app", () => {
 
   it("opens saved digest archives without requiring llm configuration", async () => {
     await withTempDir("wikigraph-app-", async (path) => {
-      const originalStateDir = process.env.WIKIGRAPH_STATE_DIR;
+      const originalStateDir = getWikiGraphStateDirectoryPathForTesting();
 
-      process.env.WIKIGRAPH_STATE_DIR = `${path}/state`;
+      setWikiGraphStateDirectoryPathForTesting(`${path}/state`);
       const document = await DirectoryDocument.open(`${path}/document`);
 
       try {
@@ -264,11 +268,7 @@ describe("facade/app", () => {
         expect(title).toBe("App Open Fixture");
       } finally {
         await document.release();
-        if (originalStateDir === undefined) {
-          delete process.env.WIKIGRAPH_STATE_DIR;
-        } else {
-          process.env.WIKIGRAPH_STATE_DIR = originalStateDir;
-        }
+        setWikiGraphStateDirectoryPathForTesting(originalStateDir);
       }
     });
   });

--- a/test/core/api/build-queue.test.ts
+++ b/test/core/api/build-queue.test.ts
@@ -17,13 +17,17 @@ import {
   cancelBuildJob,
   recordBuildJobInputRevision,
 } from "../../../packages/core/src/api/index.js";
+import {
+  getWikiGraphStateDirectoryPathForTesting,
+  setWikiGraphStateDirectoryPathForTesting,
+} from "../../../packages/core/src/runtime/common/wiki-graph/dir.js";
 import { withTempDir } from "../../helpers/temp.js";
 
-const originalStateDir = process.env.WIKIGRAPH_STATE_DIR;
+const originalStateDir = getWikiGraphStateDirectoryPathForTesting();
 
 describe("facade/build-queue", () => {
   afterEach(() => {
-    restoreEnv("WIKIGRAPH_STATE_DIR", originalStateDir);
+    restoreWikiGraphStateDir(originalStateDir);
   });
 
   it("merges active reading lane jobs for an archive chapter", async () => {
@@ -1038,16 +1042,11 @@ function requirePromise<T>(promise: Promise<T> | undefined): Promise<T> {
 }
 
 function useStateDir(path: string): void {
-  process.env.WIKIGRAPH_STATE_DIR = path;
+  setWikiGraphStateDirectoryPathForTesting(path);
 }
 
-function restoreEnv(key: string, value: string | undefined): void {
-  if (value === undefined) {
-    delete process.env[key];
-    return;
-  }
-
-  process.env[key] = value;
+function restoreWikiGraphStateDir(value: string | undefined): void {
+  setWikiGraphStateDirectoryPathForTesting(value);
 }
 
 async function withTimeout<T>(

--- a/test/core/library/registry.test.ts
+++ b/test/core/library/registry.test.ts
@@ -17,22 +17,22 @@ import {
   removeWikiGraphLibrary,
   replaceWikiGraphLibraryMetadata,
 } from "../../../packages/core/src/index.js";
+import {
+  getWikiGraphStateDirectoryPathForTesting,
+  setWikiGraphStateDirectoryPathForTesting,
+} from "../../../packages/core/src/runtime/common/wiki-graph/dir.js";
 
 describe("wiki graph library registry", () => {
-  const originalStateDir = process.env.WIKIGRAPH_STATE_DIR;
+  const originalStateDir = getWikiGraphStateDirectoryPathForTesting();
   let stateDir: string;
 
   beforeEach(async () => {
     stateDir = await mkdtemp(join(tmpdir(), "wikg-library-"));
-    process.env.WIKIGRAPH_STATE_DIR = stateDir;
+    setWikiGraphStateDirectoryPathForTesting(stateDir);
   });
 
   afterEach(async () => {
-    if (originalStateDir === undefined) {
-      delete process.env.WIKIGRAPH_STATE_DIR;
-    } else {
-      process.env.WIKIGRAPH_STATE_DIR = originalStateDir;
-    }
+    setWikiGraphStateDirectoryPathForTesting(originalStateDir);
     await rm(stateDir, { force: true, recursive: true });
   });
 

--- a/test/core/retrieval/query/archive-view/graph-search.test.ts
+++ b/test/core/retrieval/query/archive-view/graph-search.test.ts
@@ -2,9 +2,11 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   DirectoryDocument,
   findArchiveObjects,
+  getWikiGraphStateDirectoryPathForTesting,
   rebuildArchiveSearchIndex,
-  restoreEnv,
+  restoreWikiGraphStateDir,
   seedSourcedDocument,
+  setWikiGraphStateDirectoryPathForTesting,
   setupArchiveViewTestState,
   teardownArchiveViewTestState,
   withTempDir,
@@ -16,8 +18,8 @@ afterEach(teardownArchiveViewTestState);
 describe("archive/query/archive-view/graph search", () => {
   it("prioritizes entity matches before source hits", async () => {
     await withTempDir("wikigraph-archive-view-", async (path) => {
-      const previousStateDir = process.env.WIKIGRAPH_STATE_DIR;
-      process.env.WIKIGRAPH_STATE_DIR = `${path}/state`;
+      const previousStateDir = getWikiGraphStateDirectoryPathForTesting();
+      setWikiGraphStateDirectoryPathForTesting(`${path}/state`);
       const document = await DirectoryDocument.open(`${path}/document`);
 
       try {
@@ -68,7 +70,7 @@ describe("archive/query/archive-view/graph search", () => {
           },
         ]);
       } finally {
-        restoreEnv("WIKIGRAPH_STATE_DIR", previousStateDir);
+        restoreWikiGraphStateDir(previousStateDir);
         await document.release();
       }
     });
@@ -116,8 +118,8 @@ describe("archive/query/archive-view/graph search", () => {
 
   it("hydrates entity evidence after reading a search session page", async () => {
     await withTempDir("wikigraph-archive-view-", async (path) => {
-      const previousStateDir = process.env.WIKIGRAPH_STATE_DIR;
-      process.env.WIKIGRAPH_STATE_DIR = `${path}/state`;
+      const previousStateDir = getWikiGraphStateDirectoryPathForTesting();
+      setWikiGraphStateDirectoryPathForTesting(`${path}/state`);
       const document = await DirectoryDocument.open(`${path}/document`);
 
       try {
@@ -183,7 +185,7 @@ describe("archive/query/archive-view/graph search", () => {
           "evidenceMentions",
         );
       } finally {
-        restoreEnv("WIKIGRAPH_STATE_DIR", previousStateDir);
+        restoreWikiGraphStateDir(previousStateDir);
         await document.release();
       }
     });
@@ -191,8 +193,8 @@ describe("archive/query/archive-view/graph search", () => {
 
   it("continues entity search cursors without repeating --type", async () => {
     await withTempDir("wikigraph-archive-view-", async (path) => {
-      const previousStateDir = process.env.WIKIGRAPH_STATE_DIR;
-      process.env.WIKIGRAPH_STATE_DIR = `${path}/state`;
+      const previousStateDir = getWikiGraphStateDirectoryPathForTesting();
+      setWikiGraphStateDirectoryPathForTesting(`${path}/state`);
       const document = await DirectoryDocument.open(`${path}/document`);
 
       try {
@@ -244,7 +246,7 @@ describe("archive/query/archive-view/graph search", () => {
         expect(secondPage.types).toStrictEqual(["entity"]);
         expect(secondPage.items[0]).toMatchObject({ type: "entity" });
       } finally {
-        restoreEnv("WIKIGRAPH_STATE_DIR", previousStateDir);
+        restoreWikiGraphStateDir(previousStateDir);
         await document.release();
       }
     });
@@ -252,8 +254,8 @@ describe("archive/query/archive-view/graph search", () => {
 
   it("keeps exact entity surfaces ahead of weaker same-qid mentions", async () => {
     await withTempDir("wikigraph-archive-view-", async (path) => {
-      const previousStateDir = process.env.WIKIGRAPH_STATE_DIR;
-      process.env.WIKIGRAPH_STATE_DIR = `${path}/state`;
+      const previousStateDir = getWikiGraphStateDirectoryPathForTesting();
+      setWikiGraphStateDirectoryPathForTesting(`${path}/state`);
       const document = await DirectoryDocument.open(`${path}/document`);
 
       try {
@@ -302,7 +304,7 @@ describe("archive/query/archive-view/graph search", () => {
           type: "entity",
         });
       } finally {
-        restoreEnv("WIKIGRAPH_STATE_DIR", previousStateDir);
+        restoreWikiGraphStateDir(previousStateDir);
         await document.release();
       }
     });
@@ -310,8 +312,8 @@ describe("archive/query/archive-view/graph search", () => {
 
   it("does not expand entity matches through qid aliases", async () => {
     await withTempDir("wikigraph-archive-view-", async (path) => {
-      const previousStateDir = process.env.WIKIGRAPH_STATE_DIR;
-      process.env.WIKIGRAPH_STATE_DIR = `${path}/state`;
+      const previousStateDir = getWikiGraphStateDirectoryPathForTesting();
+      setWikiGraphStateDirectoryPathForTesting(`${path}/state`);
       const document = await DirectoryDocument.open(`${path}/document`);
 
       try {
@@ -356,7 +358,7 @@ describe("archive/query/archive-view/graph search", () => {
           type: "entity",
         });
       } finally {
-        restoreEnv("WIKIGRAPH_STATE_DIR", previousStateDir);
+        restoreWikiGraphStateDir(previousStateDir);
         await document.release();
       }
     });
@@ -364,8 +366,8 @@ describe("archive/query/archive-view/graph search", () => {
 
   it("adds only a small bonus for repeated entity evidence", async () => {
     await withTempDir("wikigraph-archive-view-", async (path) => {
-      const previousStateDir = process.env.WIKIGRAPH_STATE_DIR;
-      process.env.WIKIGRAPH_STATE_DIR = `${path}/state`;
+      const previousStateDir = getWikiGraphStateDirectoryPathForTesting();
+      setWikiGraphStateDirectoryPathForTesting(`${path}/state`);
       const document = await DirectoryDocument.open(`${path}/document`);
 
       try {
@@ -407,7 +409,7 @@ describe("archive/query/archive-view/graph search", () => {
         expect(multi?.score).toBeGreaterThan(single?.score ?? 0);
         expect(multi?.score).toBeLessThan((single?.score ?? 0) * 5);
       } finally {
-        restoreEnv("WIKIGRAPH_STATE_DIR", previousStateDir);
+        restoreWikiGraphStateDir(previousStateDir);
         await document.release();
       }
     });
@@ -415,8 +417,8 @@ describe("archive/query/archive-view/graph search", () => {
 
   it("finds triples when only one endpoint matches the query", async () => {
     await withTempDir("wikigraph-archive-view-", async (path) => {
-      const previousStateDir = process.env.WIKIGRAPH_STATE_DIR;
-      process.env.WIKIGRAPH_STATE_DIR = `${path}/state`;
+      const previousStateDir = getWikiGraphStateDirectoryPathForTesting();
+      setWikiGraphStateDirectoryPathForTesting(`${path}/state`);
       const document = await DirectoryDocument.open(`${path}/document`);
 
       try {
@@ -483,7 +485,7 @@ describe("archive/query/archive-view/graph search", () => {
 
         expect(filtered.items).toStrictEqual([]);
       } finally {
-        restoreEnv("WIKIGRAPH_STATE_DIR", previousStateDir);
+        restoreWikiGraphStateDir(previousStateDir);
         await document.release();
       }
     });
@@ -491,8 +493,8 @@ describe("archive/query/archive-view/graph search", () => {
 
   it("adds only a small bonus for repeated triple evidence", async () => {
     await withTempDir("wikigraph-archive-view-", async (path) => {
-      const previousStateDir = process.env.WIKIGRAPH_STATE_DIR;
-      process.env.WIKIGRAPH_STATE_DIR = `${path}/state`;
+      const previousStateDir = getWikiGraphStateDirectoryPathForTesting();
+      setWikiGraphStateDirectoryPathForTesting(`${path}/state`);
       const document = await DirectoryDocument.open(`${path}/document`);
 
       try {
@@ -542,7 +544,7 @@ describe("archive/query/archive-view/graph search", () => {
 
         expect(multi?.score).toBeCloseTo((single?.score ?? 0) * 1.3, 10);
       } finally {
-        restoreEnv("WIKIGRAPH_STATE_DIR", previousStateDir);
+        restoreWikiGraphStateDir(previousStateDir);
         await document.release();
       }
     });

--- a/test/core/retrieval/query/archive-view/helpers.ts
+++ b/test/core/retrieval/query/archive-view/helpers.ts
@@ -7,6 +7,10 @@ import {
   DirectoryDocument,
 } from "../../../../../packages/core/src/document/index.js";
 import {
+  getWikiGraphStateDirectoryPathForTesting,
+  setWikiGraphStateDirectoryPathForTesting,
+} from "../../../../../packages/core/src/runtime/common/wiki-graph/dir.js";
+import {
   findArchiveObjects,
   grepArchiveObjects,
   isArchiveSearchIndexCurrent,
@@ -29,16 +33,16 @@ import {
 import { deleteArchiveSearchSessions } from "../../../../../packages/core/src/retrieval/query/search-cache/index.js";
 import { withTempDir } from "../../../../helpers/temp.js";
 
-const originalStateDir = process.env.WIKIGRAPH_STATE_DIR;
+const originalStateDir = getWikiGraphStateDirectoryPathForTesting();
 let testStateDir: string | undefined;
 
 export async function setupArchiveViewTestState(): Promise<void> {
   testStateDir = await mkdtemp(join(tmpdir(), "wikigraph-state-"));
-  process.env.WIKIGRAPH_STATE_DIR = testStateDir;
+  setWikiGraphStateDirectoryPathForTesting(testStateDir);
 }
 
 export async function teardownArchiveViewTestState(): Promise<void> {
-  restoreEnv("WIKIGRAPH_STATE_DIR", originalStateDir);
+  restoreWikiGraphStateDir(originalStateDir);
   if (testStateDir !== undefined) {
     await rm(testStateDir, { force: true, recursive: true });
     testStateDir = undefined;
@@ -151,14 +155,14 @@ export async function seedSourcedDocument(
   await rebuildArchiveSearchIndex(document);
 }
 
-export function restoreEnv(name: string, value: string | undefined): void {
-  if (value === undefined) {
-    delete process.env[name];
-    return;
-  }
-
-  process.env[name] = value;
+export function restoreWikiGraphStateDir(value: string | undefined): void {
+  setWikiGraphStateDirectoryPathForTesting(value);
 }
+
+export {
+  getWikiGraphStateDirectoryPathForTesting,
+  setWikiGraphStateDirectoryPathForTesting,
+};
 
 export async function listDocumentTableNames(
   document: DirectoryDocument,

--- a/test/core/retrieval/query/archive-view/pages.test.ts
+++ b/test/core/retrieval/query/archive-view/pages.test.ts
@@ -3,12 +3,14 @@ import {
   DirectoryDocument,
   createEntityWikipageMockFetch,
   findArchiveObjects,
+  getWikiGraphStateDirectoryPathForTesting,
   listArchiveCollection,
   listArchiveEvidence,
   listArchiveObjects,
   readArchivePage,
-  restoreEnv,
+  restoreWikiGraphStateDir,
   seedSourcedDocument,
+  setWikiGraphStateDirectoryPathForTesting,
   setupArchiveViewTestState,
   teardownArchiveViewTestState,
   withTempDir,
@@ -128,8 +130,8 @@ describe("archive/query/archive-view/pages", () => {
 
   it("does not include metadata fields in search", async () => {
     await withTempDir("wikigraph-archive-view-", async (path) => {
-      const previousStateDir = process.env.WIKIGRAPH_STATE_DIR;
-      process.env.WIKIGRAPH_STATE_DIR = `${path}/state`;
+      const previousStateDir = getWikiGraphStateDirectoryPathForTesting();
+      setWikiGraphStateDirectoryPathForTesting(`${path}/state`);
       const document = await DirectoryDocument.open(`${path}/document`);
 
       try {
@@ -161,7 +163,7 @@ describe("archive/query/archive-view/pages", () => {
           }),
         ).resolves.toMatchObject({ items: [] });
       } finally {
-        restoreEnv("WIKIGRAPH_STATE_DIR", previousStateDir);
+        restoreWikiGraphStateDir(previousStateDir);
         await document.release();
       }
     });
@@ -169,8 +171,8 @@ describe("archive/query/archive-view/pages", () => {
 
   it("treats chapter search results as title hits only", async () => {
     await withTempDir("wikigraph-archive-view-", async (path) => {
-      const previousStateDir = process.env.WIKIGRAPH_STATE_DIR;
-      process.env.WIKIGRAPH_STATE_DIR = `${path}/state`;
+      const previousStateDir = getWikiGraphStateDirectoryPathForTesting();
+      setWikiGraphStateDirectoryPathForTesting(`${path}/state`);
       const document = await DirectoryDocument.open(`${path}/document`);
 
       try {
@@ -194,7 +196,7 @@ describe("archive/query/archive-view/pages", () => {
           }),
         );
       } finally {
-        restoreEnv("WIKIGRAPH_STATE_DIR", previousStateDir);
+        restoreWikiGraphStateDir(previousStateDir);
         await document.release();
       }
     });

--- a/test/core/retrieval/query/archive-view/text-search.test.ts
+++ b/test/core/retrieval/query/archive-view/text-search.test.ts
@@ -6,13 +6,15 @@ import {
   countStructuredCacheRowsForQuery,
   deleteArchiveSearchSessions,
   findArchiveObjects,
+  getWikiGraphStateDirectoryPathForTesting,
   listDocumentTableNames,
   listSearchIndexTableNames,
   querySearchIndex,
   readArchivePage,
   rebuildArchiveSearchIndex,
-  restoreEnv,
+  restoreWikiGraphStateDir,
   seedSourcedDocument,
+  setWikiGraphStateDirectoryPathForTesting,
   setupArchiveViewTestState,
   teardownArchiveViewTestState,
   withTempDir,
@@ -400,8 +402,8 @@ describe("archive/query/archive-view/text search", () => {
 
   it("caches empty search results for repeated queries", async () => {
     await withTempDir("wikigraph-archive-view-", async (path) => {
-      const previousStateDir = process.env.WIKIGRAPH_STATE_DIR;
-      process.env.WIKIGRAPH_STATE_DIR = `${path}/state`;
+      const previousStateDir = getWikiGraphStateDirectoryPathForTesting();
+      setWikiGraphStateDirectoryPathForTesting(`${path}/state`);
       const document = await DirectoryDocument.open(`${path}/document`);
 
       try {
@@ -430,7 +432,7 @@ describe("archive/query/archive-view/text search", () => {
         expect(first.items).toStrictEqual([]);
         expect(second.items).toStrictEqual([]);
       } finally {
-        restoreEnv("WIKIGRAPH_STATE_DIR", previousStateDir);
+        restoreWikiGraphStateDir(previousStateDir);
         await document.release();
       }
     });
@@ -438,8 +440,8 @@ describe("archive/query/archive-view/text search", () => {
 
   it("keeps search caches isolated by type and chapter filters", async () => {
     await withTempDir("wikigraph-archive-view-", async (path) => {
-      const previousStateDir = process.env.WIKIGRAPH_STATE_DIR;
-      process.env.WIKIGRAPH_STATE_DIR = `${path}/state`;
+      const previousStateDir = getWikiGraphStateDirectoryPathForTesting();
+      setWikiGraphStateDirectoryPathForTesting(`${path}/state`);
       const document = await DirectoryDocument.open(`${path}/document`);
 
       try {
@@ -527,7 +529,7 @@ describe("archive/query/archive-view/text search", () => {
           ]),
         ).resolves.toBe(0);
       } finally {
-        restoreEnv("WIKIGRAPH_STATE_DIR", previousStateDir);
+        restoreWikiGraphStateDir(previousStateDir);
         await document.release();
       }
     });
@@ -535,8 +537,8 @@ describe("archive/query/archive-view/text search", () => {
 
   it("groups field-level hits into one object search result", async () => {
     await withTempDir("wikigraph-archive-view-", async (path) => {
-      const previousStateDir = process.env.WIKIGRAPH_STATE_DIR;
-      process.env.WIKIGRAPH_STATE_DIR = `${path}/state`;
+      const previousStateDir = getWikiGraphStateDirectoryPathForTesting();
+      setWikiGraphStateDirectoryPathForTesting(`${path}/state`);
       const document = await DirectoryDocument.open(`${path}/document`);
 
       try {
@@ -567,7 +569,7 @@ describe("archive/query/archive-view/text search", () => {
           }),
         ]);
       } finally {
-        restoreEnv("WIKIGRAPH_STATE_DIR", previousStateDir);
+        restoreWikiGraphStateDir(previousStateDir);
         await document.release();
       }
     });
@@ -575,8 +577,8 @@ describe("archive/query/archive-view/text search", () => {
 
   it("refreshes cached search results after archive cache invalidation", async () => {
     await withTempDir("wikigraph-archive-view-", async (path) => {
-      const previousStateDir = process.env.WIKIGRAPH_STATE_DIR;
-      process.env.WIKIGRAPH_STATE_DIR = `${path}/state`;
+      const previousStateDir = getWikiGraphStateDirectoryPathForTesting();
+      setWikiGraphStateDirectoryPathForTesting(`${path}/state`);
       const document = await DirectoryDocument.open(`${path}/document`);
 
       try {
@@ -614,7 +616,7 @@ describe("archive/query/archive-view/text search", () => {
           }),
         ]);
       } finally {
-        restoreEnv("WIKIGRAPH_STATE_DIR", previousStateDir);
+        restoreWikiGraphStateDir(previousStateDir);
         await document.release();
       }
     });

--- a/test/core/retrieval/query/search-cache.test.ts
+++ b/test/core/retrieval/query/search-cache.test.ts
@@ -7,18 +7,22 @@ import {
   createSearchSession,
   deleteArchiveSearchSessions,
 } from "../../../../packages/core/src/retrieval/query/search-cache/index.js";
+import {
+  getWikiGraphStateDirectoryPathForTesting,
+  setWikiGraphStateDirectoryPathForTesting,
+} from "../../../../packages/core/src/runtime/common/wiki-graph/dir.js";
 import { withTempDir } from "../../../helpers/temp.js";
 
-const originalStateDir = process.env.WIKIGRAPH_STATE_DIR;
+const originalStateDir = getWikiGraphStateDirectoryPathForTesting();
 
 describe("archive/query/search-cache", () => {
   afterEach(() => {
-    restoreEnv("WIKIGRAPH_STATE_DIR", originalStateDir);
+    setWikiGraphStateDirectoryPathForTesting(originalStateDir);
   });
 
   it("creates indexes for search session lookup and ranking", async () => {
     await withTempDir("wikigraph-search-cache-", async (path) => {
-      process.env.WIKIGRAPH_STATE_DIR = path;
+      setWikiGraphStateDirectoryPathForTesting(path);
 
       await createSearchSession({
         archiveKey: "archive-key",
@@ -72,7 +76,7 @@ describe("archive/query/search-cache", () => {
 
   it("removes predicate dictionary entries after their triple hits are deleted", async () => {
     await withTempDir("wikigraph-search-cache-", async (path) => {
-      process.env.WIKIGRAPH_STATE_DIR = path;
+      setWikiGraphStateDirectoryPathForTesting(path);
 
       await createSearchSession({
         archiveKey: "archive-a",
@@ -180,13 +184,4 @@ async function listPredicates(path: string): Promise<string[]> {
   } finally {
     await database.close();
   }
-}
-
-function restoreEnv(name: string, value: string | undefined): void {
-  if (value === undefined) {
-    delete process.env[name];
-    return;
-  }
-
-  process.env[name] = value;
 }

--- a/test/core/runtime/gc/gc.test.ts
+++ b/test/core/runtime/gc/gc.test.ts
@@ -5,6 +5,11 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { createWikiGraphTempDirectory } from "../../../../packages/core/src/runtime/common/wiki-graph/temp.js";
 import {
+  getWikiGraphStateDirectoryPathForTesting,
+  resolveWikiGraphHomeDirectoryPath,
+  setWikiGraphStateDirectoryPathForTesting,
+} from "../../../../packages/core/src/runtime/common/wiki-graph/dir.js";
+import {
   Database,
   DirectoryDocument,
 } from "../../../../packages/core/src/document/index.js";
@@ -20,16 +25,16 @@ import { WikiGraphArchiveFile } from "../../../../packages/core/src/storage/wikg
 import { WikipageCache } from "../../../../packages/core/src/external/wikipage/index.js";
 import { withTempDir } from "../../../helpers/temp.js";
 
-const originalStateDir = process.env.WIKIGRAPH_STATE_DIR;
+const originalStateDir = getWikiGraphStateDirectoryPathForTesting();
 
 describe("gc", () => {
   afterEach(() => {
-    restoreEnv("WIKIGRAPH_STATE_DIR", originalStateDir);
+    restoreWikiGraphStateDir(originalStateDir);
   });
 
   it("cleans expired search sessions, completed jobs, and old controlled tmp directories", async () => {
     await withTempDir("wikigraph-gc-", async (path) => {
-      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      setWikiGraphStateDirectoryPathForTesting(join(path, "state"));
 
       await createExpiredSearchSession();
       const job = await createCompletedOldJob(path);
@@ -65,7 +70,7 @@ describe("gc", () => {
 
   it("removes expired wikipage cache entries", async () => {
     await withTempDir("wikigraph-gc-", async (path) => {
-      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      setWikiGraphStateDirectoryPathForTesting(join(path, "state"));
       await createWikipageCacheRows(
         new Date(Date.now() - 40 * 24 * 60 * 60 * 1000).toISOString(),
       );
@@ -90,7 +95,7 @@ describe("gc", () => {
 
   it("keeps fresh wikipage cache entries during forced GC", async () => {
     await withTempDir("wikigraph-gc-", async (path) => {
-      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      setWikiGraphStateDirectoryPathForTesting(join(path, "state"));
       await createWikipageCacheRows(new Date().toISOString());
 
       const report = await tryRunWikiGraphGc({ force: true });
@@ -113,7 +118,7 @@ describe("gc", () => {
 
   it("reports expired wikipage cache entries during dry-run GC", async () => {
     await withTempDir("wikigraph-gc-", async (path) => {
-      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      setWikiGraphStateDirectoryPathForTesting(join(path, "state"));
       await createWikipageCacheRows(
         new Date(Date.now() - 40 * 24 * 60 * 60 * 1000).toISOString(),
       );
@@ -141,7 +146,7 @@ describe("gc", () => {
 
   it("skips when another GC run owns the global lock", async () => {
     await withTempDir("wikigraph-gc-", async (path) => {
-      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      setWikiGraphStateDirectoryPathForTesting(join(path, "state"));
       await insertGcLock();
 
       const report = await tryRunWikiGraphGc();
@@ -153,7 +158,7 @@ describe("gc", () => {
 
   it("removes orphan library index staging while preserving valid and locked libraries", async () => {
     await withTempDir("wikigraph-gc-", async (path) => {
-      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      setWikiGraphStateDirectoryPathForTesting(join(path, "state"));
       const library = await createWikiGraphLibrary({
         folderPath: join(path, "library"),
       });
@@ -184,7 +189,7 @@ describe("gc", () => {
 
   it("keeps library index staging when registry ids cannot be read", async () => {
     await withTempDir("wikigraph-gc-", async (path) => {
-      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      setWikiGraphStateDirectoryPathForTesting(join(path, "state"));
       const libraryPath = join(path, "state", "staging", "library", "1");
 
       await mkdir(libraryPath, { recursive: true });
@@ -203,7 +208,7 @@ describe("gc", () => {
 
   it("keeps fresh sqlite cache during normal GC", async () => {
     await withTempDir("wikigraph-gc-", async (path) => {
-      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      setWikiGraphStateDirectoryPathForTesting(join(path, "state"));
       const sqliteCachePath = await createCoordinatorSqliteCache(path, {
         updatedAt: Date.now(),
       });
@@ -217,7 +222,7 @@ describe("gc", () => {
 
   it("removes fresh sqlite cache during forced GC", async () => {
     await withTempDir("wikigraph-gc-", async (path) => {
-      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      setWikiGraphStateDirectoryPathForTesting(join(path, "state"));
       const sqliteCachePath = await createCoordinatorSqliteCache(path, {
         updatedAt: Date.now(),
       });
@@ -237,7 +242,7 @@ describe("gc", () => {
 
   it("removes stale empty workspace directories", async () => {
     await withTempDir("wikigraph-gc-", async (path) => {
-      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      setWikiGraphStateDirectoryPathForTesting(join(path, "state"));
       const workspaceBucketPath = join(
         path,
         "state",
@@ -272,7 +277,7 @@ describe("gc", () => {
 
   it("removes dirty external fts sqlite cache during normal GC", async () => {
     await withTempDir("wikigraph-gc-", async (path) => {
-      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      setWikiGraphStateDirectoryPathForTesting(join(path, "state"));
       const sqliteCachePath = await createCoordinatorSqliteCache(path, {
         entryPath: "fts.db",
         updatedAt: Date.now() - 2 * 60 * 60 * 1000,
@@ -293,7 +298,7 @@ describe("gc", () => {
 
   it("keeps current external fts sqlite cache during normal GC and removes it during forced GC", async () => {
     await withTempDir("wikigraph-gc-", async (path) => {
-      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      setWikiGraphStateDirectoryPathForTesting(join(path, "state"));
       const { ftsPath } = await createArchiveWithExternalSearchIndex(path);
 
       await makeCoordinatorOverlayOld("fts.db");
@@ -314,7 +319,7 @@ describe("gc", () => {
 
   it("removes external fts sqlite cache when the source archive is missing", async () => {
     await withTempDir("wikigraph-gc-", async (path) => {
-      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      setWikiGraphStateDirectoryPathForTesting(join(path, "state"));
       const { archivePath, ftsPath } =
         await createArchiveWithExternalSearchIndex(path);
 
@@ -328,7 +333,7 @@ describe("gc", () => {
 
   it("removes external fts sqlite cache when the archive fingerprint changes", async () => {
     await withTempDir("wikigraph-gc-", async (path) => {
-      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      setWikiGraphStateDirectoryPathForTesting(join(path, "state"));
       const { archivePath, ftsPath } =
         await createArchiveWithExternalSearchIndex(path);
 
@@ -352,7 +357,7 @@ describe("gc", () => {
 
   it("removes orphaned coordinator workspace files", async () => {
     await withTempDir("wikigraph-gc-", async (path) => {
-      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      setWikiGraphStateDirectoryPathForTesting(join(path, "state"));
       const workspaceBucketPath = join(
         path,
         "state",
@@ -392,7 +397,7 @@ describe("gc", () => {
 
   it("removes empty coordinator workspace descendants", async () => {
     await withTempDir("wikigraph-gc-", async (path) => {
-      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      setWikiGraphStateDirectoryPathForTesting(join(path, "state"));
       const workspaceBucketPath = join(
         path,
         "state",
@@ -436,7 +441,7 @@ describe("gc", () => {
 
   it("keeps fresh terminal build jobs during normal GC", async () => {
     await withTempDir("wikigraph-gc-", async (path) => {
-      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      setWikiGraphStateDirectoryPathForTesting(join(path, "state"));
       const job = await createCompletedJob(path, {
         ageMs: 0,
         state: "failed",
@@ -457,7 +462,7 @@ describe("gc", () => {
 
   it("removes fresh terminal build jobs during forced GC", async () => {
     await withTempDir("wikigraph-gc-", async (path) => {
-      process.env.WIKIGRAPH_STATE_DIR = join(path, "state");
+      setWikiGraphStateDirectoryPathForTesting(join(path, "state"));
       const job = await createCompletedJob(path, {
         ageMs: 0,
         state: "failed",
@@ -895,24 +900,14 @@ async function openStateDatabase(
   databaseName: string,
   schemaSql = "",
 ): Promise<Database> {
-  if (process.env.WIKIGRAPH_STATE_DIR === undefined) {
-    throw new Error("WIKIGRAPH_STATE_DIR is not set.");
-  }
+  const stateDirPath = resolveWikiGraphHomeDirectoryPath();
 
-  await mkdir(dirname(join(process.env.WIKIGRAPH_STATE_DIR, databaseName)), {
+  await mkdir(dirname(join(stateDirPath, databaseName)), {
     recursive: true,
   });
-  return await Database.open(
-    join(process.env.WIKIGRAPH_STATE_DIR, databaseName),
-    schemaSql,
-  );
+  return await Database.open(join(stateDirPath, databaseName), schemaSql);
 }
 
-function restoreEnv(name: string, value: string | undefined): void {
-  if (value === undefined) {
-    delete process.env[name];
-    return;
-  }
-
-  process.env[name] = value;
+function restoreWikiGraphStateDir(value: string | undefined): void {
+  setWikiGraphStateDirectoryPathForTesting(value);
 }

--- a/test/core/storage/wikg/wiki-graph-archive-file.test.ts
+++ b/test/core/storage/wikg/wiki-graph-archive-file.test.ts
@@ -6,6 +6,10 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { DirectoryDocument } from "../../../../packages/core/src/document/index.js";
 import {
+  getWikiGraphStateDirectoryPathForTesting,
+  setWikiGraphStateDirectoryPathForTesting,
+} from "../../../../packages/core/src/runtime/common/wiki-graph/dir.js";
+import {
   findArchiveObjects,
   rebuildArchiveSearchIndex,
 } from "../../../../packages/core/src/retrieval/query/view.js";
@@ -14,7 +18,7 @@ import { WikiGraphArchive } from "../../../../packages/core/src/api/wiki-graph-a
 import { WikiGraphArchiveFile } from "../../../../packages/core/src/storage/wikg/wiki-graph-archive-file.js";
 import { withTempDir } from "../../../helpers/temp.js";
 
-const originalStateDir = process.env.WIKIGRAPH_STATE_DIR;
+const originalStateDir = getWikiGraphStateDirectoryPathForTesting();
 
 describe("wikg/wiki-graph-archive-file", () => {
   afterEach(() => {
@@ -676,26 +680,21 @@ function createArchiveKey(archivePath: string): string {
 }
 
 function useCoordinatorStateDir(path: string): () => void {
-  const previousStateDir = process.env.WIKIGRAPH_STATE_DIR;
+  const previousStateDir = getWikiGraphStateDirectoryPathForTesting();
 
-  process.env.WIKIGRAPH_STATE_DIR = path;
+  setWikiGraphStateDirectoryPathForTesting(path);
 
   return () => {
-    restoreEnv("WIKIGRAPH_STATE_DIR", previousStateDir);
+    restoreWikiGraphStateDir(previousStateDir);
   };
 }
 
 function restoreCoordinatorEnv(): void {
-  restoreEnv("WIKIGRAPH_STATE_DIR", originalStateDir);
+  restoreWikiGraphStateDir(originalStateDir);
 }
 
-function restoreEnv(key: string, value: string | undefined): void {
-  if (value === undefined) {
-    delete process.env[key];
-    return;
-  }
-
-  process.env[key] = value;
+function restoreWikiGraphStateDir(value: string | undefined): void {
+  setWikiGraphStateDirectoryPathForTesting(value);
 }
 
 function expectString(value: unknown): string {


### PR DESCRIPTION
## Summary
- document how to install the current branch as `wg` or run it through pnpm without installing
- bind the dev CLI state directory internally to `project/.wikigraph/state` instead of reading `WIKIGRAPH_STATE_DIR`
- add `pnpm cli:clean-dev-state` for removing local development state

## Validation
- `pnpm typecheck`
- `pnpm test:run test/core/runtime/gc/gc.test.ts test/core/api/build-queue.test.ts test/core/api/app.test.ts test/core/storage/wikg/wiki-graph-archive-file.test.ts test/core/retrieval/query/archive-view/graph-search.test.ts test/core/retrieval/query/archive-view/text-search.test.ts test/core/retrieval/query/archive-view/pages.test.ts test/core/retrieval/query/search-cache.test.ts test/core/library/registry.test.ts packages/core/src/library/membership.test.ts packages/cli/src/commands/archive-command/run/uri.test.ts`
- `pnpm --filter wiki-graph dev --help`
- `pnpm --filter wiki-graph dev "wikg://$PWD/.wikigraph/out/regression.wikg" --help`
- `pnpm cli:clean-dev-state`
