### PR TITLE
fix(library): cover library v1 regression seams

### DIFF
--- a/packages/cli/src/commands/archive-command/run/next.test.ts
+++ b/packages/cli/src/commands/archive-command/run/next.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  listWikiGraphLibraryObjects,
+  readContinuationCursor,
+  resolveWikiGraphLibraryQueryTargetById,
+} from "wiki-graph-core";
+import { writeFindHits } from "../../archive-output/index.js";
+import { runNextArchivePage } from "./next.js";
+
+vi.mock("wiki-graph-core", () => ({
+  findArchiveObjects: vi.fn(),
+  findWikiGraphLibraryObjects: vi.fn(),
+  listArchiveCollection: vi.fn(),
+  listArchiveEvidence: vi.fn(),
+  listRelatedArchiveObjects: vi.fn(),
+  listRelatedWikiGraphLibraryObjects: vi.fn(),
+  listWikiGraphLibraryEvidence: vi.fn(),
+  listWikiGraphLibraryObjects: vi.fn(),
+  readContinuationCursor: vi.fn(),
+  resolveWikiGraphLibraryQueryTargetById: vi.fn(),
+}));
+
+vi.mock("../../archive-output/index.js", () => ({
+  writeEvidence: vi.fn(),
+  writeFindHits: vi.fn(),
+  writeList: vi.fn(),
+}));
+
+vi.mock("./document.js", () => ({
+  readArchiveDocument: vi.fn(),
+}));
+
+const libraryTarget = { isDefault: true, kind: "scope" } as const;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(readContinuationCursor).mockResolvedValue({
+    archiveKey: "wikg://lib",
+    archivePath: "wikg://lib",
+    chapters: null,
+    cursor: "raw-collection-cursor",
+    format: "json",
+    ids: null,
+    indexScope: { kind: "library-index", libraryId: 42 },
+    kind: "collection",
+    order: "doc-asc",
+    types: ["entity"],
+  });
+  vi.mocked(resolveWikiGraphLibraryQueryTargetById).mockResolvedValue(
+    libraryTarget,
+  );
+});
+
+describe("runNextArchivePage library cursors", () => {
+  it("re-enters the library index path for collection cursors", async () => {
+    vi.mocked(listWikiGraphLibraryObjects).mockResolvedValue({
+      chapters: null,
+      ids: null,
+      items: [
+        {
+          archiveId: 7,
+          field: "title",
+          id: "wikg://entity/Q7",
+          libraryArchiveUri: "wikg://lib/archive-7",
+          snippet: "Entity 7",
+          title: "Entity 7",
+          type: "entity",
+        },
+      ],
+      limit: 20,
+      nextCursor: null,
+      order: "doc-asc",
+      types: ["entity"],
+    });
+
+    await runNextArchivePage({ action: "next", archivePath: "c_next" });
+
+    expect(readContinuationCursor).toHaveBeenCalledWith("c_next");
+    expect(resolveWikiGraphLibraryQueryTargetById).toHaveBeenCalledWith(42);
+    expect(listWikiGraphLibraryObjects).toHaveBeenCalledWith(libraryTarget, {
+      cursor: "raw-collection-cursor",
+      limit: 20,
+      order: "doc-asc",
+      types: ["entity"],
+    });
+    expect(writeFindHits).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [
+          expect.objectContaining({
+            archiveId: 7,
+            libraryArchiveUri: "wikg://lib/archive-7",
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        indexScope: { kind: "library-index", libraryId: 42 },
+      }),
+      "json",
+    );
+  });
+
+  it("surfaces dirty library index failures from next", async () => {
+    vi.mocked(listWikiGraphLibraryObjects).mockRejectedValue(
+      new Error("Wiki Graph library index is dirty."),
+    );
+
+    await expect(
+      runNextArchivePage({ action: "next", archivePath: "c_next" }),
+    ).rejects.toThrow("Wiki Graph library index is dirty.");
+    expect(listWikiGraphLibraryObjects).toHaveBeenCalledWith(
+      libraryTarget,
+      expect.objectContaining({ cursor: "raw-collection-cursor" }),
+    );
+  });
+});

