### PR TITLE
fix(cli): dirty library index after archive writes

### DIFF
--- a/packages/cli/src/args/archive-index.test.ts
+++ b/packages/cli/src/args/archive-index.test.ts
@@ -120,5 +120,21 @@ describe("cli/args/archive index", () => {
     expect(() =>
       parseCLIArguments(["wikg://lib/index", "enable", "--to", "x.wikg"]),
     ).toThrow("The `enable` command does not support --to.");
+    expect(() => parseCLIArguments(["wikg://lib/index", "embed"])).toThrow(
+      "The library index wikg://lib/index does not support `embed`.\nSee: wg wikg://lib/index embed --help",
+    );
+    expect(() => parseCLIArguments(["wikg://lib/index", "external"])).toThrow(
+      "The library index wikg://lib/index does not support `external`.\nSee: wg wikg://lib/index external --help",
+    );
+    expect(() =>
+      parseCLIArguments(["wikg://lib/team.lib/index", "embed"]),
+    ).toThrow(
+      "The library index wikg://lib/team.lib/index does not support `embed`.\nSee: wg wikg://lib/team.lib/index embed --help",
+    );
+    expect(() =>
+      parseCLIArguments(["wikg://lib/team.lib/index", "external"]),
+    ).toThrow(
+      "The library index wikg://lib/team.lib/index does not support `external`.\nSee: wg wikg://lib/team.lib/index external --help",
+    );
   });
 });

--- a/packages/cli/src/commands/archive-command/chapter.ts
+++ b/packages/cli/src/commands/archive-command/chapter.ts
@@ -30,6 +30,8 @@ import {
   writeTextToStdout,
 } from "../../support/index.js";
 import { formatCLIJSON } from "../../support/index.js";
+import { readArchiveDocument, writeArchiveDocument } from "./run/document.js";
+import { resolveArchiveRuntimeLocation } from "./run/uri.js";
 
 export async function runArchiveChapterCommand(
   args: CLIArchiveChapterArguments,
@@ -63,14 +65,12 @@ export async function runArchiveChapterCommand(
       });
       return;
     case "list":
