### PR TITLE
fix: aggregate library object queries across archives

### DIFF
--- a/packages/cli/src/commands/archive-output/object/objects.ts
+++ b/packages/cli/src/commands/archive-output/object/objects.ts
@@ -356,12 +356,17 @@ export async function createPageObject(
 function createLibrarySourceObject(source: {
   readonly archiveId?: number;
   readonly libraryArchiveUri?: string;
-}): Pick<ArchiveOutputObject, "archiveId" | "libraryArchiveUri"> {
+  readonly sources?: readonly {
+    readonly archiveId: number;
+    readonly libraryArchiveUri: string;
+  }[];
+}): Pick<ArchiveOutputObject, "archiveId" | "libraryArchiveUri" | "sources"> {
   return {
     ...(source.archiveId === undefined ? {} : { archiveId: source.archiveId }),
     ...(source.libraryArchiveUri === undefined
       ? {}
       : { libraryArchiveUri: source.libraryArchiveUri }),
+    ...(source.sources === undefined ? {} : { sources: source.sources }),
   };
 }
 

--- a/packages/cli/src/commands/archive-output/object/types.ts
+++ b/packages/cli/src/commands/archive-output/object/types.ts
@@ -30,11 +30,17 @@ export interface ArchiveOutputObject {
   readonly score?: number;
   readonly state?: Record<string, string>;
   readonly subjectLabel?: string;
+  readonly sources?: readonly ArchiveOutputLibrarySource[];
   readonly text?: string;
   readonly title?: string;
   readonly type?: string;
   readonly uri: string;
   readonly value?: string;
+}
+
+export interface ArchiveOutputLibrarySource {
+  readonly archiveId: number;
+  readonly libraryArchiveUri: string;
 }
 
 export interface ArchiveOutputBacklinks {

--- a/packages/cli/src/commands/archive-output/text/object.ts
+++ b/packages/cli/src/commands/archive-output/text/object.ts
@@ -121,19 +121,27 @@ function formatObjectSummaryLines(object: ArchiveOutputObject): string[] {
 }
 
 function formatLibrarySourceLines(object: ArchiveOutputObject): string[] {
-  return object.archiveId === undefined &&
-    object.libraryArchiveUri === undefined
-    ? []
-    : [
-        [
-          object.archiveId === undefined
-            ? undefined
-            : `archiveId:${object.archiveId}`,
-          object.libraryArchiveUri,
-        ]
-          .filter((part): part is string => part !== undefined)
-          .join("  "),
-      ];
+  const sources =
+    object.sources ??
+    (object.archiveId === undefined && object.libraryArchiveUri === undefined
+      ? []
+      : [
+          {
+            archiveId: object.archiveId,
+            libraryArchiveUri: object.libraryArchiveUri,
+          },
+        ]);
+
+  return sources.map((source) =>
+    [
+      source.archiveId === undefined
+        ? undefined
+        : `archiveId:${source.archiveId}`,
+      source.libraryArchiveUri,
+    ]
+      .filter((part): part is string => part !== undefined)
+      .join("  "),
+  );
 }
 
 export function getListObjectSeparator(

--- a/packages/cli/src/commands/archive-output/text/object.ts
+++ b/packages/cli/src/commands/archive-output/text/object.ts
@@ -122,15 +122,16 @@ function formatObjectSummaryLines(object: ArchiveOutputObject): string[] {
 
 function formatLibrarySourceLines(object: ArchiveOutputObject): string[] {
   const sources =
-    object.sources ??
-    (object.archiveId === undefined && object.libraryArchiveUri === undefined
-      ? []
-      : [
-          {
-            archiveId: object.archiveId,
-            libraryArchiveUri: object.libraryArchiveUri,
-          },
-        ]);
+    object.sources !== undefined && object.sources.length > 0
+      ? object.sources
+      : object.archiveId === undefined && object.libraryArchiveUri === undefined
+        ? []
+        : [
+            {
+              archiveId: object.archiveId,
+              libraryArchiveUri: object.libraryArchiveUri,
+            },
+          ];
 
   return sources.map((source) =>
     [

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -163,6 +163,7 @@ export type {
   ArchiveFindPosition,
   ArchiveFindResult,
   ArchiveObjectType,
+  ArchiveLibrarySource,
   ArchivePack,
   ArchivePage,
   ArchiveRelatedResult,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -257,6 +257,7 @@ export type {
   ArchiveFindPosition,
   ArchiveFindResult,
   ArchiveIndex,
+  ArchiveLibrarySource,
   ArchiveListItem,
   ArchiveListKind,
   ArchiveNodeLabel,

--- a/packages/core/src/library/query.ts
+++ b/packages/core/src/library/query.ts
@@ -21,6 +21,7 @@ import type {
   ArchiveFindHit,
   ArchiveFindOptions,
   ArchiveFindResult,
+  ArchiveLibrarySource,
   ArchiveListItem,
   ArchivePack,
   ArchivePage,
@@ -43,6 +44,8 @@ import {
   listWikiGraphLibraryIndexArchiveIdsForObject,
   queryWikiGraphLibrarySearchIndex,
 } from "./search-index.js";
+
+const DEFAULT_LIBRARY_PAGE_LIMIT = 20;
 
 export async function findWikiGraphLibraryObjects(
   target: ParsedWikiGraphLibraryUri,
@@ -103,7 +106,7 @@ export async function readWikiGraphLibraryPage(
   objectUri: string,
   options: Parameters<typeof readArchivePage>[2] = {},
 ): Promise<ArchivePage> {
-  return await readFirstIndexedArchiveResult(
+  const pages = await readIndexedArchiveResults(
     target,
     objectUri,
     async (document, archive) => ({
@@ -111,6 +114,21 @@ export async function readWikiGraphLibraryPage(
       ...createLibrarySource(archive),
     }),
   );
+
+  const page = createMultiArchivePage(pages);
+  if ((page.type === "entity" || page.type === "triple") && pages.length > 1) {
+    const evidence = await listWikiGraphLibraryEvidence(target, objectUri, {
+      ...createPageEvidenceOptions(options),
+      limit: Number.MAX_SAFE_INTEGER,
+    });
+
+    return {
+      ...page,
+      evidence: createEvidencePreview(evidence, options.evidenceLimit ?? 3),
+    };
+  }
+
+  return page;
 }
 
 export async function listWikiGraphLibraryEvidence(
@@ -118,11 +136,15 @@ export async function listWikiGraphLibraryEvidence(
   objectUri: string,
   options: ArchiveEvidenceOptions = {},
 ): Promise<ArchiveEvidence> {
-  const page = await readFirstIndexedArchiveResult(
+  const results = await readIndexedArchiveResults(
     target,
     objectUri,
     async (document, archive) => {
-      const result = await listArchiveEvidence(document, objectUri, options);
+      const { cursor: _cursor, ...archiveOptions } = options;
+      const result = await listArchiveEvidence(document, objectUri, {
+        ...archiveOptions,
+        limit: Number.MAX_SAFE_INTEGER,
+      });
       const source = createLibrarySource(archive);
 
       return {
@@ -137,7 +159,10 @@ export async function listWikiGraphLibraryEvidence(
     },
   );
 
-  return page;
+  return createEvidenceResult(
+    results.flatMap((result) => result.items),
+    options,
+  );
 }
 
 export async function listRelatedWikiGraphLibraryObjects(
@@ -145,15 +170,15 @@ export async function listRelatedWikiGraphLibraryObjects(
   objectUri: string,
   options: ArchiveRelatedOptions = {},
 ): Promise<ArchiveRelatedResult> {
-  return await readFirstIndexedArchiveResult(
+  const results = await readIndexedArchiveResults(
     target,
     objectUri,
     async (document, archive) => {
-      const result = await listRelatedArchiveObjects(
-        document,
-        objectUri,
-        options,
-      );
+      const { cursor: _cursor, ...archiveOptions } = options;
+      const result = await listRelatedArchiveObjects(document, objectUri, {
+        ...archiveOptions,
+        limit: Number.MAX_SAFE_INTEGER,
+      });
       const source = createLibrarySource(archive);
 
       return {
@@ -167,6 +192,11 @@ export async function listRelatedWikiGraphLibraryObjects(
       };
     },
   );
+
+  return createRelatedResult(
+    results.flatMap((result) => result.items),
+    options,
+  );
 }
 
 export async function packWikiGraphLibraryContext(
@@ -174,7 +204,7 @@ export async function packWikiGraphLibraryContext(
   objectUri: string,
   budget: number,
 ): Promise<ArchivePack> {
-  return await readFirstIndexedArchiveResult(
+  const packs = await readIndexedArchiveResults(
     target,
     objectUri,
     async (document, archive) => {
@@ -188,6 +218,17 @@ export async function packWikiGraphLibraryContext(
       };
     },
   );
+  const [first] = packs;
+
+  if (first === undefined) {
+    throw new Error(`Wiki Graph library object was not found: ${objectUri}`);
+  }
+
+  return {
+    anchor: createMultiArchivePage(packs.map((pack) => pack.anchor)),
+    budget,
+    related: packs.flatMap((pack) => pack.related),
+  };
 }
 
 export async function resolveWikiGraphLibraryQueryTargetById(
@@ -203,41 +244,205 @@ export async function resolveWikiGraphLibraryQueryTargetById(
   );
 }
 
-async function readFirstIndexedArchiveResult<T>(
+async function readIndexedArchiveResults<T>(
   target: ParsedWikiGraphLibraryUri,
   objectUri: string,
   operation: (
     document: ReadonlyDocument,
     archive: WikiGraphLibraryArchiveRecord,
   ) => Promise<T>,
-): Promise<T> {
+): Promise<T[]> {
   const library = await resolveWikiGraphLibrary(target);
   const archiveIds = await listWikiGraphLibraryIndexArchiveIdsForObject(
     target,
     objectUri,
   );
-  let lastError: unknown;
+  const results: T[] = [];
 
   for (const archiveId of archiveIds) {
     const archive = await getWikiGraphLibraryArchiveById(library, archiveId);
     if (!isReadableLibraryArchive(archive)) {
-      continue;
+      throw new Error(
+        `Wiki Graph library archive ${archiveId} is not readable while reading ${objectUri}.`,
+      );
     }
 
     try {
-      return await readLibraryArchiveDocument(
-        archive,
-        async (document) => await operation(document, archive),
+      results.push(
+        await readLibraryArchiveDocument(
+          archive,
+          async (document) => await operation(document, archive),
+        ),
       );
     } catch (error) {
-      lastError = error;
+      throw new Error(
+        `Failed to read Wiki Graph library archive ${archiveId} (${archive.uri}) for ${objectUri}: ${formatErrorMessage(error)}`,
+        { cause: error },
+      );
     }
   }
 
-  if (lastError instanceof Error) {
-    throw lastError;
+  if (results.length === 0) {
+    throw new Error(`Wiki Graph library object was not found: ${objectUri}`);
   }
-  throw new Error(`Wiki Graph library object was not found: ${objectUri}`);
+  return results;
+}
+
+function createMultiArchivePage(pages: readonly ArchivePage[]): ArchivePage {
+  const [first] = pages;
+  if (first === undefined) {
+    throw new Error(
+      "Internal error: cannot merge an empty library page result.",
+    );
+  }
+
+  const sources = createLibrarySources(pages);
+  if (sources.length === 1) {
+    return first;
+  }
+
+  const {
+    archiveId: _archiveId,
+    libraryArchiveUri: _libraryArchiveUri,
+    ...page
+  } = first;
+
+  return { ...page, sources };
+}
+
+function createPageEvidenceOptions(
+  options: Parameters<typeof readArchivePage>[2] = {},
+): ArchiveEvidenceOptions {
+  return {
+    ...(options.evidenceLimit === undefined
+      ? {}
+      : { limit: options.evidenceLimit }),
+    ...(options.order === undefined ? {} : { order: options.order }),
+    ...(options.sourceContext === undefined
+      ? {}
+      : { sourceContext: options.sourceContext }),
+  };
+}
+
+function createEvidenceResult(
+  items: readonly ArchiveEvidenceItem[],
+  options: ArchiveEvidenceOptions,
+): ArchiveEvidence {
+  const limit = options.limit ?? DEFAULT_LIBRARY_PAGE_LIMIT;
+  const offset = parseLibraryObjectCursor(options.cursor, "evidence");
+  const sorted = [...items].sort((left, right) =>
+    compareLibraryEvidenceItems(left, right, options.order ?? "doc-asc"),
+  );
+  const pageItems = sorted.slice(offset, offset + limit);
+  const nextOffset = offset + pageItems.length;
+
+  return {
+    items: pageItems,
+    limit,
+    nextCursor: nextOffset < sorted.length ? String(nextOffset) : null,
+  };
+}
+
+function createRelatedResult(
+  items: readonly ArchiveListItem[],
+  options: ArchiveRelatedOptions,
+): ArchiveRelatedResult {
+  const limit = options.limit ?? DEFAULT_LIBRARY_PAGE_LIMIT;
+  const offset = parseLibraryObjectCursor(options.cursor, "related");
+  const sorted = [...items].sort((left, right) =>
+    compareLibraryListItems(left, right, options.order ?? "doc-asc"),
+  );
+  const pageItems = sorted.slice(offset, offset + limit);
+  const nextOffset = offset + pageItems.length;
+
+  return {
+    items: pageItems,
+    limit,
+    nextCursor: nextOffset < sorted.length ? String(nextOffset) : null,
+  };
+}
+
+function createEvidencePreview(evidence: ArchiveEvidence, limit: number) {
+  const sources = evidence.items.slice(0, limit);
+
+  return {
+    nextCursor:
+      sources.length < evidence.items.length ? String(sources.length) : null,
+    shown: sources.length,
+    sources,
+    total: evidence.items.length,
+  };
+}
+
+function createLibrarySources(
+  values: readonly {
+    readonly archiveId?: number;
+    readonly libraryArchiveUri?: string;
+  }[],
+): readonly ArchiveLibrarySource[] {
+  const sources = new Map<number, ArchiveLibrarySource>();
+  for (const value of values) {
+    if (
+      value.archiveId === undefined ||
+      value.libraryArchiveUri === undefined
+    ) {
+      continue;
+    }
+    sources.set(value.archiveId, {
+      archiveId: value.archiveId,
+      libraryArchiveUri: value.libraryArchiveUri,
+    });
+  }
+  return [...sources.values()].sort(
+    (left, right) => left.archiveId - right.archiveId,
+  );
+}
+
+function compareLibraryEvidenceItems(
+  left: ArchiveEvidenceItem,
+  right: ArchiveEvidenceItem,
+  order: "doc-asc" | "doc-desc",
+): number {
+  const direction = order === "doc-asc" ? 1 : -1;
+  return (
+    (compareOptionalNumbers(left.archiveId, right.archiveId) ||
+      left.chapterId - right.chapterId ||
+      left.startSentenceIndex - right.startSentenceIndex ||
+      left.endSentenceIndex - right.endSentenceIndex ||
+      left.id.localeCompare(right.id)) * direction
+  );
+}
+
+function compareLibraryListItems(
+  left: ArchiveListItem,
+  right: ArchiveListItem,
+  order: "doc-asc" | "doc-desc",
+): number {
+  const direction = order === "doc-asc" ? 1 : -1;
+  return (
+    (compareOptionalNumbers(left.archiveId, right.archiveId) ||
+      left.id.localeCompare(right.id)) * direction
+  );
+}
+
+function compareOptionalNumbers(
+  left: number | undefined,
+  right: number | undefined,
+): number {
+  return (left ?? Number.MAX_SAFE_INTEGER) - (right ?? Number.MAX_SAFE_INTEGER);
+}
+
+function parseLibraryObjectCursor(
+  cursor: string | undefined,
+  kind: "evidence" | "related",
+): number {
+  if (cursor === undefined) {
+    return 0;
+  }
+  if (!/^(0|[1-9][0-9]*)$/u.test(cursor)) {
+    throw new Error(`Invalid library ${kind} cursor: ${cursor}`);
+  }
+  return Number(cursor);
 }
 
 async function listReadyLibraryArchives(
@@ -262,12 +467,15 @@ async function readLibraryArchiveDocument<T>(
   return await new WikiGraphArchiveFile(archive.path).readDocument(operation);
 }
 
-function createLibrarySource(archive: WikiGraphLibraryArchiveRecord): {
-  readonly archiveId: number;
-  readonly libraryArchiveUri: string;
-} {
+function createLibrarySource(
+  archive: WikiGraphLibraryArchiveRecord,
+): ArchiveLibrarySource {
   return {
     archiveId: archive.id,
     libraryArchiveUri: archive.uri,
   };
+}
+
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/core/src/library/query.ts
+++ b/packages/core/src/library/query.ts
@@ -257,6 +257,11 @@ async function readIndexedArchiveResults<T>(
     target,
     objectUri,
   );
+
+  if (archiveIds.length === 0) {
+    return await readUnindexedArchiveResults(target, objectUri, operation);
+  }
+
   const results: T[] = [];
 
   for (const archiveId of archiveIds) {
@@ -277,6 +282,41 @@ async function readIndexedArchiveResults<T>(
     } catch (error) {
       throw new Error(
         `Failed to read Wiki Graph library archive ${archiveId} (${archive.uri}) for ${objectUri}: ${formatErrorMessage(error)}`,
+        { cause: error },
+      );
+    }
+  }
+
+  if (results.length === 0) {
+    throw new Error(`Wiki Graph library object was not found: ${objectUri}`);
+  }
+  return results;
+}
+
+async function readUnindexedArchiveResults<T>(
+  target: ParsedWikiGraphLibraryUri,
+  objectUri: string,
+  operation: (
+    document: ReadonlyDocument,
+    archive: WikiGraphLibraryArchiveRecord,
+  ) => Promise<T>,
+): Promise<T[]> {
+  const results: T[] = [];
+
+  for (const archive of await listReadyLibraryArchives(target)) {
+    try {
+      results.push(
+        await readLibraryArchiveDocument(
+          archive,
+          async (document) => await operation(document, archive),
+        ),
+      );
+    } catch (error) {
+      if (isArchiveObjectNotFoundError(error)) {
+        continue;
+      }
+      throw new Error(
+        `Failed to read Wiki Graph library archive ${archive.id} (${archive.uri}) for ${objectUri}: ${formatErrorMessage(error)}`,
         { cause: error },
       );
     }
@@ -478,4 +518,11 @@ function createLibrarySource(
 
 function formatErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function isArchiveObjectNotFoundError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes(" was not found in this archive.")
+  );
 }

--- a/packages/core/src/retrieval/query/archive-view/index.ts
+++ b/packages/core/src/retrieval/query/archive-view/index.ts
@@ -53,6 +53,7 @@ export type {
   ArchiveFindPosition,
   ArchiveFindResult,
   ArchiveIndex,
+  ArchiveLibrarySource,
   ArchiveListItem,
   ArchiveListKind,
   ArchiveNodeLabel,

--- a/packages/core/src/retrieval/query/archive-view/types.ts
+++ b/packages/core/src/retrieval/query/archive-view/types.ts
@@ -75,6 +75,12 @@ export interface ArchiveIndex {
 export interface ArchiveLibrarySourceFields {
   readonly archiveId?: number;
   readonly libraryArchiveUri?: string;
+  readonly sources?: readonly ArchiveLibrarySource[];
+}
+
+export interface ArchiveLibrarySource {
+  readonly archiveId: number;
+  readonly libraryArchiveUri: string;
 }
 
 export interface ArchiveFindHit extends ArchiveLibrarySourceFields {

--- a/packages/core/src/retrieval/query/index.ts
+++ b/packages/core/src/retrieval/query/index.ts
@@ -39,6 +39,7 @@ export type {
   ArchiveFindPosition,
   ArchiveFindResult,
   ArchiveIndex,
+  ArchiveLibrarySource,
   ArchiveListItem,
   ArchiveListKind,
   ArchiveNodeLabel,

--- a/test/cli/archive/object.test.ts
+++ b/test/cli/archive/object.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { archiveMockState, resetArchiveMockState } from "./mock.js";
 import { runArchiveCommand } from "../../../packages/cli/src/commands/index.js";
+import { formatFindObject } from "../../../packages/cli/src/commands/archive-output/text/object.js";
 import {
   createContinuationCursor,
   readArchivePage,
@@ -57,6 +58,19 @@ describe("cli/archive/object", () => {
     expect(archiveMockState.textWrites[0]).toBe(
       "wikg://chapter/2  Chapter 2  source:ready reading-graph:ready reading-summary:missing knowledge-graph:missing\n",
     );
+  });
+
+  it("falls back to single archive provenance when sources is empty", () => {
+    expect(
+      formatFindObject({
+        archiveId: 7,
+        label: "Entity",
+        libraryArchiveUri: "wikg://lib/archive-7",
+        sources: [],
+        type: "entity",
+        uri: "wikg://entity/Q7",
+      }),
+    ).toBe("wikg://entity/Q7\nEntity\narchiveId:7  wikg://lib/archive-7");
   });
 
   it("gets a source range as a citation block", async () => {

--- a/test/core/library/query.test.ts
+++ b/test/core/library/query.test.ts
@@ -249,6 +249,42 @@ describe("wiki graph library object query aggregation", () => {
     expect(result.items.map((item) => item.archiveId)).toStrictEqual([1, 2]);
   });
 
+  it("scans readable archives for non-indexed triple pages", async () => {
+    const { readWikiGraphLibraryPage } =
+      await import("../../../packages/core/src/library/query.js");
+
+    const tripleUri = "wikg://triple/Q1/mentions/Q2";
+    mocks.pages.set(`archive-1.wikg:${tripleUri}`, {
+      evidence: { nextCursor: null, shown: 1, sources: [], total: 1 },
+      id: tripleUri,
+      label: "Q1 mentions Q2",
+      objectQid: "Q2",
+      predicate: "mentions",
+      subjectQid: "Q1",
+      type: "triple",
+    });
+    mocks.pages.set(`archive-2.wikg:${tripleUri}`, {
+      evidence: { nextCursor: null, shown: 1, sources: [], total: 1 },
+      id: tripleUri,
+      label: "Q1 mentions Q2",
+      objectQid: "Q2",
+      predicate: "mentions",
+      subjectQid: "Q1",
+      type: "triple",
+    });
+
+    const page = await readWikiGraphLibraryPage(target, tripleUri);
+
+    expect(page).toMatchObject({
+      id: tripleUri,
+      sources: [
+        { archiveId: 1, libraryArchiveUri: "wikg://lib/archive-1" },
+        { archiveId: 2, libraryArchiveUri: "wikg://lib/archive-2" },
+      ],
+      type: "triple",
+    });
+  });
+
   it("aggregates related items instead of returning the first archive", async () => {
     const { listRelatedWikiGraphLibraryObjects } =
       await import("../../../packages/core/src/library/query.js");

--- a/test/core/library/query.test.ts
+++ b/test/core/library/query.test.ts
@@ -1,0 +1,358 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const archives = new Map<number, Record<string, unknown>>();
+  const objectArchiveIds = new Map<string, readonly number[]>();
+  const pages = new Map<string, Record<string, unknown>>();
+  const evidence = new Map<string, readonly Record<string, unknown>[]>();
+  const related = new Map<string, readonly Record<string, unknown>[]>();
+  const packs = new Map<
+    string,
+    {
+      readonly anchor: Record<string, unknown>;
+      readonly related: readonly Record<string, unknown>[];
+    }
+  >();
+
+  return {
+    archives,
+    evidence,
+    objectArchiveIds,
+    packs,
+    pages,
+    related,
+    reset() {
+      archives.clear();
+      objectArchiveIds.clear();
+      pages.clear();
+      evidence.clear();
+      related.clear();
+      packs.clear();
+    },
+  };
+});
+
+vi.mock("../../../packages/core/src/storage/wikg/index.js", () => ({
+  WikiGraphArchiveFile: class {
+    public readonly path: string;
+
+    public constructor(path: string) {
+      this.path = path;
+    }
+
+    public async readDocument<T>(
+      operation: (document: { readonly path: string }) => T,
+    ) {
+      return await operation({ path: this.path });
+    }
+  },
+}));
+
+vi.mock("../../../packages/core/src/library/registry.js", () => ({
+  parseWikiGraphLibraryUri: vi.fn((uri: string) => ({
+    isDefault: uri === "wikg://lib",
+    kind: "scope",
+  })),
+  resolveWikiGraphLibrary: vi.fn(() =>
+    Promise.resolve({ id: 1, uri: "wikg://lib" }),
+  ),
+  resolveWikiGraphLibraryById: vi.fn((id: number) =>
+    Promise.resolve({
+      id,
+      isDefault: true,
+      publicId: "default",
+      uri: "wikg://lib",
+    }),
+  ),
+}));
+
+vi.mock("../../../packages/core/src/library/membership.js", () => ({
+  getWikiGraphLibraryArchiveById: vi.fn((_library: unknown, id: number) => {
+    const archive = mocks.archives.get(id);
+    if (archive === undefined) {
+      throw new Error(`Unknown archive ${id}`);
+    }
+    return Promise.resolve(archive);
+  }),
+  listWikiGraphLibraryArchives: vi.fn(() =>
+    Promise.resolve([...mocks.archives.values()]),
+  ),
+}));
+
+vi.mock("../../../packages/core/src/library/search-index.js", () => ({
+  assertWikiGraphLibraryIndexReady: vi.fn(() =>
+    Promise.resolve({ status: "current" }),
+  ),
+  listWikiGraphLibraryIndexArchiveIdsForObject: vi.fn(
+    (_target, objectUri: string) =>
+      Promise.resolve(mocks.objectArchiveIds.get(objectUri) ?? []),
+  ),
+  queryWikiGraphLibrarySearchIndex: vi.fn(() => Promise.resolve(undefined)),
+}));
+
+vi.mock(
+  "../../../packages/core/src/retrieval/query/archive-view/index.js",
+  () => ({
+    listArchiveCollection: vi.fn(() => Promise.resolve({ items: [] })),
+    listArchiveEvidence: vi.fn(
+      (document: { readonly path: string }, objectUri: string) =>
+        Promise.resolve({
+          items: mocks.evidence.get(`${document.path}:${objectUri}`) ?? [],
+          limit: Number.MAX_SAFE_INTEGER,
+          nextCursor: null,
+        }),
+    ),
+    listRelatedArchiveObjects: vi.fn(
+      (document: { readonly path: string }, objectUri: string) =>
+        Promise.resolve({
+          items: mocks.related.get(`${document.path}:${objectUri}`) ?? [],
+          limit: Number.MAX_SAFE_INTEGER,
+          nextCursor: null,
+        }),
+    ),
+    packArchiveContext: vi.fn(
+      (
+        document: { readonly path: string },
+        objectUri: string,
+        budget: number,
+      ) =>
+        Promise.resolve({
+          ...(mocks.packs.get(`${document.path}:${objectUri}`) ?? {
+            anchor: { id: objectUri, label: objectUri, type: "entity" },
+            related: [],
+          }),
+          budget,
+        }),
+    ),
+    readArchivePage: vi.fn(
+      (document: { readonly path: string }, objectUri: string) => {
+        const page = mocks.pages.get(`${document.path}:${objectUri}`);
+        if (page === undefined) {
+          throw new Error(`missing page ${document.path}:${objectUri}`);
+        }
+        return Promise.resolve(page);
+      },
+    ),
+  }),
+);
+
+const target = { isDefault: true, kind: "scope" as const };
+
+function seedArchive(id: number, status = "present") {
+  mocks.archives.set(id, {
+    exists: true,
+    id,
+    path: `archive-${id}.wikg`,
+    status,
+    uri: `wikg://lib/archive-${id}`,
+  });
+}
+
+describe("wiki graph library object query aggregation", () => {
+  beforeEach(() => {
+    mocks.reset();
+    seedArchive(1);
+    seedArchive(2);
+  });
+
+  it("returns all archive sources for a library get", async () => {
+    const { readWikiGraphLibraryPage } =
+      await import("../../../packages/core/src/library/query.js");
+
+    mocks.objectArchiveIds.set("wikg://entity/Q1", [1, 2]);
+    mocks.pages.set("archive-1.wikg:wikg://entity/Q1", {
+      evidence: { nextCursor: null, shown: 1, sources: [], total: 1 },
+      id: "wikg://entity/Q1",
+      label: "Shared",
+      labels: ["Shared"],
+      mentionCount: 1,
+      qid: "Q1",
+      type: "entity",
+    });
+    mocks.pages.set("archive-2.wikg:wikg://entity/Q1", {
+      evidence: { nextCursor: null, shown: 1, sources: [], total: 1 },
+      id: "wikg://entity/Q1",
+      label: "Shared",
+      labels: ["Shared"],
+      mentionCount: 1,
+      qid: "Q1",
+      type: "entity",
+    });
+
+    const page = await readWikiGraphLibraryPage(target, "wikg://entity/Q1");
+
+    expect(page).toMatchObject({
+      id: "wikg://entity/Q1",
+      sources: [
+        { archiveId: 1, libraryArchiveUri: "wikg://lib/archive-1" },
+        { archiveId: 2, libraryArchiveUri: "wikg://lib/archive-2" },
+      ],
+      type: "entity",
+    });
+  });
+
+  it("aggregates evidence with stable cursor pagination and source fields", async () => {
+    const { listWikiGraphLibraryEvidence } =
+      await import("../../../packages/core/src/library/query.js");
+
+    mocks.objectArchiveIds.set("wikg://entity/Q1", [1, 2]);
+    mocks.evidence.set("archive-1.wikg:wikg://entity/Q1", [
+      createEvidence("a", 2),
+      createEvidence("b", 4),
+    ]);
+    mocks.evidence.set("archive-2.wikg:wikg://entity/Q1", [
+      createEvidence("c", 1),
+    ]);
+
+    const first = await listWikiGraphLibraryEvidence(
+      target,
+      "wikg://entity/Q1",
+      {
+        limit: 2,
+      },
+    );
+    const second = await listWikiGraphLibraryEvidence(
+      target,
+      "wikg://entity/Q1",
+      {
+        ...(first.nextCursor === null ? {} : { cursor: first.nextCursor }),
+        limit: 2,
+      },
+    );
+
+    expect(first.items.map((item) => [item.id, item.archiveId])).toStrictEqual([
+      ["a", 1],
+      ["b", 1],
+    ]);
+    expect(first.nextCursor).toBe("2");
+    expect(second.items.map((item) => [item.id, item.archiveId])).toStrictEqual(
+      [["c", 2]],
+    );
+    expect(second.nextCursor).toBeNull();
+  });
+
+  it("aggregates triple evidence across archives", async () => {
+    const { listWikiGraphLibraryEvidence } =
+      await import("../../../packages/core/src/library/query.js");
+
+    const tripleUri = "wikg://triple/Q1/mentions/Q2";
+    mocks.objectArchiveIds.set(tripleUri, [1, 2]);
+    mocks.evidence.set(`archive-1.wikg:${tripleUri}`, [
+      createEvidence("t1", 1),
+    ]);
+    mocks.evidence.set(`archive-2.wikg:${tripleUri}`, [
+      createEvidence("t2", 1),
+    ]);
+
+    const result = await listWikiGraphLibraryEvidence(target, tripleUri);
+
+    expect(result.items.map((item) => item.archiveId)).toStrictEqual([1, 2]);
+  });
+
+  it("aggregates related items instead of returning the first archive", async () => {
+    const { listRelatedWikiGraphLibraryObjects } =
+      await import("../../../packages/core/src/library/query.js");
+
+    mocks.objectArchiveIds.set("wikg://entity/Q1", [1, 2]);
+    mocks.related.set("archive-1.wikg:wikg://entity/Q1", [
+      createRelated("wikg://entity/Q2"),
+    ]);
+    mocks.related.set("archive-2.wikg:wikg://entity/Q1", [
+      createRelated("wikg://entity/Q3"),
+    ]);
+
+    const result = await listRelatedWikiGraphLibraryObjects(
+      target,
+      "wikg://entity/Q1",
+    );
+
+    expect(result.items.map((item) => [item.id, item.archiveId])).toStrictEqual(
+      [
+        ["wikg://entity/Q2", 1],
+        ["wikg://entity/Q3", 2],
+      ],
+    );
+  });
+
+  it("merges pack anchors and related items by archive id order", async () => {
+    const { packWikiGraphLibraryContext } =
+      await import("../../../packages/core/src/library/query.js");
+
+    mocks.objectArchiveIds.set("wikg://entity/Q1", [1, 2]);
+    mocks.packs.set("archive-1.wikg:wikg://entity/Q1", {
+      anchor: createEntityPage("wikg://entity/Q1"),
+      related: [createRelated("wikg://entity/Q2")],
+    });
+    mocks.packs.set("archive-2.wikg:wikg://entity/Q1", {
+      anchor: createEntityPage("wikg://entity/Q1"),
+      related: [createRelated("wikg://entity/Q3")],
+    });
+
+    const pack = await packWikiGraphLibraryContext(
+      target,
+      "wikg://entity/Q1",
+      5000,
+    );
+
+    expect(pack.anchor).toMatchObject({
+      sources: [
+        { archiveId: 1, libraryArchiveUri: "wikg://lib/archive-1" },
+        { archiveId: 2, libraryArchiveUri: "wikg://lib/archive-2" },
+      ],
+    });
+    expect(pack.related.map((item) => [item.id, item.archiveId])).toStrictEqual(
+      [
+        ["wikg://entity/Q2", 1],
+        ["wikg://entity/Q3", 2],
+      ],
+    );
+  });
+
+  it("fails the whole aggregation when an indexed archive is not readable", async () => {
+    const { listWikiGraphLibraryEvidence } =
+      await import("../../../packages/core/src/library/query.js");
+
+    seedArchive(2, "removed");
+    mocks.objectArchiveIds.set("wikg://entity/Q1", [1, 2]);
+    mocks.evidence.set("archive-1.wikg:wikg://entity/Q1", [
+      createEvidence("a", 1),
+    ]);
+
+    await expect(
+      listWikiGraphLibraryEvidence(target, "wikg://entity/Q1"),
+    ).rejects.toThrow("archive 2 is not readable");
+  });
+});
+
+function createEntityPage(id: string) {
+  return {
+    evidence: { nextCursor: null, shown: 0, sources: [], total: 0 },
+    id,
+    label: id,
+    labels: [id],
+    mentionCount: 1,
+    qid: "Q1",
+    type: "entity" as const,
+  };
+}
+
+function createEvidence(id: string, startSentenceIndex: number) {
+  return {
+    chapterId: 1,
+    endSentenceIndex: startSentenceIndex,
+    id,
+    source: id,
+    startSentenceIndex,
+    title: id,
+    type: "source" as const,
+  };
+}
+
+function createRelated(id: string) {
+  return {
+    id,
+    label: id,
+    summary: id,
+    type: "entity" as const,
+  };
+}


### PR DESCRIPTION
## Summary
- Replace the library-wide first-result object query path with centralized multi-archive aggregation in `packages/core/src/library/query.ts`.
- Preserve archive provenance via `archiveId` / `libraryArchiveUri` on evidence, related, and pack items; multi-source get/pack anchors expose a `sources` array, and CLI object output can render/serialize it.
- Add focused library query aggregation tests for entity get/evidence/related/pack, triple evidence, cursor continuation, and unreadable archive failure.

## Aggregation strategy
- `get`: reads every indexed readable archive in stable index archive-id order, uses the first archive page as the representative object, and adds all source archives via `sources`. For entity/triple pages, the evidence preview is rebuilt from the aggregated evidence set.
- `evidence`: reads all matching indexed archives, fails if any indexed source archive is unreadable or read fails, annotates every evidence item with source fields, sorts stably by archive id then archive-local source position, and paginates globally.
- `related`: reads all matching indexed archives, fails on unreadable/read-failed indexed archives, preserves one item per archive-local related result with source fields, sorts stably by archive id then object id, and paginates globally.
- `pack`: reads pack candidates from every indexed source archive and merges deterministically in archive-id order; anchor sources are aggregated and related items keep their per-archive source fields. Output truncation still uses the existing pack writer budget path.

## Failure strategy
- Library object aggregation no longer silently skips indexed archives. If an indexed archive is missing, removed, or otherwise unreadable, or if back-source reading fails, the command fails with the concrete archive id/URI in the error.

## Out of scope
- Does not handle #142 dirty/remove lock behavior.
- Does not handle #144 list index-backed follow-up.

Fixes #143

## Verification
- `pnpm exec vitest run test/core/library/query.test.ts`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm run test`
- `pnpm run build`