### PR TITLE
feat: support library folder rebind

### DIFF
--- a/packages/cli/src/args/archive-index.test.ts
+++ b/packages/cli/src/args/archive-index.test.ts
@@ -137,4 +137,60 @@ describe("cli/args/archive index", () => {
       "The library index wikg://lib/team.lib/index does not support `external`.\nSee: wg wikg://lib/team.lib/index external --help",
     );
   });
+
+  it("parses library rebind only on library scope URIs", () => {
+    expect(
+      parseCLIArguments(["wikg://lib", "rebind", "--path", "/tmp/library"]),
+    ).toStrictEqual({
+      args: {
+        action: "rebind",
+        json: undefined,
+        path: "/tmp/library",
+        target: { isDefault: true, kind: "scope" },
+      },
+      help: false,
+      kind: "library",
+    });
+    expect(
+      parseCLIArguments([
+        "wikg://lib/team.lib",
+        "rebind",
+        "--path",
+        "/tmp/team",
+        "--json",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "rebind",
+        json: true,
+        path: "/tmp/team",
+        target: { isDefault: false, kind: "scope", publicId: "team" },
+      },
+      help: false,
+      kind: "library",
+    });
+    expect(() => parseCLIArguments(["wikg://lib", "rebind"])).toThrow(
+      "Missing --path <directory>.",
+    );
+    expect(() =>
+      parseCLIArguments([
+        "wikg://lib/archive123",
+        "rebind",
+        "--path",
+        "/tmp/x",
+      ]),
+    ).toThrow(
+      "The library archive wikg://lib/archive123 does not support `rebind`.",
+    );
+    expect(() =>
+      parseCLIArguments([
+        "wikg://lib/team.lib/archive123",
+        "rebind",
+        "--path",
+        "/tmp/x",
+      ]),
+    ).toThrow(
+      "The library archive wikg://lib/team.lib/archive123 does not support `rebind`.",
+    );
+  });
 });

--- a/packages/cli/src/args/types.ts
+++ b/packages/cli/src/args/types.ts
@@ -114,6 +114,7 @@ export type CLILibraryAction =
   | "list"
   | "move"
   | "put"
+  | "rebind"
   | "remove"
   | "scan"
   | "set";

--- a/packages/cli/src/args/uri/library.ts
+++ b/packages/cli/src/args/uri/library.ts
@@ -35,6 +35,7 @@ const LIBRARY_SCOPE_ACTIONS = new Set([
   "create",
   "get",
   "list",
+  "rebind",
   "remove",
   "scan",
 ]);
@@ -431,6 +432,20 @@ function parseLibraryScopeArguments(
         help: false,
         kind: "library",
       };
+    case "rebind":
+      rejectExtraPositionals(action, tail, 0, helpRoute);
+      if (values.path === undefined) {
+        throw new Error(
+          withHelpRoute("Missing --path <directory>.", helpRoute),
+        );
+      }
+      rejectArchiveFlag(action, "--input", values.input, helpRoute);
+      rejectArchiveFlag(action, "--to", values.to, helpRoute);
+      return {
+        args: { action, json: values.json, path: values.path, target },
+        help: false,
+        kind: "library",
+      };
     case "get":
     case "list":
     case "scan":
