### PR TITLE
fix: degrade disambiguation profile failures

### DIFF
--- a/packages/core/src/external/wikipage/cache.ts
+++ b/packages/core/src/external/wikipage/cache.ts
@@ -13,6 +13,7 @@ import type {
   CachedQidRecord,
   DisambiguationLinkedQid,
   DisambiguationPageText,
+  DisambiguationProfileError,
   DisambiguationProfile,
   DisambiguationProfileMeaning,
 } from "./types.js";
@@ -38,6 +39,7 @@ CREATE TABLE IF NOT EXISTS disambiguation_cache (
   wiki TEXT NOT NULL,
   pages_json TEXT NOT NULL,
   profile_json TEXT,
+  profile_error_json TEXT,
   checked_at TEXT NOT NULL,
   PRIMARY KEY (qid, wiki)
 );
@@ -171,6 +173,9 @@ WHERE qid = ? AND wiki = ?
       );
 
       if (record !== undefined) {
+        if (isExpiredProfileError(record.profileError)) {
+          continue;
+        }
         results.set(qid, record);
       }
     }
@@ -191,11 +196,12 @@ WHERE qid = ? AND wiki = ?
         await this.#database.run(
           `
 INSERT INTO disambiguation_cache (
-  qid, wiki, pages_json, profile_json, checked_at
-) VALUES (?, ?, ?, ?, ?)
+  qid, wiki, pages_json, profile_json, profile_error_json, checked_at
+) VALUES (?, ?, ?, ?, ?, ?)
 ON CONFLICT(qid, wiki) DO UPDATE SET
   pages_json = excluded.pages_json,
   profile_json = excluded.profile_json,
+  profile_error_json = excluded.profile_error_json,
   checked_at = excluded.checked_at
 `,
           [
@@ -205,6 +211,9 @@ ON CONFLICT(qid, wiki) DO UPDATE SET
             record.profile === undefined
               ? null
               : JSON.stringify(record.profile),
+            record.profileError === undefined
+              ? null
+              : JSON.stringify(record.profileError),
             record.checkedAt,
           ],
         );
