### PR TITLE
fix: align library help routing

### DIFF
--- a/packages/cli/src/args/archive-index.test.ts
+++ b/packages/cli/src/args/archive-index.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { parseCLIArguments } from "./index.js";
-import { renderUriPredicateHelpText } from "./help.js";
+import {
+  renderLibraryPredicateHelpText,
+  renderLibraryUriHelpText,
+  renderUriHelpText,
+  renderUriPredicateHelpText,
+} from "./help.js";
 
 describe("cli/args/archive index", () => {
   it("parses archive index object commands", () => {
@@ -114,6 +119,45 @@ describe("cli/args/archive index", () => {
       help: false,
       kind: "library",
     });
+    expect(parseCLIArguments(["wikg://lib/index", "--help"])).toStrictEqual({
+      help: true,
+      helpText: renderLibraryUriHelpText("wikg://lib/index", {
+        isDefault: true,
+        kind: "scope",
+        objectUri: "wikg://index",
+      }),
+      kind: "help",
+    });
+    expect(
+      parseCLIArguments(["wikg://lib/index", "enable", "--help"]),
+    ).toStrictEqual({
+      help: true,
+      helpText: renderLibraryPredicateHelpText(
+        "wikg://lib/index",
+        {
+          isDefault: true,
+          kind: "scope",
+          objectUri: "wikg://index",
+        },
+        "enable",
+      ),
+      kind: "help",
+    });
+    expect(
+      parseCLIArguments(["wikg://lib/index", "disable", "--help"]),
+    ).toStrictEqual({
+      help: true,
+      helpText: renderLibraryPredicateHelpText(
+        "wikg://lib/index",
+        {
+          isDefault: true,
+          kind: "scope",
+          objectUri: "wikg://index",
+        },
+        "disable",
+      ),
+      kind: "help",
+    });
     expect(() =>
       parseCLIArguments(["wikg://lib/index", "enable", "--json"]),
     ).toThrow("Use --jsonl for line-delimited progress output.");
@@ -136,6 +180,63 @@ describe("cli/args/archive index", () => {
     ).toThrow(
       "The library index wikg://lib/team.lib/index does not support `external`.\nSee: wg wikg://lib/team.lib/index external --help",
     );
+  });
+
+  it("renders library v1 management help without routing to execution", () => {
+    expect(parseCLIArguments(["wikg://lib", "scan", "--help"])).toStrictEqual({
+      help: true,
+      helpText: renderLibraryPredicateHelpText(
+        "wikg://lib",
+        { isDefault: true, kind: "scope" },
+        "scan",
+      ),
+      kind: "help",
+    });
+    expect(parseCLIArguments(["wikg://lib", "add", "--help"])).toStrictEqual({
+      help: true,
+      helpText: renderLibraryPredicateHelpText(
+        "wikg://lib",
+        { isDefault: true, kind: "scope" },
+        "add",
+      ),
+      kind: "help",
+    });
+    expect(
+      parseCLIArguments(["wikg://lib/archive123", "remove", "--help"]),
+    ).toStrictEqual({
+      help: true,
+      helpText: renderLibraryPredicateHelpText(
+        "wikg://lib/archive123",
+        {
+          archivePublicId: "archive123",
+          isDefault: true,
+          kind: "archive",
+        },
+        "remove",
+      ),
+      kind: "help",
+    });
+  });
+
+  it("renders library-wide object help through URI help templates", () => {
+    expect(
+      parseCLIArguments(["wikg://lib/entity/Q23", "--help"]),
+    ).toStrictEqual({
+      help: true,
+      helpText: renderUriHelpText("entity-object", "wikg://lib/entity/Q23"),
+      kind: "help",
+    });
+    expect(
+      parseCLIArguments(["wikg://lib/entity/Q23", "evidence", "--help"]),
+    ).toStrictEqual({
+      help: true,
+      helpText: renderUriPredicateHelpText(
+        "entity-object",
+        "evidence",
+        "wikg://lib/entity/Q23",
+      ),
+      kind: "help",
+    });
   });
 
   it("parses library rebind only on library scope URIs", () => {

--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -449,6 +449,8 @@ describe("cli/args/help", () => {
 
     expect(scopeHelpText).toContain("Library scope");
     expect(scopeHelpText).toContain("wg wikg://lib create --path <folder>");
+    expect(scopeHelpText).toContain("wg wikg://lib scan [--json]");
+    expect(scopeHelpText).toContain("wg wikg://lib/index [--json]");
     expect(scopeHelpText).toContain(".lib` suffix");
     expect(metadataHelpText).toContain("Library metadata object");
     expect(metadataHelpText).toContain("Metadata keys are free-form");
@@ -460,7 +462,14 @@ describe("cli/args/help", () => {
         { isDefault: true, kind: "scope" },
         "list",
       ),
-    ).toContain("Enumerate objects in this library scope");
+    ).toContain("List archive memberships in this library scope");
+    expect(
+      renderLibraryUriHelpText("wikg://lib/index", {
+        isDefault: true,
+        kind: "scope",
+        objectUri: "wikg://index",
+      }),
+    ).toContain("Library index object");
     expect(
       renderLibraryPredicateHelpText(
         "wikg://lib/meta",

--- a/packages/cli/src/args/help.ts
+++ b/packages/cli/src/args/help.ts
@@ -75,6 +75,8 @@ export type UriHelpPredicateName =
   | "test"
   | "watch";
 
+export type LibraryHelpPredicateName = CLILibraryAction | "disable" | "enable";
+
 interface UriHelpTarget {
   readonly name: UriHelpTargetName;
   readonly predicates: readonly UriHelpPredicateName[];
@@ -288,7 +290,7 @@ export function renderLibraryUriHelpText(
 export function renderLibraryPredicateHelpText(
   uri: string,
   target: ParsedWikiGraphLibraryUri,
-  predicate: CLILibraryAction,
+  predicate: LibraryHelpPredicateName,
 ): string {
   return renderHelpTemplate("help/commands/library-predicate", {
     predicate,

--- a/packages/cli/src/args/uri/library.ts
+++ b/packages/cli/src/args/uri/library.ts
@@ -7,6 +7,10 @@ import { withHelpRoute } from "../../support/index.js";
 import {
   renderLibraryPredicateHelpText,
   renderLibraryUriHelpText,
+  renderUriHelpText,
+  renderUriPredicateHelpText,
+  isUriHelpPredicate,
+  type UriHelpTargetName,
 } from "../help.js";
 import type {
   ArchiveArgumentValues,
@@ -21,6 +25,8 @@ import {
   stripObjectUriPrefix,
 } from "../helpers.js";
 import { parseArchiveArguments } from "../archive.js";
+import { parseChapterTarget } from "./chapter/target.js";
+import { isTripleScopePath } from "./triple-pattern.js";
 
 const LIBRARY_ARCHIVE_ACTIONS = new Set(["get", "move", "remove"]);
 const LIBRARY_METADATA_ACTIONS = new Set([
@@ -65,14 +71,6 @@ export function parseLibraryUriFirstArguments(
     throw new Error(`Expected a Wiki Graph library URI: ${uri}`);
   }
 
-  if (values.help === true && explicitAction === undefined) {
-    return {
-      help: true,
-      helpText: renderLibraryUriHelpText(uri, target),
-      kind: "help",
-    };
-  }
-
   const action =
     explicitAction ??
     (target.kind === "scope" &&
@@ -84,6 +82,10 @@ export function parseLibraryUriFirstArguments(
         : target.kind === "archive"
           ? "get"
           : "list");
+
+  if (values.help === true) {
+    return parseLibraryHelpArguments(uri, target, action, explicitAction);
+  }
 
   if (target.kind === "scope" && target.objectUri === "wikg://index") {
     return parseLibraryIndexArguments(
@@ -118,14 +120,6 @@ export function parseLibraryUriFirstArguments(
   }
   validateLibraryActionForTarget(uri, target, action);
 
-  if (values.help === true) {
-    return {
-      help: true,
-      helpText: renderLibraryPredicateHelpText(uri, target, action),
-      kind: "help",
-    };
-  }
-
   if (target.kind === "archive") {
     return parseLibraryArchiveArguments(
       uri,
@@ -153,6 +147,150 @@ export function parseLibraryUriFirstArguments(
     explicitAction === undefined ? [] : positionals.slice(2),
     values,
   );
+}
+
+function parseLibraryHelpArguments(
+  uri: string,
+  target: ParsedWikiGraphLibraryUri,
+  action: string,
+  explicitAction: string | undefined,
+): ParsedCLIArguments {
+  if (target.kind === "scope" && target.objectUri === "wikg://index") {
+    if (explicitAction === undefined) {
+      return {
+        help: true,
+        helpText: renderLibraryUriHelpText(uri, target),
+        kind: "help",
+      };
+    }
+    if (!LIBRARY_INDEX_ACTIONS.has(action)) {
+      throw new Error(
+        withHelpRoute(
+          `The library index ${uri} does not support \`${action}\`.`,
+          formatWikiGraphHelpCommand(uri),
+        ),
+      );
+    }
+    return {
+      help: true,
+      helpText: renderLibraryPredicateHelpText(
+        uri,
+        target,
+        action as CLILibraryAction,
+      ),
+      kind: "help",
+    };
+  }
+
+  if (target.kind === "scope" && target.objectUri !== undefined) {
+    const helpTarget = classifyLibraryObjectHelpTarget(target.objectUri);
+    if (explicitAction === undefined) {
+      return {
+        help: true,
+        helpText: renderUriHelpText(helpTarget, uri),
+        kind: "help",
+      };
+    }
+    if (!isUriHelpPredicate(helpTarget, action)) {
+      throw new Error(
+        withHelpRoute(
+          `The library URI target ${uri} does not support \`${action}\`.`,
+          formatWikiGraphHelpCommand(uri),
+        ),
+      );
+    }
+    return {
+      help: true,
+      helpText: renderUriPredicateHelpText(helpTarget, action, uri),
+      kind: "help",
+    };
+  }
+
+  if (!isLibraryAction(action)) {
+    throw new Error(
+      withHelpRoute(
+        `The library URI target ${uri} does not support \`${action}\`.`,
+        formatWikiGraphHelpCommand(uri),
+      ),
+    );
+  }
+  validateLibraryActionForTarget(uri, target, action);
+  return {
+    help: true,
+    helpText:
+      explicitAction === undefined
+        ? renderLibraryUriHelpText(uri, target)
+        : renderLibraryPredicateHelpText(uri, target, action),
+    kind: "help",
+  };
+}
+
+function classifyLibraryObjectHelpTarget(objectUri: string): UriHelpTargetName {
+  const path = stripObjectUriPrefix(objectUri);
+  const chapterTarget = parseChapterTarget(objectUri);
+  if (chapterTarget !== undefined) {
+    switch (chapterTarget.kind) {
+      case "collection":
+        return "chapter-collection-scope";
+      case "chapter":
+        return "chapter-scope";
+      case "tree":
+        return "chapter-tree-object";
+      case "chapter-state":
+        return "chapter-state-object";
+      case "chapter-resource":
+        switch (chapterTarget.resource) {
+          case "source":
+            return "chapter-source-object";
+          case "summary":
+            return "chapter-summary-object";
+          case "title":
+            return "chapter-title-object";
+        }
+        break;
+      case "lens":
+      case "chapter-lens":
+        switch (chapterTarget.lens) {
+          case "chunk":
+            return "chunk-scope";
+          case "entity":
+            return "entity-scope";
+          case "source":
+            return "chapter-source-object";
+          case "summary":
+            return "chapter-summary-object";
+          case "triple":
+            return "triple-scope";
+        }
+        break;
+      case "triple-pattern-lens":
+      case "chapter-triple-pattern-lens":
+        return "triple-scope";
+    }
+  }
+  if (path === "chunk") {
+    return "chunk-scope";
+  }
+  if (/^chunk\/.+$/u.test(path)) {
+    return "chunk-object";
+  }
+  if (path === "entity") {
+    return "entity-scope";
+  }
+  if (/^entity\/[^/]+\/wikipage$/u.test(path)) {
+    return "entity-wikipage-object";
+  }
+  if (/^entity\/.+$/u.test(path)) {
+    return "entity-object";
+  }
+  if (isTripleScopePath(path)) {
+    return "triple-scope";
+  }
+  if (/^triple(?:\/.*)?$/u.test(path)) {
+    return "triple-object";
+  }
+
+  return "archive-scope";
 }
 
 function parseLibraryQueryArguments(

--- a/packages/cli/src/args/uri/library.ts
+++ b/packages/cli/src/args/uri/library.ts
@@ -10,6 +10,7 @@ import {
   renderUriHelpText,
   renderUriPredicateHelpText,
   isUriHelpPredicate,
+  type LibraryHelpPredicateName,
   type UriHelpTargetName,
 } from "../help.js";
 import type {
@@ -176,7 +177,7 @@ function parseLibraryHelpArguments(
       helpText: renderLibraryPredicateHelpText(
         uri,
         target,
-        action as CLILibraryAction,
+        action as LibraryHelpPredicateName,
       ),
       kind: "help",
     };

--- a/packages/core/data/help/commands/archive/next.jinja
+++ b/packages/core/data/help/commands/archive/next.jinja
@@ -10,19 +10,22 @@ Use when:
 
 Usage:
   {{ commandName }} next <cursor> [--limit <n>] [--json|--jsonl] [--help|-h]
-  {{ commandName }} next <archive-uri> <cursor> [--limit <n>] [--json|--jsonl] [--help|-h]
+  {{ commandName }} next <uri> <cursor> [--limit <n>] [--json|--jsonl] [--help|-h]
 
 Returns:
   - The next result page for the cursor.
 
 Notes:
   - Cursors are opaque short tokens stored in local Wiki Graph state.
-  - Passing `<archive-uri>` is optional; when provided, it must match the archive stored in the cursor.
+  - A cursor stores the index scope that produced it, such as a standalone archive index or a library index.
+  - Passing `<uri>` is optional; when provided, it is used only as a safety check and must match the cursor's stored index scope.
+  - Library cursors re-check that the library index is still current before continuing.
   - Use `--limit` to override the next page size.
 
 Examples:
   {{ commandName }} next c_7Kp9x2aQ
   {{ commandName }} next wikg:///books/book.wikg c_7Kp9x2aQ
+  {{ commandName }} next wikg://lib c_7Kp9x2aQ
 
 Related help:
   - URI scopes, pagination, JSON, and JSONL result shapes:

--- a/packages/core/data/help/commands/library-predicate.jinja
+++ b/packages/core/data/help/commands/library-predicate.jinja
@@ -26,6 +26,67 @@ Notes:
 Examples:
   {{ commandName }} wikg://lib create --path ./research-library
   {{ commandName }} wikg://lib create --path ./research-library --json
+{% elif target.kind == "scope" and target.objectUri == "wikg://index" and predicate == "get" %}
+Purpose:
+  Read this library index status.
+
+Usage:
+  {{ commandName }} {{ uri }} [--json]
+
+Notes:
+  - The status tells whether the library index is current, dirty, missing, or disabled.
+  - Library-wide query and list commands require a current library index.
+  - Run `enable` when the status says the index needs to be built or rebuilt.
+{% elif target.kind == "scope" and target.objectUri == "wikg://index" and predicate == "enable" %}
+Purpose:
+  Build or rebuild this library's aggregate search index.
+
+Usage:
+  {{ commandName }} {{ uri }} enable [--jsonl]
+
+Notes:
+  - This is a full rebuild from registered present archives.
+  - Missing or unreadable library archive members are skipped and reported.
+  - Progress is emitted as text by default, or line-delimited events with `--jsonl`.
+  - `--json` is not supported for enable because progress is streamed.
+  - Library indexes are local derived state under Wiki Graph staging, not files inside the library folder.
+{% elif target.kind == "scope" and target.objectUri == "wikg://index" and predicate == "disable" %}
+Purpose:
+  Disable this library index and remove its current local materialization.
+
+Usage:
+  {{ commandName }} {{ uri }} disable [--json]
+
+Notes:
+  - This does not delete the library registry, metadata, folder, or managed `.wikg` archives.
+  - Library-wide query and list commands will fail until the index is enabled again.
+  - Library indexes do not support archive-style `embed` or `external` modes.
+{% elif target.kind == "scope" and predicate == "add" %}
+Purpose:
+  Copy a `.wikg` archive into this library folder and register it as a managed archive member.
+
+Usage:
+  {{ commandName }} {{ uri }} add --input <path> [--to <relative-wikg-path>] [--json]
+
+Notes:
+  - `--input` is a normal filesystem path, not a `wikg://` archive URI.
+  - Without `--to`, the archive is copied to the library folder using its basename.
+  - `--to` must be a relative `.wikg` path inside the library folder.
+  - Parent directories for `--to` are created as needed.
+  - Existing target files are not overwritten.
+  - Adding an archive marks the library index dirty.
+{% elif target.kind == "scope" and predicate == "scan" %}
+Purpose:
+  Reconcile this library registry with `.wikg` files currently under the library folder.
+
+Usage:
+  {{ commandName }} {{ uri }} scan [--json]
+
+Notes:
+  - Scan recursively discovers `.wikg` files in the bound library folder.
+  - Registered files that are no longer present remain visible as missing/stale instead of being deleted silently.
+  - When a moved archive can be matched by its stable mutation token, scan preserves its archive id and updates the relative path.
+  - Scan marks the library index dirty when membership changes.
 {% elif target.kind == "scope" and predicate == "rebind" %}
 Purpose:
   Bind this library to an existing directory, then scan/reconcile `.wikg` files in that directory.
@@ -45,36 +106,70 @@ Examples:
   {{ commandName }} {{ uri }} rebind --path /Volumes/Archive/wiki-library --json
 {% elif target.kind == "scope" and predicate == "get" %}
 Purpose:
-  Read a specific object in this library scope.
+  Read this library scope.
 
 Usage:
   {{ commandName }} {{ uri }} get [--json]
 
 Notes:
-  - This follows the normal URI scope contract.
-  - First-stage library support does not yet enumerate library members, so the help page is present even if the command currently returns an empty scope result.
+  - For a bare library URI, this reads the same membership listing as the default command.
+  - For concrete library-wide objects such as `{{ uri }}/entity/<qid>`, use the object URI directly or ask that URI for help.
 {% elif target.kind == "scope" and predicate == "list" %}
 Purpose:
-  Enumerate objects in this library scope.
+  List archive memberships in this library scope.
 
 Usage:
   {{ commandName }} {{ uri }} list [--json]
 
 Notes:
-  - This follows the normal URI scope contract.
-  - First-stage library support does not yet enumerate library members, so the help page is present even if the command currently returns an empty scope result.
+  - The output includes registered archive ids, relative paths, and membership status.
+  - Use `scan` when the folder contents changed outside Wiki Graph.
 {% elif target.kind == "scope" and predicate == "remove" %}
 Purpose:
   Remove this non-default library registry.
 
 Usage:
-  {{ commandName }} {{ uri }} remove [--json]
+  {{ commandName }} {{ uri }} remove --confirm [--json]
 
 Notes:
   - The default library is system-managed and cannot be removed.
-  - Removing a library deletes the core registry record and library metadata.
-  - Removing a library does not delete, inspect, scan, or clean the library folder.
-  - First-stage library support does not remove library index or archive membership because those are not created yet.
+  - Removing a library deletes its core registry record, metadata, membership records, and local derived index state.
+  - Removing a library does not delete the library folder or any `.wikg` files in it.
+  - `--confirm` is required.
+{% elif target.kind == "archive" and predicate == "get" %}
+Purpose:
+  Read this library archive membership record.
+
+Usage:
+  {{ commandName }} {{ uri }} [--json]
+
+Notes:
+  - This reads membership information, not archive content.
+  - Add archive object suffixes such as `/chapter`, `/entity`, or `/triple` to query the managed archive contents.
+{% elif target.kind == "archive" and predicate == "move" %}
+Purpose:
+  Move or rename this managed archive inside the same library folder.
+
+Usage:
+  {{ commandName }} {{ uri }} move --to <relative-wikg-path> [--json]
+
+Notes:
+  - `--to` must be a relative `.wikg` path inside the library folder.
+  - The archive public id and internal membership id stay the same.
+  - The target path must not already exist.
+  - Moving an archive marks the library index dirty.
+{% elif target.kind == "archive" and predicate == "remove" %}
+Purpose:
+  Delete this managed `.wikg` file from the library folder and unregister it.
+
+Usage:
+  {{ commandName }} {{ uri }} remove --confirm [--json]
+
+Notes:
+  - `--confirm` is required.
+  - If the registered file is already missing, the command can still clean the registry entry.
+  - This does not delete empty parent directories.
+  - Removing an archive marks the library index dirty.
 {% elif target.kind == "metadata" and predicate == "set" %}
 Purpose:
   Replace the whole library metadata map.

--- a/packages/core/data/help/commands/library.jinja
+++ b/packages/core/data/help/commands/library.jinja
@@ -29,15 +29,54 @@ Predicate commands:
   - put: write one metadata key. Help: {{ commandName }} {{ uri }} put --help
   - delete: delete one metadata key. Help: {{ commandName }} {{ uri }} delete --help
   - clear: clear the metadata map. Help: {{ commandName }} {{ uri }} clear --help
+{% elif target.kind == "archive" %}
+Library archive membership
+
+Default behavior:
+  - `{{ commandName }} {{ uri }}` reads the registry entry for this library archive member.
+  - The membership entry identifies the archive id, relative path, status, and containing library.
+  - Add archive object suffixes such as `/chapter`, `/entity`, or `/triple` when you want to query the archive contents.
+
+Use when:
+  - You need to inspect, move, or remove one archive that is already managed by a library.
+
+Usage:
+  {{ commandName }} {{ uri }} [--json]
+  {{ commandName }} {{ uri }} move --to <relative-wikg-path> [--json]
+  {{ commandName }} {{ uri }} remove --confirm [--json]
+
+Predicate commands:
+  - move: move or rename this archive inside the same library folder without changing its archive id. Help: {{ commandName }} {{ uri }} move --help
+  - remove: delete this archive file from the library folder and unregister it. Help: {{ commandName }} {{ uri }} remove --help
+{% elif target.kind == "scope" and target.objectUri == "wikg://index" %}
+Library index object
+
+Default behavior:
+  - `{{ commandName }} {{ uri }}` reads this library index status.
+  - Library index data is stored in local Wiki Graph staging state, not in the library folder.
+  - Library-wide `--query`, list, evidence, related, and pack commands require a current library index.
+
+Use when:
+  - You need to build, inspect, or drop the aggregate search index for a library.
+
+Usage:
+  {{ commandName }} {{ uri }} [--json]
+  {{ commandName }} {{ uri }} enable [--jsonl]
+  {{ commandName }} {{ uri }} disable [--json]
+
+Predicate commands:
+  - enable: rebuild this library index from registered present archives. Help: {{ commandName }} {{ uri }} enable --help
+  - disable: remove this library index materialization. Help: {{ commandName }} {{ uri }} disable --help
 {% else %}
 Library scope
 
 Default behavior:
-  - `{{ commandName }} {{ uri }}` enumerates objects in this library scope.
-  - First-stage library support does not scan the library folder, so the scope can be empty even when the folder contains `.wikg` files.
+  - `{{ commandName }} {{ uri }}` lists archive memberships registered in this library.
+  - `{{ commandName }} {{ uri }} scan` reconciles membership with `.wikg` files currently under the library folder.
+  - Library-wide object scopes such as `/entity` and `/triple` query the library index after it is enabled.
 
 Use when:
-  - You need the library entry point before future library-level archive enumeration or search.
+  - You need to manage a folder of `.wikg` archives as one library.
   - You already moved or prepared a library folder and need Wiki Graph to bind this library to that existing directory.
 {% if target.isDefault %}
   - You need to create another library registry.
@@ -54,20 +93,32 @@ Usage:
 {% if target.isDefault %}
   {{ commandName }} wikg://lib
   {{ commandName }} wikg://lib create --path <folder> [--json]
+  {{ commandName }} wikg://lib scan [--json]
+  {{ commandName }} wikg://lib add --input <path> [--to <relative-wikg-path>] [--json]
   {{ commandName }} wikg://lib rebind --path <existing-directory> [--json]
+  {{ commandName }} wikg://lib/index [--json]
+  {{ commandName }} wikg://lib/entity --query <query>
   {{ commandName }} wikg://lib/meta [--json]
 {% else %}
   {{ commandName }} {{ uri }}
+  {{ commandName }} {{ uri }} scan [--json]
+  {{ commandName }} {{ uri }} add --input <path> [--to <relative-wikg-path>] [--json]
   {{ commandName }} {{ uri }} rebind --path <existing-directory> [--json]
-  {{ commandName }} {{ uri }} remove [--json]
+  {{ commandName }} {{ uri }} remove --confirm [--json]
+  {{ commandName }} {{ uri }}/index [--json]
+  {{ commandName }} {{ uri }}/entity --query <query>
   {{ commandName }} {{ uri }}/meta [--json]
 {% endif %}
 
 Predicate commands:
 {% if target.isDefault %}
   - create: create a non-default library registry and an empty folder. Help: {{ commandName }} wikg://lib create --help
+  - scan: reconcile registered archive memberships with `.wikg` files under the library folder. Help: {{ commandName }} wikg://lib scan --help
+  - add: copy a `.wikg` file into the library folder and register it. Help: {{ commandName }} wikg://lib add --help
   - rebind: bind the default library to an existing directory, then scan/reconcile its `.wikg` files. Help: {{ commandName }} wikg://lib rebind --help
 {% else %}
+  - scan: reconcile registered archive memberships with `.wikg` files under the library folder. Help: {{ commandName }} {{ uri }} scan --help
+  - add: copy a `.wikg` file into the library folder and register it. Help: {{ commandName }} {{ uri }} add --help
   - rebind: bind this library to an existing directory, then scan/reconcile its `.wikg` files. Help: {{ commandName }} {{ uri }} rebind --help
   - remove: remove this library registry without deleting its folder. Help: {{ commandName }} {{ uri }} remove --help
 {% endif %}

--- a/packages/core/data/help/topics/runtime.jinja
+++ b/packages/core/data/help/topics/runtime.jinja
@@ -25,7 +25,7 @@ Generation job behavior:
   - Reading Graph, Reading Summary, and Knowledge Graph generation run as device-local jobs.
   - Generation jobs consume LLM tokens, may incur provider charges, and can run for minutes to hours on large archives.
   - `wikg://local/job add` requires `--accept-cost` as an explicit cost/time acknowledgement.
-  - Job records live under `~/.{{ commandName }}/jobs`.
+  - Job records live under `~/.wikigraph/jobs`.
   - `wikg://local/job add`, `wikg://local/job/<job-id> resume`, `wikg://local/job/<job-id> boost`, and `wikg://local/job/<job-id>/target set` try to start a transient worker.
   - The worker exits after idle time; it is not intended to be a permanent daemon.
   - `wikg://local/job/<job-id> watch --jsonl` is the stable agent-facing progress stream.
@@ -41,7 +41,7 @@ Progress and diagnostics:
 Workspace behavior:
   - Archive creation and EPUB import use temporary workspaces.
   - `transform --digest-dir <path>` uses the provided digest workspace for source digest runs.
-  - Generation jobs use per-job directories under `~/.{{ commandName }}/jobs/work`, `~/.{{ commandName }}/jobs/cache`, and `~/.{{ commandName }}/jobs/logs`.
+  - Generation jobs use per-job directories under `~/.wikigraph/jobs/work`, `~/.wikigraph/jobs/cache`, and `~/.wikigraph/jobs/logs`.
   - Succeeded jobs delete their workspace by default.
   - Failed and canceled jobs keep their workspace for debugging until cleanup.
   - Job events, logs, and LLM cache are kept until the job record is cleaned.
@@ -49,7 +49,7 @@ Workspace behavior:
 In-place archive edits:
   - Mutating `.wikg` commands go through the archive coordinator.
   - Active generation jobs block destructive chapter maintenance edits for the same chapter.
-  - Archive writes are coordinated through `~/.{{ commandName }}/staging`.
+  - Archive writes are coordinated through `~/.wikigraph/staging`.
 
 Where to go next:
   - Need the normal workflow before debugging:


### PR DESCRIPTION
## Summary
- prevent library index --help from executing enable/disable actions
- route library-wide object help through URI help templates instead of missing archive templates
- update library v1 help for scan/add/index/archive membership commands and fix runtime/next help text

## Verification
- pnpm run lint:fix
- pnpm exec tsc --noEmit
- pnpm test:run
- pnpm run lint

## Smoke
- pnpm --filter wiki-graph dev wikg://lib/index enable --help
- pnpm --filter wiki-graph dev wikg://lib scan --help
- pnpm --filter wiki-graph dev wikg://lib/entity/Q23 evidence --help