### PR TITLE
fix: complete schema upgrade home gate coverage

### DIFF
--- a/docs/local-cli-development.md
+++ b/docs/local-cli-development.md
@@ -129,3 +129,9 @@ text, archive operations, state handling, or bug fixes in the current checkout.
 Use the install workflow only when the question is about the packaged command
 itself: global `wg` resolution, npm package layout, `dist` artifacts, executable
 metadata, or previewing an unreleased branch outside this repository.
+
+## Related Maintainer Docs
+
+- [Schema Upgrade Maintenance](./schema-upgrade.md): how archive/home schema
+  gates, version bumps, upgrader tests, and persistent-state boundaries are
+  maintained.

--- a/docs/schema-upgrade.md
+++ b/docs/schema-upgrade.md
@@ -1,0 +1,97 @@
+# Schema Upgrade Maintenance
+
+This document is for maintainers who change persistent Wiki Graph data layouts.
+Schema versions are storage compatibility markers. They are separate from the
+published `wg --version` package version: a package release may leave schema
+versions unchanged, and a schema version bump may happen inside any package
+version that changes persisted archive or home state.
+
+## When To Bump A Schema Version
+
+Bump a schema version when a newer checkout can no longer safely read or reuse
+state written by an older checkout without a controlled migration or invalidation.
+This includes important table/column/constraint changes, changed semantics of
+stored payloads, or derived SQLite state that could be mistaken for current data.
+
+Do not use scattered ad hoc checks in CLI commands or business functions as a
+replacement for a schema upgrader. The gates must stay at storage opening
+boundaries so normal operations either see current state or fail before touching
+unsafe state.
+
+## Upgrader Shape
+
+Every bump must add exactly one adjacent upgrader path, such as `N -> N+1`.
+Do not skip versions and do not let a later version silently reinterpret older
+state. Each upgrader needs a fixture or focused regression test that proves:
+
+- important data is migrated;
+- derived data is deleted or invalidated by default instead of compatibility
+  migrated;
+- dangerous active state blocks the upgrade before writes happen;
+- future schema versions are rejected;
+- the completion marker is written only after the upgrader succeeds.
+
+Important data must survive upgrade failure. If an upgrader fails, it must not
+write the target schema marker.
+
+## Archive Gate
+
+Archive schema belongs to each `.wikg` file. The archive gate runs at archive
+open/upgrade boundaries and covers archive entries such as `database.db` and an
+embedded `fts.db`. It must not be reimplemented across query/list/search/evidence
+business paths.
+
+The v1 -> v2 archive upgrader removes the embedded archive `fts.db` as derived
+search index data and preserves important archive content and the mutation token.
+It must refuse active coordinator state for the target archive and non-`fts.db`
+overlays, because those can represent uncommitted important data.
+
+## Home Gate
+
+Home schema belongs to the machine-level Wiki Graph state directory, normally
+`~/.wikigraph`. The home gate runs before opening home/shared/runtime SQLite
+state and before derived index SQLite state that does not use shared-state
+opening helpers.
+
+The current home gate coverage is explicit. Keep this list synchronized with
+code and tests when adding new home SQLite files:
+
+- `~/.wikigraph/core.sqlite`
+  - config sections, schema versions, library registry, library metadata,
+    library archive membership, and library locks.
+- `~/.wikigraph/cache/search-sessions.sqlite`
+  - query search sessions, results, dictionaries, evidence events, and hit rows.
+- `~/.wikigraph/cache/continuation-cursors.sqlite`
+  - continuation cursor payloads and expiry state.
+- `~/.wikigraph/cache/cache.sqlite`
+  - external wikipage/QID/disambiguation cache.
+- `~/.wikigraph/jobs/job.sqlite`
+  - build jobs and build worker lease state.
+- `~/.wikigraph/tmp/gc.sqlite`
+  - GC locks.
+- `~/.wikigraph/staging/staging.sqlite`
+  - coordinator overlays, entry locks, owners, sqlite leases, and commit locks.
+- `~/.wikigraph/staging/library/<library-id>/index/fts.db`
+  - library aggregate search index SQLite.
+- `~/.wikigraph/staging/work/<archiveKey>/fts.db`
+  - archive coordinator external search index cache workspace referenced by
+    `entry_overlays(entry_path = 'fts.db')`.
+
+For v1 -> v2, derived home data is deleted or invalidated: query/search caches,
+external cache, GC state, build queue SQLite/cache when safe, library aggregate
+indexes, and external archive search index overlays/workspaces for `fts.db` only.
+The upgrader must not delete non-`fts.db` overlays and must block when active GC,
+build job, worker lease, coordinator owner/lock/sqlite lease/commit lock, or
+non-`fts.db` overlay state is present.
+
+Pure information commands such as `wg --version` and help rendering must not open
+home SQLite and must not trigger schema upgrade.
+
+## Module Boundary
+
+`document` owns low-level SQLite/shared-state opening helpers and the home gate
+implementation used by those helpers. `storage/schema-upgrade` owns archive
+schema orchestration and re-exports the home schema functions for the public API.
+This keeps low-level shared-state database code from depending upward on the
+storage archive upgrader while preserving one public schema-upgrade import path
+for callers.