--- a/packages/core/src/library/query.ts
+++ b/packages/core/src/library/query.ts
@@ -59,7 +59,10 @@ export async function findWikiGraphLibraryObjects(
   }
 
   const hits: ArchiveFindHit[] = [];
-  for (const archive of await listReadyLibraryArchives(target)) {
+  for (const archiveId of createSortedArchiveIds(result)) {
+    const archive = await resolveReadableIndexedArchive(target, archiveId, {
+      operation: "searching library objects",
+    });
     const source = createLibrarySource(archive);
     const hydrated = await readLibraryArchiveDocument(
       archive,
@@ -91,7 +94,9 @@ export async function listWikiGraphLibraryObjects(
   });
   const archiveIds = createSortedArchiveIds(result);
   for (const archiveId of archiveIds) {
-    const archive = await resolveReadableIndexedArchive(target, archiveId);
+    const archive = await resolveReadableIndexedArchive(target, archiveId, {
+      operation: "listing library objects",
+    });
     const source = createLibrarySource(archive);
     const hydrated = await readLibraryArchiveDocument(
       archive,
@@ -271,6 +276,13 @@ async function readIndexedArchiveResults<T>(
   );
 
   if (archiveIds.length === 0) {
+    if (!isTripleObjectUri(objectUri)) {
+      throw new Error(`Wiki Graph library object was not found: ${objectUri}`);
+    }
+
+    // Library v1 cannot project every triple occurrence into the index yet.
+    // Keep the archive scan explicit and restricted to triples so entity/chunk
+    // lookups remain index-backed and do not silently regress to full scans.
     return await readUnindexedArchiveResults(target, objectUri, operation);
   }
 
@@ -528,12 +540,13 @@ function createSortedArchiveIds(result: {
 async function resolveReadableIndexedArchive(
   target: ParsedWikiGraphLibraryUri,
   archiveId: number,
+  options: { readonly operation: string },
 ): Promise<WikiGraphLibraryArchiveRecord> {
   const library = await resolveWikiGraphLibrary(target);
   const archive = await getWikiGraphLibraryArchiveById(library, archiveId);
   if (!isReadableLibraryArchive(archive)) {
     throw new Error(
-      `Wiki Graph library archive ${archiveId} is not readable while listing library objects.`,
+      `Wiki Graph library archive ${archiveId} is not readable while ${options.operation}.`,
     );
   }
   return archive;
@@ -569,5 +582,11 @@ function isArchiveObjectNotFoundError(error: unknown): boolean {
   return (
     error instanceof Error &&
     error.message.includes(" was not found in this archive.")
+  );
+}
+
+function isTripleObjectUri(objectUri: string): boolean {
+  return /^wikg:\/\/(?:chapter\/[1-9][0-9]*\/)?triple\/Q[1-9][0-9]*\/[^/]+\/Q[1-9][0-9]*\/?$/u.test(
+    objectUri,
   );
 }

--- a/test/core/library/query.test.ts
+++ b/test/core/library/query.test.ts
@@ -102,7 +102,9 @@ vi.mock("../../../packages/core/src/library/search-index.js", () => ({
     (_target, objectUri: string) =>
       Promise.resolve(mocks.objectArchiveIds.get(objectUri) ?? []),
   ),
-  queryWikiGraphLibrarySearchIndex: vi.fn(() => Promise.resolve(undefined)),
+  queryWikiGraphLibrarySearchIndex: vi.fn(() =>
+    Promise.resolve(mocks.listIndexResult),
+  ),
 }));
 
 vi.mock(
@@ -323,6 +325,21 @@ describe("wiki graph library object query aggregation", () => {
     });
   });
 
+  it("does not scan archives for non-indexed entity pages", async () => {
+    const [{ readWikiGraphLibraryPage }, archiveView] = await Promise.all([
+      import("../../../packages/core/src/library/query.js"),
+      import("../../../packages/core/src/retrieval/query/archive-view/index.js"),
+    ]);
+    vi.mocked(archiveView.readArchivePage).mockClear();
+
+    await expect(
+      readWikiGraphLibraryPage(target, "wikg://entity/Q404"),
+    ).rejects.toThrow(
+      "Wiki Graph library object was not found: wikg://entity/Q404",
+    );
+    expect(archiveView.readArchivePage).not.toHaveBeenCalled();
+  });
+
   it("aggregates related items instead of returning the first archive", async () => {
     const { listRelatedWikiGraphLibraryObjects } =
       await import("../../../packages/core/src/library/query.js");
@@ -395,6 +412,50 @@ describe("wiki graph library object query aggregation", () => {
     await expect(
       listWikiGraphLibraryEvidence(target, "wikg://entity/Q1"),
     ).rejects.toThrow("archive 2 is not readable");
+  });
+
+  it.each(["removed", "conflict", "unreadable"])(
+    "fails library list hydration when an indexed archive is %s",
+    async (status) => {
+      const { listWikiGraphLibraryObjects } =
+        await import("../../../packages/core/src/library/query.js");
+
+      seedArchive(2, status);
+      mocks.listIndexResult = {
+        objectHits: [
+          createIndexObjectHit(1, "1"),
+          createIndexObjectHit(2, "1"),
+        ],
+        terms: [],
+        textHits: [],
+      };
+
+      await expect(
+        listWikiGraphLibraryObjects(target, { types: ["chapter-title"] }),
+      ).rejects.toThrow(
+        "Wiki Graph library archive 2 is not readable while listing library objects.",
+      );
+    },
+  );
+
+  it("fails library search hydration when an indexed archive is not readable", async () => {
+    const { findWikiGraphLibraryObjects } =
+      await import("../../../packages/core/src/library/query.js");
+
+    seedArchive(2, "removed");
+    mocks.listIndexResult = {
+      objectHits: [createIndexObjectHit(2, "1")],
+      terms: ["chapter"],
+      textHits: [],
+    };
+
+    await expect(
+      findWikiGraphLibraryObjects(target, "chapter", {
+        types: ["chapter-title"],
+      }),
+    ).rejects.toThrow(
+      "Wiki Graph library archive 2 is not readable while searching library objects.",
+    );
   });
 
   it("lists library objects from the library index instead of archive collection merge", async () => {


### PR DESCRIPTION
## Summary
- Make library search hydration use only archive ids returned by the library index, and fail when an indexed source archive is not readable instead of silently skipping it.
- Restrict the library v1 non-indexed archive scan fallback to triple object URIs, with an explicit comment documenting this v1 exception.
- Add regression coverage for library list hydration failures, non-indexed entity no-scan behavior, and `next` over library-index collection cursors preserving dirty/current checks and archive provenance.

## Acceptance matrix
| Area | Covered by | This PR status |
| --- | --- | --- |
| #139 library v1 index/query lifecycle, cursor scope, source provenance | #140 plus #145/#146/#147 | Adds post-merge regression tests for library-index `next`, source fields through list/next, and triple fallback boundary. |
| #142 dirty after library archive writes, dirty marker failure warning, remove-library lock, index embed/external rejection | PR #145 | Reuses the merged dirty path; adds `next` dirty propagation coverage so dirty library cursors do not bypass the ready check. |
| #143 get/evidence/related/pack multi-archive aggregation and failure strategy | PR #146 | Fixes/tests the remaining search hydration skip case and fixes/tests triple fallback as a narrow v1 exception. |
| #144 list from library index, stable archive tie-break, list cursor scope | PR #147 | Adds list hydration failure tests for removed/conflict/unreadable indexed archives and `next` tests for library-index collection cursors. |
| #149 product regression matrix | This PR | Covers dirty + list/next, list hydration failure strategy, source field consistency through list/next/search hydration, library cursor/next, and triple fallback boundary. |

## Fixed in this PR vs test-only
- Fixed: library search no longer hydrates by scanning all ready archives; it uses the indexed archive ids and fails on unreadable indexed sources.
- Fixed: non-indexed fallback is restricted to triple URIs only; entity/chunk misses stay index-backed and fail without scanning archives.
- Test-only: library-index `next` routing and dirty propagation; list hydration removed/conflict/unreadable failure cases; source provenance assertions on next output.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run test/core/library/query.test.ts packages/cli/src/commands/archive-command/run/next.test.ts packages/cli/src/commands/archive-command/run/document.test.ts packages/cli/src/commands/archive-command/run/uri.test.ts test/cli/archive/query.test.ts test/cli/archive/object.test.ts`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run build`
- `pnpm run format`

Closes #149
