### PR TITLE
fix: list library objects from index

### DIFF
--- a/packages/core/src/library/query.ts
+++ b/packages/core/src/library/query.ts
@@ -1,7 +1,6 @@
 import { WikiGraphArchiveFile } from "../storage/wikg/index.js";
 import type { ReadonlyDocument } from "../document/index.js";
 import {
-  listArchiveCollection,
   listArchiveEvidence,
   listRelatedArchiveObjects,
   packArchiveContext,
@@ -42,6 +41,7 @@ import {
 import {
   assertWikiGraphLibraryIndexReady,
   listWikiGraphLibraryIndexArchiveIdsForObject,
+  listWikiGraphLibrarySearchIndex,
   queryWikiGraphLibrarySearchIndex,
 } from "./search-index.js";
 
@@ -85,17 +85,29 @@ export async function listWikiGraphLibraryObjects(
   target: ParsedWikiGraphLibraryUri,
   options: ArchiveCollectionOptions = {},
 ): Promise<ArchiveCollectionResult> {
-  await assertWikiGraphLibraryIndexReady(target);
-
   const hits: ArchiveFindHit[] = [];
-  for (const archive of await listReadyLibraryArchives(target)) {
+  const result = await listWikiGraphLibrarySearchIndex(target, {
+    includeText: shouldListTextStreams(options),
+  });
+  const archiveIds = createSortedArchiveIds(result);
+  for (const archiveId of archiveIds) {
+    const archive = await resolveReadableIndexedArchive(target, archiveId);
     const source = createLibrarySource(archive);
-    const result = await readLibraryArchiveDocument(
+    const hydrated = await readLibraryArchiveDocument(
       archive,
-      async (document) => await listArchiveCollection(document, options),
+      async (document) =>
+        await hydrateSearchIndexHits(document, {
+          objectHits: result.objectHits.filter(
+            (hit) => hit.archiveId === archive.id,
+          ),
+          terms: result.terms,
+          textHits: result.textHits.filter(
+            (hit) => hit.archiveId === archive.id,
+          ),
+        }),
     );
 
-    hits.push(...result.items.map((item) => ({ ...item, ...source })));
+    hits.push(...hydrated.map((hit) => ({ ...hit, ...source })));
   }
 
   return createCollectionResult(hits, options);
@@ -492,6 +504,39 @@ async function listReadyLibraryArchives(
   return (await listWikiGraphLibraryArchives(target)).filter(
     isReadableLibraryArchive,
   );
+}
+
+function shouldListTextStreams(options: ArchiveCollectionOptions): boolean {
+  return (
+    options.types !== undefined &&
+    options.types.some((type) => type === "source" || type === "summary")
+  );
+}
+
+function createSortedArchiveIds(result: {
+  readonly objectHits: readonly { readonly archiveId: number }[];
+  readonly textHits: readonly { readonly archiveId: number }[];
+}): readonly number[] {
+  return [
+    ...new Set([
+      ...result.objectHits.map((hit) => hit.archiveId),
+      ...result.textHits.map((hit) => hit.archiveId),
+    ]),
+  ].sort((left, right) => left - right);
+}
+
+async function resolveReadableIndexedArchive(
+  target: ParsedWikiGraphLibraryUri,
+  archiveId: number,
+): Promise<WikiGraphLibraryArchiveRecord> {
+  const library = await resolveWikiGraphLibrary(target);
+  const archive = await getWikiGraphLibraryArchiveById(library, archiveId);
+  if (!isReadableLibraryArchive(archive)) {
+    throw new Error(
+      `Wiki Graph library archive ${archiveId} is not readable while listing library objects.`,
+    );
+  }
+  return archive;
 }
 
 function isReadableLibraryArchive(

--- a/packages/core/src/library/search-index.ts
+++ b/packages/core/src/library/search-index.ts
@@ -13,11 +13,15 @@ import {
   markDirtySearchIndexChapters,
   readSearchIndexFingerprintFromDatabase,
   readSearchIndexStatus,
+  SEARCH_OBJECT_PROPERTY_KIND,
   SEARCH_OBJECT_PROPERTY_OWNER_KIND,
   type SearchIndexInput,
   type SearchIndexObjectHit,
   type SearchIndexProgressReporter,
   type SearchIndexTextHit,
+  type SearchObjectPropertyKind,
+  type SearchObjectPropertyOwnerKind,
+  type TextSentenceKind,
 } from "../retrieval/search-index/index.js";
 import { readPathSize } from "../runtime/gc/files.js";
 import type { GcContext, GcJobResult } from "../runtime/gc/index.js";
@@ -64,6 +68,10 @@ export interface WikiGraphLibraryIndexQueryResult {
   readonly objectHits: readonly WikiGraphLibraryIndexObjectHit[];
   readonly terms: readonly string[];
   readonly textHits: readonly WikiGraphLibraryIndexTextHit[];
+}
+
+export interface WikiGraphLibraryIndexListOptions {
+  readonly includeText?: boolean;
 }
 
 export type WikiGraphLibraryIndexObjectHit = SearchIndexObjectHit & {
@@ -239,6 +247,89 @@ export async function queryWikiGraphLibrarySearchIndex(
         ...formatLibraryHitSource(sourceByArchiveId, hit.archiveId),
       })),
     };
+  });
+}
+
+export async function listWikiGraphLibrarySearchIndex(
+  target: ParsedWikiGraphLibraryUri,
+  options: WikiGraphLibraryIndexListOptions = {},
+): Promise<WikiGraphLibraryIndexQueryResult> {
+  const library = await resolveWikiGraphLibrary(target);
+
+  return await withWikiGraphLibraryLock(library.id, "read", async () => {
+    const state = await assertWikiGraphLibraryIndexReady(target);
+    const sourceByArchiveId = new Map(
+      state.sources.map((source) => [source.archiveId, source]),
+    );
+
+    return await new LibraryIndexDocument(library).readSearchIndexDatabase(
+      async (database) => {
+        const objectHits = await database.queryAll(
+          `
+            SELECT DISTINCT
+              archive_id,
+              owner_kind,
+              owner_id,
+              property_kind,
+              chapter_id
+            FROM search_object_properties_records
+            WHERE owner_kind != ? OR property_kind = ?
+            ORDER BY archive_id, COALESCE(chapter_id, 0), owner_kind, owner_id, property_kind
+          `,
+          [
+            SEARCH_OBJECT_PROPERTY_OWNER_KIND.chunk,
+            SEARCH_OBJECT_PROPERTY_KIND.label,
+          ],
+          (row): WikiGraphLibraryIndexObjectHit => {
+            const archiveId = getNumber(row, "archive_id");
+            return {
+              ...formatLibraryHitSource(sourceByArchiveId, archiveId),
+              archiveId,
+              ownerId: String(row.owner_id),
+              ownerKind: getNumber(
+                row,
+                "owner_kind",
+              ) as SearchObjectPropertyOwnerKind,
+              propertyKind: getNumber(
+                row,
+                "property_kind",
+              ) as SearchObjectPropertyKind,
+              score: 0,
+              ...(row.chapter_id === null
+                ? {}
+                : { chapterId: getNumber(row, "chapter_id") }),
+            };
+          },
+        );
+
+        const textHits =
+          options.includeText === true
+            ? await database.queryAll(
+                `
+                  SELECT archive_id, kind, chapter_id, sentence_index, words_count
+                  FROM text_sentence_records
+                  ORDER BY archive_id, chapter_id, sentence_index, kind
+                `,
+                undefined,
+                (row): WikiGraphLibraryIndexTextHit => {
+                  const archiveId = getNumber(row, "archive_id");
+                  return {
+                    ...formatLibraryHitSource(sourceByArchiveId, archiveId),
+                    archiveId,
+                    chapterId: getNumber(row, "chapter_id"),
+                    kind: getNumber(row, "kind") as TextSentenceKind,
+                    rank: 0,
+                    score: 0,
+                    sentenceIndex: getNumber(row, "sentence_index"),
+                    wordsCount: getNumber(row, "words_count"),
+                  };
+                },
+              )
+            : [];
+
+        return { objectHits, terms: [], textHits };
+      },
+    );
   });
 }
 

--- a/packages/core/src/retrieval/query/archive-view/helper/sort.ts
+++ b/packages/core/src/retrieval/query/archive-view/helper/sort.ts
@@ -82,6 +82,7 @@ export function compareListPosition(
     compareNumbers(getPositionFragment(left), getPositionFragment(right)) ||
     compareNumbers(getPositionSentence(left), getPositionSentence(right)) ||
     compareNumbers(getTypeOrder(left.type), getTypeOrder(right.type)) ||
+    compareNumbers(left.archiveId ?? 0, right.archiveId ?? 0) ||
     left.id.localeCompare(right.id)
   );
 }

