### PR TITLE
feat(storage): add schema upgrade pipeline

### DIFF
--- a/packages/core/src/document/shared-state-database.ts
+++ b/packages/core/src/document/shared-state-database.ts
@@ -12,6 +12,8 @@ import { dirname, resolve } from "path";
 import { setTimeout as sleep } from "timers/promises";
 
 import { isNodeError } from "../utils/node-error.js";
+import { ensureWikiGraphHomeSchemaCurrent } from "../storage/schema-upgrade/index.js";
+import { resolveWikiGraphCoreDatabasePath } from "./../runtime/common/wiki-graph/dir.js";
 
 import { Database } from "./database.js";
 
@@ -29,9 +31,20 @@ export async function openSharedStateDatabase(
   schemaSql: string,
   options: { readonly readonly?: boolean } = {},
 ): Promise<Database> {
+  await ensureWikiGraphHomeSchemaCurrentForPath(databasePath);
   await ensureSharedStateDatabaseInitialized(databasePath, schemaSql);
 
   return await Database.open(databasePath, "", options);
+}
+
+function ensureWikiGraphHomeSchemaCurrentForPath(
+  databasePath: string,
+): Promise<void> {
+  if (resolve(databasePath) !== resolve(resolveWikiGraphCoreDatabasePath())) {
+    return Promise.resolve();
+  }
+
+  return ensureWikiGraphHomeSchemaCurrent();
 }
 
 export async function ensureSharedStateDatabaseInitialized(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -211,6 +211,13 @@ export type { Database, Document, ReadonlyDocument } from "./document/index.js";
 export { TOC_FILE_VERSION } from "./text/source/index.js";
 export type { BookMeta } from "./text/source/index.js";
 export { isArchiveSearchIndexCurrent } from "./retrieval/query/index.js";
+export {
+  ensureWikiGraphArchiveSchemaCurrent,
+  ensureWikiGraphHomeSchemaCurrent,
+  readWikiGraphArchiveSchemaVersion,
+  readWikiGraphHomeSchemaVersion,
+  upgradeWikiGraphArchiveSchema,
+} from "./storage/schema-upgrade/index.js";
 export { readArchiveIndexSettings } from "./retrieval/search-index/index.js";
 export { migrateLegacySdpubToWikg } from "./storage/migration/legacy-sdpub/upgrade/index.js";
 export type {

--- a/packages/core/src/runtime/common/wiki-graph/dir.ts
+++ b/packages/core/src/runtime/common/wiki-graph/dir.ts
@@ -8,6 +8,12 @@ export function resolveWikiGraphHomeDirectoryPath(): string {
     return resolve(devStateDirPath);
   }
 
+  const legacyStateDirPath = process.env.WIKIGRAPH_STATE_DIR;
+
+  if (legacyStateDirPath !== undefined && legacyStateDirPath.trim() !== "") {
+    return resolve(legacyStateDirPath);
+  }
+
   return join(homedir(), ".wikigraph");
 }
 

--- a/packages/core/src/storage/schema-upgrade/index.ts
+++ b/packages/core/src/storage/schema-upgrade/index.ts
@@ -1,0 +1,622 @@
+import { randomUUID } from "crypto";
+import { mkdir, rename, rm, stat } from "fs/promises";
+import { dirname, join, resolve } from "path";
+
+import { Database } from "../../document/database.js";
+import {
+  resolveWikiGraphCacheDatabasePath,
+  resolveWikiGraphCoreDatabasePath,
+  resolveWikiGraphHomeDirectoryPath,
+  resolveWikiGraphJobsDirectoryPath,
+  resolveWikiGraphStagingDirectoryPath,
+  resolveWikiGraphTempRootDirectoryPath,
+} from "../../runtime/common/wiki-graph/dir.js";
+import {
+  SEARCH_INDEX_DATABASE_PATH,
+  WIKG_MANIFEST_PATH,
+} from "../wikg/archive/constants.js";
+import { parseWikgManifest } from "../wikg/archive/manifest.js";
+import { normalizeArchivePath } from "../wikg/archive/paths.js";
+import {
+  openIndexedArchive,
+  readArchiveEntryText,
+} from "../wikg/archive/zip.js";
+import { writeWikgArchiveWithOverlays } from "../wikg/archive/write.js";
+import { createArchiveKey } from "../wikg/wikg-coordinator/archive-key.js";
+
+const CURRENT_ARCHIVE_SCHEMA_VERSION = 2;
+const CURRENT_HOME_SCHEMA_VERSION = 2;
+const LOCK_STALE_TIMEOUT_MS = 5 * 60 * 1000;
+let homeSchemaUpgradeInFlight: Promise<void> | undefined;
+const HOME_SCHEMA_SQL = `
+  CREATE TABLE IF NOT EXISTS schema_versions (
+    scope TEXT PRIMARY KEY,
+    version INTEGER NOT NULL,
+    updated_at TEXT NOT NULL
+  );
+`;
+
+export async function ensureWikiGraphArchiveSchemaCurrent(
+  archivePath: string,
+): Promise<void> {
+  const schemaVersion = await readWikiGraphArchiveSchemaVersion(archivePath);
+
+  if (schemaVersion > CURRENT_ARCHIVE_SCHEMA_VERSION) {
+    throw new Error(
+      `Unsupported Wiki Graph archive schema version: ${schemaVersion}.`,
+    );
+  }
+  if (schemaVersion < CURRENT_ARCHIVE_SCHEMA_VERSION) {
+    await upgradeWikiGraphArchiveSchema(archivePath);
+  }
+}
+
+export async function readWikiGraphArchiveSchemaVersion(
+  archivePath: string,
+): Promise<number> {
+  const { entries, zipFile } = await openIndexedArchive(resolve(archivePath));
+
+  try {
+    const manifestEntry = entries.find(
+      (entry) => normalizeArchivePath(entry.fileName) === WIKG_MANIFEST_PATH,
+    );
+
+    if (manifestEntry === undefined) {
+      throw new Error(`Missing WIKG manifest: ${WIKG_MANIFEST_PATH}.`);
+    }
+
+    return parseWikgManifest(
+      await readArchiveEntryText(resolve(archivePath), manifestEntry),
+    ).schemaVersion;
+  } finally {
+    zipFile.close();
+  }
+}
+
+export async function upgradeWikiGraphArchiveSchema(
+  archivePath: string,
+): Promise<void> {
+  const resolvedArchivePath = resolve(archivePath);
+  const schemaVersion =
+    await readWikiGraphArchiveSchemaVersion(resolvedArchivePath);
+
+  if (schemaVersion === CURRENT_ARCHIVE_SCHEMA_VERSION) {
+    return;
+  }
+
+  if (schemaVersion > CURRENT_ARCHIVE_SCHEMA_VERSION) {
+    throw new Error(
+      `Unsupported Wiki Graph archive schema version: ${schemaVersion}.`,
+    );
+  }
+
+  await ensureWikiGraphHomeSchemaCurrent();
+
+  const archiveKey = createArchiveKey(resolvedArchivePath);
+  await assertArchiveUpgradeSafe(archiveKey);
+
+  const temporaryPath = join(
+    dirname(resolvedArchivePath),
+    `.${getArchiveBasename(resolvedArchivePath)}.${process.pid}.${randomUUID()}.upgrade.tmp`,
+  );
+
+  await writeWikgArchiveWithOverlays(resolvedArchivePath, temporaryPath, [
+    {
+      entryPath: SEARCH_INDEX_DATABASE_PATH,
+      kind: "deleted",
+    },
+  ]);
+  await rename(temporaryPath, resolvedArchivePath);
+  await cleanupArchiveDerivedData(archiveKey);
+}
+
+export async function ensureWikiGraphHomeSchemaCurrent(): Promise<void> {
+  if (homeSchemaUpgradeInFlight !== undefined) {
+    await homeSchemaUpgradeInFlight;
+    return;
+  }
+
+  homeSchemaUpgradeInFlight = (async () => {
+    const coreDatabasePath = resolveWikiGraphCoreDatabasePath();
+    const schemaVersion =
+      await readWikiGraphHomeSchemaVersion(coreDatabasePath);
+
+    if (schemaVersion > CURRENT_HOME_SCHEMA_VERSION) {
+      throw new Error(
+        `Unsupported Wiki Graph home schema version: ${schemaVersion}.`,
+      );
+    }
+
+    if (schemaVersion < CURRENT_HOME_SCHEMA_VERSION) {
+      await assertHomeUpgradeSafe();
+      await cleanupHomeDerivedData();
+      await writeHomeSchemaVersion(
+        coreDatabasePath,
+        CURRENT_HOME_SCHEMA_VERSION,
+      );
+    }
+  })();
+
+  try {
+    await homeSchemaUpgradeInFlight;
+    return;
+  } finally {
+    homeSchemaUpgradeInFlight = undefined;
+  }
+}
+
+export async function readWikiGraphHomeSchemaVersion(
+  coreDatabasePath = resolveWikiGraphCoreDatabasePath(),
+): Promise<number> {
+  if (!(await pathExists(coreDatabasePath))) {
+    return 0;
+  }
+
+  const database = await Database.open(coreDatabasePath, "", {
+    readonly: true,
+  });
+
+  try {
+    if (!(await tableExists(database, "schema_versions"))) {
+      return 1;
+    }
+
+    const version = await database.queryOne(
+      "SELECT version FROM schema_versions WHERE scope = ?",
+      ["home"],
+      (row) => Number(row.version),
+    );
+
+    return version ?? 1;
+  } finally {
+    await database.close();
+  }
+}
+
+async function writeHomeSchemaVersion(
+  coreDatabasePath: string,
+  version: number,
+): Promise<void> {
+  await mkdir(dirname(coreDatabasePath), { recursive: true });
+  const database = await Database.open(coreDatabasePath);
+
+  try {
+    await database.run(HOME_SCHEMA_SQL);
+    await database.run(
+      `
+        INSERT INTO schema_versions (scope, version, updated_at)
+        VALUES (?, ?, ?)
+        ON CONFLICT(scope) DO UPDATE SET
+          version = excluded.version,
+          updated_at = excluded.updated_at
+      `,
+      ["home", version, new Date().toISOString()],
+    );
+  } finally {
+    await database.close();
+  }
+}
+
+async function cleanupHomeDerivedData(): Promise<void> {
+  const homeDirectoryPath = resolveWikiGraphHomeDirectoryPath();
+  const cacheDirectoryPath = join(homeDirectoryPath, "cache");
+  const stagingDirectoryPath = resolveWikiGraphStagingDirectoryPath();
+  const jobsDirectoryPath = resolveWikiGraphJobsDirectoryPath();
+  const tempDirectoryPath = resolveWikiGraphTempRootDirectoryPath();
+
+  await deletePathIfExists(join(cacheDirectoryPath, "search-sessions.sqlite"));
+  await deletePathIfExists(
+    join(cacheDirectoryPath, "continuation-cursors.sqlite"),
+  );
+  await deletePathIfExists(resolveWikiGraphCacheDatabasePath());
+  await deletePathIfExists(join(stagingDirectoryPath, "library"));
+  await deletePathIfExists(join(tempDirectoryPath, "gc.sqlite"));
+  await deletePathIfExists(join(tempDirectoryPath, "gc.last-run"));
+  await deletePathIfExists(join(jobsDirectoryPath, "cache"));
+
+  const stagingDatabasePath = join(stagingDirectoryPath, "staging.sqlite");
+  if (await pathExists(stagingDatabasePath)) {
+    await removeArchiveSearchIndexOverlays(stagingDatabasePath);
+  }
+}
+
+async function cleanupArchiveDerivedData(archiveKey: string): Promise<void> {
+  const cacheDirectoryPath = join(resolveWikiGraphHomeDirectoryPath(), "cache");
+  await deletePathIfExists(join(cacheDirectoryPath, "search-sessions.sqlite"));
+  await deletePathIfExists(
+    join(cacheDirectoryPath, "continuation-cursors.sqlite"),
+  );
+
+  const stagingDatabasePath = join(
+    resolveWikiGraphStagingDirectoryPath(),
+    "staging.sqlite",
+  );
+  if (await pathExists(stagingDatabasePath)) {
+    await removeArchiveSearchIndexOverlays(stagingDatabasePath, archiveKey);
+  }
+}
+
+async function assertArchiveUpgradeSafe(archiveKey: string): Promise<void> {
+  const stagingDatabasePath = join(
+    resolveWikiGraphStagingDirectoryPath(),
+    "staging.sqlite",
+  );
+
+  if (!(await pathExists(stagingDatabasePath))) {
+    return;
+  }
+
+  const database = await Database.open(stagingDatabasePath, "", {
+    readonly: true,
+  });
+
+  try {
+    for (const tableName of [
+      "archive_owners",
+      "entry_locks",
+      "entry_sqlite_leases",
+      "archive_commit_locks",
+    ]) {
+      if (!(await tableExists(database, tableName))) {
+        continue;
+      }
+
+      const rows = await database.queryAll(
+        `
+          SELECT owner_pid, heartbeat_at
+          FROM ${tableName}
+          WHERE archive_key = ?
+        `,
+        [archiveKey],
+        (row) => ({
+          heartbeatAt: Number(row.heartbeat_at),
+          ownerPid: Number(row.owner_pid),
+        }),
+      );
+
+      if (rows.some((row) => isActiveLock(row.ownerPid, row.heartbeatAt))) {
+        throw new Error(
+          `Cannot upgrade archive with active coordinator state: ${archiveKey}.`,
+        );
+      }
+    }
+
+    if (await tableExists(database, "entry_overlays")) {
+      const overlays = await database.queryAll(
+        `
+          SELECT entry_path
+          FROM entry_overlays
+          WHERE archive_key = ?
+        `,
+        [archiveKey],
+        (row) => String(row.entry_path),
+      );
+
+      const problematicOverlay = overlays.find(
+        (entryPath) => entryPath !== SEARCH_INDEX_DATABASE_PATH,
+      );
+      if (problematicOverlay !== undefined) {
+        throw new Error(
+          `Cannot upgrade archive with non-derived overlay state: ${archiveKey}.`,
+        );
+      }
+    }
+  } finally {
+    await database.close();
+  }
+}
+
+async function assertHomeUpgradeSafe(): Promise<void> {
+  await assertCoreLocksSafe();
+  await assertGcLockSafe();
+  await assertCoordinatorStateSafe();
+  await assertBuildQueueSafe();
+}
+
+async function assertCoreLocksSafe(): Promise<void> {
+  const coreDatabasePath = resolveWikiGraphCoreDatabasePath();
+
+  if (!(await pathExists(coreDatabasePath))) {
+    return;
+  }
+
+  const database = await Database.open(coreDatabasePath, "", {
+    readonly: true,
+  });
+
+  try {
+    if (!(await tableExists(database, "library_locks"))) {
+      return;
+    }
+
+    const rows = await database.queryAll(
+      `
+        SELECT owner_pid, heartbeat_at
+        FROM library_locks
+      `,
+      undefined,
+      (row) => ({
+        heartbeatAt: Number(row.heartbeat_at),
+        ownerPid: Number(row.owner_pid),
+      }),
+    );
+
+    if (rows.some((row) => isActiveLock(row.ownerPid, row.heartbeatAt))) {
+      throw new Error("Cannot upgrade home with active library locks.");
+    }
+  } finally {
+    await database.close();
+  }
+}
+
+async function assertGcLockSafe(): Promise<void> {
+  const gcDatabasePath = join(
+    resolveWikiGraphTempRootDirectoryPath(),
+    "gc.sqlite",
+  );
+
+  if (!(await pathExists(gcDatabasePath))) {
+    return;
+  }
+
+  const database = await Database.open(gcDatabasePath, "", {
+    readonly: true,
+  });
+
+  try {
+    if (!(await tableExists(database, "gc_locks"))) {
+      return;
+    }
+
+    const rows = await database.queryAll(
+      "SELECT owner_pid, heartbeat_at FROM gc_locks",
+      undefined,
+      (row) => ({
+        heartbeatAt: Number(row.heartbeat_at),
+        ownerPid: Number(row.owner_pid),
+      }),
+    );
+
+    if (rows.some((row) => isActiveLock(row.ownerPid, row.heartbeatAt))) {
+      throw new Error("Cannot upgrade home with an active GC lock.");
+    }
+  } finally {
+    await database.close();
+  }
+}
+
+async function assertCoordinatorStateSafe(): Promise<void> {
+  const stagingDatabasePath = join(
+    resolveWikiGraphStagingDirectoryPath(),
+    "staging.sqlite",
+  );
+
+  if (!(await pathExists(stagingDatabasePath))) {
+    return;
+  }
+
+  const database = await Database.open(stagingDatabasePath, "", {
+    readonly: true,
+  });
+
+  try {
+    for (const tableName of [
+      "archive_owners",
+      "entry_locks",
+      "entry_sqlite_leases",
+      "archive_commit_locks",
+    ]) {
+      if (!(await tableExists(database, tableName))) {
+        continue;
+      }
+
+      const rows = await database.queryAll(
+        `
+          SELECT owner_pid, heartbeat_at
+          FROM ${tableName}
+        `,
+        undefined,
+        (row) => ({
+          heartbeatAt: Number(row.heartbeat_at),
+          ownerPid: Number(row.owner_pid),
+        }),
+      );
+
+      if (rows.some((row) => isActiveLock(row.ownerPid, row.heartbeatAt))) {
+        throw new Error(
+          `Cannot upgrade home with active coordinator state: ${tableName}.`,
+        );
+      }
+    }
+
+    if (!(await tableExists(database, "entry_overlays"))) {
+      return;
+    }
+
+    const overlays = await database.queryAll(
+      `
+        SELECT entry_path, workspace_path
+        FROM entry_overlays
+      `,
+      undefined,
+      (row) => ({
+        entryPath: String(row.entry_path),
+        workspacePath:
+          row.workspace_path === null ? undefined : String(row.workspace_path),
+      }),
+    );
+
+    const problematicOverlay = overlays.find(
+      (overlay) => overlay.entryPath !== SEARCH_INDEX_DATABASE_PATH,
+    );
+    if (problematicOverlay !== undefined) {
+      throw new Error(
+        "Cannot upgrade home with non-derived coordinator overlays.",
+      );
+    }
+  } finally {
+    await database.close();
+  }
+}
+
+async function assertBuildQueueSafe(): Promise<void> {
+  const jobsDatabasePath = join(
+    resolveWikiGraphJobsDirectoryPath(),
+    "job.sqlite",
+  );
+
+  if (!(await pathExists(jobsDatabasePath))) {
+    return;
+  }
+
+  const database = await Database.open(jobsDatabasePath, "", {
+    readonly: true,
+  });
+
+  try {
+    if (await tableExists(database, "build_jobs")) {
+      const activeJobs = await database.queryAll(
+        `
+          SELECT job_id
+          FROM build_jobs
+          WHERE state IN ('queued', 'running', 'canceling', 'paused')
+        `,
+        undefined,
+        (row) => String(row.job_id),
+      );
+
+      if (activeJobs.length > 0) {
+        throw new Error("Cannot upgrade home with active build jobs.");
+      }
+    }
+
+    if (await tableExists(database, "build_worker_lease")) {
+      const lease = await database.queryOne(
+        `
+          SELECT owner_pid, heartbeat_at
+          FROM build_worker_lease
+          WHERE id = 1
+        `,
+        undefined,
+        (row) => ({
+          heartbeatAt:
+            row.heartbeat_at === null ? undefined : Number(row.heartbeat_at),
+          ownerPid: row.owner_pid === null ? undefined : Number(row.owner_pid),
+        }),
+      );
+
+      if (
+        lease?.ownerPid !== undefined &&
+        lease.heartbeatAt !== undefined &&
+        isActiveLock(lease.ownerPid, lease.heartbeatAt)
+      ) {
+        throw new Error(
+          "Cannot upgrade home with an active build worker lease.",
+        );
+      }
+    }
+  } finally {
+    await database.close();
+  }
+}
+
+async function removeArchiveSearchIndexOverlays(
+  stagingDatabasePath: string,
+  archiveKey?: string,
+): Promise<void> {
+  const database = await Database.open(stagingDatabasePath);
+
+  try {
+    if (!(await tableExists(database, "entry_overlays"))) {
+      return;
+    }
+
+    const whereClause =
+      archiveKey === undefined
+        ? "WHERE entry_path = ?"
+        : "WHERE archive_key = ? AND entry_path = ?";
+    const parameters =
+      archiveKey === undefined
+        ? [SEARCH_INDEX_DATABASE_PATH]
+        : [archiveKey, SEARCH_INDEX_DATABASE_PATH];
+    const overlays = await database.queryAll(
+      `
+        SELECT archive_key, workspace_path
+        FROM entry_overlays
+        ${whereClause}
+      `,
+      parameters,
+      (row) => ({
+        archiveKey: String(row.archive_key),
+        workspacePath:
+          row.workspace_path === null ? undefined : String(row.workspace_path),
+      }),
+    );
+
+    for (const overlay of overlays) {
+      if (overlay.workspacePath !== undefined) {
+        await deletePathIfExists(overlay.workspacePath);
+      }
+    }
+
+    await database.run(
+      `
+        DELETE FROM entry_overlays
+        ${whereClause}
+      `,
+      parameters,
+    );
+  } finally {
+    await database.close();
+  }
+}
+
+async function tableExists(
+  database: Database,
+  tableName: string,
+): Promise<boolean> {
+  const row = await database.queryOne(
+    `
+      SELECT 1 AS present
+      FROM sqlite_master
+      WHERE type = 'table' AND name = ?
+    `,
+    [tableName],
+    () => true,
+  );
+
+  return row === true;
+}
+
+function isActiveLock(ownerPid: number, heartbeatAt: number): boolean {
+  return (
+    Date.now() - heartbeatAt <= LOCK_STALE_TIMEOUT_MS &&
+    isProcessAlive(ownerPid)
+  );
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function deletePathIfExists(path: string): Promise<void> {
+  await rm(path, { force: true, recursive: true });
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getArchiveBasename(archivePath: string): string {
+  return archivePath.split(/[\\/]/u).pop() ?? "archive.wikg";
+}

--- a/packages/core/src/storage/schema-upgrade/index.ts
+++ b/packages/core/src/storage/schema-upgrade/index.ts
@@ -100,12 +100,17 @@ export async function upgradeWikiGraphArchiveSchema(
     `.${getArchiveBasename(resolvedArchivePath)}.${process.pid}.${randomUUID()}.upgrade.tmp`,
   );
 
-  await writeWikgArchiveWithOverlays(resolvedArchivePath, temporaryPath, [
-    {
-      entryPath: SEARCH_INDEX_DATABASE_PATH,
-      kind: "deleted",
-    },
-  ]);
+  await writeWikgArchiveWithOverlays(
+    resolvedArchivePath,
+    temporaryPath,
+    [
+      {
+        entryPath: SEARCH_INDEX_DATABASE_PATH,
+        kind: "deleted",
+      },
+    ],
+    { preserveMutationToken: true },
+  );
   await rename(temporaryPath, resolvedArchivePath);
   await cleanupArchiveDerivedData(archiveKey);
 }

--- a/packages/core/src/storage/wikg/archive/index.ts
+++ b/packages/core/src/storage/wikg/archive/index.ts
@@ -4,8 +4,9 @@ export {
   readWikgArchiveEntry,
   readWikgArchiveFormatVersion,
   readWikgArchiveMutationToken,
+  readWikgArchiveSchemaVersion,
   WikgArchiveReader,
 } from "./reader.js";
-export { WIKG_FORMAT_VERSION } from "./manifest.js";
+export { WIKG_FORMAT_VERSION, WIKG_SCHEMA_VERSION } from "./manifest.js";
 export { writeWikgArchive, writeWikgArchiveWithOverlays } from "./write.js";
 export type { WikgArchiveOverlay } from "./types.js";

--- a/packages/core/src/storage/wikg/archive/manifest.ts
+++ b/packages/core/src/storage/wikg/archive/manifest.ts
@@ -5,8 +5,10 @@ import { z } from "zod";
 import { WIKG_MANIFEST_PATH, WIKG_MUTATION_TOKEN_PATH } from "./constants.js";
 
 export const WIKG_FORMAT_VERSION = 1;
+export const WIKG_SCHEMA_VERSION = 2;
 export const WIKG_MANIFEST_CONTENT = `${JSON.stringify({
   formatVersion: WIKG_FORMAT_VERSION,
+  schemaVersion: WIKG_SCHEMA_VERSION,
 })}\n`;
 
 const WIKG_MUTATION_TOKEN_MAGIC = "wikg-mutation-token:v1";
@@ -14,11 +16,13 @@ const WIKG_MUTATION_TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/u;
 
 const wikgManifestSchema = z.object({
   formatVersion: z.literal(WIKG_FORMAT_VERSION),
+  schemaVersion: z.number().int().positive().optional(),
 });
 
-export function parseWikgManifest(
-  content: string,
-): z.infer<typeof wikgManifestSchema> {
+export function parseWikgManifest(content: string): {
+  readonly formatVersion: number;
+  readonly schemaVersion: number;
+} {
   let parsed: unknown;
 
   try {
@@ -35,7 +39,10 @@ export function parseWikgManifest(
     );
   }
 
-  return result.data;
+  return {
+    formatVersion: result.data.formatVersion,
+    schemaVersion: result.data.schemaVersion ?? 1,
+  };
 }
 
 export function createWikgMutationTokenContent(): Buffer {

--- a/packages/core/src/storage/wikg/archive/reader.ts
+++ b/packages/core/src/storage/wikg/archive/reader.ts
@@ -7,6 +7,7 @@ import { WIKG_MANIFEST_PATH, WIKG_MUTATION_TOKEN_PATH } from "./constants.js";
 import { parseWikgManifest, parseWikgMutationToken } from "./manifest.js";
 import { isWikgArchivePath, normalizeArchivePath } from "./paths.js";
 import { openIndexedArchive, readArchiveEntryBufferFromFile } from "./zip.js";
+import { ensureWikiGraphArchiveSchemaCurrent } from "../../schema-upgrade/index.js";
 
 export class WikgArchiveReader {
   readonly #entryByPath: Map<string, Entry>;
@@ -34,6 +35,7 @@ export class WikgArchiveReader {
   }
 
   public static async open(inputPath: string): Promise<WikgArchiveReader> {
+    await ensureWikiGraphArchiveSchemaCurrent(inputPath);
     const { entries, zipFile } = await openIndexedArchive(inputPath);
 
     return new WikgArchiveReader(inputPath, zipFile, entries);
@@ -120,4 +122,12 @@ export async function readWikgArchiveFormatVersion(
   return parseWikgManifest(
     await readFile(join(documentDirectoryPath, WIKG_MANIFEST_PATH), "utf8"),
   ).formatVersion;
+}
+
+export async function readWikgArchiveSchemaVersion(
+  documentDirectoryPath: string,
+): Promise<number> {
+  return parseWikgManifest(
+    await readFile(join(documentDirectoryPath, WIKG_MANIFEST_PATH), "utf8"),
+  ).schemaVersion;
 }

--- a/packages/core/src/storage/wikg/archive/write.ts
+++ b/packages/core/src/storage/wikg/archive/write.ts
@@ -72,6 +72,7 @@ export async function writeWikgArchiveWithOverlays(
   inputPath: string,
   outputPath: string,
   overlays: readonly WikgArchiveOverlay[],
+  options: { readonly preserveMutationToken?: boolean } = {},
 ): Promise<void> {
   await mkdir(dirname(outputPath), { recursive: true });
 
@@ -110,6 +111,22 @@ export async function writeWikgArchiveWithOverlays(
       const overlay = overlayByPath.get(entryPath);
 
       if (entryPath === WIKG_MUTATION_TOKEN_PATH) {
+        if (options.preserveMutationToken === true) {
+          const sourceEntry = sourceEntries.find(
+            (candidate) =>
+              normalizeArchivePath(candidate.fileName) === entryPath,
+          );
+
+          if (sourceEntry !== undefined) {
+            outputZipFile.addBuffer(
+              await readArchiveEntryBufferFromFile(sourceFile, sourceEntry),
+              entryPath,
+              { compress: false },
+            );
+            continue;
+          }
+        }
+
         outputZipFile.addBuffer(createWikgMutationTokenContent(), entryPath, {
           compress: false,
         });

--- a/packages/core/src/storage/wikg/index.ts
+++ b/packages/core/src/storage/wikg/index.ts
@@ -4,8 +4,10 @@ export {
   readWikgArchiveEntry,
   readWikgArchiveFormatVersion,
   readWikgArchiveMutationToken,
+  readWikgArchiveSchemaVersion,
   WikgArchiveReader,
   WIKG_FORMAT_VERSION,
+  WIKG_SCHEMA_VERSION,
   writeWikgArchive,
   writeWikgArchiveWithOverlays,
 } from "./archive/index.js";

--- a/test/core/storage/schema-upgrade/index.test.ts
+++ b/test/core/storage/schema-upgrade/index.test.ts
@@ -18,7 +18,10 @@ import {
   SEARCH_INDEX_DATABASE_PATH,
 } from "../../../../packages/core/src/storage/wikg/archive/constants.js";
 import { createWikgMutationTokenContent } from "../../../../packages/core/src/storage/wikg/archive/manifest.js";
-import { readWikgArchiveEntry } from "../../../../packages/core/src/storage/wikg/index.js";
+import {
+  readWikgArchiveEntry,
+  readWikgArchiveMutationToken,
+} from "../../../../packages/core/src/storage/wikg/index.js";
 import {
   resolveWikiGraphHomeDirectoryPath,
   setWikiGraphStateDirectoryPathForTesting,
@@ -40,9 +43,13 @@ describe("schema-upgrade", () => {
       setWikiGraphStateDirectoryPathForTesting(join(root, "home"));
       const archivePath = join(root, "book.wikg");
       await writeLegacyArchive(archivePath);
+      const mutationToken = await readWikgArchiveMutationToken(archivePath);
 
       await ensureWikiGraphArchiveSchemaCurrent(archivePath);
 
+      await expect(readWikgArchiveMutationToken(archivePath)).resolves.toBe(
+        mutationToken,
+      );
       await expect(
         readWikiGraphArchiveSchemaVersion(archivePath),
       ).resolves.toBe(2);

--- a/test/core/storage/schema-upgrade/index.test.ts
+++ b/test/core/storage/schema-upgrade/index.test.ts
@@ -1,0 +1,293 @@
+import { createWriteStream } from "fs";
+import { mkdir, readFile, stat, writeFile } from "fs/promises";
+import { dirname, join } from "path";
+import { finished } from "stream/promises";
+
+import { ZipFile } from "yazl";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+
+import { Database } from "../../../../packages/core/src/document/index.js";
+import {
+  ensureWikiGraphArchiveSchemaCurrent,
+  ensureWikiGraphHomeSchemaCurrent,
+  readWikiGraphArchiveSchemaVersion,
+} from "../../../../packages/core/src/storage/schema-upgrade/index.js";
+import {
+  WIKG_MANIFEST_PATH,
+  WIKG_MUTATION_TOKEN_PATH,
+  SEARCH_INDEX_DATABASE_PATH,
+} from "../../../../packages/core/src/storage/wikg/archive/constants.js";
+import { createWikgMutationTokenContent } from "../../../../packages/core/src/storage/wikg/archive/manifest.js";
+import { readWikgArchiveEntry } from "../../../../packages/core/src/storage/wikg/index.js";
+import {
+  resolveWikiGraphHomeDirectoryPath,
+  setWikiGraphStateDirectoryPathForTesting,
+} from "../../../../packages/core/src/runtime/common/wiki-graph/dir.js";
+import { withTempDir } from "../../../helpers/temp.js";
+
+describe("schema-upgrade", () => {
+  beforeEach(() => {
+    setWikiGraphStateDirectoryPathForTesting(undefined);
+  });
+
+  afterEach(() => {
+    setWikiGraphStateDirectoryPathForTesting(undefined);
+    delete process.env.WIKIGRAPH_STATE_DIR;
+  });
+
+  it("upgrades a legacy archive in place", async () => {
+    await withTempDir("wikigraph-schema-upgrade-", async (root) => {
+      setWikiGraphStateDirectoryPathForTesting(join(root, "home"));
+      const archivePath = join(root, "book.wikg");
+      await writeLegacyArchive(archivePath);
+
+      await ensureWikiGraphArchiveSchemaCurrent(archivePath);
+
+      await expect(
+        readWikiGraphArchiveSchemaVersion(archivePath),
+      ).resolves.toBe(2);
+      await expect(
+        readWikgArchiveEntry(archivePath, SEARCH_INDEX_DATABASE_PATH),
+      ).resolves.toBeUndefined();
+      await expect(
+        readWikgArchiveEntry(archivePath, "toc.json"),
+      ).resolves.toBeInstanceOf(Uint8Array);
+      await expect(
+        readWikgArchiveEntry(archivePath, WIKG_MANIFEST_PATH),
+      ).resolves.toBeInstanceOf(Uint8Array);
+    });
+  });
+
+  it("upgrades a legacy home and keeps user config", async () => {
+    await withTempDir("wikigraph-schema-home-", async (home) => {
+      setWikiGraphStateDirectoryPathForTesting(home);
+
+      const coreDatabasePath = join(home, "core.sqlite");
+      const cacheDirectoryPath = join(home, "cache");
+      const stagingDirectoryPath = join(home, "staging");
+      const jobsDirectoryPath = join(home, "jobs");
+      const tempDirectoryPath = join(home, "tmp");
+
+      await mkdir(cacheDirectoryPath, { recursive: true });
+      await mkdir(join(stagingDirectoryPath, "library", "1", "index"), {
+        recursive: true,
+      });
+      await mkdir(join(jobsDirectoryPath, "cache"), { recursive: true });
+      await mkdir(tempDirectoryPath, { recursive: true });
+      await writeFile(join(cacheDirectoryPath, "search-sessions.sqlite"), "x");
+      await writeFile(
+        join(cacheDirectoryPath, "continuation-cursors.sqlite"),
+        "x",
+      );
+      await writeFile(join(cacheDirectoryPath, "cache.sqlite"), "x");
+      await writeFile(join(tempDirectoryPath, "gc.sqlite"), "x");
+      await writeFile(join(tempDirectoryPath, "gc.last-run"), "x");
+
+      const coreDatabase = await Database.open(coreDatabasePath);
+      try {
+        await coreDatabase.run(`
+          CREATE TABLE config_sections (
+            section TEXT NOT NULL,
+            key TEXT NOT NULL,
+            value_json TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (section, key)
+          )
+        `);
+        await coreDatabase.run(`
+          INSERT INTO config_sections (section, key, value_json, updated_at)
+          VALUES ('default', 'theme', '"dark"', '2026-07-23T00:00:00.000Z')
+        `);
+      } finally {
+        await coreDatabase.close();
+      }
+
+      const stagingDatabase = await Database.open(
+        join(stagingDirectoryPath, "staging.sqlite"),
+      );
+      try {
+        await stagingDatabase.run(`
+          CREATE TABLE entry_overlays (
+            archive_key TEXT NOT NULL,
+            archive_path TEXT NOT NULL,
+            entry_path TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            workspace_path TEXT,
+            updated_at INTEGER NOT NULL,
+            PRIMARY KEY (archive_key, entry_path)
+          )
+        `);
+        await stagingDatabase.run(
+          `
+            INSERT INTO entry_overlays (
+              archive_key, archive_path, entry_path, kind, workspace_path, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?)
+          `,
+          [
+            "archive-key",
+            join(home, "book.wikg"),
+            SEARCH_INDEX_DATABASE_PATH,
+            "file",
+            join(stagingDirectoryPath, "library", "1", "index", "fts.db"),
+            Date.now(),
+          ],
+        );
+      } finally {
+        await stagingDatabase.close();
+      }
+
+      await ensureWikiGraphHomeSchemaCurrent();
+
+      const upgradedCore = await Database.open(coreDatabasePath, "", {
+        readonly: true,
+      });
+      try {
+        await expect(
+          upgradedCore.queryOne(
+            "SELECT value_json FROM config_sections WHERE section = ? AND key = ?",
+            ["default", "theme"],
+            (row) => String(row.value_json),
+          ),
+        ).resolves.toBe('"dark"');
+        await expect(
+          upgradedCore.queryOne(
+            "SELECT version FROM schema_versions WHERE scope = ?",
+            ["home"],
+            (row) => Number(row.version),
+          ),
+        ).resolves.toBe(2);
+      } finally {
+        await upgradedCore.close();
+      }
+
+      await expect(
+        readFile(join(cacheDirectoryPath, "search-sessions.sqlite")),
+      ).rejects.toThrow();
+      await expect(
+        readFile(join(cacheDirectoryPath, "continuation-cursors.sqlite")),
+      ).rejects.toThrow();
+      await expect(
+        readFile(join(cacheDirectoryPath, "cache.sqlite")),
+      ).rejects.toThrow();
+      await expect(
+        stat(join(stagingDirectoryPath, "library")),
+      ).rejects.toThrow();
+      await expect(
+        readFile(join(tempDirectoryPath, "gc.sqlite")),
+      ).rejects.toThrow();
+      await expect(
+        readFile(join(tempDirectoryPath, "gc.last-run")),
+      ).rejects.toThrow();
+
+      const upgradedStaging = await Database.open(
+        join(stagingDirectoryPath, "staging.sqlite"),
+        "",
+        {
+          readonly: true,
+        },
+      );
+      try {
+        await expect(
+          upgradedStaging.queryOne(
+            "SELECT entry_path FROM entry_overlays WHERE archive_key = ?",
+            ["archive-key"],
+            (row) => String(row.entry_path),
+          ),
+        ).resolves.toBeUndefined();
+      } finally {
+        await upgradedStaging.close();
+      }
+    });
+  });
+
+  it("rejects a home upgrade when a library lock is active", async () => {
+    await withTempDir("wikigraph-schema-block-", async (home) => {
+      setWikiGraphStateDirectoryPathForTesting(home);
+
+      const coreDatabase = await Database.open(join(home, "core.sqlite"));
+      try {
+        await coreDatabase.run(`
+          CREATE TABLE library_locks (
+            library_id INTEGER PRIMARY KEY,
+            mode TEXT NOT NULL,
+            owner_id TEXT NOT NULL,
+            owner_pid INTEGER NOT NULL,
+            heartbeat_at INTEGER NOT NULL,
+            created_at INTEGER NOT NULL
+          )
+        `);
+        await coreDatabase.run(
+          `
+            INSERT INTO library_locks (
+              library_id, mode, owner_id, owner_pid, heartbeat_at, created_at
+            ) VALUES (1, 'write', 'owner', ?, ?, ?)
+          `,
+          [process.pid, Date.now(), Date.now()],
+        );
+      } finally {
+        await coreDatabase.close();
+      }
+
+      await expect(ensureWikiGraphHomeSchemaCurrent()).rejects.toThrow(
+        "active library locks",
+      );
+    });
+  });
+
+  it("resolves the legacy home env fallback", async () => {
+    await withTempDir("wikigraph-schema-home-env-", async (home) => {
+      process.env.WIKIGRAPH_STATE_DIR = home;
+      setWikiGraphStateDirectoryPathForTesting(undefined);
+      expect(resolveWikiGraphHomeDirectoryPath()).toBe(home);
+      await Promise.resolve();
+    });
+  });
+});
+
+async function writeLegacyArchive(archivePath: string): Promise<void> {
+  await mkdir(dirname(archivePath), { recursive: true });
+
+  const zipFile = new ZipFile();
+  zipFile.addBuffer(
+    createWikgMutationTokenContent(),
+    WIKG_MUTATION_TOKEN_PATH,
+    {
+      compress: false,
+    },
+  );
+  zipFile.addBuffer(
+    Buffer.from('{"formatVersion":1}\n', "utf8"),
+    WIKG_MANIFEST_PATH,
+    {
+      compress: false,
+    },
+  );
+  zipFile.addBuffer(Buffer.from("legacy db", "utf8"), "database.db", {
+    compress: false,
+  });
+  zipFile.addBuffer(Buffer.from("legacy toc", "utf8"), "toc.json", {
+    compress: false,
+  });
+  zipFile.addBuffer(
+    Buffer.from("legacy index", "utf8"),
+    SEARCH_INDEX_DATABASE_PATH,
+    {
+      compress: false,
+    },
+  );
+
+  zipFile.end();
+  await writeZipFile(zipFile, archivePath);
+}
+
+async function writeZipFile(
+  zipFile: ZipFile,
+  outputPath: string,
+): Promise<void> {
+  const output = createWriteStream(outputPath);
+  const outputDone = finished(output);
+  const zipDone = finished(zipFile.outputStream);
+
+  zipFile.outputStream.pipe(output);
+  await Promise.all([outputDone, zipDone]);
+}

--- a/test/core/storage/wikg/archive.test.ts
+++ b/test/core/storage/wikg/archive.test.ts
@@ -51,7 +51,7 @@ describe("wikg/archive", () => {
       ).toMatch(/^wikg-mutation-token:v1\n[A-Za-z0-9_-]{43}\n$/u);
       expect(
         JSON.parse(await readFile(`${extractDir}/manifest.json`, "utf8")),
-      ).toEqual({ formatVersion: 1 });
+      ).toEqual({ formatVersion: 1, schemaVersion: 2 });
       expect(await readFile(`${extractDir}/database.db`, "utf8")).toBe(
         "sqlite",
       );
@@ -182,7 +182,7 @@ describe("wikg/archive", () => {
 
       expect(
         JSON.parse(await readFile(`${extractDir}/manifest.json`, "utf8")),
-      ).toEqual({ formatVersion: 1 });
+      ).toEqual({ formatVersion: 1, schemaVersion: 2 });
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds a centralized schema upgrade module for archive/home schema v1→v2 handling.
- Archive manifest now carries `schemaVersion=2` while keeping `formatVersion=1`.
- Home schema upgrades run through shared-state initialization and preserve config while clearing derived caches.
- Follow-up close fix: archive schema upgrade now preserves `.wikg-mutation-token`; ordinary overlay flushes still refresh mutation tokens.

## Issue
Fixes #153

## Real materials used
- `/Users/taozeyu/Documents/WIKG/三国演义.wikg`
- `/Users/taozeyu/Documents/WIKG/great-gatsby.wikg`
- `/tmp/wikigraph-upgrade-selftest.04Eiju/home` (copy of `~/.wikigraph`)

## X → Y manual upgrade notes
- Source materials were copied before upgrade; original `.wikg` archives and original `~/.wikigraph` were not modified.
- The copied home contained active/non-derived coordinator overlays, so home upgrade intentionally blocked there rather than deleting possibly-unflushed user state.
- Archive samples covered normal archive entries plus embedded search index behavior; tests cover missing sample-specific cache/cursor cases.

## Y checklist coverage
### Archive Y
- Entry whitelist/layout: preserved primary entries (`database.db`, `manifest.json`, `.wikg-mutation-token`, `toc.json`, cover/text entries when present); derived `fts.db` is removed/invalidated.
- Manifest: `formatVersion` remains `1`; product `schemaVersion` is set to `2`.
- Mutation token: preserved across schema upgrade to keep cache/index inheritance semantics.
- Main database and metadata: archive main data remains readable; `archive_index_settings` is not rewritten by upgrade.
- External derived data: archive `fts.db` overlays/workspace files, search session cache, and continuation cursor cache are cleaned or invalidated.
- Dangerous state: active owner/lock/lease/commit lock and non-`fts.db` overlays block upgrade.
- Future versions: archive schema versions above current are rejected.

### Home Y
- Home marker: existing home without marker is treated as v1 and upgraded to schema version `2`; missing home initializes as current, not legacy.
- Env compatibility: `WIKIGRAPH_DEV` takes precedence; legacy `WIKIGRAPH_STATE_DIR` is used as fallback instead of silently ignoring old homes.
- `core.sqlite`: existing `config_sections` values are preserved; library registry/metadata/archive/lock schemas are initialized by the shared-state path.
- User data/logs: `.wikg` files and logs are not deleted by home upgrade.
- Derived cache/staging: search sessions, continuation cursors, wikimedia/disambiguation cache, library index staging, GC temp state, and jobs cache are removed or invalidated.
- Jobs/GC/locks: active GC lock, library lock, coordinator state, non-`fts.db` overlay, active build job, or active worker lease blocks upgrade.
- Future versions: home schema versions above current are rejected.

## Automated checks
- `pnpm vitest run test/core/storage/schema-upgrade/index.test.ts test/core/storage/wikg/archive.test.ts`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run format:check`
- `pnpm run test`

## Notes
- The self-test on copied real material exposed pre-existing non-derived coordinator overlays in the copied home state; the implementation intentionally blocks upgrades in that case to avoid corrupting active state.