@@ -315,33 +324,42 @@ async function migrateDisambiguationCacheSchema(
 ): Promise<void> {
   const columns = await listTableColumns(database, "disambiguation_cache");
 
-  if (columns.has("wiki")) {
-    return;
-  }
+  if (!columns.has("wiki")) {
+    await database.transaction(async () => {
+      const transactionColumns = await listTableColumns(
+        database,
+        "disambiguation_cache",
+      );
 
-  await database.transaction(async () => {
-    const transactionColumns = await listTableColumns(
-      database,
-      "disambiguation_cache",
-    );
+      if (transactionColumns.has("wiki")) {
+        return;
+      }
 
-    if (transactionColumns.has("wiki")) {
-      return;
-    }
-
-    await database.run(
-      "ALTER TABLE disambiguation_cache RENAME TO disambiguation_cache_legacy",
-    );
-    await database.run(CREATE_DISAMBIGUATION_CACHE_SQL);
-    await database.run(`
+      await database.run(
+        "ALTER TABLE disambiguation_cache RENAME TO disambiguation_cache_legacy",
+      );
+      await database.run(CREATE_DISAMBIGUATION_CACHE_SQL);
+      await database.run(`
 INSERT OR IGNORE INTO disambiguation_cache (
   qid, wiki, pages_json, profile_json, checked_at
 )
 SELECT qid, 'enwiki', pages_json, profile_json, checked_at
 FROM disambiguation_cache_legacy
 `);
-    await database.run("DROP TABLE disambiguation_cache_legacy");
-  });
+      await database.run("DROP TABLE disambiguation_cache_legacy");
+    });
+  }
+
+  const updatedColumns = await listTableColumns(
+    database,
+    "disambiguation_cache",
+  );
+
+  if (!updatedColumns.has("profile_error_json")) {
+    await database.run(
+      "ALTER TABLE disambiguation_cache ADD COLUMN profile_error_json TEXT",
+    );
+  }
 }
 
 async function listTableColumns(
@@ -423,10 +441,17 @@ function mapQidRecord(row: SqlRow): CachedQidRecord {
 }
 
 function mapDisambiguationRecord(row: SqlRow): CachedDisambiguationRecord {
+  const profileErrorJson = getOptionalString(row.profile_error_json);
+  const profileError =
+    profileErrorJson === undefined
+      ? undefined
+      : parseDisambiguationProfileError(profileErrorJson);
+
   return {
     checkedAt: getString(row.checked_at, "checked_at"),
     disambiguationQid: getString(row.qid, "qid"),
     pages: parseDisambiguationPages(getString(row.pages_json, "pages_json")),
+    ...(profileError === undefined ? {} : { profileError }),
     ...(getOptionalString(row.profile_json) === undefined
       ? {}
       : {
@@ -435,6 +460,18 @@ function mapDisambiguationRecord(row: SqlRow): CachedDisambiguationRecord {
           ),
         }),
   };
+}
+
+function isExpiredProfileError(
+  error: DisambiguationProfileError | undefined,
+): boolean {
+  if (error === undefined) {
+    return false;
+  }
+
+  const retryAt = Date.parse(error.retryAfter);
+
+  return Number.isFinite(retryAt) && retryAt <= Date.now();
 }
 
 function parsePageRecords(value: string): readonly CachedPageRecord[] {
@@ -506,6 +543,18 @@ function parseDisambiguationProfile(value: string): DisambiguationProfile {
   return parsed;
 }
 
+function parseDisambiguationProfileError(
+  value: string,
+): DisambiguationProfileError | undefined {
+  const parsed: unknown = JSON.parse(value);
+
+  if (!isDisambiguationProfileError(parsed)) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
 function isDisambiguationProfile(
   value: unknown,
 ): value is DisambiguationProfile {
@@ -543,6 +592,22 @@ function isDisambiguationProfileMeaning(
       record.priority === "other") &&
     typeof record.qid === "string" &&
     /^Q[1-9]\d*$/u.test(record.qid)
+  );
+}
+
+function isDisambiguationProfileError(
+  value: unknown,
+): value is DisambiguationProfileError {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+
+  return (
+    typeof record.failedAt === "string" &&
+    typeof record.message === "string" &&
+    typeof record.retryAfter === "string"
   );
 }
 

--- a/packages/core/src/external/wikipage/index.ts
+++ b/packages/core/src/external/wikipage/index.ts
@@ -15,6 +15,7 @@ export type {
   DisambiguationPageText,
   DisambiguationMeaningPriority,
   DisambiguationProfile,
+  DisambiguationProfileError,
   DisambiguationProfileMeaning,
   DisambiguationProfileNormalizer,
   DisambiguationProfileNormalizerInput,

--- a/packages/core/src/external/wikipage/normalizer.test.ts
+++ b/packages/core/src/external/wikipage/normalizer.test.ts
@@ -10,6 +10,56 @@ import { renderDisambiguationHtml } from "./wikimedia-client/index.js";
 import type { GuaranteedRequest } from "../guaranteed/index.js";
 
 describe("wikipage/normalizer", () => {
+  it("omits meanings without qids before returning the final profile", async () => {
+    const input = createInput();
+    const request = vi.fn<GuaranteedRequest>().mockResolvedValueOnce(
+      JSON.stringify({
+        meanings: [
+          {
+            category: "concept",
+            information: "unlinked page item",
+            name: "Unlinked meaning",
+            priority: "primary",
+            qid: null,
+          },
+          {
+            category: "work",
+            information: "empty qid page item",
+            name: "Empty QID meaning",
+            priority: "secondary",
+            qid: "",
+          },
+          {
+            category: "place",
+            information: "美国首都",
+            name: "华盛顿哥伦比亚特区",
+            priority: "primary",
+            qid: "Q61",
+          },
+        ],
+        sourceQid: "Q25301",
+        surface: "华盛顿",
+      }),
+    );
+
+    await expect(
+      createDisambiguationProfileNormalizer({ request })(input),
+    ).resolves.toStrictEqual({
+      meanings: [
+        {
+          category: "place",
+          information: "美国首都",
+          name: "华盛顿哥伦比亚特区",
+          priority: "primary",
+          qid: "Q61",
+        },
+      ],
+      sourceQid: "Q25301",
+      surface: "华盛顿",
+    });
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
   it("normalizes disambiguation page text and rejects invented qids", async () => {
     const input = createInput();
     const request = vi

--- a/packages/core/src/external/wikipage/normalizer.ts
+++ b/packages/core/src/external/wikipage/normalizer.ts
@@ -22,7 +22,7 @@ const profileMeaningSchema = z
     information: z.string(),
     name: z.string().min(1),
     priority: z.enum(["primary", "secondary", "other"]),
-    qid: z.string().regex(/^Q[1-9]\d*$/u),
+    qid: z.union([z.string(), z.null()]),
   })
   .strict();
 
@@ -60,7 +60,7 @@ export function createDisambiguationProfileNormalizer(
 
 function normalizeProfile(
   profile: z.infer<typeof profileSchema>,
-): DisambiguationProfile {
+): NormalizedDisambiguationProfile {
   return {
     meanings: profile.meanings.map((meaning) => ({
       ...(meaning.category === undefined ? {} : { category: meaning.category }),
@@ -76,7 +76,7 @@ function normalizeProfile(
 
 function parseDisambiguationProfile(
   input: DisambiguationProfileNormalizerInput,
-  profile: DisambiguationProfile,
+  profile: NormalizedDisambiguationProfile,
 ): DisambiguationProfile {
   const pageQidLinks = new Set(input.pageQidLinks.map((item) => item.qid));
   const issues: string[] = [];
@@ -90,6 +90,9 @@ function parseDisambiguationProfile(
   }
 
   for (const meaning of profile.meanings) {
+    if (meaning.qid === null || meaning.qid === "") {
+      continue;
+    }
     if (!pageQidLinks.has(meaning.qid)) {
       issues.push(
         `Meaning "${meaning.name}" selected qid ${meaning.qid}, but it is not present in the input disambiguation page links.`,
@@ -104,7 +107,13 @@ function parseDisambiguationProfile(
     }
 
     seen.add(meaning.qid);
-    meanings.push(meaning);
+    meanings.push({
+      ...(meaning.category === undefined ? {} : { category: meaning.category }),
+      information: meaning.information,
+      name: meaning.name,
+      priority: meaning.priority,
+      qid: meaning.qid,
+    });
   }
 
   if (meanings.length === 0) {
@@ -133,6 +142,9 @@ function buildNormalizerMessages(
         "Return JSON only.",
         "Do not invent QIDs, pages, people, places, works, or meanings.",
         "Only use QIDs from the pageQidLinks list.",
+        "Only include meanings whose target has a QID in pageQidLinks.",
+        "Omit disambiguation bullets or page items that have no QID link.",
+        "Never use null, empty strings, placeholder QIDs, or made-up QIDs.",
         "The information field must only copy or summarize text present on the disambiguation page itself.",
         "Do not use Wikidata descriptions or external knowledge to fill information.",
         "When a bullet contains multiple links, treat administrative divisions, parent locations, categories, and locator/explanatory links as context only.",
@@ -186,6 +198,19 @@ function buildNormalizerMessages(
         .join("\n"),
     },
   ];
+}
+
+interface NormalizedDisambiguationProfile {
+  readonly meanings: readonly NormalizedDisambiguationProfileMeaning[];
+  readonly sourceQid: string;
+  readonly surface?: string;
+}
+
+interface NormalizedDisambiguationProfileMeaning extends Omit<
+  DisambiguationProfileMeaning,
+  "qid"
+> {
+  readonly qid: string | null;
 }
 
 function formatPageQidLink(item: DisambiguationLinkedQid): object {

--- a/packages/core/src/external/wikipage/resolver.ts
+++ b/packages/core/src/external/wikipage/resolver.ts
@@ -1,5 +1,6 @@
 import { WikipageCache } from "./cache.js";
 import { createWikipageFetchLog } from "./fetch-log.js";
+import { GuaranteedRequestFailureError } from "../guaranteed/index.js";
 import {
   WikimediaClient,
   replaceTitleUriWithQidUri,
@@ -28,6 +29,7 @@ const DEFAULT_RETRY_BASE_DELAY_MS = 1_000;
 const DEFAULT_RETRY_TIMES = 3;
 const DEFAULT_USER_AGENT =
   "WikiGraph/0.3 (https://github.com/oomol-lab/wiki-graph)";
+const DISAMBIGUATION_PROFILE_ERROR_RETRY_DELAY_MS = 6 * 60 * 60 * 1_000;
 
 export class WikipageResolver {
   readonly #cache: WikipageCache;
@@ -289,22 +291,56 @@ export class WikipageResolver {
     }
 
     const linkedQids = mergeLinkedQids(pages);
-    const profile =
-      this.#normalizer === undefined || linkedQids.length === 0
-        ? undefined
-        : await this.#normalizer({
-            pageQidLinks: linkedQids,
-            pages,
-            sourceQid: record.qid,
-            ...(record.label === undefined ? {} : { surface: record.label }),
-          });
+    const profileResult = await this.#normalizeDisambiguationProfile(
+      record,
+      pages,
+      linkedQids,
+    );
 
     return {
       checkedAt: new Date().toISOString(),
       disambiguationQid: record.qid,
       pages,
-      ...(profile === undefined ? {} : { profile }),
+      ...profileResult,
     };
+  }
+
+  async #normalizeDisambiguationProfile(
+    record: CachedQidRecord,
+    pages: readonly DisambiguationPageText[],
+    linkedQids: readonly DisambiguationLinkedQid[],
+  ): Promise<Pick<CachedDisambiguationRecord, "profile" | "profileError">> {
+    if (this.#normalizer === undefined || linkedQids.length === 0) {
+      return {};
+    }
+
+    try {
+      return {
+        profile: await this.#normalizer({
+          pageQidLinks: linkedQids,
+          pages,
+          sourceQid: record.qid,
+          ...(record.label === undefined ? {} : { surface: record.label }),
+        }),
+      };
+    } catch (error) {
+      if (!(error instanceof GuaranteedRequestFailureError)) {
+        throw error;
+      }
+
+      const failedAt = new Date();
+      const retryAfter = new Date(
+        failedAt.getTime() + DISAMBIGUATION_PROFILE_ERROR_RETRY_DELAY_MS,
+      );
+
+      return {
+        profileError: {
+          failedAt: failedAt.toISOString(),
+          message: error.message,
+          retryAfter: retryAfter.toISOString(),
+        },
+      };
+    }
   }
 
   async #reportProgress(

--- a/packages/core/src/external/wikipage/types.ts
+++ b/packages/core/src/external/wikipage/types.ts
@@ -81,7 +81,14 @@ export interface CachedDisambiguationRecord {
   readonly checkedAt: string;
   readonly disambiguationQid: string;
   readonly pages: readonly DisambiguationPageText[];
+  readonly profileError?: DisambiguationProfileError;
   readonly profile?: DisambiguationProfile;
+}
+
+export interface DisambiguationProfileError {
+  readonly failedAt: string;
+  readonly message: string;
+  readonly retryAfter: string;
 }
 
 export interface CachedPageRecord {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -131,6 +131,7 @@ export {
   type DisambiguationMeaningPriority,
   type DisambiguationPageText,
   type DisambiguationProfile,
+  type DisambiguationProfileError,
   type DisambiguationProfileMeaning,
   type DisambiguationProfileNormalizer,
   type DisambiguationProfileNormalizerInput,

--- a/test/core/external/wikipage/resolver.test.ts
+++ b/test/core/external/wikipage/resolver.test.ts
@@ -4,7 +4,11 @@ import { describe, expect, it } from "vitest";
 
 import { withLoggingContext } from "../../../../packages/core/src/runtime/common/logging.js";
 import { Database } from "../../../../packages/core/src/document/index.js";
-import { WikipageResolver } from "../../../../packages/core/src/external/wikipage/index.js";
+import { GuaranteedSchemaValidationError } from "../../../../packages/core/src/external/guaranteed/index.js";
+import {
+  WikipageCache,
+  WikipageResolver,
+} from "../../../../packages/core/src/external/wikipage/index.js";
 import { listCandidateSelectableQids } from "../../../../packages/core/src/external/wikimatch/index.js";
 import { withTempDir } from "../../../helpers/temp.js";
 
@@ -445,6 +449,150 @@ describe("wikipage/resolver", () => {
     });
   });
 
+  it("caches disambiguation profile failures briefly and retries after expiry", async () => {
+    await withTempDir("wikigraph-wikipage-", async (path) => {
+      const calls: string[] = [];
+      const cacheDatabasePath = `${path}/cache.sqlite`;
+      let normalizerCalls = 0;
+      const firstResolver = await WikipageResolver.open({
+        cacheDatabasePath,
+        fetch: createMockFetch(calls),
+        language: "en",
+        minRequestIntervalMs: 0,
+        normalizer: () => {
+          normalizerCalls += 1;
+
+          throw new GuaranteedSchemaValidationError(
+            13,
+            12,
+            {
+              issues: ["meanings.0.qid must be a valid QID"],
+              response: "{}",
+            },
+            new Error("invalid profile"),
+          );
+        },
+        retryBaseDelayMs: 0,
+      });
+
+      try {
+        const [resolution] = await firstResolver.resolveQids(["Q48397"]);
+
+        expect(resolution?.qid).toBe("Q48397");
+        expect(resolution?.isDisambiguation).toBe(true);
+        expect(resolution?.disambiguation?.profile).toBeUndefined();
+        expect(resolution?.disambiguation?.linkedQids).toStrictEqual([
+          {
+            qid: "Q925",
+            title: "Mercury (element)",
+          },
+          {
+            qid: "Q308",
+            title: "Mercury (planet)",
+          },
+        ]);
+      } finally {
+        await firstResolver.close();
+      }
+
+      expect(normalizerCalls).toBe(1);
+      const cachedError = await readProfileError(cacheDatabasePath, "Q48397");
+
+      expect(cachedError).toMatchObject({
+        message: "Schema validation failed after all retries",
+      });
+
+      const callCountAfterFailure = calls.length;
+      const secondResolver = await WikipageResolver.open({
+        cacheDatabasePath,
+        fetch: createMockFetch(calls),
+        language: "en",
+        minRequestIntervalMs: 0,
+        normalizer: () => {
+          normalizerCalls += 1;
+
+          return Promise.resolve({
+            meanings: [
+              {
+                information: "first planet from the Sun",
+                name: "Mercury (planet)",
+                priority: "primary",
+                qid: "Q308",
+              },
+            ],
+            sourceQid: "Q48397",
+          });
+        },
+        retryBaseDelayMs: 0,
+      });
+
+      try {
+        const [resolution] = await secondResolver.resolveQids(["Q48397"]);
+
+        expect(resolution?.disambiguation?.profile).toBeUndefined();
+      } finally {
+        await secondResolver.close();
+      }
+
+      expect(normalizerCalls).toBe(1);
+      expect(calls).toHaveLength(callCountAfterFailure);
+
+      await expireProfileError(cacheDatabasePath, "Q48397");
+      expect(await readProfileError(cacheDatabasePath, "Q48397")).toMatchObject(
+        {
+          retryAfter: "1969-01-01T00:00:00.000Z",
+        },
+      );
+      const cache = await WikipageCache.open(cacheDatabasePath);
+
+      try {
+        expect(
+          await cache.getDisambiguations(["Q48397"], "enwiki"),
+        ).toHaveProperty("size", 0);
+      } finally {
+        await cache.close();
+      }
+
+      const thirdResolver = await WikipageResolver.open({
+        cacheDatabasePath,
+        fetch: createMockFetch(calls),
+        language: "en",
+        minRequestIntervalMs: 0,
+        normalizer: () => {
+          normalizerCalls += 1;
+
+          return Promise.resolve({
+            meanings: [
+              {
+                information: "first planet from the Sun",
+                name: "Mercury (planet)",
+                priority: "primary",
+                qid: "Q308",
+              },
+            ],
+            sourceQid: "Q48397",
+          });
+        },
+        retryBaseDelayMs: 0,
+      });
+
+      try {
+        const [resolution] = await thirdResolver.resolveQids(["Q48397"]);
+
+        expect(normalizerCalls).toBe(2);
+        expect(
+          resolution?.disambiguation?.profile?.meanings.map(
+            (meaning) => meaning.qid,
+          ),
+        ).toStrictEqual(["Q308"]);
+      } finally {
+        await thirdResolver.close();
+      }
+
+      expect(normalizerCalls).toBe(2);
+    });
+  });
+
   it("keeps cache entries across resolver reopen", async () => {
     await withTempDir("wikigraph-wikipage-", async (path) => {
       const calls: string[] = [];
@@ -698,6 +846,61 @@ async function readWikipageFetchLog(logDirPath: string): Promise<string> {
     `${logDirPath}/${runDirName}/artifacts/wikipage/wikipage-fetch.jsonl`,
     "utf8",
   );
+}
+
+async function readProfileError(
+  cacheDatabasePath: string,
+  qid: string,
+): Promise<Record<string, unknown> | undefined> {
+  const database = await Database.open(cacheDatabasePath);
+
+  try {
+    const value = await database.queryOne(
+      `
+SELECT profile_error_json
+FROM disambiguation_cache
+WHERE qid = ?
+`,
+      [qid],
+      (row) =>
+        typeof row.profile_error_json === "string"
+          ? row.profile_error_json
+          : undefined,
+    );
+
+    return value === undefined
+      ? undefined
+      : (JSON.parse(value) as Record<string, unknown>);
+  } finally {
+    await database.close();
+  }
+}
+
+async function expireProfileError(
+  cacheDatabasePath: string,
+  qid: string,
+): Promise<void> {
+  const database = await Database.open(cacheDatabasePath);
+
+  try {
+    await database.run(
+      `
+UPDATE disambiguation_cache
+SET profile_error_json = ?
+WHERE qid = ?
+`,
+      [
+        JSON.stringify({
+          failedAt: "1969-01-01T00:00:00.000Z",
+          message: "Schema validation failed after all retries",
+          retryAfter: "1969-01-01T00:00:00.000Z",
+        }),
+        qid,
+      ],
+    );
+  } finally {
+    await database.close();
+  }
 }
 
 async function readOnlyRunDirName(logDirPath: string): Promise<string> {


### PR DESCRIPTION
## Summary
- allow disambiguation profile normalization to omit LLM-returned meanings with null or empty QIDs while keeping final profile meanings QID-strict
- cache guaranteed-JSON disambiguation profile failures as short-lived profile error records and fall back to linkedQids instead of failing Knowledge Graph jobs
- retry profile normalization after the cached failure retry window expires

## Context
Related to #73. This keeps the guaranteed structured-output path from becoming a hard failure point when a later LLM enrichment step exhausts retries.

Related to #110 and #124. The disambiguation profile remains the precise selectable-QID boundary when it succeeds; failed profile generation now degrades to the existing linkedQids fallback path rather than aborting the build.

## Verification
- pnpm exec eslint packages/core/src/external/wikipage/cache.ts packages/core/src/external/wikipage/index.ts packages/core/src/external/wikipage/normalizer.test.ts packages/core/src/external/wikipage/normalizer.ts packages/core/src/external/wikipage/resolver.ts packages/core/src/external/wikipage/types.ts packages/core/src/index.ts test/core/external/wikipage/resolver.test.ts
- pnpm exec prettier packages/core/src/external/wikipage/cache.ts packages/core/src/external/wikipage/index.ts packages/core/src/external/wikipage/normalizer.test.ts packages/core/src/external/wikipage/normalizer.ts packages/core/src/external/wikipage/resolver.ts packages/core/src/external/wikipage/types.ts packages/core/src/index.ts test/core/external/wikipage/resolver.test.ts --check
- pnpm typecheck
- pnpm exec vitest run packages/core/src/external/wikipage/normalizer.test.ts test/core/external/wikipage/resolver.test.ts
- pnpm exec vitest run test/cli/queue.test.ts packages/core/src/external/wikimatch/options.test.ts packages/core/src/external/wikimatch/option-narrowing.test.ts packages/core/src/external/wikimatch/policy-judge.test.ts
- pnpm test:run
- pnpm build

Note: I did not use full `pnpm verify` because this checkout has an unrelated untracked `.worktrees/` directory and the repository-level prettier command scans `.`. I ran eslint and prettier check on all changed files instead.
