### PR TITLE
Fix internal child processes in dev CLI

### DIFF
--- a/docs/local-cli-development.md
+++ b/docs/local-cli-development.md
@@ -69,9 +69,10 @@ The extra `--` is passed to the CLI and changes the parsed command.
 ## Development State Directory
 
 The installed CLI stores local runtime state under `~/.wikigraph`. The
-development CLI entry point is compiled to use the repository-level
-`.wikigraph/state` directory instead, so users cannot change CLI state
-location through environment variables.
+development CLI entry point sets an internal `WIKIGRAPH_DEV` value that points
+at the repository-level `.wikigraph/state` directory instead. Do not set this
+variable manually; use the pnpm dev script so child processes such as build
+workers and GC use the same checkout-local state.
 
 Use repository-root `.wikigraph/` for local development data:
 

--- a/packages/cli/src/bin/dev-gc-worker.ts
+++ b/packages/cli/src/bin/dev-gc-worker.ts
@@ -1,6 +1,7 @@
+#!/usr/bin/env node
+
 import { enableDevStateDirectory } from "../runtime/dev-state.js";
 
 enableDevStateDirectory();
-const { main } = await import("../app/index.js");
 
-void main();
+await import("./gc-worker.js");

--- a/packages/cli/src/bin/dev-queue-worker.ts
+++ b/packages/cli/src/bin/dev-queue-worker.ts
@@ -1,6 +1,7 @@
+#!/usr/bin/env node
+
 import { enableDevStateDirectory } from "../runtime/dev-state.js";
 
 enableDevStateDirectory();
-const { main } = await import("../app/index.js");
 
-void main();
+await import("./queue-worker.js");

--- a/packages/cli/src/bin/gc-worker.ts
+++ b/packages/cli/src/bin/gc-worker.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+import { tryRunWikiGraphGc } from "wiki-graph-core/gc";
+
+import { formatCLIJSON } from "../support/index.js";
+
+async function main(): Promise<void> {
+  if (process.env.WIKIGRAPH_INTERNAL_CHILD !== "gc-worker") {
+    process.stderr.write("This Wiki Graph worker entry is internal.\n");
+    process.exitCode = 1;
+    return;
+  }
+
+  const args = parseGcWorkerArguments(process.argv.slice(2));
+  process.stdout.write(
+    formatCLIJSON(
+      await tryRunWikiGraphGc({
+        dryRun: args.dryRun,
+        force: args.force,
+      }),
+    ),
+  );
+}
+
+function parseGcWorkerArguments(argv: readonly string[]): {
+  readonly dryRun: boolean;
+  readonly force: boolean;
+} {
+  return {
+    dryRun: argv.includes("--dry-run"),
+    force: argv.includes("--force"),
+  };
+}
+
+void main().catch((error: unknown) => {
+  process.stderr.write(
+    `${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`,
+  );
+  process.exitCode = 1;
+});