--- a/test/core/library/query.test.ts
+++ b/test/core/library/query.test.ts
@@ -3,6 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => {
   const archives = new Map<number, Record<string, unknown>>();
   const objectArchiveIds = new Map<string, readonly number[]>();
+  let listIndexResult: {
+    readonly objectHits: readonly Record<string, unknown>[];
+    readonly terms: readonly string[];
+    readonly textHits: readonly Record<string, unknown>[];
+  };
   const pages = new Map<string, Record<string, unknown>>();
   const evidence = new Map<string, readonly Record<string, unknown>[]>();
   const related = new Map<string, readonly Record<string, unknown>[]>();
@@ -18,11 +23,18 @@ const mocks = vi.hoisted(() => {
     archives,
     evidence,
     objectArchiveIds,
+    get listIndexResult() {
+      return listIndexResult;
+    },
+    set listIndexResult(value: typeof listIndexResult) {
+      listIndexResult = value;
+    },
     packs,
     pages,
     related,
     reset() {
       archives.clear();
+      listIndexResult = { objectHits: [], terms: [], textHits: [] };
       objectArchiveIds.clear();
       pages.clear();
       evidence.clear();
@@ -83,6 +95,9 @@ vi.mock("../../../packages/core/src/library/search-index.js", () => ({
   assertWikiGraphLibraryIndexReady: vi.fn(() =>
     Promise.resolve({ status: "current" }),
   ),
+  listWikiGraphLibrarySearchIndex: vi.fn(() =>
+    Promise.resolve(mocks.listIndexResult),
+  ),
   listWikiGraphLibraryIndexArchiveIdsForObject: vi.fn(
     (_target, objectUri: string) =>
       Promise.resolve(mocks.objectArchiveIds.get(objectUri) ?? []),
@@ -132,6 +147,29 @@ vi.mock(
         }
         return Promise.resolve(page);
       },
+    ),
+  }),
+);
+
+vi.mock(
+  "../../../packages/core/src/retrieval/query/archive-view/search/hydration.js",
+  () => ({
+    hydrateSearchIndexHits: vi.fn(
+      (
+        _document: { readonly path: string },
+        result: { readonly objectHits: readonly Record<string, unknown>[] },
+      ) =>
+        Promise.resolve(
+          result.objectHits.map((hit) => ({
+            chapter: Number(hit.ownerId),
+            field: "title" as const,
+            id: `wikg://chapter/${String(hit.ownerId)}/title`,
+            position: { chapter: Number(hit.ownerId) },
+            snippet: `Chapter ${String(hit.ownerId)}`,
+            title: `Chapter ${String(hit.ownerId)}`,
+            type: "chapter-title" as const,
+          })),
+        ),
     ),
   }),
 );
@@ -358,7 +396,60 @@ describe("wiki graph library object query aggregation", () => {
       listWikiGraphLibraryEvidence(target, "wikg://entity/Q1"),
     ).rejects.toThrow("archive 2 is not readable");
   });
+
+  it("lists library objects from the library index instead of archive collection merge", async () => {
+    const [{ listWikiGraphLibraryObjects }, archiveView] = await Promise.all([
+      import("../../../packages/core/src/library/query.js"),
+      import("../../../packages/core/src/retrieval/query/archive-view/index.js"),
+    ]);
+
+    mocks.listIndexResult = {
+      objectHits: [createIndexObjectHit(2, "1"), createIndexObjectHit(1, "1")],
+      terms: [],
+      textHits: [],
+    };
+
+    const result = await listWikiGraphLibraryObjects(target, {
+      limit: 10,
+      types: ["chapter-title"],
+    });
+
+    expect(archiveView.listArchiveCollection).not.toHaveBeenCalled();
+    expect(result.items.map((item) => [item.id, item.archiveId])).toStrictEqual(
+      [
+        ["wikg://chapter/1/title", 1],
+        ["wikg://chapter/1/title", 2],
+      ],
+    );
+  });
+
+  it("requests text sentence hits only for text-stream library list types", async () => {
+    const [{ listWikiGraphLibraryObjects }, searchIndex] = await Promise.all([
+      import("../../../packages/core/src/library/query.js"),
+      import("../../../packages/core/src/library/search-index.js"),
+    ]);
+
+    await listWikiGraphLibraryObjects(target, { types: ["source"] });
+
+    expect(searchIndex.listWikiGraphLibrarySearchIndex).toHaveBeenCalledWith(
+      target,
+      { includeText: true },
+    );
+  });
 });