--- a/packages/core/src/document/home-schema-upgrade.ts
+++ b/packages/core/src/document/home-schema-upgrade.ts
@@ -5,7 +5,6 @@ import {
   resolveWikiGraphCacheDatabasePath,
   resolveWikiGraphCacheDirectoryPath,
   resolveWikiGraphCoreDatabasePath,
-  resolveWikiGraphHomeDirectoryPath,
   resolveWikiGraphJobsDirectoryPath,
   resolveWikiGraphStagingDirectoryPath,
   resolveWikiGraphTempRootDirectoryPath,
@@ -17,6 +16,7 @@ const CURRENT_HOME_SCHEMA_VERSION = 2;
 const LOCK_STALE_TIMEOUT_MS = 5 * 60 * 1000;
 const SEARCH_INDEX_DATABASE_PATH = "fts.db";
 let homeSchemaUpgradeInFlight: Promise<void> | undefined;
+let currentHomeSchemaDatabasePath: string | undefined;
 const HOME_SCHEMA_SQL = `
   CREATE TABLE IF NOT EXISTS schema_versions (
     scope TEXT PRIMARY KEY,
@@ -26,18 +26,31 @@ const HOME_SCHEMA_SQL = `
 `;
 
 export async function ensureWikiGraphHomeSchemaCurrent(): Promise<void> {
+  const coreDatabasePath = resolveWikiGraphCoreDatabasePath();
+  const resolvedCoreDatabasePath = resolve(coreDatabasePath);
+
+  if (currentHomeSchemaDatabasePath === resolvedCoreDatabasePath) {
+    return;
+  }
+
   if (homeSchemaUpgradeInFlight !== undefined) {
     await homeSchemaUpgradeInFlight;
+    if (currentHomeSchemaDatabasePath === resolvedCoreDatabasePath) {
+      return;
+    }
+  }
+
+  if (currentHomeSchemaDatabasePath === resolvedCoreDatabasePath) {
     return;
   }
 
   homeSchemaUpgradeInFlight = (async () => {
-    const coreDatabasePath = resolveWikiGraphCoreDatabasePath();
     if (!(await pathExists(coreDatabasePath))) {
       await writeHomeSchemaVersion(
         coreDatabasePath,
         CURRENT_HOME_SCHEMA_VERSION,
       );
+      currentHomeSchemaDatabasePath = resolvedCoreDatabasePath;
       return;
     }
 
@@ -58,6 +71,8 @@ export async function ensureWikiGraphHomeSchemaCurrent(): Promise<void> {
         CURRENT_HOME_SCHEMA_VERSION,
       );
     }
+
+    currentHomeSchemaDatabasePath = resolvedCoreDatabasePath;
   })();
 
   try {
@@ -145,8 +160,7 @@ async function writeHomeSchemaVersion(
 }
 
 async function cleanupHomeDerivedData(): Promise<void> {
-  const homeDirectoryPath = resolveWikiGraphHomeDirectoryPath();
-  const cacheDirectoryPath = join(homeDirectoryPath, "cache");
+  const cacheDirectoryPath = resolveWikiGraphCacheDirectoryPath();
   const stagingDirectoryPath = resolveWikiGraphStagingDirectoryPath();
   const jobsDirectoryPath = resolveWikiGraphJobsDirectoryPath();
   const tempDirectoryPath = resolveWikiGraphTempRootDirectoryPath();

--- a/packages/core/src/document/home-schema-upgrade.ts
+++ b/packages/core/src/document/home-schema-upgrade.ts
@@ -1,0 +1,476 @@
+import { mkdir, rm, stat } from "fs/promises";
+import { dirname, join, resolve } from "path";
+
+import {
+  resolveWikiGraphCacheDatabasePath,
+  resolveWikiGraphCacheDirectoryPath,
+  resolveWikiGraphCoreDatabasePath,
+  resolveWikiGraphHomeDirectoryPath,
+  resolveWikiGraphJobsDirectoryPath,
+  resolveWikiGraphStagingDirectoryPath,
+  resolveWikiGraphTempRootDirectoryPath,
+} from "../runtime/common/wiki-graph/dir.js";
+
+import { Database } from "./database.js";
+
+const CURRENT_HOME_SCHEMA_VERSION = 2;
+const LOCK_STALE_TIMEOUT_MS = 5 * 60 * 1000;
+const SEARCH_INDEX_DATABASE_PATH = "fts.db";
+let homeSchemaUpgradeInFlight: Promise<void> | undefined;
+const HOME_SCHEMA_SQL = `
+  CREATE TABLE IF NOT EXISTS schema_versions (
+    scope TEXT PRIMARY KEY,
+    version INTEGER NOT NULL,
+    updated_at TEXT NOT NULL
+  );
+`;
+
+export async function ensureWikiGraphHomeSchemaCurrent(): Promise<void> {
+  if (homeSchemaUpgradeInFlight !== undefined) {
+    await homeSchemaUpgradeInFlight;
+    return;
+  }
+
+  homeSchemaUpgradeInFlight = (async () => {
+    const coreDatabasePath = resolveWikiGraphCoreDatabasePath();
+    if (!(await pathExists(coreDatabasePath))) {
+      await writeHomeSchemaVersion(
+        coreDatabasePath,
+        CURRENT_HOME_SCHEMA_VERSION,
+      );
+      return;
+    }
+
+    const schemaVersion =
+      await readWikiGraphHomeSchemaVersion(coreDatabasePath);
+
+    if (schemaVersion > CURRENT_HOME_SCHEMA_VERSION) {
+      throw new Error(
+        `Unsupported Wiki Graph home schema version: ${schemaVersion}.`,
+      );
+    }
+
+    if (schemaVersion < CURRENT_HOME_SCHEMA_VERSION) {
+      await assertHomeUpgradeSafe();
+      await cleanupHomeDerivedData();
+      await writeHomeSchemaVersion(
+        coreDatabasePath,
+        CURRENT_HOME_SCHEMA_VERSION,
+      );
+    }
+  })();
+
+  try {
+    await homeSchemaUpgradeInFlight;
+    return;
+  } finally {
+    homeSchemaUpgradeInFlight = undefined;
+  }
+}
+
+export async function readWikiGraphHomeSchemaVersion(
+  coreDatabasePath = resolveWikiGraphCoreDatabasePath(),
+): Promise<number> {
+  if (!(await pathExists(coreDatabasePath))) {
+    return 0;
+  }
+
+  const database = await Database.open(coreDatabasePath, "", {
+    readonly: true,
+  });
+
+  try {
+    if (!(await tableExists(database, "schema_versions"))) {
+      return 1;
+    }
+
+    const version = await database.queryOne(
+      "SELECT version FROM schema_versions WHERE scope = ?",
+      ["home"],
+      (row) => Number(row.version),
+    );
+
+    return version ?? 1;
+  } finally {
+    await database.close();
+  }
+}
+
+export function isWikiGraphHomeSchemaGateDatabasePath(
+  databasePath: string,
+): boolean {
+  const resolvedDatabasePath = resolve(databasePath);
+
+  return getWikiGraphHomeSchemaGateDatabasePaths().some(
+    (gatePath) => resolvedDatabasePath === resolve(gatePath),
+  );
+}
+
+function getWikiGraphHomeSchemaGateDatabasePaths(): readonly string[] {
+  const cacheDirectoryPath = resolveWikiGraphCacheDirectoryPath();
+
+  return [
+    resolveWikiGraphCoreDatabasePath(),
+    join(cacheDirectoryPath, "search-sessions.sqlite"),
+    join(cacheDirectoryPath, "continuation-cursors.sqlite"),
+    resolveWikiGraphCacheDatabasePath(),
+    join(resolveWikiGraphJobsDirectoryPath(), "job.sqlite"),
+    join(resolveWikiGraphTempRootDirectoryPath(), "gc.sqlite"),
+    join(resolveWikiGraphStagingDirectoryPath(), "staging.sqlite"),
+  ];
+}
+
+async function writeHomeSchemaVersion(
+  coreDatabasePath: string,
+  version: number,
+): Promise<void> {
+  await mkdir(dirname(coreDatabasePath), { recursive: true });
+  const database = await Database.open(coreDatabasePath);
+
+  try {
+    await database.run(HOME_SCHEMA_SQL);
+    await database.run(
+      `
+        INSERT INTO schema_versions (scope, version, updated_at)
+        VALUES (?, ?, ?)
+        ON CONFLICT(scope) DO UPDATE SET
+          version = excluded.version,
+          updated_at = excluded.updated_at
+      `,
+      ["home", version, new Date().toISOString()],
+    );
+  } finally {
+    await database.close();
+  }
+}
+
+async function cleanupHomeDerivedData(): Promise<void> {
+  const homeDirectoryPath = resolveWikiGraphHomeDirectoryPath();
+  const cacheDirectoryPath = join(homeDirectoryPath, "cache");
+  const stagingDirectoryPath = resolveWikiGraphStagingDirectoryPath();
+  const jobsDirectoryPath = resolveWikiGraphJobsDirectoryPath();
+  const tempDirectoryPath = resolveWikiGraphTempRootDirectoryPath();
+
+  await deletePathIfExists(join(cacheDirectoryPath, "search-sessions.sqlite"));
+  await deletePathIfExists(
+    join(cacheDirectoryPath, "continuation-cursors.sqlite"),
+  );
+  await deletePathIfExists(resolveWikiGraphCacheDatabasePath());
+  await deletePathIfExists(join(stagingDirectoryPath, "library"));
+  await deletePathIfExists(join(tempDirectoryPath, "gc.sqlite"));
+  await deletePathIfExists(join(tempDirectoryPath, "gc.last-run"));
+  await deletePathIfExists(join(jobsDirectoryPath, "cache"));
+  await deletePathIfExists(join(jobsDirectoryPath, "job.sqlite"));
+
+  const stagingDatabasePath = join(stagingDirectoryPath, "staging.sqlite");
+  if (await pathExists(stagingDatabasePath)) {
+    await removeArchiveSearchIndexOverlays(stagingDatabasePath);
+  }
+}
+
+async function assertHomeUpgradeSafe(): Promise<void> {
+  await assertCoreLocksSafe();
+  await assertGcLockSafe();
+  await assertCoordinatorStateSafe();
+  await assertBuildQueueSafe();
+}
+
+async function assertCoreLocksSafe(): Promise<void> {
+  const coreDatabasePath = resolveWikiGraphCoreDatabasePath();
+
+  if (!(await pathExists(coreDatabasePath))) {
+    return;
+  }
+
+  const database = await Database.open(coreDatabasePath, "", {
+    readonly: true,
+  });
+
+  try {
+    if (!(await tableExists(database, "library_locks"))) {
+      return;
+    }
+
+    const rows = await database.queryAll(
+      `
+        SELECT owner_pid, heartbeat_at
+        FROM library_locks
+      `,
+      undefined,
+      (row) => ({
+        heartbeatAt: Number(row.heartbeat_at),
+        ownerPid: Number(row.owner_pid),
+      }),
+    );
+
+    if (rows.some((row) => isActiveLock(row.ownerPid, row.heartbeatAt))) {
+      throw new Error("Cannot upgrade home with active library locks.");
+    }
+  } finally {
+    await database.close();
+  }
+}
+
+async function assertGcLockSafe(): Promise<void> {
+  const gcDatabasePath = join(
+    resolveWikiGraphTempRootDirectoryPath(),
+    "gc.sqlite",
+  );
+
+  if (!(await pathExists(gcDatabasePath))) {
+    return;
+  }
+
+  const database = await Database.open(gcDatabasePath, "", {
+    readonly: true,
+  });
+
+  try {
+    if (!(await tableExists(database, "gc_locks"))) {
+      return;
+    }
+
+    const rows = await database.queryAll(
+      "SELECT owner_pid, heartbeat_at FROM gc_locks",
+      undefined,
+      (row) => ({
+        heartbeatAt: Number(row.heartbeat_at),
+        ownerPid: Number(row.owner_pid),
+      }),
+    );
+
+    if (rows.some((row) => isActiveLock(row.ownerPid, row.heartbeatAt))) {
+      throw new Error("Cannot upgrade home with an active GC lock.");
+    }
+  } finally {
+    await database.close();
+  }
+}
+
+async function assertCoordinatorStateSafe(): Promise<void> {
+  const stagingDatabasePath = join(
+    resolveWikiGraphStagingDirectoryPath(),
+    "staging.sqlite",
+  );
+
+  if (!(await pathExists(stagingDatabasePath))) {
+    return;
+  }
+
+  const database = await Database.open(stagingDatabasePath, "", {
+    readonly: true,
+  });
+
+  try {
+    for (const tableName of [
+      "archive_owners",
+      "entry_locks",
+      "entry_sqlite_leases",
+      "archive_commit_locks",
+    ]) {
+      if (!(await tableExists(database, tableName))) {
+        continue;
+      }
+
+      const rows = await database.queryAll(
+        `
+          SELECT owner_pid, heartbeat_at
+          FROM ${tableName}
+        `,
+        undefined,
+        (row) => ({
+          heartbeatAt: Number(row.heartbeat_at),
+          ownerPid: Number(row.owner_pid),
+        }),
+      );
+
+      if (rows.some((row) => isActiveLock(row.ownerPid, row.heartbeatAt))) {
+        throw new Error(
+          `Cannot upgrade home with active coordinator state: ${tableName}.`,
+        );
+      }
+    }
+
+    if (!(await tableExists(database, "entry_overlays"))) {
+      return;
+    }
+
+    const overlays = await database.queryAll(
+      `
+        SELECT entry_path
+        FROM entry_overlays
+      `,
+      undefined,
+      (row) => String(row.entry_path),
+    );
+
+    const problematicOverlay = overlays.find(
+      (entryPath) => entryPath !== SEARCH_INDEX_DATABASE_PATH,
+    );
+    if (problematicOverlay !== undefined) {
+      throw new Error(
+        "Cannot upgrade home with non-derived coordinator overlays.",
+      );
+    }
+  } finally {
+    await database.close();
+  }
+}
+
+async function assertBuildQueueSafe(): Promise<void> {
+  const jobsDatabasePath = join(
+    resolveWikiGraphJobsDirectoryPath(),
+    "job.sqlite",
+  );
+
+  if (!(await pathExists(jobsDatabasePath))) {
+    return;
+  }
+
+  const database = await Database.open(jobsDatabasePath, "", {
+    readonly: true,
+  });
+
+  try {
+    if (await tableExists(database, "build_jobs")) {
+      const activeJobs = await database.queryAll(
+        `
+          SELECT job_id
+          FROM build_jobs
+          WHERE state IN ('queued', 'running', 'canceling', 'paused')
+        `,
+        undefined,
+        (row) => String(row.job_id),
+      );
+
+      if (activeJobs.length > 0) {
+        throw new Error("Cannot upgrade home with active build jobs.");
+      }
+    }
+
+    if (await tableExists(database, "build_worker_lease")) {
+      const lease = await database.queryOne(
+        `
+          SELECT owner_pid, heartbeat_at
+          FROM build_worker_lease
+          WHERE id = 1
+        `,
+        undefined,
+        (row) => ({
+          heartbeatAt:
+            row.heartbeat_at === null ? undefined : Number(row.heartbeat_at),
+          ownerPid: row.owner_pid === null ? undefined : Number(row.owner_pid),
+        }),
+      );
+
+      if (
+        lease?.ownerPid !== undefined &&
+        lease.heartbeatAt !== undefined &&
+        isActiveLock(lease.ownerPid, lease.heartbeatAt)
+      ) {
+        throw new Error(
+          "Cannot upgrade home with an active build worker lease.",
+        );
+      }
+    }
+  } finally {
+    await database.close();
+  }
+}
+
+async function removeArchiveSearchIndexOverlays(
+  stagingDatabasePath: string,
+  archiveKey?: string,
+): Promise<void> {
+  const database = await Database.open(stagingDatabasePath);
+
+  try {
+    if (!(await tableExists(database, "entry_overlays"))) {
+      return;
+    }
+
+    const whereClause =
+      archiveKey === undefined
+        ? "WHERE entry_path = ?"
+        : "WHERE archive_key = ? AND entry_path = ?";
+    const parameters =
+      archiveKey === undefined
+        ? [SEARCH_INDEX_DATABASE_PATH]
+        : [archiveKey, SEARCH_INDEX_DATABASE_PATH];
+    const overlays = await database.queryAll(
+      `
+        SELECT archive_key, workspace_path
+        FROM entry_overlays
+        ${whereClause}
+      `,
+      parameters,
+      (row) => ({
+        archiveKey: String(row.archive_key),
+        workspacePath:
+          row.workspace_path === null ? undefined : String(row.workspace_path),
+      }),
+    );
+
+    for (const overlay of overlays) {
+      if (overlay.workspacePath !== undefined) {
+        await deletePathIfExists(overlay.workspacePath);
+      }
+    }
+
+    await database.run(
+      `
+        DELETE FROM entry_overlays
+        ${whereClause}
+      `,
+      parameters,
+    );
+  } finally {
+    await database.close();
+  }
+}
+
+async function tableExists(
+  database: Database,
+  tableName: string,
+): Promise<boolean> {
+  const row = await database.queryOne(
+    `
+      SELECT 1 AS present
+      FROM sqlite_master
+      WHERE type = 'table' AND name = ?
+    `,
+    [tableName],
+    () => true,
+  );
+
+  return row === true;
+}
+
+function isActiveLock(ownerPid: number, heartbeatAt: number): boolean {
+  return (
+    Date.now() - heartbeatAt <= LOCK_STALE_TIMEOUT_MS &&
+    isProcessAlive(ownerPid)
+  );
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function deletePathIfExists(path: string): Promise<void> {
+  await rm(path, { force: true, recursive: true });
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/core/src/document/shared-state-database.ts
+++ b/packages/core/src/document/shared-state-database.ts
@@ -12,8 +12,10 @@ import { dirname, resolve } from "path";
 import { setTimeout as sleep } from "timers/promises";
 
 import { isNodeError } from "../utils/node-error.js";
-import { ensureWikiGraphHomeSchemaCurrent } from "../storage/schema-upgrade/index.js";
-import { resolveWikiGraphCoreDatabasePath } from "./../runtime/common/wiki-graph/dir.js";
+import {
+  ensureWikiGraphHomeSchemaCurrent,
+  isWikiGraphHomeSchemaGateDatabasePath,
+} from "./home-schema-upgrade.js";
 
 import { Database } from "./database.js";
 
@@ -40,7 +42,7 @@ export async function openSharedStateDatabase(
 function ensureWikiGraphHomeSchemaCurrentForPath(
   databasePath: string,
 ): Promise<void> {
-  if (resolve(databasePath) !== resolve(resolveWikiGraphCoreDatabasePath())) {
+  if (!isWikiGraphHomeSchemaGateDatabasePath(databasePath)) {
     return Promise.resolve();
   }
 

--- a/packages/core/src/library/search-index.ts
+++ b/packages/core/src/library/search-index.ts
@@ -3,6 +3,7 @@ import { mkdir, readdir, rm, stat, writeFile } from "fs/promises";
 import { join } from "path";
 
 import { Database, getNumber, getString } from "../document/database.js";
+import { ensureWikiGraphHomeSchemaCurrent } from "../document/home-schema-upgrade.js";
 import { SEARCH_INDEX_SCHEMA_SQL } from "../document/schema.js";
 import { openSharedStateDatabase } from "../document/index.js";
 import { WikiGraphArchiveFile } from "../storage/wikg/index.js";
@@ -652,6 +653,7 @@ class LibraryIndexDocument {
     operation: (database: Database) => Promise<T> | T,
     readonly: boolean,
   ): Promise<T> {
+    await ensureWikiGraphHomeSchemaCurrent();
     await mkdir(createLibraryIndexDirectory(this.#library), {
       recursive: true,
     });

--- a/packages/core/src/storage/schema-upgrade/index.ts
+++ b/packages/core/src/storage/schema-upgrade/index.ts
@@ -1,15 +1,12 @@
 import { randomUUID } from "crypto";
-import { mkdir, rename, rm, stat } from "fs/promises";
+import { rename, rm, stat } from "fs/promises";
 import { dirname, join, resolve } from "path";
 
 import { Database } from "../../document/database.js";
+import { ensureWikiGraphHomeSchemaCurrent } from "../../document/home-schema-upgrade.js";
 import {
-  resolveWikiGraphCacheDatabasePath,
-  resolveWikiGraphCoreDatabasePath,
   resolveWikiGraphHomeDirectoryPath,
-  resolveWikiGraphJobsDirectoryPath,
   resolveWikiGraphStagingDirectoryPath,
-  resolveWikiGraphTempRootDirectoryPath,
 } from "../../runtime/common/wiki-graph/dir.js";
 import {
   SEARCH_INDEX_DATABASE_PATH,
@@ -24,17 +21,13 @@ import {
 import { writeWikgArchiveWithOverlays } from "../wikg/archive/write.js";
 import { createArchiveKey } from "../wikg/wikg-coordinator/archive-key.js";
 
+export {
+  ensureWikiGraphHomeSchemaCurrent,
+  readWikiGraphHomeSchemaVersion,
+} from "../../document/home-schema-upgrade.js";
+
 const CURRENT_ARCHIVE_SCHEMA_VERSION = 2;
-const CURRENT_HOME_SCHEMA_VERSION = 2;
 const LOCK_STALE_TIMEOUT_MS = 5 * 60 * 1000;
-let homeSchemaUpgradeInFlight: Promise<void> | undefined;
-const HOME_SCHEMA_SQL = `
-  CREATE TABLE IF NOT EXISTS schema_versions (
-    scope TEXT PRIMARY KEY,
-    version INTEGER NOT NULL,
-    updated_at TEXT NOT NULL
-  );
-`;
 
 export async function ensureWikiGraphArchiveSchemaCurrent(
   archivePath: string,
@@ -115,116 +108,6 @@ export async function upgradeWikiGraphArchiveSchema(
   await cleanupArchiveDerivedData(archiveKey);
 }
 
-export async function ensureWikiGraphHomeSchemaCurrent(): Promise<void> {
-  if (homeSchemaUpgradeInFlight !== undefined) {
-    await homeSchemaUpgradeInFlight;
-    return;
-  }
-
-  homeSchemaUpgradeInFlight = (async () => {
-    const coreDatabasePath = resolveWikiGraphCoreDatabasePath();
-    const schemaVersion =
-      await readWikiGraphHomeSchemaVersion(coreDatabasePath);
-
-    if (schemaVersion > CURRENT_HOME_SCHEMA_VERSION) {
-      throw new Error(
-        `Unsupported Wiki Graph home schema version: ${schemaVersion}.`,
-      );
-    }
-
-    if (schemaVersion < CURRENT_HOME_SCHEMA_VERSION) {
-      await assertHomeUpgradeSafe();
-      await cleanupHomeDerivedData();
-      await writeHomeSchemaVersion(
-        coreDatabasePath,
-        CURRENT_HOME_SCHEMA_VERSION,
-      );
-    }
-  })();
-
-  try {
-    await homeSchemaUpgradeInFlight;
-    return;
-  } finally {
-    homeSchemaUpgradeInFlight = undefined;
-  }
-}
-
-export async function readWikiGraphHomeSchemaVersion(
-  coreDatabasePath = resolveWikiGraphCoreDatabasePath(),
-): Promise<number> {
-  if (!(await pathExists(coreDatabasePath))) {
-    return 0;
-  }
-
-  const database = await Database.open(coreDatabasePath, "", {
-    readonly: true,
-  });
-
-  try {
-    if (!(await tableExists(database, "schema_versions"))) {
-      return 1;
-    }
-
-    const version = await database.queryOne(
-      "SELECT version FROM schema_versions WHERE scope = ?",
-      ["home"],
-      (row) => Number(row.version),
-    );
-
-    return version ?? 1;
-  } finally {
-    await database.close();
-  }
-}
-
-async function writeHomeSchemaVersion(
-  coreDatabasePath: string,
-  version: number,
-): Promise<void> {
-  await mkdir(dirname(coreDatabasePath), { recursive: true });
-  const database = await Database.open(coreDatabasePath);
-
-  try {
-    await database.run(HOME_SCHEMA_SQL);
-    await database.run(
-      `
-        INSERT INTO schema_versions (scope, version, updated_at)
-        VALUES (?, ?, ?)
-        ON CONFLICT(scope) DO UPDATE SET
-          version = excluded.version,
-          updated_at = excluded.updated_at
-      `,
-      ["home", version, new Date().toISOString()],
-    );
-  } finally {
-    await database.close();
-  }
-}
-
-async function cleanupHomeDerivedData(): Promise<void> {
-  const homeDirectoryPath = resolveWikiGraphHomeDirectoryPath();
-  const cacheDirectoryPath = join(homeDirectoryPath, "cache");
-  const stagingDirectoryPath = resolveWikiGraphStagingDirectoryPath();
-  const jobsDirectoryPath = resolveWikiGraphJobsDirectoryPath();
-  const tempDirectoryPath = resolveWikiGraphTempRootDirectoryPath();
-
-  await deletePathIfExists(join(cacheDirectoryPath, "search-sessions.sqlite"));
-  await deletePathIfExists(
-    join(cacheDirectoryPath, "continuation-cursors.sqlite"),
-  );
-  await deletePathIfExists(resolveWikiGraphCacheDatabasePath());
-  await deletePathIfExists(join(stagingDirectoryPath, "library"));
-  await deletePathIfExists(join(tempDirectoryPath, "gc.sqlite"));
-  await deletePathIfExists(join(tempDirectoryPath, "gc.last-run"));
-  await deletePathIfExists(join(jobsDirectoryPath, "cache"));
-
-  const stagingDatabasePath = join(stagingDirectoryPath, "staging.sqlite");
-  if (await pathExists(stagingDatabasePath)) {
-    await removeArchiveSearchIndexOverlays(stagingDatabasePath);
-  }
-}
-
 async function cleanupArchiveDerivedData(archiveKey: string): Promise<void> {
   const cacheDirectoryPath = join(resolveWikiGraphHomeDirectoryPath(), "cache");
   await deletePathIfExists(join(cacheDirectoryPath, "search-sessions.sqlite"));
@@ -303,220 +186,6 @@ async function assertArchiveUpgradeSafe(archiveKey: string): Promise<void> {
       if (problematicOverlay !== undefined) {
         throw new Error(
           `Cannot upgrade archive with non-derived overlay state: ${archiveKey}.`,
-        );
-      }
-    }
-  } finally {
-    await database.close();
-  }
-}
-
-async function assertHomeUpgradeSafe(): Promise<void> {
-  await assertCoreLocksSafe();
-  await assertGcLockSafe();
-  await assertCoordinatorStateSafe();
-  await assertBuildQueueSafe();
-}
-
-async function assertCoreLocksSafe(): Promise<void> {
-  const coreDatabasePath = resolveWikiGraphCoreDatabasePath();
-
-  if (!(await pathExists(coreDatabasePath))) {
-    return;
-  }
-
-  const database = await Database.open(coreDatabasePath, "", {
-    readonly: true,
-  });
-
-  try {
-    if (!(await tableExists(database, "library_locks"))) {
-      return;
-    }
-
-    const rows = await database.queryAll(
-      `
-        SELECT owner_pid, heartbeat_at
-        FROM library_locks
-      `,
-      undefined,
-      (row) => ({
-        heartbeatAt: Number(row.heartbeat_at),
-        ownerPid: Number(row.owner_pid),
-      }),
-    );
-
-    if (rows.some((row) => isActiveLock(row.ownerPid, row.heartbeatAt))) {
-      throw new Error("Cannot upgrade home with active library locks.");
-    }
-  } finally {
-    await database.close();
-  }
-}
-
-async function assertGcLockSafe(): Promise<void> {
-  const gcDatabasePath = join(
-    resolveWikiGraphTempRootDirectoryPath(),
-    "gc.sqlite",
-  );
-
-  if (!(await pathExists(gcDatabasePath))) {
-    return;
-  }
-
-  const database = await Database.open(gcDatabasePath, "", {
-    readonly: true,
-  });
-
-  try {
-    if (!(await tableExists(database, "gc_locks"))) {
-      return;
-    }
-
-    const rows = await database.queryAll(
-      "SELECT owner_pid, heartbeat_at FROM gc_locks",
-      undefined,
-      (row) => ({
-        heartbeatAt: Number(row.heartbeat_at),
-        ownerPid: Number(row.owner_pid),
-      }),
-    );
-
-    if (rows.some((row) => isActiveLock(row.ownerPid, row.heartbeatAt))) {
-      throw new Error("Cannot upgrade home with an active GC lock.");
-    }
-  } finally {
-    await database.close();
-  }
-}
-
-async function assertCoordinatorStateSafe(): Promise<void> {
-  const stagingDatabasePath = join(
-    resolveWikiGraphStagingDirectoryPath(),
-    "staging.sqlite",
-  );
-
-  if (!(await pathExists(stagingDatabasePath))) {
-    return;
-  }
-
-  const database = await Database.open(stagingDatabasePath, "", {
-    readonly: true,
-  });
-
-  try {
-    for (const tableName of [
-      "archive_owners",
-      "entry_locks",
-      "entry_sqlite_leases",
-      "archive_commit_locks",
-    ]) {
-      if (!(await tableExists(database, tableName))) {
-        continue;
-      }
-
-      const rows = await database.queryAll(
-        `
-          SELECT owner_pid, heartbeat_at
-          FROM ${tableName}
-        `,
-        undefined,
-        (row) => ({
-          heartbeatAt: Number(row.heartbeat_at),
-          ownerPid: Number(row.owner_pid),
-        }),
-      );
-
-      if (rows.some((row) => isActiveLock(row.ownerPid, row.heartbeatAt))) {
-        throw new Error(
-          `Cannot upgrade home with active coordinator state: ${tableName}.`,
-        );
-      }
-    }
-
-    if (!(await tableExists(database, "entry_overlays"))) {
-      return;
-    }
-
-    const overlays = await database.queryAll(
-      `
-        SELECT entry_path, workspace_path
-        FROM entry_overlays
-      `,
-      undefined,
-      (row) => ({
-        entryPath: String(row.entry_path),
-        workspacePath:
-          row.workspace_path === null ? undefined : String(row.workspace_path),
-      }),
-    );
-
-    const problematicOverlay = overlays.find(
-      (overlay) => overlay.entryPath !== SEARCH_INDEX_DATABASE_PATH,
-    );
-    if (problematicOverlay !== undefined) {
-      throw new Error(
-        "Cannot upgrade home with non-derived coordinator overlays.",
-      );
-    }
-  } finally {
-    await database.close();
-  }
-}
-
-async function assertBuildQueueSafe(): Promise<void> {
-  const jobsDatabasePath = join(
-    resolveWikiGraphJobsDirectoryPath(),
-    "job.sqlite",
-  );
-
-  if (!(await pathExists(jobsDatabasePath))) {
-    return;
-  }
-
-  const database = await Database.open(jobsDatabasePath, "", {
-    readonly: true,
-  });
-
-  try {
-    if (await tableExists(database, "build_jobs")) {
-      const activeJobs = await database.queryAll(
-        `
-          SELECT job_id
-          FROM build_jobs
-          WHERE state IN ('queued', 'running', 'canceling', 'paused')
-        `,
-        undefined,
-        (row) => String(row.job_id),
-      );
-
-      if (activeJobs.length > 0) {
-        throw new Error("Cannot upgrade home with active build jobs.");
-      }
-    }
-
-    if (await tableExists(database, "build_worker_lease")) {
-      const lease = await database.queryOne(
-        `
-          SELECT owner_pid, heartbeat_at
-          FROM build_worker_lease
-          WHERE id = 1
-        `,
-        undefined,
-        (row) => ({
-          heartbeatAt:
-            row.heartbeat_at === null ? undefined : Number(row.heartbeat_at),
-          ownerPid: row.owner_pid === null ? undefined : Number(row.owner_pid),
-        }),
-      );
-
-      if (
-        lease?.ownerPid !== undefined &&
-        lease.heartbeatAt !== undefined &&
-        isActiveLock(lease.ownerPid, lease.heartbeatAt)
-      ) {
-        throw new Error(
-          "Cannot upgrade home with an active build worker lease.",
         );
       }
     }

--- a/packages/core/src/storage/wikg/wikg-coordinator/file-store.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/file-store.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, rename, rm, writeFile } from "fs/promises";
 import { dirname, posix, resolve } from "path";
 
 import type { DocumentFileStore } from "../../../document/directory/index.js";
+import { ensureWikiGraphHomeSchemaCurrent } from "../../../document/home-schema-upgrade.js";
 
 import { readWikgArchiveEntry, WikgArchiveReader } from "../archive/index.js";
 
@@ -281,6 +282,10 @@ export class WikgDocumentFileStore implements DocumentFileStore {
     entryPath: string,
     options: { readonly createIfMissing: boolean; readonly readonly: boolean },
   ): Promise<string> {
+    if (entryPath === SEARCH_INDEX_DATABASE_ENTRY_PATH) {
+      await ensureWikiGraphHomeSchemaCurrent();
+    }
+
     return await withEntryLock(
       this.#archiveKey,
       entryPath,

--- a/packages/core/src/storage/wikg/wikg-coordinator/search-index-cache.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/search-index-cache.ts
@@ -7,6 +7,7 @@ import {
   Database as DocumentDatabase,
   DirectoryDocument,
 } from "../../../document/index.js";
+import { ensureWikiGraphHomeSchemaCurrent } from "../../../document/home-schema-upgrade.js";
 import { readSearchIndexFingerprintFromDatabase } from "../../../retrieval/search-index/index.js";
 
 import {
@@ -62,6 +63,7 @@ export async function readSearchIndexCacheStatus(
 async function readSearchIndexCacheFingerprint(
   databasePath: string,
 ): Promise<string | undefined> {
+  await ensureWikiGraphHomeSchemaCurrent();
   const database = await DocumentDatabase.open(databasePath, "", {
     readonly: true,
   });

--- a/test/core/api/sdk/wiki-graph-core.test.ts
+++ b/test/core/api/sdk/wiki-graph-core.test.ts
@@ -1,7 +1,7 @@
 import { join } from "path";
 import { stat } from "fs/promises";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   WikiGraph,
@@ -11,9 +11,14 @@ import {
 } from "wiki-graph-core";
 import { tryRunWikiGraphGc } from "wiki-graph-core/gc";
 import { runBuildJobWorker } from "wiki-graph-core/worker";
+import { setWikiGraphStateDirectoryPathForTesting } from "../../../../packages/core/src/runtime/common/wiki-graph/dir.js";
 import { withTempDir } from "../../../helpers/temp.js";
 
 describe("wiki-graph-core sdk", () => {
+  afterEach(() => {
+    setWikiGraphStateDirectoryPathForTesting(undefined);
+  });
+
   it("exports the main SDK surface without CLI entrypoints", () => {
     expect(typeof WikiGraph).toBe("function");
     expect(typeof WikiGraphArchive).toBe("function");
@@ -30,6 +35,7 @@ describe("wiki-graph-core sdk", () => {
 
   it("can create and reopen an archive from the SDK", async () => {
     await withTempDir("wikigraph-sdk-", async (path) => {
+      setWikiGraphStateDirectoryPathForTesting(join(path, "state"));
       const archivePath = join(path, "note.wikg");
       const app = new WikiGraph({});
 

--- a/test/core/storage/schema-upgrade/index.test.ts
+++ b/test/core/storage/schema-upgrade/index.test.ts
@@ -7,6 +7,17 @@ import { ZipFile } from "yazl";
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 
 import { Database } from "../../../../packages/core/src/document/index.js";
+import { WikipageCache } from "../../../../packages/core/src/external/wikipage/cache.js";
+import {
+  ensureDefaultWikiGraphLibrary,
+  parseWikiGraphLibraryUri,
+} from "../../../../packages/core/src/library/registry.js";
+import { withWikiGraphLibraryLock } from "../../../../packages/core/src/library/lock.js";
+import { readWikiGraphLibraryIndexState } from "../../../../packages/core/src/library/search-index.js";
+import { openContinuationCursorDatabase } from "../../../../packages/core/src/retrieval/query/continuation-cursor/store.js";
+import { openSearchSessionDatabase } from "../../../../packages/core/src/retrieval/query/search-cache/database.js";
+import { tryAcquireGcLock } from "../../../../packages/core/src/runtime/gc/lock.js";
+import { openBuildQueueDatabase } from "../../../../packages/core/src/runtime/jobs/database.js";
 import {
   ensureWikiGraphArchiveSchemaCurrent,
   ensureWikiGraphHomeSchemaCurrent,
@@ -22,6 +33,8 @@ import {
   readWikgArchiveEntry,
   readWikgArchiveMutationToken,
 } from "../../../../packages/core/src/storage/wikg/index.js";
+import { createArchiveKey } from "../../../../packages/core/src/storage/wikg/wikg-coordinator/archive-key.js";
+import { withStateDatabase } from "../../../../packages/core/src/storage/wikg/wikg-coordinator/state.js";
 import {
   resolveWikiGraphHomeDirectoryPath,
   setWikiGraphStateDirectoryPathForTesting,
@@ -62,6 +75,29 @@ describe("schema-upgrade", () => {
       await expect(
         readWikgArchiveEntry(archivePath, WIKG_MANIFEST_PATH),
       ).resolves.toBeInstanceOf(Uint8Array);
+    });
+  });
+
+  it("rejects a future archive schema version", async () => {
+    await withTempDir("wikigraph-schema-future-archive-", async (root) => {
+      setWikiGraphStateDirectoryPathForTesting(join(root, "home"));
+      const archivePath = join(root, "book.wikg");
+      await writeArchiveWithSchemaVersion(archivePath, 999);
+
+      await expect(
+        ensureWikiGraphArchiveSchemaCurrent(archivePath),
+      ).rejects.toThrow("Unsupported Wiki Graph archive schema version: 999");
+    });
+  });
+
+  it("rejects a future home schema version", async () => {
+    await withTempDir("wikigraph-schema-future-home-", async (home) => {
+      setWikiGraphStateDirectoryPathForTesting(home);
+      await writeHomeSchemaVersion(home, 999);
+
+      await expect(ensureWikiGraphHomeSchemaCurrent()).rejects.toThrow(
+        "Unsupported Wiki Graph home schema version: 999",
+      );
     });
   });
 
@@ -241,6 +277,179 @@ describe("schema-upgrade", () => {
     });
   });
 
+  it.each([
+    ["archive_owners"],
+    ["entry_locks"],
+    ["entry_sqlite_leases"],
+    ["archive_commit_locks"],
+  ])("rejects an archive upgrade with active %s", async (tableName) => {
+    await withTempDir("wikigraph-schema-archive-block-", async (root) => {
+      setWikiGraphStateDirectoryPathForTesting(join(root, "home"));
+      const archivePath = join(root, "book.wikg");
+      await writeLegacyArchive(archivePath);
+      await writeActiveCoordinatorState(join(root, "home"), {
+        archiveKey: createArchiveKey(archivePath),
+        tableName,
+      });
+
+      await expect(
+        ensureWikiGraphArchiveSchemaCurrent(archivePath),
+      ).rejects.toThrow("active coordinator state");
+    });
+  });
+
+  it("rejects an archive upgrade with a non-fts overlay", async () => {
+    await withTempDir(
+      "wikigraph-schema-archive-overlay-block-",
+      async (root) => {
+        setWikiGraphStateDirectoryPathForTesting(join(root, "home"));
+        const archivePath = join(root, "book.wikg");
+        await writeLegacyArchive(archivePath);
+        await writeHomeSchemaVersion(join(root, "home"), 2);
+        await writeCoordinatorOverlay(join(root, "home"), {
+          archiveKey: createArchiveKey(archivePath),
+          entryPath: "database.db",
+        });
+
+        await expect(
+          ensureWikiGraphArchiveSchemaCurrent(archivePath),
+        ).rejects.toThrow("non-derived overlay state");
+      },
+    );
+  });
+
+  it("rejects a home upgrade with an active GC lock", async () => {
+    await withBlockedHomeUpgrade("gc", async (home) => {
+      await writeActiveGcLock(home);
+
+      await expect(ensureWikiGraphHomeSchemaCurrent()).rejects.toThrow(
+        "active GC lock",
+      );
+    });
+  });
+
+  it("rejects a home upgrade with an active build job", async () => {
+    await withBlockedHomeUpgrade("job", async (home) => {
+      await writeBuildQueue(home, { activeJob: true });
+
+      await expect(ensureWikiGraphHomeSchemaCurrent()).rejects.toThrow(
+        "active build jobs",
+      );
+    });
+  });
+
+  it("rejects a home upgrade with an active worker lease", async () => {
+    await withBlockedHomeUpgrade("worker", async (home) => {
+      await writeBuildQueue(home, { activeWorkerLease: true });
+
+      await expect(ensureWikiGraphHomeSchemaCurrent()).rejects.toThrow(
+        "active build worker lease",
+      );
+    });
+  });
+
+  it.each([
+    ["archive_owners"],
+    ["entry_locks"],
+    ["entry_sqlite_leases"],
+    ["archive_commit_locks"],
+  ])("rejects a home upgrade with active %s", async (tableName) => {
+    await withBlockedHomeUpgrade(`coordinator-${tableName}`, async (home) => {
+      await writeActiveCoordinatorState(home, {
+        archiveKey: "archive-key",
+        tableName,
+      });
+
+      await expect(ensureWikiGraphHomeSchemaCurrent()).rejects.toThrow(
+        "active coordinator state",
+      );
+    });
+  });
+
+  it("rejects a home upgrade with a non-fts overlay", async () => {
+    await withBlockedHomeUpgrade("overlay", async (home) => {
+      await writeCoordinatorOverlay(home, {
+        archiveKey: "archive-key",
+        entryPath: "database.db",
+      });
+
+      await expect(ensureWikiGraphHomeSchemaCurrent()).rejects.toThrow(
+        "non-derived coordinator overlays",
+      );
+    });
+  });
+
+  it("keeps core registry tables and constraints available after home upgrade", async () => {
+    await withLegacyHome("wikigraph-schema-core-registry-", async (home) => {
+      const library = await ensureDefaultWikiGraphLibrary();
+      const target = parseWikiGraphLibraryUri("wikg://lib/index");
+      expect(target).toBeDefined();
+      await readWikiGraphLibraryIndexState(target!);
+      await withWikiGraphLibraryLock(library.id, "read", () =>
+        Promise.resolve(),
+      );
+
+      const database = await Database.open(join(home, "core.sqlite"), "", {
+        readonly: true,
+      });
+      try {
+        for (const tableName of [
+          "libraries",
+          "library_metadata",
+          "library_archives",
+          "library_locks",
+        ]) {
+          await expect(hasTable(database, tableName)).resolves.toBe(true);
+        }
+        await expect(
+          hasIndex(database, "idx_libraries_single_default"),
+        ).resolves.toBe(true);
+        await expect(
+          hasIndex(database, "idx_library_archives_library"),
+        ).resolves.toBe(true);
+      } finally {
+        await database.close();
+      }
+    });
+  });
+
+  it.each([
+    [
+      "search-sessions.sqlite",
+      async () => await closeDatabase(await openSearchSessionDatabase()),
+    ],
+    [
+      "continuation-cursors.sqlite",
+      async () => await closeDatabase(await openContinuationCursorDatabase()),
+    ],
+    [
+      "cache/cache.sqlite",
+      async () => await (await WikipageCache.open()).close(),
+    ],
+    [
+      "jobs/job.sqlite",
+      async () => await closeDatabase(await openBuildQueueDatabase()),
+    ],
+    ["tmp/gc.sqlite", async () => await (await tryAcquireGcLock())?.()],
+    [
+      "staging/staging.sqlite",
+      async () => await withStateDatabase(() => Promise.resolve()),
+    ],
+    [
+      "staging/library/<library-id>/index/fts.db",
+      async () => {
+        const target = parseWikiGraphLibraryUri("wikg://lib/index");
+        expect(target).toBeDefined();
+        await readWikiGraphLibraryIndexState(target!);
+      },
+    ],
+  ])("opens %s only after the home schema gate", async (_name, open) => {
+    await withLegacyHome("wikigraph-schema-gate-", async (home) => {
+      await open();
+      await expect(readHomeSchemaVersion(home)).resolves.toBe(2);
+    });
+  });
+
   it("resolves the legacy home env fallback", async () => {
     await withTempDir("wikigraph-schema-home-env-", async (home) => {
       process.env.WIKIGRAPH_STATE_DIR = home;
@@ -251,7 +460,263 @@ describe("schema-upgrade", () => {
   });
 });
 
+async function withLegacyHome(
+  prefix: string,
+  operation: (home: string) => Promise<void>,
+): Promise<void> {
+  await withTempDir(prefix, async (home) => {
+    setWikiGraphStateDirectoryPathForTesting(home);
+    const database = await Database.open(join(home, "core.sqlite"));
+    try {
+      await database.run(`
+        CREATE TABLE config_sections (
+          section TEXT NOT NULL,
+          key TEXT NOT NULL,
+          value_json TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          PRIMARY KEY (section, key)
+        )
+      `);
+    } finally {
+      await database.close();
+    }
+
+    await operation(home);
+  });
+}
+
+async function withBlockedHomeUpgrade(
+  prefix: string,
+  operation: (home: string) => Promise<void>,
+): Promise<void> {
+  await withLegacyHome(`wikigraph-schema-block-${prefix}-`, operation);
+}
+
+async function closeDatabase(database: Database): Promise<void> {
+  await database.close();
+}
+
+async function readHomeSchemaVersion(
+  home: string,
+): Promise<number | undefined> {
+  const database = await Database.open(join(home, "core.sqlite"), "", {
+    readonly: true,
+  });
+  try {
+    return await database.queryOne(
+      "SELECT version FROM schema_versions WHERE scope = ?",
+      ["home"],
+      (row) => Number(row.version),
+    );
+  } finally {
+    await database.close();
+  }
+}
+
+async function writeHomeSchemaVersion(
+  home: string,
+  version: number,
+): Promise<void> {
+  await mkdir(home, { recursive: true });
+  const database = await Database.open(join(home, "core.sqlite"));
+  try {
+    await database.run(`
+      CREATE TABLE schema_versions (
+        scope TEXT PRIMARY KEY,
+        version INTEGER NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `);
+    await database.run(
+      "INSERT INTO schema_versions (scope, version, updated_at) VALUES ('home', ?, 'now')",
+      [version],
+    );
+  } finally {
+    await database.close();
+  }
+}
+
+async function hasTable(
+  database: Database,
+  tableName: string,
+): Promise<boolean> {
+  return (
+    (await database.queryOne(
+      "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ?",
+      [tableName],
+      () => true,
+    )) === true
+  );
+}
+
+async function hasIndex(
+  database: Database,
+  indexName: string,
+): Promise<boolean> {
+  return (
+    (await database.queryOne(
+      "SELECT 1 AS present FROM sqlite_master WHERE type = 'index' AND name = ?",
+      [indexName],
+      () => true,
+    )) === true
+  );
+}
+
+async function writeActiveGcLock(home: string): Promise<void> {
+  await mkdir(join(home, "tmp"), { recursive: true });
+  const database = await Database.open(join(home, "tmp", "gc.sqlite"));
+  try {
+    await database.run(`
+      CREATE TABLE gc_locks (
+        scope TEXT PRIMARY KEY,
+        owner_id TEXT NOT NULL,
+        owner_pid INTEGER NOT NULL,
+        heartbeat_at INTEGER NOT NULL,
+        created_at INTEGER NOT NULL
+      )
+    `);
+    await database.run(
+      "INSERT INTO gc_locks (scope, owner_id, owner_pid, heartbeat_at, created_at) VALUES ('global', 'owner', ?, ?, ?)",
+      [process.pid, Date.now(), Date.now()],
+    );
+  } finally {
+    await database.close();
+  }
+}
+
+async function writeBuildQueue(
+  home: string,
+  options: {
+    readonly activeJob?: boolean;
+    readonly activeWorkerLease?: boolean;
+  },
+): Promise<void> {
+  await mkdir(join(home, "jobs"), { recursive: true });
+  const database = await Database.open(join(home, "jobs", "job.sqlite"));
+  try {
+    await database.run(`
+      CREATE TABLE build_jobs (
+        job_id TEXT PRIMARY KEY,
+        state TEXT NOT NULL
+      )
+    `);
+    await database.run(`
+      CREATE TABLE build_worker_lease (
+        id INTEGER PRIMARY KEY,
+        owner_pid INTEGER,
+        heartbeat_at INTEGER
+      )
+    `);
+    if (options.activeJob === true) {
+      await database.run(
+        "INSERT INTO build_jobs (job_id, state) VALUES ('job', 'running')",
+      );
+    }
+    if (options.activeWorkerLease === true) {
+      await database.run(
+        "INSERT INTO build_worker_lease (id, owner_pid, heartbeat_at) VALUES (1, ?, ?)",
+        [process.pid, Date.now()],
+      );
+    }
+  } finally {
+    await database.close();
+  }
+}
+
+async function writeActiveCoordinatorState(
+  home: string,
+  input: { readonly archiveKey: string; readonly tableName: string },
+): Promise<void> {
+  await mkdir(join(home, "staging"), { recursive: true });
+  const database = await Database.open(join(home, "staging", "staging.sqlite"));
+  try {
+    await createCoordinatorStateTable(database, input.tableName);
+    const entryPathColumn =
+      input.tableName === "entry_locks" ||
+      input.tableName === "entry_sqlite_leases"
+        ? ", entry_path, mode"
+        : "";
+    const entryPathValues =
+      input.tableName === "entry_locks" ||
+      input.tableName === "entry_sqlite_leases"
+        ? ", 'fts.db', 'read'"
+        : "";
+    await database.run(
+      `INSERT INTO ${input.tableName} (archive_key${entryPathColumn}, owner_id, owner_pid, heartbeat_at, created_at) VALUES (?${entryPathValues}, 'owner', ?, ?, ?)`,
+      [input.archiveKey, process.pid, Date.now(), Date.now()],
+    );
+  } finally {
+    await database.close();
+  }
+}
+
+async function writeCoordinatorOverlay(
+  home: string,
+  input: { readonly archiveKey: string; readonly entryPath: string },
+): Promise<void> {
+  await mkdir(join(home, "staging"), { recursive: true });
+  const database = await Database.open(join(home, "staging", "staging.sqlite"));
+  try {
+    await database.run(`
+      CREATE TABLE entry_overlays (
+        archive_key TEXT NOT NULL,
+        archive_path TEXT NOT NULL,
+        entry_path TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        workspace_path TEXT,
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (archive_key, entry_path)
+      )
+    `);
+    await database.run(
+      "INSERT INTO entry_overlays (archive_key, archive_path, entry_path, kind, workspace_path, updated_at) VALUES (?, ?, ?, 'file', NULL, ?)",
+      [input.archiveKey, join(home, "book.wikg"), input.entryPath, Date.now()],
+    );
+  } finally {
+    await database.close();
+  }
+}
+
+async function createCoordinatorStateTable(
+  database: Database,
+  tableName: string,
+): Promise<void> {
+  if (tableName === "archive_commit_locks") {
+    await database.run(`
+      CREATE TABLE archive_commit_locks (
+        archive_key TEXT PRIMARY KEY,
+        owner_id TEXT NOT NULL,
+        owner_pid INTEGER NOT NULL,
+        heartbeat_at INTEGER NOT NULL,
+        created_at INTEGER NOT NULL
+      )
+    `);
+    return;
+  }
+
+  const entryColumns =
+    tableName === "entry_locks" || tableName === "entry_sqlite_leases"
+      ? ", entry_path TEXT NOT NULL, mode TEXT NOT NULL"
+      : "";
+  await database.run(`
+    CREATE TABLE ${tableName} (
+      archive_key TEXT NOT NULL${entryColumns},
+      owner_id TEXT NOT NULL,
+      owner_pid INTEGER NOT NULL,
+      heartbeat_at INTEGER NOT NULL,
+      created_at INTEGER NOT NULL
+    )
+  `);
+}
+
 async function writeLegacyArchive(archivePath: string): Promise<void> {
+  await writeArchiveWithSchemaVersion(archivePath, 1);
+}
+
+async function writeArchiveWithSchemaVersion(
+  archivePath: string,
+  schemaVersion: number,
+): Promise<void> {
   await mkdir(dirname(archivePath), { recursive: true });
 
   const zipFile = new ZipFile();
@@ -263,7 +728,10 @@ async function writeLegacyArchive(archivePath: string): Promise<void> {
     },
   );
   zipFile.addBuffer(
-    Buffer.from('{"formatVersion":1}\n', "utf8"),
+    Buffer.from(
+      `${JSON.stringify({ formatVersion: 1, schemaVersion })}\n`,
+      "utf8",
+    ),
     WIKG_MANIFEST_PATH,
     {
       compress: false,


### PR DESCRIPTION
## Summary

Resolves https://github.com/oomol-lab/wiki-graph/issues/159 as a follow-up to #153 / #157. This is a schema v1 -> v2 quality/coverage closeout only; it does not change the product boundary of the v1 -> v2 upgrade.

## Home SQLite gate coverage

Issue #159's explicit home SQLite list is covered as follows:

- `~/.wikigraph/core.sqlite`: `openSharedStateDatabase()` now gates the explicit core path before registry, metadata, membership, lock, config, and direct core-state access.
- `~/.wikigraph/cache/search-sessions.sqlite`: the shared-state opener gates `openSearchSessionDatabase()` before the search-session DB is initialized or opened.
- `~/.wikigraph/cache/continuation-cursors.sqlite`: the shared-state opener gates `openContinuationCursorDatabase()` before cursor state is initialized or opened.
- `~/.wikigraph/cache/cache.sqlite`: the shared-state opener gates `WikipageCache.open()` and wikipage cache GC before cache state is initialized or opened.
- `~/.wikigraph/jobs/job.sqlite`: the shared-state opener gates `openBuildQueueDatabase()` / readonly queue access before job state is initialized or opened; v1 -> v2 cleanup removes the queue DB only after active jobs/leases are ruled out.
- `~/.wikigraph/tmp/gc.sqlite`: the shared-state opener gates GC lock acquisition before GC state is initialized or opened.
- `~/.wikigraph/staging/staging.sqlite`: the shared-state opener gates coordinator state access before staging state is initialized or opened.
- `~/.wikigraph/staging/library/<library-id>/index/fts.db`: `LibraryIndexDocument` now calls the home gate before opening the aggregate library index DB.
- `~/.wikigraph/staging/work/<archiveKey>/fts.db`: coordinator search-index cache reads and materialization now call the home gate before touching external FTS workspace SQLite.

## Module boundary

Moved the home schema gate implementation out of `storage/schema-upgrade` into `document/home-schema-upgrade.ts`, so `document/shared-state-database.ts` no longer imports the storage upgrader. `storage/schema-upgrade` now keeps archive upgrade orchestration and re-exports the home schema API for the existing public import path.

## Tests

Expanded `test/core/storage/schema-upgrade/index.test.ts` for:

- future archive schema version rejection;
- future home schema version rejection;
- archive active owner / entry lock / sqlite lease / commit lock blockers;
- archive non-`fts.db` overlay blocker;
- home active GC lock, active build job, and active build worker lease blockers;
- home active coordinator owner / entry lock / sqlite lease / commit lock blockers;
- home non-`fts.db` overlay blocker;
- post-upgrade core registry tables and key indexes/constraints;
- gate-trigger coverage for search sessions, continuation cursors, wikipage cache, jobs, GC, staging, and library index state.

Also isolated the SDK archive reopen test from the machine-level home directory so schema-gate behavior is not affected by local `~/.wikigraph` state. Existing `cli/main` tests continue to cover help/version paths skipping command execution.

## Maintainer docs

Added `docs/schema-upgrade.md` covering schema version vs `wg --version`, when to bump schema, adjacent `N -> N+1` upgrader requirements, fixture/test expectations, derived-data invalidation, important-data safety, archive/home gate boundaries, the explicit home SQLite coverage list, and the rule against ad hoc business-path schema checks.

Updated `docs/local-cli-development.md` to route maintainers to the schema upgrade document.

## Verification

- `pnpm exec vitest run test/core/storage/schema-upgrade/index.test.ts --passWithNoTests`
- `pnpm run test`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm run build`