-      await new WikiGraphArchiveFile(args.path).readDocument(
-        async (document) => {
-          await writeChapterList(
-            await listChapters(document),
-            args.json ?? false,
-          );
-        },
-      );
+      await readArchiveDocument(args.path, async (document) => {
+        await writeChapterList(
+          await listChapters(document),
+          args.json ?? false,
+        );
+      });
       return;
     case "move":
       await runEditableCommand(args.path, async (document) => {
@@ -218,34 +218,36 @@ export async function runArchiveChapterCommand(
       return;
     case "tree":
       if (args.treeAction === "apply") {
-        await runEditableCommand(args.path, async (document) => {
-          if (args.dryRun !== true) {
-            await assertNoActiveBuildJobConflicts({
-              archivePath: args.path,
-              operation: "Changing chapter tree",
-              scope: { kind: "archive" },
-            });
-          }
-          await writeChapterTreeApplyResult(
-            await applyChapterTree(
-              document,
-              parseChapterTreeInput(JSON.parse(await readContentText(args))),
-              { dryRun: args.dryRun ?? false },
-            ),
-            args.dryRun ?? false,
-          );
-        });
+        await runEditableCommand(
+          args.path,
+          async (document) => {
+            if (args.dryRun !== true) {
+              await assertNoActiveBuildJobConflicts({
+                archivePath: args.path,
+                operation: "Changing chapter tree",
+                scope: { kind: "archive" },
+              });
+            }
+            await writeChapterTreeApplyResult(
+              await applyChapterTree(
+                document,
+                parseChapterTreeInput(JSON.parse(await readContentText(args))),
+                { dryRun: args.dryRun ?? false },
+              ),
+              args.dryRun ?? false,
+            );
+          },
+          { markLibraryDirty: args.dryRun !== true },
+        );
         return;
       }
 
-      await new WikiGraphArchiveFile(args.path).readDocument(
-        async (document) => {
-          await writeChapterTree(
-            await getChapterTree(document),
-            args.json ?? false,
-          );
-        },
-      );
+      await readArchiveDocument(args.path, async (document) => {
+        await writeChapterTree(
+          await getChapterTree(document),
+          args.json ?? false,
+        );
+      });
       return;
   }
 }
@@ -272,8 +274,15 @@ async function resolveOptionalChapterPath(
 async function runEditableCommand(
   path: string,
   operation: (document: DirectoryDocument) => Promise<void> | void,
+  options: { readonly markLibraryDirty?: boolean } = {},
 ): Promise<void> {
-  await new WikiGraphArchiveFile(path).write(operation);
+  if (options.markLibraryDirty === false) {
+    const location = await resolveArchiveRuntimeLocation(path);
+    await new WikiGraphArchiveFile(location.archivePath).write(operation);
+    return;
+  }
+
+  await writeArchiveDocument(path, operation);
 }
 
 async function readContentText(

--- a/packages/cli/src/commands/archive-command/maintenance.ts
+++ b/packages/cli/src/commands/archive-command/maintenance.ts
@@ -1,5 +1,4 @@
 import { WikiGraph } from "wiki-graph-core";
-import { WikiGraphArchiveFile } from "wiki-graph-core";
 import type { BookMeta } from "wiki-graph-core";
 
 import type {
@@ -9,6 +8,7 @@ import type {
 } from "../../args/index.js";
 import { writeBinaryToStdout, writeTextToStdout } from "../../support/index.js";
 import { formatCLIJSON } from "../../support/index.js";
+import { writeArchiveDocument } from "./run/document.js";
 
 export async function runArchiveMetaCommand(
   args: CLIArchiveMetadataArguments,
@@ -51,7 +51,7 @@ async function updateArchiveMeta(
   path: string,
   patch: ArchiveMetaPatch,
 ): Promise<void> {
-  await new WikiGraphArchiveFile(path).write(async (document) => {
+  await writeArchiveDocument(path, async (document) => {
     const meta = await document.readBookMeta();
 
     if (meta === undefined) {

--- a/packages/cli/src/commands/archive-command/run/document.test.ts
+++ b/packages/cli/src/commands/archive-command/run/document.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { markWikiGraphLibraryIndexDirty } from "wiki-graph-core";
+import { writeArchiveDocument } from "./document.js";
+import { resolveArchiveRuntimeLocation } from "./uri.js";
+
+const mocks = vi.hoisted(() => ({
+  writeArchive: vi.fn(),
+}));
+
+vi.mock("wiki-graph-core", () => ({
+  markWikiGraphLibraryIndexDirty: vi.fn(),
+  WikiGraphArchiveFile: class {
+    public readonly archivePath: string;
+
+    public constructor(archivePath: string) {
+      this.archivePath = archivePath;
+    }
+
+    public write = mocks.writeArchive;
+  },
+}));
+
+vi.mock("./uri.js", () => ({
+  resolveArchiveRuntimeLocation: vi.fn(),
+}));
+
+describe("writeArchiveDocument", () => {
+  beforeEach(() => {
+    vi.mocked(resolveArchiveRuntimeLocation).mockReset();
+    vi.mocked(markWikiGraphLibraryIndexDirty).mockReset();
+    mocks.writeArchive.mockReset();
+  });
+
+  it("preserves a successful write result when dirty marking fails", async () => {
+    vi.mocked(resolveArchiveRuntimeLocation).mockResolvedValue({
+      archiveKey: "/tmp/book.wikg",
+      archivePath: "/tmp/book.wikg",
+      indexScope: {
+        archiveKey: "/tmp/book.wikg",
+        archivePath: "/tmp/book.wikg",
+        kind: "archive-index",
+      },
+      libraryDirtyTarget: { alias: "lib" } as never,
+      locatedUri: "wikg:///tmp/book.wikg",
+    });
+    mocks.writeArchive.mockResolvedValue("written");
+    vi.mocked(markWikiGraphLibraryIndexDirty).mockRejectedValue(
+      new Error("sqlite is locked"),
+    );
+    const stderrWrite = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((() => true) as typeof process.stderr.write);
+
+    await expect(
+      writeArchiveDocument("wikg://lib/book", () => undefined),
+    ).resolves.toBe("written");
+    expect(stderrWrite).toHaveBeenCalledWith(
+      expect.stringContaining("sqlite is locked"),
+    );
+
+    stderrWrite.mockRestore();
+  });
+});

--- a/packages/cli/src/commands/archive-command/run/document.test.ts
+++ b/packages/cli/src/commands/archive-command/run/document.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { markWikiGraphLibraryIndexDirty } from "wiki-graph-core";
 import { writeArchiveDocument } from "./document.js";
@@ -7,6 +7,8 @@ import { resolveArchiveRuntimeLocation } from "./uri.js";
 const mocks = vi.hoisted(() => ({
   writeArchive: vi.fn(),
 }));
+
+let restoreStderrWrite: (() => void) | undefined;
 
 vi.mock("wiki-graph-core", () => ({
   markWikiGraphLibraryIndexDirty: vi.fn(),
@@ -32,7 +34,13 @@ describe("writeArchiveDocument", () => {
     mocks.writeArchive.mockReset();
   });
 
+  afterEach(() => {
+    restoreStderrWrite?.();
+    restoreStderrWrite = undefined;
+  });
+
   it("preserves a successful write result when dirty marking fails", async () => {
+    const libraryDirtyTarget = { isDefault: true, kind: "scope" } as const;
     vi.mocked(resolveArchiveRuntimeLocation).mockResolvedValue({
       archiveKey: "/tmp/book.wikg",
       archivePath: "/tmp/book.wikg",
@@ -41,7 +49,7 @@ describe("writeArchiveDocument", () => {
         archivePath: "/tmp/book.wikg",
         kind: "archive-index",
       },
-      libraryDirtyTarget: { alias: "lib" } as never,
+      libraryDirtyTarget,
       locatedUri: "wikg:///tmp/book.wikg",
     });
     mocks.writeArchive.mockResolvedValue("written");
@@ -51,14 +59,18 @@ describe("writeArchiveDocument", () => {
     const stderrWrite = vi
       .spyOn(process.stderr, "write")
       .mockImplementation((() => true) as typeof process.stderr.write);
+    restoreStderrWrite = () => {
+      stderrWrite.mockRestore();
+    };
 
     await expect(
       writeArchiveDocument("wikg://lib/book", () => undefined),
     ).resolves.toBe("written");
+    expect(markWikiGraphLibraryIndexDirty).toHaveBeenCalledWith(
+      libraryDirtyTarget,
+    );
     expect(stderrWrite).toHaveBeenCalledWith(
       expect.stringContaining("sqlite is locked"),
     );
-
-    stderrWrite.mockRestore();
   });
 });

--- a/packages/cli/src/commands/archive-command/run/document.ts
+++ b/packages/cli/src/commands/archive-command/run/document.ts
@@ -27,8 +27,25 @@ export async function writeArchiveDocument<T>(
   );
 
   if (location.libraryDirtyTarget !== undefined) {
-    await markWikiGraphLibraryIndexDirty(location.libraryDirtyTarget);
+    try {
+      await markWikiGraphLibraryIndexDirty(location.libraryDirtyTarget);
+    } catch (error) {
+      reportLibraryDirtyMarkFailure(error);
+    }
   }
 
   return result;
+}
+
+function reportLibraryDirtyMarkFailure(error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+
+  try {
+    process.stderr.write(
+      `Warning: failed to mark library index dirty after archive write: ${message}\n`,
+    );
+  } catch {
+    // The archive write already succeeded; diagnostics must not turn it into a
+    // reported failure.
+  }
 }

--- a/packages/cli/src/commands/archive-command/run/document.ts
+++ b/packages/cli/src/commands/archive-command/run/document.ts
@@ -1,8 +1,34 @@
-import { WikiGraphArchiveFile, type ReadonlyDocument } from "wiki-graph-core";
+import {
+  markWikiGraphLibraryIndexDirty,
+  WikiGraphArchiveFile,
+  type DirectoryDocument,
+  type ReadonlyDocument,
+} from "wiki-graph-core";
+
+import { resolveArchiveRuntimeLocation } from "./uri.js";
 
 export async function readArchiveDocument<T>(
   path: string,
   operation: (document: ReadonlyDocument) => Promise<T> | T,
 ): Promise<void> {
-  await new WikiGraphArchiveFile(path).readDocument(operation);
+  const location = await resolveArchiveRuntimeLocation(path);
+  await new WikiGraphArchiveFile(location.archivePath).readDocument(operation);
+}
+
+export async function writeArchiveDocument<T>(
+  path: string,
+  operation: (document: DirectoryDocument) => Promise<T> | T,
+  options: Parameters<WikiGraphArchiveFile["write"]>[1] = {},
+): Promise<T> {
+  const location = await resolveArchiveRuntimeLocation(path);
+  const result = await new WikiGraphArchiveFile(location.archivePath).write(
+    operation,
+    options,
+  );
+
+  if (location.libraryDirtyTarget !== undefined) {
+    await markWikiGraphLibraryIndexDirty(location.libraryDirtyTarget);
+  }
+
+  return result;
 }

--- a/packages/cli/src/commands/archive-command/run/uri.test.ts
+++ b/packages/cli/src/commands/archive-command/run/uri.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import { mkdtemp, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -5,12 +6,19 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   addWikiGraphLibraryArchive,
+  createWikiGraphLibrary,
+  DirectoryDocument,
   parseWikiGraphLibraryUri,
+  readWikiGraphLibraryIndexState,
+  rebuildWikiGraphLibraryIndex,
+  TOC_FILE_VERSION,
+  writeWikgArchive,
 } from "wiki-graph-core";
 import {
   getWikiGraphStateDirectoryPathForTesting,
   setWikiGraphStateDirectoryPathForTesting,
 } from "../../../../../core/src/runtime/common/wiki-graph/dir.js";
+import { runArchiveChapterCommand } from "../chapter.js";
 import { resolveArchiveCommandRuntimeArguments } from "./uri.js";
 
 let previousStateDir: string | undefined;
@@ -53,4 +61,126 @@ describe("archive-command URI runtime resolution", () => {
       objectId: `wikg://${archive.path}/entity/Q23`,
     });
   });
+
+  it("marks the default library index dirty after successful archive writes through a library locator", async () => {
+    const target = parseWikiGraphLibraryUri("wikg://lib");
+    expect(target).toBeDefined();
+    const archive = await addTestArchiveToLibrary(target!);
+
+    await rebuildWikiGraphLibraryIndex(target!);
+    await expect(
+      readWikiGraphLibraryIndexState(target!),
+    ).resolves.toMatchObject({
+      status: "current",
+    });
+
+    await runArchiveChapterCommand({ action: "add", path: archive.uri });
+
+    await expect(
+      readWikiGraphLibraryIndexState(target!),
+    ).resolves.toMatchObject({
+      status: "dirty",
+    });
+  });
+
+  it("marks the explicit library index dirty after successful archive writes through a library locator", async () => {
+    const library = await createWikiGraphLibrary({
+      folderPath: join(tempDir, "team-library"),
+    });
+    const target = parseWikiGraphLibraryUri(library.uri);
+    expect(target).toBeDefined();
+    const archive = await addTestArchiveToLibrary(target!);
+
+    await rebuildWikiGraphLibraryIndex(target!);
+    await expect(
+      readWikiGraphLibraryIndexState(target!),
+    ).resolves.toMatchObject({
+      status: "current",
+    });
+
+    await runArchiveChapterCommand({ action: "add", path: archive.uri });
+
+    await expect(
+      readWikiGraphLibraryIndexState(target!),
+    ).resolves.toMatchObject({
+      status: "dirty",
+    });
+  });
+
+  it("does not dirty a library index for filesystem archive URI writes", async () => {
+    const target = parseWikiGraphLibraryUri("wikg://lib");
+    expect(target).toBeDefined();
+    const archive = await addTestArchiveToLibrary(target!);
+
+    await rebuildWikiGraphLibraryIndex(target!);
+    await expect(
+      readWikiGraphLibraryIndexState(target!),
+    ).resolves.toMatchObject({
+      status: "current",
+    });
+
+    await runArchiveChapterCommand({
+      action: "add",
+      path: `wikg://${archive.path}`,
+    });
+
+    await expect(
+      readWikiGraphLibraryIndexState(target!),
+    ).resolves.toMatchObject({
+      status: "current",
+    });
+  });
+
+  it("does not dirty a library index when an archive write fails", async () => {
+    const target = parseWikiGraphLibraryUri("wikg://lib");
+    expect(target).toBeDefined();
+    const archive = await addTestArchiveToLibrary(target!);
+
+    await rebuildWikiGraphLibraryIndex(target!);
+    await expect(
+      runArchiveChapterCommand({
+        action: "set-title",
+        path: archive.uri,
+        chapterPath: "missing",
+        title: "Nope",
+      }),
+    ).rejects.toThrow();
+
+    await expect(
+      readWikiGraphLibraryIndexState(target!),
+    ).resolves.toMatchObject({
+      status: "current",
+    });
+  });
 });
+
+async function addTestArchiveToLibrary(
+  target: NonNullable<ReturnType<typeof parseWikiGraphLibraryUri>>,
+): ReturnType<typeof addWikiGraphLibraryArchive> {
+  const source = join(tempDir, `${randomUUID()}.wikg`);
+  await createEmptyArchive(source);
+
+  return await addWikiGraphLibraryArchive({
+    inputPath: source,
+    target,
+    to: `${randomUUID()}.wikg`,
+  });
+}
+
+async function createEmptyArchive(path: string): Promise<void> {
+  const sourceDir = await mkdtemp(join(tempDir, "wikg-source-"));
+  const document = await DirectoryDocument.open(sourceDir);
+
+  try {
+    try {
+      await document.openSession(async (openedDocument) => {
+        await openedDocument.writeToc({ items: [], version: TOC_FILE_VERSION });
+      });
+    } finally {
+      await document.release();
+    }
+    await writeWikgArchive(sourceDir, path);
+  } finally {
+    await rm(sourceDir, { force: true, recursive: true });
+  }
+}

--- a/packages/cli/src/commands/archive-command/run/uri.ts
+++ b/packages/cli/src/commands/archive-command/run/uri.ts
@@ -4,6 +4,7 @@ import {
   parseLocatedWikiGraphUri,
   requireLocatedObjectOrArchiveUri,
   resolveWikiGraphLibraryArchivePath,
+  type ParsedWikiGraphLibraryUri,
   type QueryIndexScope,
 } from "wiki-graph-core";
 
@@ -13,6 +14,7 @@ export interface ArchiveRuntimeLocation {
   readonly archiveKey: string;
   readonly archivePath: string;
   readonly indexScope: QueryIndexScope;
+  readonly libraryDirtyTarget?: ParsedWikiGraphLibraryUri;
   readonly locatedUri: string;
 }
 
@@ -34,14 +36,29 @@ export async function resolveArchiveRuntimeLocation(
 
   const parsed = parseLocatedWikiGraphUri(uriOrPath);
   const archiveLocator = parsed.archivePath ?? uriOrPath;
-  const archivePath = archiveLocator.startsWith("wikg://lib/")
-    ? await resolveWikiGraphLibraryArchivePath(archiveLocator)
-    : archiveLocator;
+  const libraryArchiveTarget = archiveLocator.startsWith("wikg://lib/")
+    ? parseWikiGraphLibraryUri(archiveLocator)
+    : undefined;
+  const archivePath =
+    libraryArchiveTarget?.kind === "archive"
+      ? await resolveWikiGraphLibraryArchivePath(archiveLocator)
+      : archiveLocator;
 
   return {
     archiveKey: archivePath,
     archivePath,
     indexScope: { archiveKey: archivePath, archivePath, kind: "archive-index" },
+    ...(libraryArchiveTarget?.kind === "archive"
+      ? {
+          libraryDirtyTarget: {
+            isDefault: libraryArchiveTarget.isDefault,
+            kind: "scope",
+            ...(libraryArchiveTarget.publicId === undefined
+              ? {}
+              : { publicId: libraryArchiveTarget.publicId }),
+          },
+        }
+      : {}),
     locatedUri: formatLocatedWikiGraphUri(archivePath, parsed.objectUri),
   };
 }

--- a/packages/cli/src/commands/archive-command/search-index.ts
+++ b/packages/cli/src/commands/archive-command/search-index.ts
@@ -13,6 +13,7 @@ import {
   ProgressOutputWriter,
   type ProgressCounter,
 } from "../../runtime/index.js";
+import { writeArchiveDocument } from "./run/document.js";
 
 const INDEX_PROGRESS_OUTPUT_INTERVAL_MS = 6_000;
 
@@ -59,7 +60,8 @@ async function enableIndex(args: CLIArchiveIndexArguments): Promise<void> {
     throttleMs: INDEX_PROGRESS_OUTPUT_INTERVAL_MS,
   });
 
-  await new WikiGraphArchiveFile(args.archivePath).write(
+  await writeArchiveDocument(
+    args.archivePath,
     async (document) => {
       await writer.write({
         json: { type: "started" },
@@ -122,7 +124,8 @@ async function enableIndex(args: CLIArchiveIndexArguments): Promise<void> {
 async function embedIndex(args: CLIArchiveIndexArguments): Promise<void> {
   let built = false;
 
-  await new WikiGraphArchiveFile(args.archivePath).write(
+  await writeArchiveDocument(
+    args.archivePath,
     async (document) => {
       await setFtsIndexEmbedded(document, true);
       if (await isArchiveSearchIndexCurrent(document)) {
@@ -147,7 +150,8 @@ async function embedIndex(args: CLIArchiveIndexArguments): Promise<void> {
 }
 
 async function externalizeIndex(args: CLIArchiveIndexArguments): Promise<void> {
-  await new WikiGraphArchiveFile(args.archivePath).write(
+  await writeArchiveDocument(
+    args.archivePath,
     async (document) => {
       await setFtsIndexEmbedded(document, false);
       await document.deleteSearchIndexDatabase();
@@ -162,7 +166,8 @@ async function externalizeIndex(args: CLIArchiveIndexArguments): Promise<void> {
 }
 
 async function disableIndex(args: CLIArchiveIndexArguments): Promise<void> {
-  await new WikiGraphArchiveFile(args.archivePath).write(
+  await writeArchiveDocument(
+    args.archivePath,
     async (document) => {
       await document.deleteSearchIndexDatabase();
       const settings = await readArchiveIndexSettings(document);

--- a/packages/cli/src/commands/object-metadata.ts
+++ b/packages/cli/src/commands/object-metadata.ts
@@ -4,6 +4,7 @@ import { ObjectMetadataKind, type ObjectMetadataTarget } from "wiki-graph-core";
 import { WikiGraphArchiveFile } from "wiki-graph-core";
 
 import type { CLIObjectMetadataArguments } from "../args/index.js";
+import { writeArchiveDocument } from "./archive-command/run/document.js";
 import {
   readTextStreamFromStdin,
   writeTextToStdout,
@@ -30,56 +31,48 @@ export async function runObjectMetadataCommand(
       const value = await readMetadataInput(args, { jsonRequired: true });
       const map = parseMetadataMap(value);
 
-      await new WikiGraphArchiveFile(args.archivePath).write(
-        async (document) => {
-          await document.metadata.replaceMap(target, map);
-          await writeMetadataMap(
-            await document.metadata.getMap(args.objectPath),
-            args.json ?? false,
-          );
-        },
-      );
+      await writeArchiveDocument(args.archivePath, async (document) => {
+        await document.metadata.replaceMap(target, map);
+        await writeMetadataMap(
+          await document.metadata.getMap(args.objectPath),
+          args.json ?? false,
+        );
+      });
       return;
     }
     case "put": {
       const key = normalizeMetadataKey(args.key);
       const value = await readMetadataInput(args, { jsonRequired: false });
 
-      await new WikiGraphArchiveFile(args.archivePath).write(
-        async (document) => {
-          await document.metadata.put(target, key, value);
-          await writeMetadataMap(
-            await document.metadata.getMap(args.objectPath),
-            args.json ?? false,
-          );
-        },
-      );
+      await writeArchiveDocument(args.archivePath, async (document) => {
+        await document.metadata.put(target, key, value);
+        await writeMetadataMap(
+          await document.metadata.getMap(args.objectPath),
+          args.json ?? false,
+        );
+      });
       return;
     }
     case "delete":
-      await new WikiGraphArchiveFile(args.archivePath).write(
-        async (document) => {
-          await document.metadata.deleteKey(
-            args.objectPath,
-            normalizeMetadataKey(args.key),
-          );
-          await writeMetadataMap(
-            await document.metadata.getMap(args.objectPath),
-            args.json ?? false,
-          );
-        },
-      );
+      await writeArchiveDocument(args.archivePath, async (document) => {
+        await document.metadata.deleteKey(
+          args.objectPath,
+          normalizeMetadataKey(args.key),
+        );
+        await writeMetadataMap(
+          await document.metadata.getMap(args.objectPath),
+          args.json ?? false,
+        );
+      });
       return;
     case "clear":
-      await new WikiGraphArchiveFile(args.archivePath).write(
-        async (document) => {
-          await document.metadata.clear(args.objectPath);
-          await writeMetadataMap(
-            await document.metadata.getMap(args.objectPath),
-            args.json ?? false,
-          );
-        },
-      );
+      await writeArchiveDocument(args.archivePath, async (document) => {
+        await document.metadata.clear(args.objectPath);
+        await writeMetadataMap(
+          await document.metadata.getMap(args.objectPath),
+          args.json ?? false,
+        );
+      });
       return;
   }
 }

--- a/packages/core/src/library/membership.test.ts
+++ b/packages/core/src/library/membership.test.ts
@@ -13,11 +13,13 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   addWikiGraphLibraryArchive,
+  createWikiGraphLibrary,
   ensureDefaultWikiGraphLibrary,
   isWikiGraphLibraryUri,
   moveWikiGraphLibraryArchive,
   parseLocatedWikiGraphUri,
   parseWikiGraphLibraryUri,
+  removeWikiGraphLibrary,
   removeWikiGraphLibraryArchive,
   resolveWikiGraphLibraryArchivePath,
   scanWikiGraphLibrary,
@@ -27,6 +29,7 @@ import {
   setWikiGraphStateDirectoryPathForTesting,
 } from "../runtime/common/wiki-graph/dir.js";
 import { writeWikgArchive } from "../storage/wikg/index.js";
+import { acquireWikiGraphLibraryLock } from "./lock.js";
 
 let previousStateDir: string | undefined;
 let tempDir: string;
@@ -180,6 +183,27 @@ describe("library archive membership", () => {
     });
     expect(removed.publicId).toBe(added.publicId);
     await expect(readFile(moved.path, "utf8")).rejects.toThrow();
+  });
+
+  it("requires the library write lock when removing a library registry", async () => {
+    const library = await createWikiGraphLibrary({
+      folderPath: join(tempDir, "locked-library"),
+    });
+    const target = parseWikiGraphLibraryUri(library.uri);
+    expect(target).toBeDefined();
+    const release = await acquireWikiGraphLibraryLock(library.id, "write");
+
+    try {
+      await expect(removeWikiGraphLibrary(target!)).rejects.toThrow(
+        `Wiki Graph library is locked for write: ${library.id}.`,
+      );
+    } finally {
+      await release();
+    }
+
+    await expect(removeWikiGraphLibrary(target!)).resolves.toMatchObject({
+      id: library.id,
+    });
   });
 });
 

--- a/packages/core/src/library/registry.ts
+++ b/packages/core/src/library/registry.ts
@@ -16,6 +16,7 @@ import {
 } from "../runtime/common/wiki-graph/dir.js";
 import { WIKI_GRAPH_ARCHIVE_EXTENSION } from "../runtime/common/wiki-graph/uri.js";
 import { isNodeError } from "../utils/node-error.js";
+import { withWikiGraphLibraryLock } from "./lock.js";
 
 const DEFAULT_LIBRARY_FOLDER_NAME = "default-library";
 const PUBLIC_ID_BYTES = 6;
@@ -310,12 +311,15 @@ export async function removeWikiGraphLibrary(
     );
   }
 
-  await withLibraryRegistryDatabase(async (database) => {
-    await database.transaction(async () => {
-      await database.run("DELETE FROM library_metadata WHERE library_id = ?", [
-        library.id,
-      ]);
-      await database.run("DELETE FROM libraries WHERE id = ?", [library.id]);
+  await withWikiGraphLibraryLock(library.id, "write", async () => {
+    await withLibraryRegistryDatabase(async (database) => {
+      await database.transaction(async () => {
+        await database.run(
+          "DELETE FROM library_metadata WHERE library_id = ?",
+          [library.id],
+        );
+        await database.run("DELETE FROM libraries WHERE id = ?", [library.id]);
+      });
     });
   });
 

--- a/test/cli/archive/maintenance.test.ts
+++ b/test/cli/archive/maintenance.test.ts
@@ -33,6 +33,9 @@ const archiveMaintenanceMockState = vi.hoisted(() => ({
 }));
 
 vi.mock("../../../packages/core/src/index.js", () => ({
+  formatLocatedWikiGraphUri: (path: string, objectUri?: string) =>
+    objectUri === undefined ? `wikg://${path}` : `wikg://${path}/${objectUri}`,
+  markWikiGraphLibraryIndexDirty: vi.fn(() => Promise.resolve()),
   WikiGraph: class {
     public async openSession(
       path: string,


### PR DESCRIPTION
## Summary
- Preserve library archive locator context during archive runtime resolution and centralize successful archive write handling in `writeArchiveDocument()` so library archive locator writes mark the owning library index dirty.
- Route chapter writes, object metadata writes, archive metadata writes, and archive index enable/embed/external/disable through the centralized write wrapper; dry-run chapter tree applies do not dirty the library index.
- Make `removeWikiGraphLibrary()` acquire the existing library-level write lock before deleting registry/metadata state.
- Add explicit parser coverage rejecting unsupported `<lib-uri>/index embed` and `<lib-uri>/index external` for both default and explicit libraries.

## Archive write command search / dirty-mark coverage
Searched existing direct archive write command paths:
- `packages/cli/src/commands/archive-command/chapter.ts`: chapter add/move/remove/reset/set-source/set-summary/set-title/tree apply now uses `runEditableCommand()` -> `writeArchiveDocument()` after runtime resolution.
- `packages/cli/src/commands/object-metadata.ts`: metadata set/put/delete/clear now uses `writeArchiveDocument()`.
- `packages/cli/src/commands/archive-command/maintenance.ts`: archive metadata patch now uses `writeArchiveDocument()`.
- `packages/cli/src/commands/archive-command/search-index.ts`: archive index enable/embed/external/disable now uses `writeArchiveDocument()`.
- `packages/cli/src/commands/archive-command/create.ts`: create/export were checked and intentionally not changed because runtime resolution explicitly excludes create/export/next and they are not writes through an existing library archive locator.
- `packages/cli/src/commands/queue/worker.ts`: build worker archive commits were checked; this PR keeps scope to direct archive write commands entered through library archive locators and does not redesign queued job storage/dispatch.

The dirty marker is invoked only after `WikiGraphArchiveFile.write()` succeeds and only when `resolveArchiveRuntimeLocation()` identified a `wikg://lib/<archive-id>/...` or `wikg://lib/<lib-id>.lib/<archive-id>/...` locator. Filesystem archive URI/path writes do not perform path -> membership reverse lookup.

## Out of scope
- Does not implement #143 query aggregation semantics.
- Does not finish #144 list index-backed behavior.

## Verification
- `pnpm exec vitest run packages/cli/src/args/archive-index.test.ts packages/cli/src/commands/archive-command/run/uri.test.ts packages/core/src/library/membership.test.ts --passWithNoTests`
- `pnpm exec vitest run test/cli/archive/maintenance.test.ts --passWithNoTests`
- `pnpm run test`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run format:check`

Fixes #142
