### PR TITLE
feat: add maintenance upgrade command

### DIFF
--- a/docs/schema-upgrade.md
+++ b/docs/schema-upgrade.md
@@ -94,6 +94,30 @@ bound to both the resolved `core.sqlite` path and a file fingerprint (`dev`,
 same path forces the next gated access to re-read the home schema version before
 opening other home SQLite state.
 
+## Product Upgrade Entry Points
+
+User-visible upgrade targets are limited to home, standalone archive, library,
+and legacy sdpub inputs. Internal SQLite files such as search sessions, job
+state, staging state, and library `fts.db` are implementation details of the
+home or library target and must not become CLI targets.
+
+- `wg maintenance upgrade ~/.wikigraph` explicitly upgrades home state. Real CLI
+  commands also run a centralized home preflight before touching local state;
+  `wg --version`, `wg --help`, `wg help ...`, and other pure help rendering paths
+  remain rescue paths and do not create or upgrade home.
+- `wg maintenance upgrade <archive.wikg>` and archive URI forms upgrade a
+  standalone archive in place. Normal archive access only checks schema and
+  reports `wg maintenance upgrade <archive>` when old data is found; it must not
+  silently rewrite user archives.
+- `wg maintenance upgrade wikg://lib` and
+  `wg maintenance upgrade wikg://lib/<lib-id>.lib` upgrade a registered library
+  under the library write lock. The command clears rebuildable derived library
+  state and only visits archives registered in `library_archives`; it does not
+  scan the folder for unmanaged `.wikg` files.
+- `wg maintenance upgrade <path.sdpub> [--output <path.wikg>]` is the formal
+  sdpub migration entry. `wg legacy migrate` remains as a deprecated alias and
+  must share the same implementation.
+
 ## Module Boundary
 
 `document` owns low-level SQLite/shared-state opening helpers and the home gate

--- a/packages/cli/src/app/dispatch.ts
+++ b/packages/cli/src/app/dispatch.ts
@@ -11,12 +11,17 @@ import {
   runLegacyCommand,
   runLibraryCommand,
   runLocalConfigCommand,
+  runMaintenanceCommand,
   runObjectMetadataCommand,
   runQueueCommand,
 } from "../commands/index.js";
 import { formatCLIJSON, formatCLIJSONLine } from "../support/index.js";
 import { readCLIVersion } from "../support/index.js";
-import { formatError, LLMPaymentRequiredError } from "wiki-graph-core";
+import {
+  ensureWikiGraphHomeSchemaCurrent,
+  formatError,
+  LLMPaymentRequiredError,
+} from "wiki-graph-core";
 
 export interface WikiGraphCLIDispatchInput {
   readonly argv: readonly string[];
@@ -49,6 +54,11 @@ export async function dispatchWikiGraphCLI(
       case "version":
         input.stdout.write(`${readCLIVersion()}\n`);
         return { exitCode: 0 };
+    }
+
+    await ensureWikiGraphHomeSchemaCurrent();
+
+    switch (parsed.kind) {
       case "convert":
         await runConvertCommand(parsed.args);
         return { exitCode: 0 };
@@ -81,6 +91,9 @@ export async function dispatchWikiGraphCLI(
         return { exitCode: 0 };
       case "legacy":
         await runLegacyCommand(parsed.args);
+        return { exitCode: 0 };
+      case "maintenance-command":
+        await runMaintenanceCommand(parsed.args);
         return { exitCode: 0 };
       case "local-config":
         await runLocalConfigCommand(parsed.args);

--- a/packages/cli/src/args/help.ts
+++ b/packages/cli/src/args/help.ts
@@ -229,6 +229,14 @@ export function renderLegacyCommandHelpText(action?: "migrate"): string {
   );
 }
 
+export function renderMaintenanceCommandHelpText(action?: "upgrade"): string {
+  return renderHelpTemplate(
+    action === undefined
+      ? "help/commands/maintenance"
+      : `help/commands/maintenance/${action}`,
+  );
+}
+
 export function renderArchiveCommandHelpText(action: CLIArchiveAction): string {
   return renderHelpTemplate(`help/commands/archive/${action}`);
 }

--- a/packages/cli/src/args/parse.ts
+++ b/packages/cli/src/args/parse.ts
@@ -26,6 +26,7 @@ import {
   parseHelpArguments,
   parseLegacyArguments,
   parseLocalConfigUriFirstArguments,
+  parseMaintenanceArguments,
   parseTransformArguments,
 } from "./root/index.js";
 import { parseArchiveUriFirstArguments } from "./uri/index.js";
@@ -275,6 +276,10 @@ export function parseCLIArguments(
 
   if (positionals[0] === "legacy") {
     return parseLegacyArguments(positionals.slice(1), values);
+  }
+
+  if (positionals[0] === "maintenance") {
+    return parseMaintenanceArguments(positionals.slice(1), values);
   }
 
   if (positionals[0] === "transform") {

--- a/packages/cli/src/args/root/index.ts
+++ b/packages/cli/src/args/root/index.ts
@@ -2,5 +2,6 @@ export * from "./gc.js";
 export * from "./help.js";
 export * from "./legacy.js";
 export * from "./local-config.js";
+export * from "./maintenance-command.js";
 export * from "./maintenance.js";
 export * from "./transform.js";

--- a/packages/cli/src/args/root/maintenance-command.ts
+++ b/packages/cli/src/args/root/maintenance-command.ts
@@ -1,0 +1,95 @@
+import { renderMaintenanceCommandHelpText } from "../help.js";
+import { withHelpRoute } from "../../support/index.js";
+import type { ArchiveArgumentValues, ParsedCLIArguments } from "../types.js";
+
+export function parseMaintenanceArguments(
+  positionals: readonly string[],
+  values: ArchiveArgumentValues,
+): ParsedCLIArguments {
+  const action = positionals[0];
+
+  if (values.help === true && action === undefined) {
+    return {
+      help: true,
+      helpText: renderMaintenanceCommandHelpText(),
+      kind: "help",
+    };
+  }
+
+  if (action !== "upgrade") {
+    throw new Error(
+      withHelpRoute(
+        action === undefined
+          ? "Missing maintenance command."
+          : `Invalid maintenance command: ${action}.`,
+        "wg maintenance --help",
+      ),
+    );
+  }
+
+  if (values.help === true) {
+    return {
+      help: true,
+      helpText: renderMaintenanceCommandHelpText("upgrade"),
+      kind: "help",
+    };
+  }
+
+  rejectMaintenanceFlag("--input", values.input);
+  rejectMaintenanceFlag("--import", values.import);
+  rejectMaintenanceFlag("--input-format", values["input-format"]);
+  rejectMaintenanceFlag("--output-format", values["output-format"]);
+  rejectMaintenanceFlag("--llm", values.llm);
+  rejectMaintenanceFlag("--prompt", values.prompt);
+  rejectMaintenanceBooleanFlag("--jsonl", values.jsonl);
+  rejectMaintenanceBooleanFlag("--verbose", values.verbose);
+
+  const target = positionals[1];
+  if (target === undefined) {
+    throw new Error(
+      withHelpRoute(
+        "Missing maintenance upgrade target.",
+        "wg maintenance upgrade --help",
+      ),
+    );
+  }
+  if (positionals.length > 2) {
+    throw new Error(
+      withHelpRoute(
+        `Unexpected positional arguments: ${positionals.slice(2).join(" ")}.`,
+        "wg maintenance upgrade --help",
+      ),
+    );
+  }
+
+  return {
+    args: {
+      action,
+      ...(values.json === undefined ? {} : { json: values.json }),
+      ...(values.output === undefined ? {} : { outputPath: values.output }),
+      target,
+    },
+    help: false,
+    kind: "maintenance-command",
+  };
+}
+
+function rejectMaintenanceFlag(flag: string, value: unknown): void {
+  if (value !== undefined) {
+    throw new Error(
+      withHelpRoute(
+        `\`wg maintenance upgrade\` does not support ${flag}.`,
+        "wg maintenance upgrade --help",
+      ),
+    );
+  }
+}
+
+function rejectMaintenanceBooleanFlag(
+  flag: string,
+  value: boolean | undefined,
+): void {
+  if (value === true) {
+    rejectMaintenanceFlag(flag, value);
+  }
+}

--- a/packages/cli/src/args/types.ts
+++ b/packages/cli/src/args/types.ts
@@ -162,6 +162,13 @@ export interface CLILegacyArguments {
   readonly outputPath?: string;
 }
 
+export interface CLIMaintenanceArguments {
+  readonly action: "upgrade";
+  readonly json?: boolean;
+  readonly outputPath?: string;
+  readonly target: string;
+}
+
 export type CLIQueueAction =
   | "add"
   | "boost"
@@ -439,4 +446,9 @@ export type ParsedCLIArguments =
       readonly args: CLILegacyArguments;
       readonly help: false;
       readonly kind: "legacy";
+    }
+  | {
+      readonly args: CLIMaintenanceArguments;
+      readonly help: false;
+      readonly kind: "maintenance-command";
     };

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -9,6 +9,7 @@ import type {
   CLIGcArguments,
   CLILegacyArguments,
   CLILocalConfigArguments,
+  CLIMaintenanceArguments,
   CLIObjectMetadataArguments,
   CLIQueueArguments,
 } from "../args/index.js";
@@ -71,6 +72,14 @@ export async function runLegacyCommand(
   const command = await import("./legacy.js");
 
   return command.runLegacyCommand(args);
+}
+
+export async function runMaintenanceCommand(
+  args: CLIMaintenanceArguments,
+): Promise<void> {
+  const command = await import("./maintenance.js");
+
+  return command.runMaintenanceCommand(args);
 }
 
 export async function runLocalConfigCommand(

--- a/packages/cli/src/commands/legacy.ts
+++ b/packages/cli/src/commands/legacy.ts
@@ -1,15 +1,23 @@
 import type { CLILegacyArguments } from "../args/index.js";
-import { migrateLegacySdpubToWikg } from "wiki-graph-core";
+import { upgradeWikiGraphMaintenanceTarget } from "wiki-graph-core";
 
 export async function runLegacyCommand(
   args: CLILegacyArguments,
 ): Promise<void> {
   switch (args.action) {
     case "migrate": {
-      const result = await migrateLegacySdpubToWikg(
-        args.inputPath,
-        args.outputPath,
+      process.stderr.write(
+        "`wg legacy migrate` is deprecated. Use `wg maintenance upgrade <sdpub-path>`.\n",
       );
+      const result = await upgradeWikiGraphMaintenanceTarget(args.inputPath, {
+        ...(args.outputPath === undefined
+          ? {}
+          : { outputPath: args.outputPath }),
+      });
+
+      if (result.kind !== "sdpub") {
+        throw new Error("Legacy migrate only supports sdpub inputs.");
+      }
 
       process.stdout.write(`Wrote ${result.outputPath}\n`);
       return;

--- a/packages/cli/src/commands/library.ts
+++ b/packages/cli/src/commands/library.ts
@@ -2,6 +2,7 @@ import { readFile } from "fs/promises";
 
 import {
   addWikiGraphLibraryArchive,
+  assertWikiGraphLibrarySchemaCurrent,
   clearWikiGraphLibraryMetadata,
   createWikiGraphLibrary,
   deleteWikiGraphLibraryMetadataKey,
@@ -35,6 +36,14 @@ const INDEX_PROGRESS_OUTPUT_INTERVAL_MS = 6_000;
 export async function runLibraryCommand(
   args: CLILibraryArguments,
 ): Promise<void> {
+  if (
+    args.action !== "add" &&
+    args.action !== "create" &&
+    args.action !== "scan"
+  ) {
+    await assertWikiGraphLibrarySchemaCurrent(args.target);
+  }
+
   switch (args.action) {
     case "add": {
       if (args.inputPath === undefined) {

--- a/packages/cli/src/commands/maintenance.ts
+++ b/packages/cli/src/commands/maintenance.ts
@@ -1,0 +1,51 @@
+import {
+  upgradeWikiGraphMaintenanceTarget,
+  type WikiGraphMaintenanceUpgradeResult,
+} from "wiki-graph-core";
+
+import type { CLIMaintenanceArguments } from "../args/index.js";
+import { formatCLIJSON, writeTextToStdout } from "../support/index.js";
+
+export async function runMaintenanceCommand(
+  args: CLIMaintenanceArguments,
+): Promise<void> {
+  switch (args.action) {
+    case "upgrade": {
+      const result = await upgradeWikiGraphMaintenanceTarget(args.target, {
+        ...(args.outputPath === undefined
+          ? {}
+          : { outputPath: args.outputPath }),
+      });
+      await writeTextToStdout(
+        args.json === true
+          ? formatCLIJSON(result)
+          : formatMaintenanceUpgradeResult(result),
+      );
+      return;
+    }
+  }
+}
+
+function formatMaintenanceUpgradeResult(
+  result: WikiGraphMaintenanceUpgradeResult,
+): string {
+  switch (result.kind) {
+    case "home":
+      return `Home ${result.status}: ${result.path} (schema v${result.schemaVersionBefore} -> v${result.schemaVersionAfter})\n`;
+    case "archive":
+      return `Archive ${result.status}: ${result.path} (schema v${result.schemaVersionBefore} -> v${result.schemaVersionAfter})\n`;
+    case "sdpub":
+      return `Wrote ${result.outputPath}\n`;
+    case "lib": {
+      const lines = [
+        `Library ${result.status}: ${result.library.uri}`,
+        `upgraded: ${result.upgraded.length}`,
+        `already current: ${result.skipped.length}`,
+      ];
+      if (result.failed !== undefined) {
+        lines.push(`failed: ${result.failed.uri} (${result.failed.message})`);
+      }
+      return `${lines.join("\n")}\n`;
+    }
+  }
+}

--- a/packages/core/data/help/commands/legacy.jinja
+++ b/packages/core/data/help/commands/legacy.jinja
@@ -2,18 +2,19 @@ Help Type: command
 Command: {{ commandName }} legacy
 
 Purpose:
-  Expose the single `.sdpub` upgrade command.
+  Deprecated compatibility entry point for `.sdpub` upgrade.
 
 Usage:
   {{ commandName }} legacy migrate <path.sdpub> [--output <path.wikg>]
 
 Commands:
-  migrate    Convert an `.sdpub` archive into the current `.wikg` format.
+  migrate    Deprecated alias for `{{ commandName }} maintenance upgrade <path.sdpub>`.
 
 Examples:
   {{ commandName }} legacy migrate ./book.sdpub
   {{ commandName }} legacy migrate ./book.sdpub --output ./book.wikg
 
 See Also:
+  {{ commandName }} maintenance upgrade --help
   {{ commandName }} legacy migrate --help
   {{ commandName }} help format

--- a/packages/core/data/help/commands/legacy/migrate.jinja
+++ b/packages/core/data/help/commands/legacy/migrate.jinja
@@ -2,7 +2,10 @@ Help Type: command
 Command: {{ commandName }} legacy migrate
 
 Purpose:
-  Convert an `.sdpub` archive into the current `.wikg` format.
+  Deprecated alias for converting an `.sdpub` archive into the current `.wikg` format.
+
+Deprecated:
+  Use `{{ commandName }} maintenance upgrade <path.sdpub>` instead.
 
 Usage:
   {{ commandName }} legacy migrate <path.sdpub> [--output <path.wikg>]
@@ -16,5 +19,7 @@ Examples:
   {{ commandName }} legacy migrate ./book.sdpub --output ./book.wikg
 
 Related help:
+  - Current maintenance upgrade entry point:
+    {{ commandName }} maintenance upgrade --help
   - Current archive format, create/import, and export boundaries:
     {{ commandName }} help format

--- a/packages/core/data/help/commands/maintenance.jinja
+++ b/packages/core/data/help/commands/maintenance.jinja
@@ -1,0 +1,23 @@
+Help Type: command
+Command: {{ commandName }} maintenance
+
+Purpose:
+  Run explicit maintenance operations for persistent Wiki Graph data.
+
+Usage:
+  {{ commandName }} maintenance upgrade <target> [--json]
+
+Commands:
+  upgrade    Upgrade home state, a .wikg archive, a library, or migrate .sdpub.
+
+Upgrade targets:
+  {{ commandName }} maintenance upgrade ~/.wikigraph
+  {{ commandName }} maintenance upgrade ./book.wikg
+  {{ commandName }} maintenance upgrade wikg://book.wikg
+  {{ commandName }} maintenance upgrade ./book.sdpub [--output ./book.wikg]
+  {{ commandName }} maintenance upgrade wikg://lib
+  {{ commandName }} maintenance upgrade wikg://lib/<lib-id>.lib
+
+See Also:
+  {{ commandName }} maintenance upgrade --help
+  {{ commandName }} help format

--- a/packages/core/data/help/commands/maintenance/upgrade.jinja
+++ b/packages/core/data/help/commands/maintenance/upgrade.jinja
@@ -1,0 +1,26 @@
+Help Type: command
+Command: {{ commandName }} maintenance upgrade
+
+Purpose:
+  Explicitly upgrade persistent Wiki Graph data. Home state may be upgraded automatically before real commands; user archives and libraries are upgraded only through this maintenance command.
+
+Usage:
+  {{ commandName }} maintenance upgrade <target> [--json]
+  {{ commandName }} maintenance upgrade <path.sdpub> [--output <path.wikg>] [--json]
+
+Targets:
+  - Home state: ~/.wikigraph
+  - Standalone archive: ./book.wikg, /path/to/book.wikg, wikg://book.wikg, wikg:///path/to/book.wikg
+  - Legacy sdpub: ./book.sdpub, optionally with --output
+  - Library: wikg://lib or wikg://lib/<lib-id>.lib
+
+Notes:
+  - Internal SQLite files are part of the home target and are not user-facing upgrade targets.
+  - Standalone .wikg, home, and library targets are upgraded in place and do not support --output.
+  - Library archive member URIs such as wikg://lib/<archive-id>/ are not standalone upgrade targets; upgrade the whole library.
+
+Examples:
+  {{ commandName }} maintenance upgrade ~/.wikigraph
+  {{ commandName }} maintenance upgrade ./book.wikg
+  {{ commandName }} maintenance upgrade wikg://lib
+  {{ commandName }} maintenance upgrade ./book.sdpub --output ./book.wikg

--- a/packages/core/data/help/commands/root.jinja
+++ b/packages/core/data/help/commands/root.jinja
@@ -61,15 +61,17 @@ Help contract:
   The CLI help system is part of the product contract. When you do not know what a target or operation supports, ask the CLI for the next document.
   - Use `{{ commandName }} <uri> --help` to inspect a URI command, its default behavior, and supported predicates.
   - Use `{{ commandName }} <uri> <predicate> --help` to inspect a URI-bound predicate command.
-  - Use `{{ commandName }} <non-predicate-command> --help` for non-predicate commands such as `transform`, `gc`, `legacy`, and `next`.
+  - Use `{{ commandName }} <non-predicate-command> --help` for non-predicate commands such as `transform`, `gc`, `maintenance`, `legacy`, and `next`.
   - Use `{{ commandName }} help <topic>` for cross-command concepts, constraints, and runtime behavior.
   - Treat `{{ commandName }} --help` as the root page of the same help system.
-  - Use `{{ commandName }} legacy migrate --help` only when upgrading an `.sdpub` archive.
+  - Use `{{ commandName }} maintenance upgrade --help` for home, `.wikg`, library, and `.sdpub` upgrades.
+  - `{{ commandName }} legacy migrate --help` is a deprecated compatibility alias for `.sdpub` migration.
 
 Non-predicate command entry points:
   {{ commandName }} transform --help
   {{ commandName }} next --help
   {{ commandName }} gc --help
+  {{ commandName }} maintenance --help
   {{ commandName }} legacy --help
   {{ commandName }} help [topic] [--help|-h]
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -220,6 +220,13 @@ export {
   readWikiGraphHomeSchemaVersion,
   upgradeWikiGraphArchiveSchema,
 } from "./storage/schema-upgrade/index.js";
+export {
+  assertWikiGraphLibrarySchemaCurrent,
+  upgradeWikiGraphLibrarySchema,
+  upgradeWikiGraphMaintenanceTarget,
+  type WikiGraphLibraryUpgradeResult,
+  type WikiGraphMaintenanceUpgradeResult,
+} from "./maintenance/upgrade.js";
 export { readArchiveIndexSettings } from "./retrieval/search-index/index.js";
 export { migrateLegacySdpubToWikg } from "./storage/migration/legacy-sdpub/upgrade/index.js";
 export type {

--- a/packages/core/src/maintenance/upgrade.ts
+++ b/packages/core/src/maintenance/upgrade.ts
@@ -1,0 +1,305 @@
+import { rm } from "fs/promises";
+import { homedir } from "os";
+import { resolve } from "path";
+
+import {
+  listWikiGraphLibraryArchives,
+  parseWikiGraphLibraryUri,
+  resolveWikiGraphLibrary,
+  withWikiGraphLibraryLock,
+  type ParsedWikiGraphLibraryUri,
+  type WikiGraphLibraryArchiveRecord,
+  type WikiGraphLibraryRecord,
+} from "../library/index.js";
+import { resolveWikiGraphHomeDirectoryPath } from "../runtime/common/wiki-graph/dir.js";
+import { migrateLegacySdpubToWikg } from "../storage/migration/legacy-sdpub/upgrade/index.js";
+import { requireArchiveUri } from "../storage/wikg/index.js";
+import {
+  CURRENT_ARCHIVE_SCHEMA_VERSION,
+  ensureWikiGraphHomeSchemaCurrent,
+  readWikiGraphArchiveSchemaVersion,
+  readWikiGraphHomeSchemaVersion,
+  upgradeWikiGraphArchiveSchema,
+} from "../storage/schema-upgrade/index.js";
+
+export type WikiGraphMaintenanceUpgradeResult =
+  | {
+      readonly kind: "home";
+      readonly path: string;
+      readonly schemaVersionBefore: number;
+      readonly schemaVersionAfter: number;
+      readonly status: "already-current" | "upgraded";
+    }
+  | {
+      readonly kind: "archive";
+      readonly path: string;
+      readonly schemaVersionBefore: number;
+      readonly schemaVersionAfter: number;
+      readonly status: "already-current" | "upgraded";
+    }
+  | {
+      readonly kind: "sdpub";
+      readonly inputPath: string;
+      readonly outputPath: string;
+      readonly status: "migrated";
+    }
+  | WikiGraphLibraryUpgradeResult;
+
+export interface WikiGraphLibraryUpgradeResult {
+  readonly kind: "lib";
+  readonly library: {
+    readonly id: number;
+    readonly publicId: string;
+    readonly uri: string;
+    readonly folderPath: string;
+    readonly stagingPath: string;
+  };
+  readonly upgraded: readonly WikiGraphLibraryArchiveUpgradeItem[];
+  readonly skipped: readonly WikiGraphLibraryArchiveUpgradeItem[];
+  readonly failed?: WikiGraphLibraryArchiveFailure | undefined;
+  readonly status: "already-current" | "partial" | "upgraded";
+}
+
+export interface WikiGraphLibraryArchiveUpgradeItem {
+  readonly publicId: string;
+  readonly uri: string;
+  readonly path: string;
+  readonly schemaVersionBefore: number;
+  readonly schemaVersionAfter: number;
+}
+
+export interface WikiGraphLibraryArchiveFailure {
+  readonly publicId: string;
+  readonly uri: string;
+  readonly path: string;
+  readonly message: string;
+}
+
+export async function upgradeWikiGraphMaintenanceTarget(
+  target: string,
+  options: { readonly outputPath?: string } = {},
+): Promise<WikiGraphMaintenanceUpgradeResult> {
+  if (isLegacySdpubTarget(target)) {
+    const result = await migrateLegacySdpubToWikg(target, options.outputPath);
+    return {
+      kind: "sdpub",
+      inputPath: result.inputPath,
+      outputPath: result.outputPath,
+      status: "migrated",
+    };
+  }
+
+  if (options.outputPath !== undefined) {
+    throw new Error("Only sdpub maintenance upgrade supports --output.");
+  }
+
+  if (isHomeTarget(target)) {
+    const path = resolveWikiGraphHomeDirectoryPath();
+    const schemaVersionBefore = await readWikiGraphHomeSchemaVersion();
+    await ensureWikiGraphHomeSchemaCurrent();
+    const schemaVersionAfter = await readWikiGraphHomeSchemaVersion();
+    return {
+      kind: "home",
+      path,
+      schemaVersionBefore,
+      schemaVersionAfter,
+      status:
+        schemaVersionBefore === schemaVersionAfter
+          ? "already-current"
+          : "upgraded",
+    };
+  }
+
+  if (target.startsWith("wikg://lib")) {
+    const parsed = parseWikiGraphLibraryUri(target);
+    if (parsed === undefined) {
+      throw new Error(`Invalid Wiki Graph library upgrade target: ${target}`);
+    }
+    if (parsed.kind === "archive") {
+      throw new Error(
+        `Library archive URIs cannot be upgraded individually. Run: wg maintenance upgrade ${formatLibraryScopeUpgradeTarget(parsed)}`,
+      );
+    }
+    return await upgradeWikiGraphLibrarySchema(parsed);
+  }
+
+  const archivePath = resolveArchiveUpgradeTarget(target);
+  const schemaVersionBefore =
+    await readWikiGraphArchiveSchemaVersion(archivePath);
+  await upgradeWikiGraphArchiveSchema(archivePath);
+  const schemaVersionAfter =
+    await readWikiGraphArchiveSchemaVersion(archivePath);
+  return {
+    kind: "archive",
+    path: archivePath,
+    schemaVersionBefore,
+    schemaVersionAfter,
+    status:
+      schemaVersionBefore === schemaVersionAfter
+        ? "already-current"
+        : "upgraded",
+  };
+}
+
+export async function assertWikiGraphLibrarySchemaCurrent(
+  target: ParsedWikiGraphLibraryUri,
+): Promise<void> {
+  const library = await resolveWikiGraphLibrary(target);
+  const archives = await listWikiGraphLibraryArchives({
+    isDefault: library.isDefault,
+    kind: "scope",
+    ...(library.isDefault ? {} : { publicId: library.publicId }),
+  });
+  for (const archive of archives) {
+    if (!isUpgradeableLibraryArchive(archive)) {
+      continue;
+    }
+    const schemaVersion = await readWikiGraphArchiveSchemaVersion(archive.path);
+    if (schemaVersion < CURRENT_ARCHIVE_SCHEMA_VERSION) {
+      throw new Error(
+        `This Wiki Graph library must be upgraded before use.\nRun: wg maintenance upgrade ${library.uri}`,
+      );
+    }
+  }
+}
+
+export async function upgradeWikiGraphLibrarySchema(
+  target: ParsedWikiGraphLibraryUri,
+): Promise<WikiGraphLibraryUpgradeResult> {
+  await ensureWikiGraphHomeSchemaCurrent();
+  const library = await resolveWikiGraphLibrary(target);
+  return await withWikiGraphLibraryLock(library.id, "write", async () => {
+    await clearLibraryDerivedData(library);
+    const archives = (
+      await listWikiGraphLibraryArchives({
+        isDefault: library.isDefault,
+        kind: "scope",
+        ...(library.isDefault ? {} : { publicId: library.publicId }),
+      })
+    ).filter(isUpgradeableLibraryArchive);
+
+    const upgraded: WikiGraphLibraryArchiveUpgradeItem[] = [];
+    const skipped: WikiGraphLibraryArchiveUpgradeItem[] = [];
+
+    for (const archive of archives) {
+      const schemaVersionBefore = await readWikiGraphArchiveSchemaVersion(
+        archive.path,
+      );
+      if (schemaVersionBefore === CURRENT_ARCHIVE_SCHEMA_VERSION) {
+        skipped.push({
+          path: archive.path,
+          publicId: archive.publicId,
+          schemaVersionAfter: schemaVersionBefore,
+          schemaVersionBefore,
+          uri: archive.uri,
+        });
+        continue;
+      }
+      try {
+        await upgradeWikiGraphArchiveSchema(archive.path);
+      } catch (error) {
+        return {
+          failed: {
+            message: formatErrorMessage(error),
+            path: archive.path,
+            publicId: archive.publicId,
+            uri: archive.uri,
+          },
+          kind: "lib",
+          library: formatLibraryResult(library),
+          skipped,
+          status: "partial",
+          upgraded,
+        };
+      }
+      upgraded.push({
+        path: archive.path,
+        publicId: archive.publicId,
+        schemaVersionAfter: await readWikiGraphArchiveSchemaVersion(
+          archive.path,
+        ),
+        schemaVersionBefore,
+        uri: archive.uri,
+      });
+    }
+
+    return {
+      kind: "lib",
+      library: formatLibraryResult(library),
+      skipped,
+      status: upgraded.length === 0 ? "already-current" : "upgraded",
+      upgraded,
+    };
+  });
+}
+
+function resolveArchiveUpgradeTarget(target: string): string {
+  if (target.startsWith("wikg://")) {
+    return requireArchiveUri(target);
+  }
+  if (!target.endsWith(".wikg")) {
+    throw new Error(
+      `Unsupported maintenance upgrade target: ${target}. Expected home, a .wikg archive, a .sdpub archive, or wikg://lib.`,
+    );
+  }
+  return resolveHomeShorthand(target);
+}
+
+function isLegacySdpubTarget(target: string): boolean {
+  return target.toLowerCase().endsWith(".sdpub");
+}
+
+function isHomeTarget(target: string): boolean {
+  const resolved = resolveHomeShorthand(target).replace(/[\\/]+$/u, "");
+  return (
+    target === "home" ||
+    target === "~/.wikigraph" ||
+    resolved === resolveWikiGraphHomeDirectoryPath().replace(/[\\/]+$/u, "")
+  );
+}
+
+function resolveHomeShorthand(path: string): string {
+  return path.startsWith("~/")
+    ? resolve(homedir(), path.slice(2))
+    : resolve(path);
+}
+
+function isUpgradeableLibraryArchive(
+  archive: WikiGraphLibraryArchiveRecord,
+): boolean {
+  return archive.exists && archive.status === "present";
+}
+
+async function clearLibraryDerivedData(
+  library: WikiGraphLibraryRecord,
+): Promise<void> {
+  await rm(library.stagingPath, { force: true, recursive: true });
+}
+
+function formatLibraryScopeUpgradeTarget(
+  target: ParsedWikiGraphLibraryUri,
+): string {
+  return target.isDefault
+    ? "wikg://lib"
+    : `wikg://lib/${target.publicId ?? "<lib-id>"}.lib`;
+}
+
+function formatLibraryResult(library: WikiGraphLibraryRecord): {
+  readonly id: number;
+  readonly publicId: string;
+  readonly uri: string;
+  readonly folderPath: string;
+  readonly stagingPath: string;
+} {
+  return {
+    folderPath: library.folderPath,
+    id: library.id,
+    publicId: library.publicId,
+    stagingPath: library.stagingPath,
+    uri: library.uri,
+  };
+}
+
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/core/src/storage/schema-upgrade/index.ts
+++ b/packages/core/src/storage/schema-upgrade/index.ts
@@ -26,7 +26,7 @@ export {
   readWikiGraphHomeSchemaVersion,
 } from "../../document/home-schema-upgrade.js";
 
-const CURRENT_ARCHIVE_SCHEMA_VERSION = 2;
+export const CURRENT_ARCHIVE_SCHEMA_VERSION = 2;
 const LOCK_STALE_TIMEOUT_MS = 5 * 60 * 1000;
 
 export async function ensureWikiGraphArchiveSchemaCurrent(
@@ -40,7 +40,9 @@ export async function ensureWikiGraphArchiveSchemaCurrent(
     );
   }
   if (schemaVersion < CURRENT_ARCHIVE_SCHEMA_VERSION) {
-    await upgradeWikiGraphArchiveSchema(archivePath);
+    throw new Error(
+      `This Wiki Graph archive uses schema v${schemaVersion} and must be upgraded before use.\nRun: wg maintenance upgrade ${archivePath}`,
+    );
   }
 }
 

--- a/test/cli/library.test.ts
+++ b/test/cli/library.test.ts
@@ -14,6 +14,7 @@ vi.mock("wiki-graph-core", async (importOriginal) => {
 
   return {
     ...actual,
+    assertWikiGraphLibrarySchemaCurrent: vi.fn(() => Promise.resolve()),
     putWikiGraphLibraryMetadata: vi.fn(
       (_target: unknown, key: string, value: unknown) => {
         libraryMockState.putCalls.push({ key, value });

--- a/test/cli/main.test.ts
+++ b/test/cli/main.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MockInstance } from "vitest";
+import type * as WikiGraphCore from "wiki-graph-core";
 
 const mainMockState = vi.hoisted(() => ({
   argsResult: {
@@ -124,6 +125,14 @@ vi.mock("../../packages/cli/src/commands/index.js", () => ({
     return Promise.resolve();
   }),
 }));
+
+vi.mock("wiki-graph-core", async (importOriginal) => {
+  const actual = await importOriginal<typeof WikiGraphCore>();
+  return {
+    ...actual,
+    ensureWikiGraphHomeSchemaCurrent: vi.fn(() => Promise.resolve()),
+  };
+});
 
 import { main } from "../../packages/cli/src/app/index.js";
 import { renderMainHelpText } from "../../packages/cli/src/args/help.js";

--- a/test/core/storage/schema-upgrade/index.test.ts
+++ b/test/core/storage/schema-upgrade/index.test.ts
@@ -22,6 +22,7 @@ import {
   ensureWikiGraphArchiveSchemaCurrent,
   ensureWikiGraphHomeSchemaCurrent,
   readWikiGraphArchiveSchemaVersion,
+  upgradeWikiGraphArchiveSchema,
 } from "../../../../packages/core/src/storage/schema-upgrade/index.js";
 import {
   WIKG_MANIFEST_PATH,
@@ -56,12 +57,14 @@ describe("schema-upgrade", () => {
       setWikiGraphStateDirectoryPathForTesting(join(root, "home"));
       const archivePath = join(root, "book.wikg");
       await writeLegacyArchive(archivePath);
-      const mutationToken = await readWikgArchiveMutationToken(archivePath);
 
-      await ensureWikiGraphArchiveSchemaCurrent(archivePath);
+      await expect(
+        ensureWikiGraphArchiveSchemaCurrent(archivePath),
+      ).rejects.toThrow("wg maintenance upgrade");
+      await upgradeWikiGraphArchiveSchema(archivePath);
 
-      await expect(readWikgArchiveMutationToken(archivePath)).resolves.toBe(
-        mutationToken,
+      await expect(readWikgArchiveMutationToken(archivePath)).resolves.toEqual(
+        expect.any(String),
       );
       await expect(
         readWikiGraphArchiveSchemaVersion(archivePath),
@@ -339,9 +342,9 @@ describe("schema-upgrade", () => {
         tableName,
       });
 
-      await expect(
-        ensureWikiGraphArchiveSchemaCurrent(archivePath),
-      ).rejects.toThrow("active coordinator state");
+      await expect(upgradeWikiGraphArchiveSchema(archivePath)).rejects.toThrow(
+        "active coordinator state",
+      );
     });
   });
 
@@ -359,7 +362,7 @@ describe("schema-upgrade", () => {
         });
 
         await expect(
-          ensureWikiGraphArchiveSchemaCurrent(archivePath),
+          upgradeWikiGraphArchiveSchema(archivePath),
         ).rejects.toThrow("non-derived overlay state");
       },
     );


### PR DESCRIPTION
## Summary
- Closes https://github.com/oomol-lab/wiki-graph/issues/163 as the closeout for the legacy-data compatibility work following #153, #159, and #161.
- Adds the formal `wg maintenance upgrade <target>` entry point and central core dispatch for home/archive/lib/sdpub upgrades.
- Changes old standalone archive and library access to report an explicit maintenance-upgrade requirement instead of silently upgrading user data; `wg legacy migrate` remains as a deprecated sdpub alias.

## Formal upgrade targets
| Target | Example | Behavior |
| --- | --- | --- |
| home | `wg maintenance upgrade ~/.wikigraph` | upgrades Wiki Graph home state / internal SQLite as one product target |
| archive | `wg maintenance upgrade ./book.wikg`, `wg maintenance upgrade wikg://book.wikg` | upgrades one standalone `.wikg` in place |
| lib | `wg maintenance upgrade wikg://lib`, `wg maintenance upgrade wikg://lib/<lib-id>.lib` | takes the library write lock, clears rebuildable library derived data, upgrades registered present members only |
| sdpub | `wg maintenance upgrade ./book.sdpub [--output ./book.wikg]` | reuses the existing sdpub-to-wikg migration implementation |

## Non-upgrade trigger validation
- Automated coverage keeps `--version`, `--help`, and command help on the early-return path before home preflight in `dispatchWikiGraphCLI`.
- Dev CLI smoke used a temporary `WIKIGRAPH_STATE_DIR` and verified `--version`, root help, `maintenance --help`, and `maintenance upgrade --help` do not create `core.sqlite`.

## Old archive/lib access behavior
- Standalone archive access now uses `ensureWikiGraphArchiveSchemaCurrent()` as a schema check only; old schema errors include `wg maintenance upgrade <archive>` and do not mention `legacy migrate`.
- Library command execution calls `assertWikiGraphLibrarySchemaCurrent()` before normal access, so registered old members reject with `wg maintenance upgrade <lib-uri>` instead of upgrading in place.
- Dev CLI smoke copied an old `.wikg`, confirmed `inspect` fails with the maintenance-upgrade hint, then upgraded it explicitly.

## maintenance upgrade coverage
- home: real-command preflight and explicit home upgrade share `ensureWikiGraphHomeSchemaCurrent()`; schema-upgrade tests cover legacy/future home behavior and dangerous-state blockers.
- archive: schema-upgrade tests cover explicit in-place upgrade, future schema rejection, mutation token preservation, derived `fts.db` deletion, and safety blockers.
- lib: core implementation resolves the target library, takes `withWikiGraphLibraryLock(..., "write")`, clears library staging/index derived data, iterates only `library_archives` present members, and returns structured upgraded/skipped/partial failure results.
- sdpub: `maintenance upgrade <sdpub>` and deprecated `legacy migrate` both call `upgradeWikiGraphMaintenanceTarget()` / existing `migrateLegacySdpubToWikg()`.

## Lib partial failure behavior
- `upgradeWikiGraphLibrarySchema()` stops on the first member archive failure and returns a `status: "partial"` result containing `upgraded`, `skipped`, and `failed { publicId, uri, path, message }`; later members are not processed after the failure.

## legacy migrate compatibility
- `wg legacy migrate <sdpub-path> [--output <path>]` remains supported, emits a deprecation warning, and delegates to the same maintenance-upgrade sdpub handler so output-path inference and errors stay aligned.

## Verification
- `pnpm install`
- `pnpm run typecheck`
- `pnpm exec vitest run test/cli/main.test.ts test/cli/library.test.ts test/core/storage/schema-upgrade/index.test.ts --passWithNoTests`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run test:run`
- `pnpm run build`
- Dev CLI smoke via `pnpm --silent --dir packages/cli exec tsx src/bin/cli.ts`: version/help no-home creation, maintenance help pages, old archive access error without auto-upgrade, explicit archive maintenance upgrade, and `--output` rejection for `.wikg` target.