@@ -527,6 +542,7 @@ function parseLibraryMetadataArguments(
     case "remove":
     case "add":
     case "move":
+    case "rebind":
     case "disable-index":
     case "enable-index":
     case "get-index":
@@ -593,6 +609,7 @@ function isLibraryAction(action: string): action is CLILibraryAction {
     action === "list" ||
     action === "move" ||
     action === "put" ||
+    action === "rebind" ||
     action === "remove" ||
     action === "scan" ||
     action === "set"

--- a/packages/cli/src/commands/library.ts
+++ b/packages/cli/src/commands/library.ts
@@ -13,6 +13,7 @@ import {
   putWikiGraphLibraryMetadata,
   readWikiGraphLibraryIndexState,
   rebuildWikiGraphLibraryIndex,
+  rebindWikiGraphLibrary,
   removeWikiGraphLibrary,
   removeWikiGraphLibraryArchive,
   replaceWikiGraphLibraryMetadata,
@@ -67,6 +68,17 @@ export async function runLibraryCommand(
     }
     case "scan": {
       const result = await scanWikiGraphLibrary(args.target);
+      await writeLibraryArchives(result.archives, args.json ?? false);
+      return;
+    }
+    case "rebind": {
+      if (args.path === undefined) {
+        throw new Error("Missing --path <directory> for library rebind.");
+      }
+      const result = await rebindWikiGraphLibrary({
+        folderPath: args.path,
+        target: args.target,
+      });
       await writeLibraryArchives(result.archives, args.json ?? false);
       return;
     }

--- a/packages/core/data/help/commands/library-predicate.jinja
+++ b/packages/core/data/help/commands/library-predicate.jinja
@@ -26,6 +26,23 @@ Notes:
 Examples:
   {{ commandName }} wikg://lib create --path ./research-library
   {{ commandName }} wikg://lib create --path ./research-library --json
+{% elif target.kind == "scope" and predicate == "rebind" %}
+Purpose:
+  Bind this library to an existing directory, then scan/reconcile `.wikg` files in that directory.
+
+Usage:
+  {{ commandName }} {{ uri }} rebind --path <existing-directory> [--json]
+
+Notes:
+  - Use this after you manually move, sync, or restore a library folder outside Wiki Graph.
+  - `--path` must already exist, be an accessible directory, and not be bound to another library.
+  - The command updates only this library registry's folder path, preserving the library id, public id, default marker, and metadata.
+  - The command does not copy, move, or delete files from the old or new folder.
+  - After updating the folder path, it runs the same scan/reconcile lifecycle used by `scan`.
+
+Examples:
+  {{ commandName }} {{ uri }} rebind --path ~/Library/Mobile\ Documents/wiki-library
+  {{ commandName }} {{ uri }} rebind --path /Volumes/Archive/wiki-library --json
 {% elif target.kind == "scope" and predicate == "get" %}
 Purpose:
   Read a specific object in this library scope.

--- a/packages/core/data/help/commands/library.jinja
+++ b/packages/core/data/help/commands/library.jinja
@@ -38,6 +38,7 @@ Default behavior:
 
 Use when:
   - You need the library entry point before future library-level archive enumeration or search.
+  - You already moved or prepared a library folder and need Wiki Graph to bind this library to that existing directory.
 {% if target.isDefault %}
   - You need to create another library registry.
 {% else %}
@@ -53,9 +54,11 @@ Usage:
 {% if target.isDefault %}
   {{ commandName }} wikg://lib
   {{ commandName }} wikg://lib create --path <folder> [--json]
+  {{ commandName }} wikg://lib rebind --path <existing-directory> [--json]
   {{ commandName }} wikg://lib/meta [--json]
 {% else %}
   {{ commandName }} {{ uri }}
+  {{ commandName }} {{ uri }} rebind --path <existing-directory> [--json]
   {{ commandName }} {{ uri }} remove [--json]
   {{ commandName }} {{ uri }}/meta [--json]
 {% endif %}
@@ -63,7 +66,9 @@ Usage:
 Predicate commands:
 {% if target.isDefault %}
   - create: create a non-default library registry and an empty folder. Help: {{ commandName }} wikg://lib create --help
+  - rebind: bind the default library to an existing directory, then scan/reconcile its `.wikg` files. Help: {{ commandName }} wikg://lib rebind --help
 {% else %}
+  - rebind: bind this library to an existing directory, then scan/reconcile its `.wikg` files. Help: {{ commandName }} {{ uri }} rebind --help
   - remove: remove this library registry without deleting its folder. Help: {{ commandName }} {{ uri }} remove --help
 {% endif %}
 {% endif %}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,6 +63,7 @@ export {
   readWikiGraphLibraryIndexState,
   readWikiGraphLibraryPage,
   rebuildWikiGraphLibraryIndex,
+  rebindWikiGraphLibrary,
   removeWikiGraphLibraryArchive,
   removeWikiGraphLibrary,
   replaceWikiGraphLibraryMetadata,

--- a/packages/core/src/library/membership.test.ts
+++ b/packages/core/src/library/membership.test.ts
@@ -15,13 +15,17 @@ import {
   addWikiGraphLibraryArchive,
   createWikiGraphLibrary,
   ensureDefaultWikiGraphLibrary,
+  getWikiGraphLibraryMetadata,
   isWikiGraphLibraryUri,
   moveWikiGraphLibraryArchive,
   parseLocatedWikiGraphUri,
   parseWikiGraphLibraryUri,
+  putWikiGraphLibraryMetadata,
+  rebindWikiGraphLibrary,
   removeWikiGraphLibrary,
   removeWikiGraphLibraryArchive,
   resolveWikiGraphLibraryArchivePath,
+  resolveWikiGraphLibrary,
   scanWikiGraphLibrary,
 } from "../index.js";
 import { withWikiGraphStateDirectoryPathForTesting } from "../runtime/common/wiki-graph/dir.js";
@@ -209,7 +213,162 @@ describe("library archive membership", () => {
       });
     });
   });
