### PR TITLE
fix: invalidate home schema memo on core changes

### DIFF
--- a/docs/schema-upgrade.md
+++ b/docs/schema-upgrade.md
@@ -87,6 +87,13 @@ non-`fts.db` overlay state is present.
 Pure information commands such as `wg --version` and help rendering must not open
 home SQLite and must not trigger schema upgrade.
 
+After a home `core.sqlite` file is confirmed current, the home gate may memoize
+that result inside the current process for hot gated access. The memo must be
+bound to both the resolved `core.sqlite` path and a file fingerprint (`dev`,
+`ino`, `mtimeMs`, `size`), so replacing, deleting/recreating, or rewriting the
+same path forces the next gated access to re-read the home schema version before
+opening other home SQLite state.
+
 ## Module Boundary
 
 `document` owns low-level SQLite/shared-state opening helpers and the home gate

--- a/packages/core/src/document/home-schema-upgrade.ts
+++ b/packages/core/src/document/home-schema-upgrade.ts
@@ -9,6 +9,7 @@ import {
   resolveWikiGraphStagingDirectoryPath,
   resolveWikiGraphTempRootDirectoryPath,
 } from "../runtime/common/wiki-graph/dir.js";
+import { isNodeError } from "../utils/node-error.js";
 
 import { Database } from "./database.js";
 
@@ -16,7 +17,7 @@ const CURRENT_HOME_SCHEMA_VERSION = 2;
 const LOCK_STALE_TIMEOUT_MS = 5 * 60 * 1000;
 const SEARCH_INDEX_DATABASE_PATH = "fts.db";
 let homeSchemaUpgradeInFlight: Promise<void> | undefined;