--- a/packages/cli/src/bin/queue-worker.ts
+++ b/packages/cli/src/bin/queue-worker.ts
@@ -3,7 +3,7 @@
 import { runQueueWorker } from "../commands/index.js";
 
 async function main(): Promise<void> {
-  if (process.env.WIKIGRAPH_INTERNAL_WORKER !== "queue-v1") {
+  if (process.env.WIKIGRAPH_INTERNAL_CHILD !== "queue-worker") {
     process.stderr.write("This Wiki Graph worker entry is internal.\n");
     process.exitCode = 1;
     return;

--- a/packages/cli/src/commands/gc.ts
+++ b/packages/cli/src/commands/gc.ts
@@ -1,13 +1,16 @@
-import { tryRunWikiGraphGc } from "wiki-graph-core/gc";
+import type { GcRunReport } from "wiki-graph-core/gc";
 
 import type { CLIGcArguments } from "../args/index.js";
+import { runInternalChildJSON } from "../runtime/internal-child.js";
 import { writeTextToStdout } from "../support/index.js";
 import { formatCLIJSON } from "../support/index.js";
 
 export async function runGcCommand(args: CLIGcArguments): Promise<void> {
-  const report = await tryRunWikiGraphGc({
-    dryRun: args.dryRun === true,
-    force: args.force === true,
+  const report = await runInternalChildJSON<GcRunReport>("gc-worker", {
+    args: [
+      ...(args.dryRun === true ? ["--dry-run"] : []),
+      ...(args.force === true ? ["--force"] : []),
+    ],
   });
 
   if (args.json === true) {

--- a/packages/cli/src/commands/queue/add.ts
+++ b/packages/cli/src/commands/queue/add.ts
@@ -1,6 +1,3 @@
-import { spawn } from "child_process";
-import { fileURLToPath } from "url";
-
 import {
   addBuildJob,
   listChapters,
@@ -11,6 +8,7 @@ import { WikiGraphArchiveFile } from "wiki-graph-core";
 
 import type { CLIQueueArguments } from "../../args/index.js";
 import type { CLIConfig } from "../../runtime/config.js";
+import { spawnInternalChild } from "../../runtime/internal-child.js";
 import { createQueueAddEstimate } from "./estimate.js";
 import { writeArchiveAddSummary } from "./output.js";
 
@@ -155,17 +153,8 @@ export function tryStartQueueWorker(): void {
     return;
   }
 
-  const entryPath = fileURLToPath(
-    new URL("../../../queue-worker.js", import.meta.url),
-  );
-
-  const child = spawn(process.execPath, [entryPath], {
+  const child = spawnInternalChild("queue-worker", {
     detached: true,
-    env: {
-      ...process.env,
-      WIKIGRAPH_INTERNAL_WORKER: "queue-v1",
-    },
-    stdio: "ignore",
   });
 
   child.unref();

--- a/packages/cli/src/runtime/dev-state.ts
+++ b/packages/cli/src/runtime/dev-state.ts
@@ -1,0 +1,9 @@
+import { resolve } from "path";
+
+export function resolveDevStateDirectoryPath(): string {
+  return resolve(import.meta.dirname, "../../../../.wikigraph/state");
+}
+
+export function enableDevStateDirectory(): void {
+  process.env.WIKIGRAPH_DEV = resolveDevStateDirectoryPath();
+}

--- a/packages/cli/src/runtime/internal-child.test.ts
+++ b/packages/cli/src/runtime/internal-child.test.ts
@@ -1,0 +1,53 @@
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+
+import { createInternalChildCommandForTesting } from "./internal-child.js";
+
+describe("runtime/internal-child", () => {
+  it("uses dev worker entries when WIKIGRAPH_DEV is set", () => {
+    const previous = process.env.WIKIGRAPH_DEV;
+
+    try {
+      process.env.WIKIGRAPH_DEV = join("/repo", ".wikigraph", "state");
+
+      expect(
+        createInternalChildCommandForTesting("queue-worker", ["--flag"]),
+      ).toStrictEqual({
+        args: [
+          join("/repo", "node_modules", "tsx", "dist", "cli.mjs"),
+          join("/repo", "packages", "cli", "src", "bin", "dev-queue-worker.ts"),
+          "--flag",
+        ],
+        command: process.execPath,
+      });
+      expect(createInternalChildCommandForTesting("gc-worker").args[1]).toBe(
+        join("/repo", "packages", "cli", "src", "bin", "dev-gc-worker.ts"),
+      );
+    } finally {
+      if (previous === undefined) {
+        delete process.env.WIKIGRAPH_DEV;
+      } else {
+        process.env.WIKIGRAPH_DEV = previous;
+      }
+    }
+  });
+
+  it("uses production worker entries when WIKIGRAPH_DEV is unset", () => {
+    const previous = process.env.WIKIGRAPH_DEV;
+
+    try {
+      delete process.env.WIKIGRAPH_DEV;
+
+      expect(createInternalChildCommandForTesting("queue-worker").args[0]).toBe(
+        join(process.cwd(), "packages", "cli", "dist", "queue-worker.js"),
+      );
+      expect(createInternalChildCommandForTesting("gc-worker").args[0]).toBe(
+        join(process.cwd(), "packages", "cli", "dist", "gc-worker.js"),
+      );
+    } finally {
+      if (previous !== undefined) {
+        process.env.WIKIGRAPH_DEV = previous;
+      }
+    }
+  });
+});

--- a/packages/cli/src/runtime/internal-child.ts
+++ b/packages/cli/src/runtime/internal-child.ts
@@ -1,0 +1,135 @@
+import { spawn } from "child_process";
+import { existsSync } from "fs";
+import { join, resolve } from "path";
+
+export type InternalChildKind = "gc-worker" | "queue-worker";
+
+export interface InternalChildSpawnOptions {
+  readonly args?: readonly string[];
+  readonly detached?: boolean;
+}
+
+const INTERNAL_CHILD_ENV_KEY = "WIKIGRAPH_INTERNAL_CHILD";
+
+declare global {
+  var __WIKIGRAPH_CLI_DIST_DIR__: string | undefined;
+}
+
+export function spawnInternalChild(
+  kind: InternalChildKind,
+  options: InternalChildSpawnOptions = {},
+): ReturnType<typeof spawn> {
+  const command = createInternalChildCommand(kind, options.args ?? []);
+
+  return spawn(command.command, command.args, {
+    detached: options.detached === true,
+    env: {
+      ...process.env,
+      [INTERNAL_CHILD_ENV_KEY]: kind,
+    },
+    stdio: options.detached === true ? "ignore" : ["ignore", "pipe", "pipe"],
+  });
+}
+
+export async function runInternalChildJSON<T>(
+  kind: InternalChildKind,
+  options: InternalChildSpawnOptions = {},
+): Promise<T> {
+  const child = spawnInternalChild(kind, options);
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+
+  child.stdout?.on("data", (chunk: Buffer) => stdout.push(chunk));
+  child.stderr?.on("data", (chunk: Buffer) => stderr.push(chunk));
+
+  await new Promise<void>((resolvePromise, reject) => {
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(
+          new Error(
+            `Internal ${kind} failed with exit code ${code}: ${Buffer.concat(stderr).toString("utf8").trim()}`,
+          ),
+        );
+        return;
+      }
+      resolvePromise();
+    });
+  });
+
+  try {
+    return JSON.parse(Buffer.concat(stdout).toString("utf8")) as T;
+  } catch (error) {
+    throw new Error(
+      `Internal ${kind} returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+export function createInternalChildCommandForTesting(
+  kind: InternalChildKind,
+  args: readonly string[] = [],
+): { readonly args: readonly string[]; readonly command: string } {
+  return createInternalChildCommand(kind, args);
+}
+
+function createInternalChildCommand(
+  kind: InternalChildKind,
+  args: readonly string[],
+): { readonly args: readonly string[]; readonly command: string } {
+  if (process.env.WIKIGRAPH_DEV !== undefined) {
+    const projectRoot = resolveDevProjectRoot(process.env.WIKIGRAPH_DEV);
+
+    return {
+      args: [
+        join(projectRoot, "node_modules", "tsx", "dist", "cli.mjs"),
+        join(
+          projectRoot,
+          "packages",
+          "cli",
+          "src",
+          "bin",
+          createDevEntryName(kind),
+        ),
+        ...args,
+      ],
+      command: process.execPath,
+    };
+  }
+
+  return {
+    args: [resolveProductionEntryPath(kind), ...args],
+    command: process.execPath,
+  };
+}
+
+function createDevEntryName(kind: InternalChildKind): string {
+  switch (kind) {
+    case "gc-worker":
+      return "dev-gc-worker.ts";
+    case "queue-worker":
+      return "dev-queue-worker.ts";
+  }
+}
+
+function resolveDevProjectRoot(devStateDirPath: string | undefined): string {
+  if (devStateDirPath === undefined || devStateDirPath.trim() === "") {
+    throw new Error("WIKIGRAPH_DEV must contain the development state path.");
+  }
+
+  return resolve(devStateDirPath, "..", "..");
+}
+
+function resolveProductionEntryPath(kind: InternalChildKind): string {
+  const filename = `${kind}.js`;
+  const distDirPath =
+    globalThis.__WIKIGRAPH_CLI_DIST_DIR__ ??
+    resolve(process.cwd(), "packages", "cli", "dist");
+  const adjacent = join(distDirPath, filename);
+
+  if (existsSync(adjacent)) {
+    return adjacent;
+  }
+
+  return adjacent;
+}

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "tsup";
 
 const CJS_DATA_DIR_BANNER = [
+  "globalThis.__WIKIGRAPH_CLI_DIST_DIR__ ??= __dirname;",
   'globalThis.__WIKIGRAPH_DATA_DIR__ ??= require("path").resolve(',
   "  __dirname,",
   '  "data",',
@@ -9,6 +10,7 @@ const CJS_DATA_DIR_BANNER = [
 const ESM_DATA_DIR_BANNER = [
   'import { fileURLToPath as __WIKIGRAPH_FILE_URL_TO_PATH__ } from "url";',
   'import { resolve as __WIKIGRAPH_RESOLVE__ } from "path";',
+  'globalThis.__WIKIGRAPH_CLI_DIST_DIR__ ??= __WIKIGRAPH_RESOLVE__(__WIKIGRAPH_FILE_URL_TO_PATH__(new URL(".", import.meta.url)));',
   'globalThis.__WIKIGRAPH_DATA_DIR__ ??= __WIKIGRAPH_RESOLVE__(__WIKIGRAPH_FILE_URL_TO_PATH__(new URL("./data", import.meta.url)));',
 ].join("\n");
 const SHARED_OPTIONS = {
@@ -48,6 +50,7 @@ export default defineConfig([
     dts: true,
     entry: {
       cli: "src/bin/cli.ts",
+      "gc-worker": "src/bin/gc-worker.ts",
       index: "src/index.ts",
       "queue-worker": "src/bin/queue-worker.ts",
     },

--- a/packages/core/src/runtime/common/wiki-graph/dir.ts
+++ b/packages/core/src/runtime/common/wiki-graph/dir.ts
@@ -1,18 +1,11 @@
 import { homedir } from "os";
 import { join, resolve } from "path";
 
-declare global {
-  var __WIKIGRAPH_STATE_DIR__: string | undefined;
-}
-
 export function resolveWikiGraphHomeDirectoryPath(): string {
-  const injectedStateDirPath = globalThis.__WIKIGRAPH_STATE_DIR__;
+  const devStateDirPath = process.env.WIKIGRAPH_DEV;
 
-  if (
-    injectedStateDirPath !== undefined &&
-    injectedStateDirPath.trim() !== ""
-  ) {
-    return resolve(injectedStateDirPath);
+  if (devStateDirPath !== undefined && devStateDirPath.trim() !== "") {
+    return resolve(devStateDirPath);
   }
 
   return join(homedir(), ".wikigraph");
@@ -21,11 +14,16 @@ export function resolveWikiGraphHomeDirectoryPath(): string {
 export function setWikiGraphStateDirectoryPathForTesting(
   path: string | undefined,
 ): void {
-  globalThis.__WIKIGRAPH_STATE_DIR__ = path;
+  if (path === undefined) {
+    delete process.env.WIKIGRAPH_DEV;
+    return;
+  }
+
+  process.env.WIKIGRAPH_DEV = path;
 }
 
 export function getWikiGraphStateDirectoryPathForTesting(): string | undefined {
-  return globalThis.__WIKIGRAPH_STATE_DIR__;
+  return process.env.WIKIGRAPH_DEV;
 }
 
 export function resolveWikiGraphCoreDatabasePath(): string {


### PR DESCRIPTION
## Summary
- route queue worker and GC worker startup through a shared internal child process helper
- make pnpm dev CLI set checkout-local WIKIGRAPH_DEV state for internal child processes
- add dev worker entries and regression coverage for child command resolution

## Verification
- pnpm exec eslint <touched files> --fix
- pnpm exec prettier <touched files> --write
- pnpm test:run packages/cli/src/runtime/internal-child.test.ts packages/cli/src/args/gc.test.ts
- pnpm typecheck
- pnpm build
- node packages/cli/dist/cli.js gc --dry-run --json
- pnpm --filter wiki-graph dev gc --dry-run --json

Note: full lint/format are currently affected by the pre-existing untracked .worktrees/ directory and were not used for this cleanup.