### PR TITLE
fix: stream library index rebuilds

### DIFF
--- a/packages/cli/src/args/uri/library.ts
+++ b/packages/cli/src/args/uri/library.ts
@@ -22,7 +22,7 @@ import {
 } from "../helpers.js";
 import { parseArchiveArguments } from "../archive.js";
 
-const LIBRARY_ARCHIVE_ACTIONS = new Set(["move", "remove"]);
+const LIBRARY_ARCHIVE_ACTIONS = new Set(["get", "move", "remove"]);
 const LIBRARY_METADATA_ACTIONS = new Set([
   "clear",
   "delete",
@@ -73,24 +73,17 @@ export function parseLibraryUriFirstArguments(
     };
   }
 
-  if (target.kind === "archive" && explicitAction === undefined) {
-    throw new Error(
-      withHelpRoute(
-        `The library archive ${uri} requires an explicit action: move or remove.`,
-        formatWikiGraphHelpCommand(uri),
-      ),
-    );
-  }
-
   const action =
     explicitAction ??
     (target.kind === "scope" &&
-    target.objectUri !== undefined &&
-    target.objectUri !== "wikg://index"
+    ((target.objectUri !== undefined && target.objectUri !== "wikg://index") ||
+      values.query !== undefined)
       ? resolveImplicitLibraryQueryAction(target.objectUri, values.query)
       : target.kind === "metadata" || target.objectUri === "wikg://index"
         ? "get"
-        : "list");
+        : target.kind === "archive"
+          ? "get"
+          : "list");
 
   if (target.kind === "scope" && target.objectUri === "wikg://index") {
     return parseLibraryIndexArguments(
@@ -102,7 +95,10 @@ export function parseLibraryUriFirstArguments(
     );
   }
 
-  if (target.kind === "scope" && target.objectUri !== undefined) {
+  if (
+    target.kind === "scope" &&
+    (target.objectUri !== undefined || action === "search")
+  ) {
     return parseLibraryQueryArguments(
       uri,
       target,
@@ -174,13 +170,18 @@ function parseLibraryQueryArguments(
       ),
     );
   }
-  if (target.objectUri === undefined) {
+  if (target.objectUri === undefined && action !== "search") {
     throw new Error("Internal error: missing library query object URI.");
   }
 
   const parsed = parseArchiveArguments(
     action as "evidence" | "get" | "list" | "pack" | "related" | "search",
-    [formatTemporaryLocatedLibraryQueryUri(target.objectUri), ...tail],
+    [
+      target.objectUri === undefined
+        ? "wikg://__library_index__.wikg"
+        : formatTemporaryLocatedLibraryQueryUri(target.objectUri),
+      ...tail,
+    ],
     values,
     formatWikiGraphHelpCommand(uri, action),
     {
@@ -230,8 +231,11 @@ function formatTemporaryLocatedLibraryQueryUri(objectUri: string): string {
 }
 
 function getLibraryQueryDefaultKinds(
-  objectUri: string,
+  objectUri: string | undefined,
 ): readonly CLIObjectKind[] | undefined {
+  if (objectUri === undefined) {
+    return undefined;
+  }
   const path = stripObjectUriPrefix(objectUri);
   const [head] = path.split("/");
 
@@ -254,9 +258,12 @@ function getLibraryQueryDefaultKinds(
 }
 
 function resolveImplicitLibraryQueryAction(
-  objectUri: string,
+  objectUri: string | undefined,
   query: string | undefined,
 ): "get" | "list" | "search" {
+  if (objectUri === undefined) {
+    return query === undefined ? "list" : "search";
+  }
   const path = stripObjectUriPrefix(objectUri);
   if (/^(?:chapter|chunk|entity|source|summary|triple)$/u.test(path)) {
     return query === undefined ? "list" : "search";
@@ -341,6 +348,16 @@ function parseLibraryArchiveArguments(
   rejectArchiveFlag(action, "--json-input", values["json-input"], helpRoute);
   rejectArchiveBooleanFlag(action, "--jsonl", values.jsonl, helpRoute);
   rejectExtraPositionals(action, tail, 0, helpRoute);
+
+  if (action === "get") {
+    rejectArchiveFlag(action, "--to", values.to, helpRoute);
+    rejectArchiveBooleanFlag(action, "--confirm", values.confirm, helpRoute);
+    return {
+      args: { action, json: values.json, target },
+      help: false,
+      kind: "library",
+    };
+  }
 
   if (action === "remove") {
     if (values.confirm !== true) {

--- a/packages/cli/src/commands/archive-command/index.ts
+++ b/packages/cli/src/commands/archive-command/index.ts
@@ -57,8 +57,8 @@ export async function runArchiveCommand(
   const libraryTarget = parseWikiGraphLibraryUri(args.archivePath);
   if (
     libraryTarget?.kind === "scope" &&
-    libraryTarget.objectUri !== undefined &&
-    libraryTarget.objectUri !== "wikg://index"
+    libraryTarget.objectUri !== "wikg://index" &&
+    (libraryTarget.objectUri !== undefined || args.action === "search")
   ) {
     await runLibraryIndexArchiveCommand(args, libraryTarget);
     return;
@@ -327,7 +327,10 @@ async function runLibraryIndexArchiveCommand(
   target: NonNullable<ReturnType<typeof parseWikiGraphLibraryUri>>,
 ): Promise<void> {
   const library = await resolveWikiGraphLibrary(target);
-  const objectUri = getObjectUri(args.objectId ?? args.archivePath);
+  const objectUri =
+    target.objectUri === undefined && args.objectId === undefined
+      ? "wikg://"
+      : getObjectUri(args.objectId ?? args.archivePath);
   const context = {
     ...createArchiveOutputContext(args),
     archiveKey: args.archivePath,

--- a/packages/core/src/library/search-index.ts
+++ b/packages/core/src/library/search-index.ts
@@ -9,11 +9,10 @@ import { openSharedStateDatabase } from "../document/index.js";
 import { WikiGraphArchiveFile } from "../storage/wikg/index.js";
 import { buildArchiveIndexProjection } from "../retrieval/query/archive-view/index-state.js";
 import {
-  createSearchIndexFingerprint,
-  ensureSearchIndex,
   markDirtySearchIndexChapters,
   readSearchIndexFingerprintFromDatabase,
   readSearchIndexStatus,
+  replaceSearchIndex,
   SEARCH_OBJECT_PROPERTY_KIND,
   SEARCH_OBJECT_PROPERTY_OWNER_KIND,
   type SearchIndexInput,
@@ -141,18 +140,20 @@ export async function rebuildWikiGraphLibraryIndex(
     const present = archives.filter(
       (archive) => archive.exists && archive.status === "present",
     );
-    const projection = await buildLibraryIndexProjection(present, progress);
     const document = new LibraryIndexDocument(library);
     const sourceFingerprint = createLibraryIndexSourceFingerprint(sources);
+    const indexFingerprint =
+      createLibraryIndexSearchFingerprint(sourceFingerprint);
 
-    await ensureSearchIndex(document as never, projection, progress);
+    await replaceSearchIndex(
+      document as never,
+      streamLibraryIndexProjection(present, progress),
+      indexFingerprint,
+      progress,
+    );
     await document.writeSearchIndexDatabase(async (database) => {
       await setStateValue(database, "sourceFingerprint", sourceFingerprint);
-      await setStateValue(
-        database,
-        "libraryFingerprint",
-        createSearchIndexFingerprint(projection),
-      );
+      await setStateValue(database, "libraryFingerprint", indexFingerprint);
     });
 
     return await readWikiGraphLibraryIndexState(target);
@@ -436,31 +437,27 @@ export async function runLibraryIndexGc(
   return { freedBytes, removed, scanned };
 }
 
-async function buildLibraryIndexProjection(
+async function* streamLibraryIndexProjection(
   archives: readonly WikiGraphLibraryArchiveRecord[],
   progress?: SearchIndexProgressReporter,
-): Promise<SearchIndexInput> {
-  const objectProperties: SearchIndexInput["objectProperties"][number][] = [];
-  const textSentences: SearchIndexInput["textSentences"][number][] = [];
+): AsyncIterable<SearchIndexInput> {
   let done = 0;
 
   for (const archive of archives) {
-    await new WikiGraphArchiveFile(archive.path).readDocument(
+    yield await new WikiGraphArchiveFile(archive.path).readDocument(
       async (document) => {
         const projection = await buildArchiveIndexProjection(document);
 
-        objectProperties.push(
-          ...projection.objectProperties.map((record) => ({
+        return {
+          objectProperties: projection.objectProperties.map((record) => ({
             ...record,
             archiveId: archive.id,
           })),
-        );
-        textSentences.push(
-          ...projection.textSentences.map((record) => ({
+          textSentences: projection.textSentences.map((record) => ({
             ...record,
             archiveId: archive.id,
           })),
-        );
+        };
       },
     );
     done += 1;
@@ -471,8 +468,16 @@ async function buildLibraryIndexProjection(
       unit: "chapter",
     });
   }
+}
 
-  return { objectProperties, textSentences };
+function createLibraryIndexSearchFingerprint(
+  sourceFingerprint: string,
+): string {
+  return createHash("sha256")
+    .update("library-index")
+    .update("\0")
+    .update(sourceFingerprint)
+    .digest("hex");
 }
 
 function formatLibraryHitSource(

--- a/packages/core/src/retrieval/search-index/index.ts
+++ b/packages/core/src/retrieval/search-index/index.ts
@@ -7,6 +7,7 @@ export {
   readArchiveIndexSettings,
   readSearchIndexFingerprintFromDatabase,
   readSearchIndexStatus,
+  replaceSearchIndex,
   SEARCH_INDEX_FTS_HIT_LIMIT,
   SEARCH_OBJECT_PROPERTY_KIND,
   SEARCH_OBJECT_PROPERTY_OWNER_KIND,

--- a/packages/core/src/retrieval/search-index/search/build.ts
+++ b/packages/core/src/retrieval/search-index/search/build.ts
@@ -13,6 +13,7 @@ import type { SearchIndexInput, SearchIndexProgressReporter } from "./types.js";
 import { SEARCH_INDEX_VERSION } from "./types.js";
 
 export type ArchiveIndexProjection = SearchIndexInput;
+export type SearchIndexWriteBatch = SearchIndexInput;
 
 export async function writeArchiveIndexProjection(
   document: Document,
@@ -80,6 +81,88 @@ export async function ensureSearchIndex(
           total: input.objectProperties.length,
           unit: "object",
         });
+      }
+
+      await progress?.({ phase: "finalizing" });
+      await database.run(
+        `
+          INSERT INTO search_index_state(key, value)
+          VALUES ('version', ?)
+        `,
+        [SEARCH_INDEX_VERSION],
+      );
+      await database.run(
+        `
+          INSERT INTO search_index_state(key, value)
+          VALUES ('fingerprint', ?)
+        `,
+        [fingerprint],
+      );
+      await database.run(
+        `
+          INSERT INTO search_index_state(key, value)
+          VALUES ('chaptersRevision', ?)
+        `,
+        [String(chaptersRevision)],
+      );
+    });
+  });
+}
+
+export async function replaceSearchIndex(
+  document: Document,
+  batches: AsyncIterable<SearchIndexWriteBatch>,
+  fingerprint: string,
+  progress?: SearchIndexProgressReporter,
+): Promise<void> {
+  const chaptersRevision = await document.serials.getChaptersRevision();
+
+  await document.writeSearchIndexDatabase(async (database) => {
+    await database.transaction(async () => {
+      await progress?.({ phase: "clearing" });
+      await database.run("DELETE FROM text_sentence_fts");
+      await database.run("DELETE FROM search_object_properties_fts");
+      await database.run("DELETE FROM text_sentence_records");
+      await database.run("DELETE FROM search_object_properties_records");
+      await database.run("DELETE FROM index_dirty_chapters");
+      await database.run("DELETE FROM search_index_state");
+
+      let textDone = 0;
+      let objectDone = 0;
+      for await (const batch of batches) {
+        for (const record of batch.textSentences) {
+          const plan = createSearchTokenPlan(record.text);
+          const rowId = await insertTextSentenceRecord(database, record);
+
+          await insertFtsRecord(database, "text_sentence_fts", rowId, plan);
+          textDone += 1;
+          await progress?.({
+            done: textDone,
+            phase: "indexing-text",
+            unit: "sentence",
+          });
+        }
+
+        for (const record of batch.objectProperties) {
+          const plan = createSearchTokenPlan(record.text);
+          const rowId = await insertSearchObjectPropertyRecord(
+            database,
+            record,
+          );
+
+          await insertFtsRecord(
+            database,
+            "search_object_properties_fts",
+            rowId,
+            plan,
+          );
+          objectDone += 1;
+          await progress?.({
+            done: objectDone,
+            phase: "indexing-objects",
+            unit: "object",
+          });
+        }
       }
 
       await progress?.({ phase: "finalizing" });

--- a/test/cli/library.test.ts
+++ b/test/cli/library.test.ts
@@ -114,6 +114,20 @@ describe("cli/library args", () => {
 
   it("parses library archive member commands and rejects unsupported inspect", () => {
     expect(
+      parseCLIArguments(["wikg://lib/archive123", "--json"]),
+    ).toMatchObject({
+      args: {
+        action: "get",
+        json: true,
+        target: {
+          archivePublicId: "archive123",
+          isDefault: true,
+          kind: "archive",
+        },
+      },
+      kind: "library",
+    });
+    expect(
       parseCLIArguments(["wikg://lib/archive123", "remove", "--confirm"]),
     ).toMatchObject({
       args: {
@@ -145,9 +159,6 @@ describe("cli/library args", () => {
     expect(() =>
       parseCLIArguments(["wikg://lib/archive123", "remove"]),
     ).toThrow("Missing --confirm");
-    expect(() => parseCLIArguments(["wikg://lib/archive123"])).toThrow(
-      "requires an explicit action: move or remove",
-    );
     expect(() => parseCLIArguments(["wikg://lib/meta", "move"])).toThrow(
       "does not support `move`",
     );
@@ -183,6 +194,28 @@ describe("cli/library args", () => {
       args: {
         action: "list",
         archivePath: expect.stringContaining("lib/book.wikg") as string,
+      },
+      kind: "archive",
+    });
+  });
+
+  it("routes library root query through archive search arguments", () => {
+    expect(
+      parseCLIArguments([
+        "wikg://lib",
+        "--query",
+        "曹操",
+        "--limit",
+        "5",
+        "--json",
+      ]),
+    ).toMatchObject({
+      args: {
+        action: "search",
+        archivePath: "wikg://lib",
+        format: "json",
+        limit: 5,
+        query: "曹操",
       },
       kind: "archive",
     });


### PR DESCRIPTION
## Summary

Fixes the remaining regressions tracked by `oomol/wiki-graph-private#54`:

- stream default/named library index rebuilds archive-by-archive instead of accumulating every archive projection in memory before writing the FTS index;
- keep dirty library rebuilds recoverable by always replacing the index contents and clearing dirty markers during `wikg://lib/index enable`;
- make library archive root locators readable as membership records, e.g. `wikg://lib/<archive-id>/ --json`;
- route `wikg://lib --query ...` through the library index search path instead of rejecting it as a list command flag.

## Notes / follow-up

- This PR does not change the explicit index contract for pre-index archive/library queries: query still requires the relevant index to be enabled.
- The broader #51 follow-ups remain separate: stable clean-state `next <cursor>` coverage, multi-archive evidence fixtures, `.sdpub`/future schema/home stale memo/locked staging fixtures.

## Verification

Automated:

- `pnpm install`
- `pnpm lint:fix`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:run test/cli/library.test.ts packages/cli/src/args/archive-index.test.ts`
- `pnpm test:run` — 128 files / 813 tests passed
- `pnpm build`

Manual CLI smoke, using only `pnpm --filter wiki-graph dev` and temporary `.wikigraph/out` archives generated from repo fixtures:

- `pnpm --filter wiki-graph dev wikg://lib/c8290e46e13d/ --json` returned the library membership record for the archive root locator.
- `pnpm --filter wiki-graph dev wikg://lib --query Dawn --limit 5 --json` returned library search results across indexed archives.
- After mutating a library archive through `wikg://lib/c8290e46e13d/chapter/dawn-brief/title set ...`, `wikg://lib/entity --limit 1 --json` rejected the dirty index as expected, then `pnpm --filter wiki-graph dev wikg://lib/index enable --jsonl` completed with `status: current` and no OOM/abort, and the root query worked again.
