### PR TITLE
fix: tighten CLI regression contracts

### DIFF
--- a/packages/cli/src/args/archive.test.ts
+++ b/packages/cli/src/args/archive.test.ts
@@ -84,7 +84,7 @@ describe("cli/args/archive", () => {
         "2",
         "--jsonl",
       ]),
-    ).toThrow("`--query` requires a scope URI");
+    ).toThrow("numeric chapter ids are internal and are not accepted");
 
     expect(parseCLIArguments(["wikg://book.wikg/entity"])).toStrictEqual({
       args: {
@@ -1128,6 +1128,25 @@ describe("cli/args/archive", () => {
       kind: "chapter",
     });
     expect(
+      parseCLIArguments([
+        "wikg://book.wikg/chapter/tree",
+        "apply",
+        "--input",
+        "tree.json",
+        "--dry-run",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "tree",
+        dryRun: true,
+        inputPath: "tree.json",
+        path: archivePath,
+        treeAction: "apply",
+      },
+      help: false,
+      kind: "chapter",
+    });
+    expect(
       parseCLIArguments(["wikg://book.wikg/chapter/tree", "set", "--dry-run"]),
     ).toStrictEqual({
       args: {
@@ -1198,6 +1217,9 @@ describe("cli/args/archive", () => {
         "book.epub",
       ]),
     ).toThrow("The `chapter tree` action does not support --import.");
+    expect(() =>
+      parseCLIArguments(["wikg://book.wikg/chapter/3/source", "--json"]),
+    ).toThrow("numeric chapter ids are internal and are not accepted");
   });
 
   it("parses chapter subtree depth only for scope reads", () => {

--- a/packages/cli/src/args/archive.test.ts
+++ b/packages/cli/src/args/archive.test.ts
@@ -1109,6 +1109,12 @@ describe("cli/args/archive", () => {
       kind: "help",
     });
     expect(
+      parseCLIArguments(["wikg://book.wikg/chapter/tree", "apply", "--help"]),
+    ).toMatchObject({
+      help: true,
+      kind: "help",
+    });
+    expect(
       parseCLIArguments([
         "wikg://book.wikg/chapter/tree",
         "set",

--- a/packages/cli/src/args/uri/chapter/target.ts
+++ b/packages/cli/src/args/uri/chapter/target.ts
@@ -133,15 +133,11 @@ function parseChapterPathAndSuffix(
   const pathParts = suffixStart === -1 ? parts : parts.slice(0, suffixStart);
   const suffixParts = suffixStart === -1 ? [] : parts.slice(suffixStart);
 
-  try {
-    const chapterPath = parseChapterPath(pathParts.join("/"), "chapter URI");
-    return {
-      chapterPath,
-      ...(suffixParts.length === 0 ? {} : { suffix: suffixParts.join("/") }),
-    };
-  } catch {
-    return undefined;
-  }
+  const chapterPath = parseChapterPath(pathParts.join("/"), "chapter URI");
+  return {
+    chapterPath,
+    ...(suffixParts.length === 0 ? {} : { suffix: suffixParts.join("/") }),
+  };
 }
 
 function parseChapterStateSuffix(

--- a/packages/cli/src/args/uri/entry.ts
+++ b/packages/cli/src/args/uri/entry.ts
@@ -48,8 +48,10 @@ export function parseArchiveUriFirstArguments(
     throw new Error("Internal error: missing URI-first archive URI.");
   }
 
-  const action =
-    explicitAction ?? resolveImplicitArchiveUriAction(uri, values.query);
+  const action = normalizeArchiveUriAction(
+    uri,
+    explicitAction ?? resolveImplicitArchiveUriAction(uri, values.query),
+  );
 
   if (explicitAction === "get") {
     throw new Error(formatRemovedImplicitVerbMessage(explicitAction));
@@ -103,6 +105,19 @@ export function parseArchiveUriFirstArguments(
 }
 
 type ArchiveUriKind = "object" | "scope";
+
+function normalizeArchiveUriAction(uri: string, action: string): string {
+  if (action !== "apply") {
+    return action;
+  }
+
+  const parsed = parseLocatedWikiGraphUri(uri);
+  if (parsed.objectUri === "wikg://chapter/tree") {
+    return "set";
+  }
+
+  return action;
+}
 
 function resolveImplicitArchiveUriAction(
   uri: string,

--- a/packages/cli/src/args/uri/entry.ts
+++ b/packages/cli/src/args/uri/entry.ts
@@ -70,17 +70,17 @@ export function parseArchiveUriFirstArguments(
   if (values.help === true && explicitAction !== undefined) {
     const helpTarget = classifyArchiveUriHelpTarget(uri);
 
-    if (!isUriHelpPredicate(helpTarget, explicitAction)) {
+    if (!isUriHelpPredicate(helpTarget, action)) {
       throw new Error(
         withHelpRoute(
-          `The URI target ${uri} does not support \`${explicitAction}\`.`,
+          `The URI target ${uri} does not support \`${action}\`.`,
           formatWikiGraphHelpCommand(uri),
         ),
       );
     }
     return {
       help: true,
-      helpText: renderUriPredicateHelpText(helpTarget, explicitAction, uri),
+      helpText: renderUriPredicateHelpText(helpTarget, action, uri),
       kind: "help",
     };
   }

--- a/packages/cli/src/args/uri/library.ts
+++ b/packages/cli/src/args/uri/library.ts
@@ -383,7 +383,9 @@ function parseLibraryScopeArguments(
       ),
     );
   }
-  rejectCommonLibraryFlags(action, values, helpRoute);
+  rejectCommonLibraryFlags(action, values, helpRoute, {
+    allowConfirm: action === "remove",
+  });
   rejectArchiveBooleanFlag(action, "--jsonl", values.jsonl, helpRoute);
   rejectArchiveFlag(action, "--json-input", values["json-input"], helpRoute);
 
@@ -427,8 +429,16 @@ function parseLibraryScopeArguments(
       rejectArchiveFlag(action, "--path", values.path, helpRoute);
       rejectArchiveFlag(action, "--input", values.input, helpRoute);
       rejectArchiveFlag(action, "--to", values.to, helpRoute);
+      if (!target.isDefault && values.confirm !== true) {
+        throw new Error(withHelpRoute("Missing --confirm.", helpRoute));
+      }
       return {
-        args: { action, json: values.json, target },
+        args: {
+          action,
+          ...(values.confirm === undefined ? {} : { confirm: values.confirm }),
+          json: values.json,
+          target,
+        },
         help: false,
         kind: "library",
       };

--- a/packages/cli/src/args/uri/library.ts
+++ b/packages/cli/src/args/uri/library.ts
@@ -429,7 +429,10 @@ function parseLibraryScopeArguments(
       rejectArchiveFlag(action, "--path", values.path, helpRoute);
       rejectArchiveFlag(action, "--input", values.input, helpRoute);
       rejectArchiveFlag(action, "--to", values.to, helpRoute);
-      if (!target.isDefault && values.confirm !== true) {
+      if (
+        (target.kind === "archive" || !target.isDefault) &&
+        values.confirm !== true
+      ) {
         throw new Error(withHelpRoute("Missing --confirm.", helpRoute));
       }
       return {

--- a/packages/cli/src/args/validation.test.ts
+++ b/packages/cli/src/args/validation.test.ts
@@ -60,7 +60,9 @@ describe("cli/args/validation", () => {
     ).toThrow("The `cover` command does not support --json.");
     expect(() =>
       parseCLIArguments(["wikg://book.wikg/chapter/../source", "set"]),
-    ).toThrow("does not support `set`");
+    ).toThrow(
+      "chapter paths do not support empty, '.', '..', or relative segments",
+    );
     expect(() => parseCLIArguments(["wikg://entity/Q9957"])).toThrow(
       "Short object URIs from output are archive-relative handles.",
     );

--- a/test/cli/library.test.ts
+++ b/test/cli/library.test.ts
@@ -77,11 +77,21 @@ describe("cli/library args", () => {
       kind: "library",
     });
 
-    expect(
+    expect(() =>
       parseCLIArguments(["wikg://lib/abc123abc123.lib", "remove", "--json"]),
+    ).toThrow("Missing --confirm");
+
+    expect(
+      parseCLIArguments([
+        "wikg://lib/abc123abc123.lib",
+        "remove",
+        "--confirm",
+        "--json",
+      ]),
     ).toMatchObject({
       args: {
         action: "remove",
+        confirm: true,
         json: true,
         target: { publicId: "abc123abc123" },
       },


### PR DESCRIPTION
## Summary

Fixes the reviewable CLI regressions tracked from oomol/wiki-graph-private#52 that were still present on current main:

- Reject invalid/numeric chapter URI paths before they fall through to generic object URI handling, so `chapter/<number>/source` no longer reaches the old internal-id read path.
- Accept the regression-documented URI-first `chapter/tree apply` form as an alias for the existing tree apply handler.
- Require `--confirm` when removing a non-default named library, while still allowing default-library remove requests to reach the existing “default library cannot be removed” product guard.

## Notes / not changed

- Current main already has the P0 `maintenance upgrade` top-level command, shared search-cache table initialization, library rebind parsing, and named-library index enable path working in the local smoke covered below.
- I did not add `wikg://lib --query` root query support in this PR. The existing supported command surface is object-scoped library query such as `wikg://lib/chapter`, `wikg://lib/entity`, and `wikg://lib/triple`; root query remains a contract/documentation decision from oomol/wiki-graph-private#52 rather than a safe product change here.
- I did not cover LLM-backed Reading Graph / Summary / Knowledge Graph jobs in this PR; the search-cache schema path is covered by existing unit/GC tests and an archive index/query smoke.

## Tests

- `pnpm exec vitest run packages/cli/src/args/archive.test.ts packages/cli/src/args/archive-index.test.ts test/cli/library.test.ts --passWithNoTests`
- `pnpm exec vitest run test/core/retrieval/query/search-cache.test.ts test/core/runtime/gc/gc.test.ts test/core/storage/schema-upgrade/index.test.ts --passWithNoTests`
- `pnpm typecheck`
- `pnpm lint:fix`
- `pnpm test:run`
- `pnpm build`
- `pnpm typecheck && pnpm format:check`

## Manual smoke

All smoke commands used the source checkout via `pnpm --silent --filter wiki-graph dev ...`:

- `maintenance upgrade --help` returns the maintenance upgrade help successfully.
- Created a temporary `.wikg`, added two chapters, verified `wikg://.../chapter/1/source --json` fails with `Invalid chapter URI: numeric chapter ids are internal and are not accepted.`
- Verified `wikg://.../chapter/tree apply --dry-run --input tree.json` succeeds and reports `Dry run: chapter tree not changed.`
- Rebuilt archive index and ran `wikg://.../chapter --query Alpha --limit 5 --json`, verifying search-cache tables are initialized and query succeeds.
- Created a named library with two tiny copied archives, ran `<named-lib>/index enable --jsonl` through `succeeded` without OOM/abort.
- Verified named library `remove --json` now fails with `Missing --confirm`, and `remove --confirm --json` succeeds.