+
+  it("rebinds the default library to an existing folder while preserving registry identity and metadata", async () => {
+    await withLibraryTestState(async (tempDir) => {
+      const library = await ensureDefaultWikiGraphLibrary();
+      const target = parseWikiGraphLibraryUri("wikg://lib");
+      expect(target).toBeDefined();
+      await putWikiGraphLibraryMetadata(target!, "owner", "default-team");
+      await writeFile(join(library.folderPath, "old-only.wikg"), "old");
+
+      const newFolder = join(tempDir, "icloud-library");
+      await mkdir(newFolder);
+      await createTestWikgArchive(tempDir, join(newFolder, "synced.wikg"));
+
+      const result = await rebindWikiGraphLibrary({
+        folderPath: newFolder,
+        target: target!,
+      });
+      const rebound = await ensureDefaultWikiGraphLibrary();
+
+      expect(rebound).toMatchObject({
+        id: library.id,
+        isDefault: true,
+        publicId: library.publicId,
+        uri: library.uri,
+      });
+      expect(rebound.folderPath).toBe(newFolder);
+      await expect(
+        readFile(join(library.folderPath, "old-only.wikg"), "utf8"),
+      ).resolves.toBe("old");
+      await expect(
+        readFile(join(newFolder, "synced.wikg")),
+      ).resolves.toBeDefined();
+      await expect(getDefaultMetadata(target!)).resolves.toStrictEqual({
+        owner: "default-team",
+      });
+      expect(result.archives).toContainEqual(
+        expect.objectContaining({
+          relativePath: "synced.wikg",
+          status: "present",
+        }),
+      );
+    });
+  });
+
+  it("rebinds only the addressed non-default library and rejects invalid folder targets", async () => {
+    await withLibraryTestState(async (tempDir) => {
+      const defaultLibrary = await ensureDefaultWikiGraphLibrary();
+      const teamLibrary = await createWikiGraphLibrary({
+        folderPath: join(tempDir, "team-old"),
+      });
+      const otherLibrary = await createWikiGraphLibrary({
+        folderPath: join(tempDir, "other-bound"),
+      });
+      const teamTarget = parseWikiGraphLibraryUri(teamLibrary.uri);
+      expect(teamTarget).toBeDefined();
+      const newFolder = join(tempDir, "team-new");
+      await mkdir(newFolder);
+
+      await expect(
+        rebindWikiGraphLibrary({
+          folderPath: join(tempDir, "missing"),
+          target: teamTarget!,
+        }),
+      ).rejects.toThrow("does not exist");
+      const fileTarget = join(tempDir, "not-directory");
+      await writeFile(fileTarget, "file");
+      await expect(
+        rebindWikiGraphLibrary({ folderPath: fileTarget, target: teamTarget! }),
+      ).rejects.toThrow("must be an existing directory");
+      await expect(
+        rebindWikiGraphLibrary({
+          folderPath: otherLibrary.folderPath,
+          target: teamTarget!,
+        }),
+      ).rejects.toThrow("already bound to another library");
+
+      await rebindWikiGraphLibrary({
+        folderPath: newFolder,
+        target: teamTarget!,
+      });
+
+      await expect(resolveWikiGraphLibrary(teamTarget!)).resolves.toMatchObject(
+        {
+          folderPath: newFolder,
+          id: teamLibrary.id,
+        },
+      );
+      await expect(
+        resolveWikiGraphLibrary(parseWikiGraphLibraryUri("wikg://lib")!),
+      ).resolves.toMatchObject({ folderPath: defaultLibrary.folderPath });
+    });
+  });
+
+  it("preserves archive public ids when rebind scan sees a moved mutation token", async () => {
+    await withLibraryTestState(async (tempDir) => {
+      const library = await ensureDefaultWikiGraphLibrary();
+      const target = parseWikiGraphLibraryUri("wikg://lib");
+      expect(target).toBeDefined();
+      await createTestWikgArchive(
+        tempDir,
+        join(library.folderPath, "old.wikg"),
+      );
+      const first = await scanWikiGraphLibrary(target!);
+      const oldArchive = first.archives.find(
+        (archive) => archive.relativePath === "old.wikg",
+      );
+      expect(oldArchive?.lastSeenMutationToken).toBeDefined();
+
+      const newFolder = join(tempDir, "new-library-folder");
+      await mkdir(newFolder);
+      await rename(
+        join(library.folderPath, "old.wikg"),
+        join(newFolder, "renamed.wikg"),
+      );
+
+      const rebound = await rebindWikiGraphLibrary({
+        folderPath: newFolder,
+        target: target!,
+      });
+      const renamed = rebound.archives.find(
+        (archive) => archive.relativePath === "renamed.wikg",
+      );
+
+      expect(renamed?.publicId).toBe(oldArchive?.publicId);
+      expect(renamed?.status).toBe("present");
+      expect(
+        rebound.archives.some((archive) => archive.relativePath === "old.wikg"),
+      ).toBe(false);
+    });
+  });
+
+  it("rejects rebind on library archive URI targets", async () => {
+    await withLibraryTestState(async (tempDir) => {
+      const target = parseWikiGraphLibraryUri("wikg://lib");
+      expect(target).toBeDefined();
+      const source = join(tempDir, "source.wikg");
+      await writeFile(source, "content");
+      const added = await addWikiGraphLibraryArchive({
+        inputPath: source,
+        target: target!,
+      });
+      const archiveTarget = parseWikiGraphLibraryUri(added.uri);
+      expect(archiveTarget?.kind).toBe("archive");
+
+      await expect(
+        rebindWikiGraphLibrary({ folderPath: tempDir, target: archiveTarget! }),
+      ).rejects.toThrow("requires a library scope URI");
+    });
+  });
 });
