### PR TITLE
test(wiki-graph): isolate state dir overrides

### DIFF
--- a/packages/core/src/library/membership.test.ts
+++ b/packages/core/src/library/membership.test.ts
@@ -9,7 +9,7 @@ import {
 } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import {
   addWikiGraphLibraryArchive,
@@ -24,185 +24,189 @@ import {
   resolveWikiGraphLibraryArchivePath,
   scanWikiGraphLibrary,
 } from "../index.js";
-import {
-  getWikiGraphStateDirectoryPathForTesting,
-  setWikiGraphStateDirectoryPathForTesting,
-} from "../runtime/common/wiki-graph/dir.js";
+import { withWikiGraphStateDirectoryPathForTesting } from "../runtime/common/wiki-graph/dir.js";
 import { writeWikgArchive } from "../storage/wikg/index.js";
 import { acquireWikiGraphLibraryLock } from "./lock.js";
 
-let previousStateDir: string | undefined;
-let tempDir: string;
-
-beforeEach(async () => {
-  previousStateDir = getWikiGraphStateDirectoryPathForTesting();
-  tempDir = await mkdtemp(join(tmpdir(), "wikigraph-library-test-"));
-  setWikiGraphStateDirectoryPathForTesting(join(tempDir, "state"));
-});
-
-afterEach(async () => {
-  setWikiGraphStateDirectoryPathForTesting(previousStateDir);
-  await rm(tempDir, { force: true, recursive: true });
-});
-
 describe("library archive membership", () => {
   it("scans nested .wikg files and reports missing registered files", async () => {
-    const library = await ensureDefaultWikiGraphLibrary();
-    await mkdir(join(library.folderPath, "nested"), { recursive: true });
-    await writeFile(join(library.folderPath, "a.wikg"), "a");
-    await writeFile(join(library.folderPath, "nested", "b.wikg"), "b");
+    await withLibraryTestState(async () => {
+      const library = await ensureDefaultWikiGraphLibrary();
+      await mkdir(join(library.folderPath, "nested"), { recursive: true });
+      await writeFile(join(library.folderPath, "a.wikg"), "a");
+      await writeFile(join(library.folderPath, "nested", "b.wikg"), "b");
 
-    const target = parseWikiGraphLibraryUri("wikg://lib");
-    expect(target).toBeDefined();
-    const first = await scanWikiGraphLibrary(target!);
-    expect(first.archives.map((archive) => archive.relativePath)).toStrictEqual(
-      ["a.wikg", "nested/b.wikg"],
-    );
+      const target = parseWikiGraphLibraryUri("wikg://lib");
+      expect(target).toBeDefined();
+      const first = await scanWikiGraphLibrary(target!);
+      expect(
+        first.archives.map((archive) => archive.relativePath),
+      ).toStrictEqual(["a.wikg", "nested/b.wikg"]);
 
-    await rm(join(library.folderPath, "a.wikg"));
-    const second = await scanWikiGraphLibrary(target!);
-    expect(
-      second.archives.map((archive) => ({
-        relativePath: archive.relativePath,
-        status: archive.status,
-      })),
-    ).toContainEqual({ relativePath: "a.wikg", status: "missing" });
+      await rm(join(library.folderPath, "a.wikg"));
+      const second = await scanWikiGraphLibrary(target!);
+      expect(
+        second.archives.map((archive) => ({
+          relativePath: archive.relativePath,
+          status: archive.status,
+        })),
+      ).toContainEqual({ relativePath: "a.wikg", status: "missing" });
+    });
   });
 
   it("adopts a moved archive only when its mutation token uniquely matches a missing member", async () => {
-    const library = await ensureDefaultWikiGraphLibrary();
-    const target = parseWikiGraphLibraryUri("wikg://lib");
-    expect(target).toBeDefined();
-    await createTestWikgArchive(join(library.folderPath, "old.wikg"));
+    await withLibraryTestState(async (tempDir) => {
+      const library = await ensureDefaultWikiGraphLibrary();
+      const target = parseWikiGraphLibraryUri("wikg://lib");
+      expect(target).toBeDefined();
+      await createTestWikgArchive(
+        tempDir,
+        join(library.folderPath, "old.wikg"),
+      );
 
-    const first = await scanWikiGraphLibrary(target!);
-    const oldArchive = first.archives.find(
-      (archive) => archive.relativePath === "old.wikg",
-    );
-    expect(oldArchive?.lastSeenMutationToken).toBeDefined();
+      const first = await scanWikiGraphLibrary(target!);
+      const oldArchive = first.archives.find(
+        (archive) => archive.relativePath === "old.wikg",
+      );
+      expect(oldArchive?.lastSeenMutationToken).toBeDefined();
 
-    await rename(
-      join(library.folderPath, "old.wikg"),
-      join(library.folderPath, "renamed.wikg"),
-    );
-    const second = await scanWikiGraphLibrary(target!);
-    const renamedArchive = second.archives.find(
-      (archive) => archive.relativePath === "renamed.wikg",
-    );
-    expect(renamedArchive?.publicId).toBe(oldArchive?.publicId);
-    expect(renamedArchive?.status).toBe("present");
-    expect(
-      second.archives.some((archive) => archive.relativePath === "old.wikg"),
-    ).toBe(false);
+      await rename(
+        join(library.folderPath, "old.wikg"),
+        join(library.folderPath, "renamed.wikg"),
+      );
+      const second = await scanWikiGraphLibrary(target!);
+      const renamedArchive = second.archives.find(
+        (archive) => archive.relativePath === "renamed.wikg",
+      );
+      expect(renamedArchive?.publicId).toBe(oldArchive?.publicId);
+      expect(renamedArchive?.status).toBe("present");
+      expect(
+        second.archives.some((archive) => archive.relativePath === "old.wikg"),
+      ).toBe(false);
+    });
   });
 
   it("reports copied-token conflicts instead of silently reusing an archive id", async () => {
-    const library = await ensureDefaultWikiGraphLibrary();
-    const target = parseWikiGraphLibraryUri("wikg://lib");
-    expect(target).toBeDefined();
-    await createTestWikgArchive(join(library.folderPath, "original.wikg"));
-    const first = await scanWikiGraphLibrary(target!);
+    await withLibraryTestState(async (tempDir) => {
+      const library = await ensureDefaultWikiGraphLibrary();
+      const target = parseWikiGraphLibraryUri("wikg://lib");
+      expect(target).toBeDefined();
+      await createTestWikgArchive(
+        tempDir,
+        join(library.folderPath, "original.wikg"),
+      );
+      const first = await scanWikiGraphLibrary(target!);
 
-    await copyFile(
-      join(library.folderPath, "original.wikg"),
-      join(library.folderPath, "copy.wikg"),
-    );
-    const second = await scanWikiGraphLibrary(target!);
-    const original = second.archives.find(
-      (archive) => archive.relativePath === "original.wikg",
-    );
-    const copy = second.archives.find(
-      (archive) => archive.relativePath === "copy.wikg",
-    );
+      await copyFile(
+        join(library.folderPath, "original.wikg"),
+        join(library.folderPath, "copy.wikg"),
+      );
+      const second = await scanWikiGraphLibrary(target!);
+      const original = second.archives.find(
+        (archive) => archive.relativePath === "original.wikg",
+      );
+      const copy = second.archives.find(
+        (archive) => archive.relativePath === "copy.wikg",
+      );
 
-    expect(original?.publicId).toBe(first.archives[0]?.publicId);
-    expect(copy?.status).toBe("conflict");
-    expect(copy?.publicId).not.toBe(original?.publicId);
+      expect(original?.publicId).toBe(first.archives[0]?.publicId);
+      expect(copy?.status).toBe("conflict");
+      expect(copy?.publicId).not.toBe(original?.publicId);
+    });
   });
 
   it("does not adopt by basename, size, or mtime without a mutation-token match", async () => {
-    const library = await ensureDefaultWikiGraphLibrary();
-    const target = parseWikiGraphLibraryUri("wikg://lib");
-    expect(target).toBeDefined();
-    await writeFile(join(library.folderPath, "old.wikg"), "same");
-    const first = await scanWikiGraphLibrary(target!);
+    await withLibraryTestState(async () => {
+      const library = await ensureDefaultWikiGraphLibrary();
+      const target = parseWikiGraphLibraryUri("wikg://lib");
+      expect(target).toBeDefined();
+      await writeFile(join(library.folderPath, "old.wikg"), "same");
+      const first = await scanWikiGraphLibrary(target!);
 
-    await rm(join(library.folderPath, "old.wikg"));
-    await writeFile(join(library.folderPath, "new.wikg"), "same");
-    const second = await scanWikiGraphLibrary(target!);
-    const fresh = second.archives.find(
-      (archive) => archive.relativePath === "new.wikg",
-    );
+      await rm(join(library.folderPath, "old.wikg"));
+      await writeFile(join(library.folderPath, "new.wikg"), "same");
+      const second = await scanWikiGraphLibrary(target!);
+      const fresh = second.archives.find(
+        (archive) => archive.relativePath === "new.wikg",
+      );
 
-    expect(fresh?.publicId).not.toBe(first.archives[0]?.publicId);
-    expect(second.archives).toContainEqual(
-      expect.objectContaining({ relativePath: "old.wikg", status: "missing" }),
-    );
+      expect(fresh?.publicId).not.toBe(first.archives[0]?.publicId);
+      expect(second.archives).toContainEqual(
+        expect.objectContaining({
+          relativePath: "old.wikg",
+          status: "missing",
+        }),
+      );
+    });
   });
 
   it("adds, moves, and removes managed archives inside the library folder", async () => {
-    const target = parseWikiGraphLibraryUri("wikg://lib");
-    expect(target).toBeDefined();
-    const source = join(tempDir, "source.wikg");
-    await writeFile(source, "content");
+    await withLibraryTestState(async (tempDir) => {
+      const target = parseWikiGraphLibraryUri("wikg://lib");
+      expect(target).toBeDefined();
+      const source = join(tempDir, "source.wikg");
+      await writeFile(source, "content");
 
-    const added = await addWikiGraphLibraryArchive({
-      inputPath: source,
-      target: target!,
-      to: "nested/book.wikg",
-    });
-    expect(added.relativePath).toBe("nested/book.wikg");
-    expect(added.status).toBe("present");
-    expect(await readFile(added.path, "utf8")).toBe("content");
-
-    await expect(
-      addWikiGraphLibraryArchive({
-        inputPath: "wikg://elsewhere/book.wikg",
-        target: target!,
-      }),
-    ).rejects.toThrow("not a Wiki Graph URI");
-    await expect(
-      addWikiGraphLibraryArchive({
+      const added = await addWikiGraphLibraryArchive({
         inputPath: source,
         target: target!,
-        to: "../x.wikg",
-      }),
-    ).rejects.toThrow("relative path inside the library folder");
+        to: "nested/book.wikg",
+      });
+      expect(added.relativePath).toBe("nested/book.wikg");
+      expect(added.status).toBe("present");
+      expect(await readFile(added.path, "utf8")).toBe("content");
 
-    const archiveTarget = parseWikiGraphLibraryUri(added.uri);
-    expect(archiveTarget?.kind).toBe("archive");
-    const moved = await moveWikiGraphLibraryArchive({
-      target: archiveTarget!,
-      to: "renamed.wikg",
-    });
-    expect(moved.publicId).toBe(added.publicId);
-    expect(moved.relativePath).toBe("renamed.wikg");
+      await expect(
+        addWikiGraphLibraryArchive({
+          inputPath: "wikg://elsewhere/book.wikg",
+          target: target!,
+        }),
+      ).rejects.toThrow("not a Wiki Graph URI");
+      await expect(
+        addWikiGraphLibraryArchive({
+          inputPath: source,
+          target: target!,
+          to: "../x.wikg",
+        }),
+      ).rejects.toThrow("relative path inside the library folder");
 
-    const removed = await removeWikiGraphLibraryArchive({
-      target: archiveTarget!,
+      const archiveTarget = parseWikiGraphLibraryUri(added.uri);
+      expect(archiveTarget?.kind).toBe("archive");
+      const moved = await moveWikiGraphLibraryArchive({
+        target: archiveTarget!,
+        to: "renamed.wikg",
+      });
+      expect(moved.publicId).toBe(added.publicId);
+      expect(moved.relativePath).toBe("renamed.wikg");
+
+      const removed = await removeWikiGraphLibraryArchive({
+        target: archiveTarget!,
+      });
+      expect(removed.publicId).toBe(added.publicId);
+      await expect(readFile(moved.path, "utf8")).rejects.toThrow();
     });
-    expect(removed.publicId).toBe(added.publicId);
-    await expect(readFile(moved.path, "utf8")).rejects.toThrow();
   });
 
   it("requires the library write lock when removing a library registry", async () => {
-    const library = await createWikiGraphLibrary({
-      folderPath: join(tempDir, "locked-library"),
-    });
-    const target = parseWikiGraphLibraryUri(library.uri);
-    expect(target).toBeDefined();
-    const release = await acquireWikiGraphLibraryLock(library.id, "write");
+    await withLibraryTestState(async (tempDir) => {
+      const library = await createWikiGraphLibrary({
+        folderPath: join(tempDir, "locked-library"),
+      });
+      const target = parseWikiGraphLibraryUri(library.uri);
+      expect(target).toBeDefined();
+      const release = await acquireWikiGraphLibraryLock(library.id, "write");
 
-    try {
-      await expect(removeWikiGraphLibrary(target!)).rejects.toThrow(
-        `Wiki Graph library is locked for write: ${library.id}.`,
-      );
-    } finally {
-      await release();
-    }
+      try {
+        await expect(removeWikiGraphLibrary(target!)).rejects.toThrow(
+          `Wiki Graph library is locked for write: ${library.id}.`,
+        );
+      } finally {
+        await release();
+      }
 
-    await expect(removeWikiGraphLibrary(target!)).resolves.toMatchObject({
-      id: library.id,
+      await expect(removeWikiGraphLibrary(target!)).resolves.toMatchObject({
+        id: library.id,
+      });
     });
   });
 });
@@ -252,27 +256,49 @@ describe("library URI locators", () => {
   });
 
   it("resolves a library archive locator to the managed .wikg file", async () => {
-    const target = parseWikiGraphLibraryUri("wikg://lib");
-    expect(target).toBeDefined();
-    const source = join(tempDir, "source.wikg");
-    await writeFile(source, "content");
+    await withLibraryTestState(async (tempDir) => {
+      const target = parseWikiGraphLibraryUri("wikg://lib");
+      expect(target).toBeDefined();
+      const source = join(tempDir, "source.wikg");
+      await writeFile(source, "content");
 
-    const added = await addWikiGraphLibraryArchive({
-      inputPath: source,
-      target: target!,
-      to: "nested/book.wikg",
+      const added = await addWikiGraphLibraryArchive({
+        inputPath: source,
+        target: target!,
+        to: "nested/book.wikg",
+      });
+
+      await expect(resolveWikiGraphLibraryArchivePath(added.uri)).resolves.toBe(
+        added.path,
+      );
+      await expect(
+        resolveWikiGraphLibraryArchivePath(`${added.uri}-missing`),
+      ).rejects.toThrow("Unknown Wiki Graph library archive");
     });
-
-    await expect(resolveWikiGraphLibraryArchivePath(added.uri)).resolves.toBe(
-      added.path,
-    );
-    await expect(
-      resolveWikiGraphLibraryArchivePath(`${added.uri}-missing`),
-    ).rejects.toThrow("Unknown Wiki Graph library archive");
   });
 });
 
-async function createTestWikgArchive(path: string): Promise<void> {
+async function withLibraryTestState(
+  operation: (tempDir: string) => Promise<void>,
+): Promise<void> {
+  const tempDir = await mkdtemp(join(tmpdir(), "wikigraph-library-test-"));
+
+  try {
+    await withWikiGraphStateDirectoryPathForTesting(
+      join(tempDir, "state"),
+      async () => {
+        await operation(tempDir);
+      },
+    );
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+}
+
+async function createTestWikgArchive(
+  tempDir: string,
+  path: string,
+): Promise<void> {
   const sourceDir = await mkdtemp(join(tempDir, "wikg-source-"));
   await writeFile(join(sourceDir, "database.db"), "test", "utf8");
   await writeWikgArchive(sourceDir, path);

--- a/packages/core/src/runtime/common/wiki-graph/dir.test.ts
+++ b/packages/core/src/runtime/common/wiki-graph/dir.test.ts
@@ -1,0 +1,42 @@
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  getWikiGraphStateDirectoryPathForTesting,
+  resolveWikiGraphHomeDirectoryPath,
+  setWikiGraphStateDirectoryPathForTesting,
+} from "./dir.js";
+
+describe("wiki graph runtime directories", () => {
+  it("keeps testing state directory overrides scoped to async chains", async () => {
+    const originalStateDir = getWikiGraphStateDirectoryPathForTesting();
+    const leftStateDir = join(tmpdir(), "wikigraph-state-left");
+    const rightStateDir = join(tmpdir(), "wikigraph-state-right");
+
+    try {
+      const [left, right] = await Promise.all([
+        readScopedHomeDirectory(leftStateDir, 10),
+        readScopedHomeDirectory(rightStateDir, 0),
+      ]);
+
+      expect(left).toBe(resolve(leftStateDir));
+      expect(right).toBe(resolve(rightStateDir));
+    } finally {
+      setWikiGraphStateDirectoryPathForTesting(originalStateDir);
+    }
+  });
+});
+
+async function readScopedHomeDirectory(
+  stateDir: string,
+  delayMs: number,
+): Promise<string> {
+  setWikiGraphStateDirectoryPathForTesting(stateDir);
+  await new Promise((resolveDelay) => {
+    setTimeout(resolveDelay, delayMs);
+  });
+
+  return resolveWikiGraphHomeDirectoryPath();
+}

--- a/packages/core/src/runtime/common/wiki-graph/dir.ts
+++ b/packages/core/src/runtime/common/wiki-graph/dir.ts
@@ -1,7 +1,18 @@
+import { AsyncLocalStorage } from "async_hooks";
 import { homedir } from "os";
 import { join, resolve } from "path";
 
+const testingStateDirectoryPath = new AsyncLocalStorage<{
+  readonly path: string | undefined;
+}>();
+
 export function resolveWikiGraphHomeDirectoryPath(): string {
+  const testingStateDirPath = testingStateDirectoryPath.getStore()?.path;
+
+  if (testingStateDirPath !== undefined && testingStateDirPath.trim() !== "") {
+    return resolve(testingStateDirPath);
+  }
+
   const devStateDirPath = process.env.WIKIGRAPH_DEV;
 
   if (devStateDirPath !== undefined && devStateDirPath.trim() !== "") {
@@ -14,6 +25,8 @@ export function resolveWikiGraphHomeDirectoryPath(): string {
 export function setWikiGraphStateDirectoryPathForTesting(
   path: string | undefined,
 ): void {
+  testingStateDirectoryPath.enterWith({ path });
+
   if (path === undefined) {
     delete process.env.WIKIGRAPH_DEV;
     return;

--- a/packages/core/src/runtime/common/wiki-graph/dir.ts
+++ b/packages/core/src/runtime/common/wiki-graph/dir.ts
@@ -35,6 +35,13 @@ export function setWikiGraphStateDirectoryPathForTesting(
   process.env.WIKIGRAPH_DEV = path;
 }
 
+export async function withWikiGraphStateDirectoryPathForTesting<T>(
+  path: string | undefined,
+  operation: () => Promise<T> | T,
+): Promise<T> {
+  return await testingStateDirectoryPath.run({ path }, operation);
+}
+
 export function getWikiGraphStateDirectoryPathForTesting(): string | undefined {
   return process.env.WIKIGRAPH_DEV;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    fileParallelism: false,
     include: ["test/**/*.test.ts", "packages/*/src/**/*.test.ts"],
     passWithNoTests: true,
     coverage: {


### PR DESCRIPTION
## Summary

- isolate testing wiki graph state directory overrides with async-local state
- keep `WIKIGRAPH_DEV` updates for child process inheritance
- add a regression test for concurrent async state directory overrides

## Verification

- `pnpm test:run`
- `pnpm test:run packages/core/src/runtime/common/wiki-graph/dir.test.ts test/core/storage/wikg/wiki-graph-archive-file.test.ts`
- `pnpm typecheck`
- `pnpm eslint packages/core/src/runtime/common/wiki-graph/dir.ts packages/core/src/runtime/common/wiki-graph/dir.test.ts`
- `pnpm format:check`

Note: full `pnpm verify` hit local Node heap OOM during `pnpm lint` even with an 8GB heap, so lint was verified against the changed files directly.