+
+function createIndexObjectHit(archiveId: number, ownerId: string) {
+  return {
+    archiveId,
+    archiveUri: `wikg://lib/archive-${archiveId}`,
+    chapterId: Number(ownerId),
+    libraryArchiveUri: `wikg://lib/archive-${archiveId}`,
+    ownerId,
+    ownerKind: 1,
+    propertyKind: 1,
+    score: 0,
+  };
+}
 
 function createEntityPage(id: string) {
   return {


### PR DESCRIPTION
## Summary
- Add a library index listing query in `packages/core/src/library/search-index.ts` so library `list` reads collection candidates from the library `index.db` projection instead of enumerating each archive with `listArchiveCollection()`.
- Change `listWikiGraphLibraryObjects()` to hydrate only the indexed hits it selected, preserving `archiveId` / `libraryArchiveUri` for display while keeping filtering/sorting/listing rooted in the library index.
- Add an archive-id tie-break to collection ordering so cross-archive list results are stable when archive-local sort keys collide.
- Add focused library query tests proving `list` no longer calls per-archive collection listing and that text-stream list types request index text sentence hits.

## #139 remaining acceptance covered here
- Library `list` under `wikg://lib...` is now index-backed: the entry point is `listWikiGraphLibrarySearchIndex()` over library `index.db`, followed by per-hit hydration only for display data.
- Cross-archive list ordering is deterministic by existing list sort keys plus `archiveId` tie-break.
- Collection cursors / `next` continue to use the existing `library-index` output context; this PR keeps that centralized path and changes the library list page provider behind it.
- Chapter / node / entity and optional source / summary list hits preserve source identity through `archiveId` and `libraryArchiveUri` after hydration.

## Not repeated from #142 / #143
- #142 / PR #145 already covers library archive write dirty marking, remove library locking, and unsupported `embed` / `external` parser coverage.
- #143 / PR #146 already covers multi-archive aggregation for `get`, `evidence`, `related`, and `pack`.
- This PR intentionally focuses on the #144 list index-backed gap and the sorting/source-identity tests directly related to that gap.

Fixes #144

## Verification
- `pnpm exec vitest run test/core/library/query.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run test`
- `pnpm run build`