+
+async function getDefaultMetadata(
+  target: NonNullable<ReturnType<typeof parseWikiGraphLibraryUri>>,
+): Promise<Readonly<Record<string, unknown>>> {
+  return await getWikiGraphLibraryMetadata(target);
+}
 
 describe("library URI locators", () => {
   it("separates library archives from library scopes", () => {

--- a/packages/core/src/library/membership.ts
+++ b/packages/core/src/library/membership.ts
@@ -26,6 +26,7 @@ import { isNodeError } from "../utils/node-error.js";
 import {
   parseWikiGraphLibraryUri,
   resolveWikiGraphLibrary,
+  updateWikiGraphLibraryFolderPathForRebind,
   type ParsedWikiGraphLibraryUri,
   type WikiGraphLibraryRecord,
 } from "./registry.js";
@@ -95,6 +96,27 @@ export async function scanWikiGraphLibrary(
     const result = await scanWikiGraphLibraryUnlocked(target, library);
 
     await markWikiGraphLibraryIndexDirty(library);
+    return result;
+  });
+}
+
+export async function rebindWikiGraphLibrary(input: {
+  readonly target: ParsedWikiGraphLibraryUri;
+  readonly folderPath: string;
+}): Promise<WikiGraphLibraryScanResult> {
+  if (input.target.kind !== "scope" || input.target.objectUri !== undefined) {
+    throw new Error("Library rebind requires a library scope URI.");
+  }
+
+  const library = await resolveWikiGraphLibrary(input.target);
+  return await withWikiGraphLibraryLock(library.id, "write", async () => {
+    const rebound = await updateWikiGraphLibraryFolderPathForRebind(
+      library,
+      input.folderPath,
+    );
+    const result = await scanWikiGraphLibraryUnlocked(input.target, rebound);
+
+    await markWikiGraphLibraryIndexDirty(rebound);
     return result;
   });
 }

--- a/packages/core/src/library/registry.ts
+++ b/packages/core/src/library/registry.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from "crypto";
-import { mkdir, stat } from "fs/promises";
+import { constants } from "fs";
+import { access, mkdir, stat } from "fs/promises";
 import { join, resolve } from "path";
 
 import {
@@ -324,6 +325,57 @@ export async function removeWikiGraphLibrary(
   });
 
   return library;
+}
+
+export async function updateWikiGraphLibraryFolderPathForRebind(
+  library: WikiGraphLibraryRecord,
+  inputFolderPath: string,
+): Promise<WikiGraphLibraryRecord> {
+  const folderPath = resolve(inputFolderPath);
+  let folderStats;
+  try {
+    folderStats = await stat(folderPath);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      throw new Error(`Library rebind --path does not exist: ${folderPath}`);
+    }
+    throw new Error(
+      `Library rebind --path is not accessible: ${folderPath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (!folderStats.isDirectory()) {
+    throw new Error(
+      `Library rebind --path must be an existing directory: ${folderPath}`,
+    );
+  }
+  try {
+    await access(folderPath, constants.R_OK);
+  } catch (error) {
+    throw new Error(
+      `Library rebind --path is not accessible: ${folderPath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  return await withLibraryRegistryDatabase(async (database) => {
+    return await database.transaction(async () => {
+      const existing = await database.queryOne(
+        "SELECT id FROM libraries WHERE folder_path = ?",
+        [folderPath],
+        (row) => getNumber(row, "id"),
+      );
+      if (existing !== undefined && existing !== library.id) {
+        throw new Error(
+          `Library rebind --path is already bound to another library: ${folderPath}`,
+        );
+      }
+
+      await database.run(
+        "UPDATE libraries SET folder_path = ?, updated_at = ? WHERE id = ?",
+        [folderPath, new Date().toISOString(), library.id],
+      );
+      return await requireLibraryRecordById(database, library.id);
+    });
+  });
 }
 
 export async function getWikiGraphLibraryMetadata(


### PR DESCRIPTION
## Summary
- add library-scope `rebind --path <existing-directory>` for default and explicit library URIs
- update `libraries.folder_path` under the library write lock, then reuse scan/reconcile and dirty index lifecycle
- reject archive-scope rebinds, invalid paths, and folder paths already bound to another library
- document the manual move/sync then rebind workflow

Fixes #164

## Verification
- pnpm vitest run packages/core/src/library/membership.test.ts packages/cli/src/args/archive-index.test.ts --passWithNoTests
- pnpm run test
- pnpm run lint
- pnpm run typecheck
- pnpm run build
- pnpm run format:check