### PR TITLE
fix: recreate shared state after stale init markers

### DIFF
--- a/packages/core/src/document/shared-state-database.ts
+++ b/packages/core/src/document/shared-state-database.ts
@@ -238,7 +238,7 @@ async function hasInitMarker(
   markerPath: string,
   schemaHash: string,
 ): Promise<boolean> {
-  if (!(await pathExists(databasePath))) {
+  if (!(await pathIsRegularFile(databasePath))) {
     return false;
   }
 
@@ -257,10 +257,9 @@ function createInitMarkerPath(databasePath: string): string {
   return `${databasePath}.initialized`;
 }
 
-async function pathExists(path: string): Promise<boolean> {
+async function pathIsRegularFile(path: string): Promise<boolean> {
   try {
-    await stat(path);
-    return true;
+    return (await stat(path)).isFile();
   } catch (error) {
     if (isNodeError(error) && error.code === "ENOENT") {
       return false;

--- a/packages/core/src/document/shared-state-database.ts
+++ b/packages/core/src/document/shared-state-database.ts
@@ -57,7 +57,7 @@ export async function ensureSharedStateDatabaseInitialized(
   const markerPath = createInitMarkerPath(resolvedDatabasePath);
   const schemaHash = hashSchema(schemaSql);
 
-  if (await hasInitMarker(markerPath, schemaHash)) {
+  if (await hasInitMarker(resolvedDatabasePath, markerPath, schemaHash)) {
     await hardenSharedStateFile(resolvedDatabasePath);
     await hardenSharedStateFile(markerPath);
     return;
@@ -65,7 +65,7 @@ export async function ensureSharedStateDatabaseInitialized(
 
   await mkdir(dirname(resolvedDatabasePath), { recursive: true });
   await withInitLock(resolvedDatabasePath, async () => {
-    if (await hasInitMarker(markerPath, schemaHash)) {
+    if (await hasInitMarker(resolvedDatabasePath, markerPath, schemaHash)) {
       await hardenSharedStateFile(resolvedDatabasePath);
       await hardenSharedStateFile(markerPath);
       return;
@@ -234,9 +234,14 @@ function isProcessAlive(pid: number): boolean {
 }
 
 async function hasInitMarker(
+  databasePath: string,
   markerPath: string,
   schemaHash: string,
 ): Promise<boolean> {
+  if (!(await pathExists(databasePath))) {
+    return false;
+  }
+
   try {
     return (await readFile(markerPath, "utf8")).trim() === schemaHash;
   } catch (error) {
@@ -250,6 +255,19 @@ async function hasInitMarker(
 
 function createInitMarkerPath(databasePath: string): string {
   return `${databasePath}.initialized`;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return false;
+    }
+
+    throw error;
+  }
 }
 
 async function hardenSharedStateFile(path: string): Promise<void> {

--- a/test/core/retrieval/query/search-cache.test.ts
+++ b/test/core/retrieval/query/search-cache.test.ts
@@ -1,4 +1,5 @@
 import { join } from "path";
+import { rm } from "fs/promises";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -135,7 +136,40 @@ describe("archive/query/search-cache", () => {
       await expect(listPredicates(path)).resolves.toStrictEqual(["mentions"]);
     });
   });
+
+  it("recreates the search session database when only the init marker remains", async () => {
+    await withTempDir("wikigraph-search-cache-marker-", async (path) => {
+      setWikiGraphStateDirectoryPathForTesting(path);
+
+      await createEmptySession("archive-a", "query-a");
+      await rm(join(path, "cache", "search-sessions.sqlite"));
+
+      await createEmptySession("archive-b", "query-b");
+
+      await expect(listTableNamesAt(path)).resolves.toEqual(
+        expect.arrayContaining(["search_sessions", "search_results"]),
+      );
+    });
+  });
 });
+
+async function createEmptySession(
+  archiveKey: string,
+  query: string,
+): Promise<void> {
+  await createSearchSession({
+    archiveKey,
+    chapters: null,
+    items: [],
+    lens: "broad",
+    match: "any",
+    order: "rank",
+    query,
+    revisionScope: JSON.stringify({ chaptersRevision: 0, scope: "all" }),
+    terms: [query],
+    types: null,
+  });
+}
 
 async function listIndexNames(database: Database): Promise<string[]> {
   return await database.queryAll(
@@ -162,6 +196,20 @@ async function listTableNames(database: Database): Promise<string[]> {
     undefined,
     (row) => String(row.name),
   );
+}
+
+async function listTableNamesAt(path: string): Promise<string[]> {
+  const database = await Database.open(
+    join(path, "cache", "search-sessions.sqlite"),
+    "",
+    { readonly: true },
+  );
+
+  try {
+    return await listTableNames(database);
+  } finally {
+    await database.close();
+  }
 }
 
 async function listPredicates(path: string): Promise<string[]> {


### PR DESCRIPTION
## Summary
- Fixes the shared state database init-marker contract so a matching `.initialized` marker is only trusted when the SQLite database file still exists.
- Covers the #53 search cache/cursor missing-table regression by recreating derived shared databases after schema/home/archive cleanup leaves stale markers behind.
- Adds a regression test for `search-sessions.sqlite` being deleted while its init marker remains.

## Context
- Regression source: oomol/wiki-graph-private#53.
- The affected paths include archive object query/list/index, library query/list cursor creation, and `gc search-cache`; they all use `openSharedStateDatabase` for derived state (`search-sessions.sqlite`, `continuation-cursors.sqlite`, `gc.sqlite`, etc.).

## Fixed
- P0 search cache missing `search_sessions`: fixed at the shared database bootstrap boundary.
- P0 continuation cursor missing `continuation_cursors`: covered by the same shared bootstrap boundary.
- P0 `gc search-cache` missing `search_sessions`: fixed by forcing schema initialization when the DB file has been removed.
- P1 `chapter/tree apply --dry-run` being dragged to exit 1 by missing search cache tables: covered by the same bootstrap fix.

## Not changed / follow-up
- `wikg://lib/<archive-id>/ --json` explicit-action behavior is left as the current parser contract; this PR does not change library archive root semantics.
- `wikg://lib --query ...` support semantics are left unchanged; unsupported/missing-index behavior is still reported by existing library query paths.
- Pre-index chapter query and broader Step 10 fixture/evidence gaps from #53 remain follow-up regression coverage work, not part of this minimal product fix.

## Verification
- `pnpm install`
- `pnpm lint:fix`
- `pnpm vitest run test/core/retrieval/query/search-cache.test.ts test/core/storage/schema-upgrade/index.test.ts test/core/runtime/gc/gc.test.ts test/cli/archive/query.test.ts test/cli/library.test.ts`
- `pnpm typecheck`
- `pnpm test:run` (812 tests / 128 files passed)
- `pnpm build`
- `pnpm format:check`

## Manual smoke
- Removed `.wikigraph/state/cache/search-sessions.sqlite` and `.wikigraph/state/cache/continuation-cursors.sqlite` while leaving init markers, then verified these commands no longer report `no such table`:
  - `pnpm --filter wiki-graph dev gc --json`
  - `pnpm --filter wiki-graph dev wikg://lib/entity --limit 1 --json`
  - `pnpm --filter wiki-graph dev wikg://lib/entity --query 曹操 --limit 5 --json`
- Created `.wikigraph/out/smoke.wikg`, removed the same derived SQLite files, then verified these commands no longer report `no such table`:
  - `pnpm --filter wiki-graph dev "$MING_URI/index" enable --jsonl`
  - `pnpm --filter wiki-graph dev "$MING_URI/chapter" --limit 5 --json`
  - `pnpm --filter wiki-graph dev "$MING_URI/chunk" --query 朱重八 --limit 5 --json`