-let currentHomeSchemaDatabasePath: string | undefined;
+let currentHomeSchemaDatabaseMemo: HomeSchemaDatabaseMemo | undefined;
 const HOME_SCHEMA_SQL = `
   CREATE TABLE IF NOT EXISTS schema_versions (
     scope TEXT PRIMARY KEY,
@@ -25,22 +26,49 @@ const HOME_SCHEMA_SQL = `
   );
 `;
 
+interface HomeSchemaDatabaseFingerprint {
+  readonly dev: number;
+  readonly ino: number;
+  readonly mtimeMs: number;
+  readonly size: number;
+}
+
+interface HomeSchemaDatabaseMemo {
+  readonly fingerprint: HomeSchemaDatabaseFingerprint;
+  readonly path: string;
+}
+
 export async function ensureWikiGraphHomeSchemaCurrent(): Promise<void> {
   const coreDatabasePath = resolveWikiGraphCoreDatabasePath();
   const resolvedCoreDatabasePath = resolve(coreDatabasePath);
+  const fingerprint = await readHomeSchemaDatabaseFingerprint(coreDatabasePath);
 
-  if (currentHomeSchemaDatabasePath === resolvedCoreDatabasePath) {
+  if (isCurrentHomeSchemaDatabaseMemo(resolvedCoreDatabasePath, fingerprint)) {
     return;
   }
 
   if (homeSchemaUpgradeInFlight !== undefined) {
     await homeSchemaUpgradeInFlight;
-    if (currentHomeSchemaDatabasePath === resolvedCoreDatabasePath) {
+    const refreshedFingerprint =
+      await readHomeSchemaDatabaseFingerprint(coreDatabasePath);
+    if (
+      isCurrentHomeSchemaDatabaseMemo(
+        resolvedCoreDatabasePath,
+        refreshedFingerprint,
+      )
+    ) {
       return;
     }
   }
 
-  if (currentHomeSchemaDatabasePath === resolvedCoreDatabasePath) {
+  const refreshedFingerprint =
+    await readHomeSchemaDatabaseFingerprint(coreDatabasePath);
+  if (
+    isCurrentHomeSchemaDatabaseMemo(
+      resolvedCoreDatabasePath,
+      refreshedFingerprint,
+    )
+  ) {
     return;
   }
 
@@ -50,7 +78,7 @@ export async function ensureWikiGraphHomeSchemaCurrent(): Promise<void> {
         coreDatabasePath,
         CURRENT_HOME_SCHEMA_VERSION,
       );
-      currentHomeSchemaDatabasePath = resolvedCoreDatabasePath;
+      await memoizeCurrentHomeSchemaDatabase(resolvedCoreDatabasePath);
       return;
     }
 
@@ -72,7 +100,7 @@ export async function ensureWikiGraphHomeSchemaCurrent(): Promise<void> {
       );
     }
 
-    currentHomeSchemaDatabasePath = resolvedCoreDatabasePath;
+    await memoizeCurrentHomeSchemaDatabase(resolvedCoreDatabasePath);
   })();
 
   try {
@@ -81,6 +109,77 @@ export async function ensureWikiGraphHomeSchemaCurrent(): Promise<void> {
   } finally {
     homeSchemaUpgradeInFlight = undefined;
   }
+}
+
+async function memoizeCurrentHomeSchemaDatabase(
+  resolvedCoreDatabasePath: string,
+): Promise<void> {
+  const fingerprint = await readHomeSchemaDatabaseFingerprint(
+    resolvedCoreDatabasePath,
+  );
+
+  if (fingerprint === undefined) {
+    currentHomeSchemaDatabaseMemo = undefined;
+    return;
+  }
+
+  currentHomeSchemaDatabaseMemo = {
+    fingerprint,
+    path: resolvedCoreDatabasePath,
+  };
+}
+
+async function readHomeSchemaDatabaseFingerprint(
+  coreDatabasePath: string,
+): Promise<HomeSchemaDatabaseFingerprint | undefined> {
+  try {
+    const stats = await stat(coreDatabasePath);
+
+    return {
+      dev: stats.dev,
+      ino: stats.ino,
+      mtimeMs: stats.mtimeMs,
+      size: stats.size,
+    };
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  }
+}
+
+function isCurrentHomeSchemaDatabaseMemo(
+  resolvedCoreDatabasePath: string,
+  fingerprint: HomeSchemaDatabaseFingerprint | undefined,
+): boolean {
+  if (
+    fingerprint === undefined ||
+    currentHomeSchemaDatabaseMemo === undefined
+  ) {
+    return false;
+  }
+
+  return (
+    currentHomeSchemaDatabaseMemo.path === resolvedCoreDatabasePath &&
+    isSameHomeSchemaDatabaseFingerprint(
+      currentHomeSchemaDatabaseMemo.fingerprint,
+      fingerprint,
+    )
+  );
+}
+
+function isSameHomeSchemaDatabaseFingerprint(
+  left: HomeSchemaDatabaseFingerprint,
+  right: HomeSchemaDatabaseFingerprint,
+): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mtimeMs === right.mtimeMs &&
+    left.size === right.size
+  );
 }
 
 export async function readWikiGraphHomeSchemaVersion(

--- a/packages/core/src/document/home-schema-upgrade.ts
+++ b/packages/core/src/document/home-schema-upgrade.ts
@@ -63,6 +63,12 @@ export async function ensureWikiGraphHomeSchemaCurrent(): Promise<void> {
 
   const refreshedFingerprint =
     await readHomeSchemaDatabaseFingerprint(coreDatabasePath);
+
+  if (homeSchemaUpgradeInFlight !== undefined) {
+    await homeSchemaUpgradeInFlight;
+    return ensureWikiGraphHomeSchemaCurrent();
+  }
+
   if (
     isCurrentHomeSchemaDatabaseMemo(
       resolvedCoreDatabasePath,

--- a/test/core/storage/schema-upgrade/index.test.ts
+++ b/test/core/storage/schema-upgrade/index.test.ts
@@ -1,5 +1,5 @@
 import { createWriteStream } from "fs";
-import { mkdir, readFile, stat, writeFile } from "fs/promises";
+import { mkdir, readFile, rm, stat, writeFile } from "fs/promises";
 import { dirname, join } from "path";
 import { finished } from "stream/promises";
 
@@ -94,6 +94,53 @@ describe("schema-upgrade", () => {
     await withTempDir("wikigraph-schema-future-home-", async (home) => {
       setWikiGraphStateDirectoryPathForTesting(home);
       await writeHomeSchemaVersion(home, 999);
+
+      await expect(ensureWikiGraphHomeSchemaCurrent()).rejects.toThrow(
+        "Unsupported Wiki Graph home schema version: 999",
+      );
+    });
+  });
+
+  it("invalidates the home schema memo when core sqlite is replaced by future schema", async () => {
+    await withTempDir("wikigraph-schema-future-home-replace-", async (home) => {
+      setWikiGraphStateDirectoryPathForTesting(home);
+      await ensureWikiGraphHomeSchemaCurrent();
+
+      await rm(join(home, "core.sqlite"), { force: true });
+      await writeHomeSchemaVersion(home, 999);
+
+      await expect(ensureWikiGraphHomeSchemaCurrent()).rejects.toThrow(
+        "Unsupported Wiki Graph home schema version: 999",
+      );
+    });
+  });
+
+  it("invalidates the home schema memo when core sqlite is deleted and recreated as legacy", async () => {
+    await withTempDir(
+      "wikigraph-schema-legacy-home-recreate-",
+      async (home) => {
+        setWikiGraphStateDirectoryPathForTesting(home);
+        await ensureWikiGraphHomeSchemaCurrent();
+
+        await rm(join(home, "core.sqlite"), { force: true });
+        await writeLegacyCoreDatabase(home);
+        await ensureWikiGraphHomeSchemaCurrent();
+
+        await expect(readHomeSchemaVersion(home)).resolves.toBe(2);
+      },
+    );
+  });
+
+  it("does not reuse the home schema memo after switching test home paths", async () => {
+    await withTempDir("wikigraph-schema-home-switch-", async (root) => {
+      const firstHome = join(root, "first-home");
+      const secondHome = join(root, "second-home");
+
+      setWikiGraphStateDirectoryPathForTesting(firstHome);
+      await ensureWikiGraphHomeSchemaCurrent();
+
+      setWikiGraphStateDirectoryPathForTesting(secondHome);
+      await writeHomeSchemaVersion(secondHome, 999);
 
       await expect(ensureWikiGraphHomeSchemaCurrent()).rejects.toThrow(
         "Unsupported Wiki Graph home schema version: 999",
@@ -466,23 +513,27 @@ async function withLegacyHome(
 ): Promise<void> {
   await withTempDir(prefix, async (home) => {
     setWikiGraphStateDirectoryPathForTesting(home);
-    const database = await Database.open(join(home, "core.sqlite"));
-    try {
-      await database.run(`
-        CREATE TABLE config_sections (
-          section TEXT NOT NULL,
-          key TEXT NOT NULL,
-          value_json TEXT NOT NULL,
-          updated_at TEXT NOT NULL,
-          PRIMARY KEY (section, key)
-        )
-      `);
-    } finally {
-      await database.close();
-    }
+    await writeLegacyCoreDatabase(home);
 
     await operation(home);
   });
+}
+
+async function writeLegacyCoreDatabase(home: string): Promise<void> {
+  const database = await Database.open(join(home, "core.sqlite"));
+  try {
+    await database.run(`
+      CREATE TABLE config_sections (
+        section TEXT NOT NULL,
+        key TEXT NOT NULL,
+        value_json TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (section, key)
+      )
+    `);
+  } finally {
+    await database.close();
+  }
 }
 
 async function withBlockedHomeUpgrade(


### PR DESCRIPTION
## Summary
- Resolves https://github.com/oomol-lab/wiki-graph/issues/161.
- Binds the home schema gate memo to the resolved `core.sqlite` path plus a file fingerprint (`dev`, `ino`, `mtimeMs`, `size`) instead of only the path.
- Re-reads the home schema version when the same `core.sqlite` path is replaced, deleted/recreated, or rewritten, while keeping the gate centralized in `ensureWikiGraphHomeSchemaCurrent()`.
- Documents the memo invalidation semantics in `docs/schema-upgrade.md`.

## Memo invalidation strategy
After a home `core.sqlite` is confirmed current, the process memo stores the resolved path and current file fingerprint. Every gated access stats `core.sqlite`; a memo hit is accepted only when both the path and fingerprint still match. Missing files, changed inode/device, changed size, or changed mtime all fall through to the existing home schema read/upgrade path.

## Test coverage
- Same-process memo followed by replacing `core.sqlite` with future schema now re-detects and rejects the unsupported version.
- Same-process memo followed by deleting/recreating `core.sqlite` as legacy v1 now re-enters upgrade and writes current schema.
- Switching testing home paths does not reuse another home's memo.
- Existing schema upgrade home/archive gate coverage remains intact.

## Verification
- `pnpm vitest run test/core/storage/schema-upgrade/index.test.ts --passWithNoTests`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run format:check`
- `CI=1 pnpm run test`
- `pnpm run build`

Note: `pnpm run build` still emits the existing tsup CommonJS `import.meta` warning for `runtime/common/data-dir.ts`; build exits successfully.