### PR TITLE
fix: stream library index projections

### DIFF
--- a/packages/core/src/library/query.ts
+++ b/packages/core/src/library/query.ts
@@ -46,13 +46,19 @@ import {
 } from "./search-index.js";
 
 const DEFAULT_LIBRARY_PAGE_LIMIT = 20;
+const LIBRARY_QUERY_INDEX_LIMIT_MULTIPLIER = 20;
+const LIBRARY_QUERY_INDEX_MIN_LIMIT = 100;
 
 export async function findWikiGraphLibraryObjects(
   target: ParsedWikiGraphLibraryUri,
   query: string,
   options: ArchiveFindOptions = {},
 ): Promise<ArchiveFindResult> {
-  const result = await queryWikiGraphLibrarySearchIndex(target, query);
+  const indexHitLimit = createLibraryQueryIndexHitLimit(options);
+  const result = await queryWikiGraphLibrarySearchIndex(target, query, {
+    objectHitLimit: indexHitLimit,
+    textHitLimit: indexHitLimit,
+  });
 
   if (result === undefined) {
     return createFindResult(query, [], options);
@@ -82,6 +88,14 @@ export async function findWikiGraphLibraryObjects(
   }
 
   return createFindResult(query, hits, options, result.terms);
+}
+
+function createLibraryQueryIndexHitLimit(options: ArchiveFindOptions): number {
+  return Math.max(
+    (options.limit ?? DEFAULT_LIBRARY_PAGE_LIMIT) *
+      LIBRARY_QUERY_INDEX_LIMIT_MULTIPLIER,
+    LIBRARY_QUERY_INDEX_MIN_LIMIT,
+  );
 }
 
 export async function listWikiGraphLibraryObjects(

--- a/packages/core/src/library/search-index.ts
+++ b/packages/core/src/library/search-index.ts
@@ -7,21 +7,23 @@ import { ensureWikiGraphHomeSchemaCurrent } from "../document/home-schema-upgrad
 import { SEARCH_INDEX_SCHEMA_SQL } from "../document/schema.js";
 import { openSharedStateDatabase } from "../document/index.js";
 import { WikiGraphArchiveFile } from "../storage/wikg/index.js";
-import { buildArchiveIndexProjection } from "../retrieval/query/archive-view/index-state.js";
+import { streamArchiveIndexProjection } from "../retrieval/query/archive-view/index-state.js";
 import {
   markDirtySearchIndexChapters,
+  finalizeSearchIndexReplacement,
+  prepareSearchIndexReplacement,
   readSearchIndexFingerprintFromDatabase,
   readSearchIndexStatus,
-  replaceSearchIndex,
   SEARCH_OBJECT_PROPERTY_KIND,
   SEARCH_OBJECT_PROPERTY_OWNER_KIND,
-  type SearchIndexInput,
   type SearchIndexObjectHit,
   type SearchIndexProgressReporter,
   type SearchIndexTextHit,
+  type SearchIndexWriteCounters,
   type SearchObjectPropertyKind,
   type SearchObjectPropertyOwnerKind,
   type TextSentenceKind,
+  writeSearchIndexBatch,
 } from "../retrieval/search-index/index.js";
 import { readPathSize } from "../runtime/gc/files.js";
 import type { GcContext, GcJobResult } from "../runtime/gc/index.js";
@@ -72,6 +74,11 @@ export interface WikiGraphLibraryIndexQueryResult {
 
 export interface WikiGraphLibraryIndexListOptions {
   readonly includeText?: boolean;
+}
+
+export interface WikiGraphLibraryIndexQueryOptions {
+  readonly objectHitLimit?: number;
+  readonly textHitLimit?: number;
 }
 
 export type WikiGraphLibraryIndexObjectHit = SearchIndexObjectHit & {
@@ -145,9 +152,9 @@ export async function rebuildWikiGraphLibraryIndex(
     const indexFingerprint =
       createLibraryIndexSearchFingerprint(sourceFingerprint);
 
-    await replaceSearchIndex(
-      document as never,
-      streamLibraryIndexProjection(present, progress),
+    await replaceLibrarySearchIndex(
+      document,
+      present,
       indexFingerprint,
       progress,
     );
@@ -219,6 +226,7 @@ export async function assertWikiGraphLibraryIndexReady(
 export async function queryWikiGraphLibrarySearchIndex(
   target: ParsedWikiGraphLibraryUri,
   query: string,
+  options: WikiGraphLibraryIndexQueryOptions = {},
 ): Promise<WikiGraphLibraryIndexQueryResult | undefined> {
   const library = await resolveWikiGraphLibrary(target);
 
@@ -232,6 +240,7 @@ export async function queryWikiGraphLibrarySearchIndex(
     const result = await querySearchIndex(
       new LibraryIndexDocument(library) as never,
       query,
+      options,
     );
 
     if (result === undefined) {
@@ -437,37 +446,36 @@ export async function runLibraryIndexGc(
   return { freedBytes, removed, scanned };
 }
 
-async function* streamLibraryIndexProjection(
+async function replaceLibrarySearchIndex(
+  document: LibraryIndexDocument,
   archives: readonly WikiGraphLibraryArchiveRecord[],
+  fingerprint: string,
   progress?: SearchIndexProgressReporter,
-): AsyncIterable<SearchIndexInput> {
-  let done = 0;
+): Promise<void> {
+  await document.writeSearchIndexDatabase(async (database) => {
+    await prepareSearchIndexReplacement(database, progress);
 
-  for (const archive of archives) {
-    yield await new WikiGraphArchiveFile(archive.path).readDocument(
-      async (document) => {
-        const projection = await buildArchiveIndexProjection(document);
+    let counters: SearchIndexWriteCounters = { objectDone: 0, textDone: 0 };
+    for (const archive of archives) {
+      await new WikiGraphArchiveFile(archive.path).readDocument(
+        async (archiveDocument) => {
+          for await (const batch of streamArchiveIndexProjection(
+            archiveDocument,
+            archive.id,
+          )) {
+            counters = await writeSearchIndexBatch(
+              database,
+              batch,
+              counters,
+              progress,
+            );
+          }
+        },
+      );
+    }
 
-        return {
-          objectProperties: projection.objectProperties.map((record) => ({
-            ...record,
-            archiveId: archive.id,
-          })),
-          textSentences: projection.textSentences.map((record) => ({
-            ...record,
-            archiveId: archive.id,
-          })),
-        };
-      },
-    );
-    done += 1;
-    await progress?.({
-      done,
-      phase: "collecting",
-      total: archives.length,
-      unit: "chapter",
-    });
-  }
+    await finalizeSearchIndexReplacement(database, fingerprint, 0, progress);
+  });
 }
 
 function createLibraryIndexSearchFingerprint(

--- a/packages/core/src/retrieval/query/archive-view/index-state.ts
+++ b/packages/core/src/retrieval/query/archive-view/index-state.ts
@@ -9,13 +9,14 @@ import {
   TEXT_SENTENCE_KIND,
   type SearchIndexInput,
   type SearchIndexProgressReporter,
+  type SearchIndexWriteBatch,
   writeArchiveIndexProjection,
 } from "../../search-index/search/index.js";
 
-import { createTextStreamIndex } from "./text-streams.js";
 import type { ArchiveTextStreamKind } from "./types.js";
 
 const SEARCH_INDEX_REBUILD_ATTEMPTS = 2;
+const ARCHIVE_INDEX_BATCH_RECORDS = 512;
 
 export async function rebuildArchiveSearchIndex(
   document: Document,
@@ -88,14 +89,33 @@ export async function buildArchiveIndexProjection(
 ): Promise<SearchIndexInput> {
   const objectProperties: SearchIndexInput["objectProperties"][number][] = [];
   const textSentences: SearchIndexInput["textSentences"][number][] = [];
+
+  for await (const batch of streamArchiveIndexProjection(
+    document,
+    SINGLE_ARCHIVE_INDEX_ID,
+    progress,
+  )) {
+    objectProperties.push(...batch.objectProperties);
+    textSentences.push(...batch.textSentences);
+  }
+
+  return { objectProperties, textSentences };
+}
+
+export async function* streamArchiveIndexProjection(
+  document: ReadonlyDocument,
+  archiveId: number,
+  progress?: SearchIndexProgressReporter,
+): AsyncIterable<SearchIndexWriteBatch> {
   const chapters = await listChapters(document);
   let chapterDone = 0;
+  let batch = createEmptySearchIndexBatch();
 
   for (const chapter of chapters) {
     const title = chapter.title ?? `[chapter ${chapter.chapterId}]`;
 
-    objectProperties.push({
-      archiveId: SINGLE_ARCHIVE_INDEX_ID,
+    batch = appendObjectProperty(batch, {
+      archiveId,
       chapterId: chapter.chapterId,
       ownerId: String(chapter.chapterId),
       ownerKind: SEARCH_OBJECT_PROPERTY_OWNER_KIND.chapter,
@@ -103,22 +123,74 @@ export async function buildArchiveIndexProjection(
       text: title,
     });
 
-    textSentences.push(
-      ...(await createTextStreamSearchIndexRecords(
-        document,
-        chapter.chapterId,
-        "summary",
-        title,
-      )),
-    );
-    textSentences.push(
-      ...(await createTextStreamSearchIndexRecords(
-        document,
-        chapter.chapterId,
-        "source",
-        title,
-      )),
-    );
+    for await (const record of streamTextStreamSearchIndexRecords(
+      document,
+      archiveId,
+      chapter.chapterId,
+      "summary",
+    )) {
+      batch = appendTextSentence(batch, record);
+      if (countSearchIndexBatchRecords(batch) >= ARCHIVE_INDEX_BATCH_RECORDS) {
+        yield batch;
+        batch = createEmptySearchIndexBatch();
+      }
+    }
+
+    for await (const record of streamTextStreamSearchIndexRecords(
+      document,
+      archiveId,
+      chapter.chapterId,
+      "source",
+    )) {
+      batch = appendTextSentence(batch, record);
+      if (countSearchIndexBatchRecords(batch) >= ARCHIVE_INDEX_BATCH_RECORDS) {
+        yield batch;
+        batch = createEmptySearchIndexBatch();
+      }
+    }
+
+    for (const node of await document.chunks.listBySerial(chapter.chapterId)) {
+      batch = appendObjectProperty(batch, {
+        archiveId,
+        chapterId: node.sentenceId[0],
+        ownerId: String(node.id),
+        ownerKind: SEARCH_OBJECT_PROPERTY_OWNER_KIND.chunk,
+        propertyKind: SEARCH_OBJECT_PROPERTY_KIND.label,
+        text: node.label,
+      });
+      batch = appendObjectProperty(batch, {
+        archiveId,
+        chapterId: node.sentenceId[0],
+        ownerId: String(node.id),
+        ownerKind: SEARCH_OBJECT_PROPERTY_OWNER_KIND.chunk,
+        propertyKind: SEARCH_OBJECT_PROPERTY_KIND.content,
+        text: node.content,
+      });
+
+      if (countSearchIndexBatchRecords(batch) >= ARCHIVE_INDEX_BATCH_RECORDS) {
+        yield batch;
+        batch = createEmptySearchIndexBatch();
+      }
+    }
+
+    for (const mention of await document.mentions.listByChapter(
+      chapter.chapterId,
+    )) {
+      batch = appendObjectProperty(batch, {
+        archiveId,
+        chapterId: mention.chapterId,
+        ownerId: mention.qid,
+        ownerKind: SEARCH_OBJECT_PROPERTY_OWNER_KIND.entity,
+        propertyKind: SEARCH_OBJECT_PROPERTY_KIND.surface,
+        text: mention.surface,
+      });
+
+      if (countSearchIndexBatchRecords(batch) >= ARCHIVE_INDEX_BATCH_RECORDS) {
+        yield batch;
+        batch = createEmptySearchIndexBatch();
+      }
+    }
+
     chapterDone += 1;
     await progress?.({
       done: chapterDone,
@@ -128,56 +200,67 @@ export async function buildArchiveIndexProjection(
     });
   }
 
-  for (const node of await document.chunks.listAll()) {
-    objectProperties.push({
-      archiveId: SINGLE_ARCHIVE_INDEX_ID,
-      chapterId: node.sentenceId[0],
-      ownerId: String(node.id),
-      ownerKind: SEARCH_OBJECT_PROPERTY_OWNER_KIND.chunk,
-      propertyKind: SEARCH_OBJECT_PROPERTY_KIND.label,
-      text: node.label,
-    });
-    objectProperties.push({
-      archiveId: SINGLE_ARCHIVE_INDEX_ID,
-      chapterId: node.sentenceId[0],
-      ownerId: String(node.id),
-      ownerKind: SEARCH_OBJECT_PROPERTY_OWNER_KIND.chunk,
-      propertyKind: SEARCH_OBJECT_PROPERTY_KIND.content,
-      text: node.content,
-    });
+  if (countSearchIndexBatchRecords(batch) > 0) {
+    yield batch;
   }
-
-  for (const mention of await document.mentions.listAll()) {
-    objectProperties.push({
-      archiveId: SINGLE_ARCHIVE_INDEX_ID,
-      chapterId: mention.chapterId,
-      ownerId: mention.qid,
-      ownerKind: SEARCH_OBJECT_PROPERTY_OWNER_KIND.entity,
-      propertyKind: SEARCH_OBJECT_PROPERTY_KIND.surface,
-      text: mention.surface,
-    });
-  }
-
-  return { objectProperties, textSentences };
 }
 
-async function createTextStreamSearchIndexRecords(
+function createEmptySearchIndexBatch(): SearchIndexWriteBatch {
+  return { objectProperties: [], textSentences: [] };
+}
+
+function appendTextSentence(
+  batch: SearchIndexWriteBatch,
+  record: SearchIndexWriteBatch["textSentences"][number],
+): SearchIndexWriteBatch {
+  (
+    batch.textSentences as SearchIndexWriteBatch["textSentences"][number][]
+  ).push(record);
+  return batch;
+}
+
+function appendObjectProperty(
+  batch: SearchIndexWriteBatch,
+  record: SearchIndexWriteBatch["objectProperties"][number],
+): SearchIndexWriteBatch {
+  (
+    batch.objectProperties as SearchIndexWriteBatch["objectProperties"][number][]
+  ).push(record);
+  return batch;
+}
+
+function countSearchIndexBatchRecords(batch: SearchIndexWriteBatch): number {
+  return batch.objectProperties.length + batch.textSentences.length;
+}
+
+async function* streamTextStreamSearchIndexRecords(
   document: ReadonlyDocument,
+  archiveId: number,
   chapterId: number,
   stream: ArchiveTextStreamKind,
-  _title: string,
-): Promise<SearchIndexInput["textSentences"]> {
-  const index = await createTextStreamIndex(document, chapterId, stream);
+): AsyncIterable<SearchIndexWriteBatch["textSentences"][number]> {
+  const fragments =
+    stream === "summary"
+      ? document.getSummaryFragments(chapterId)
+      : document.getSerialFragments(chapterId);
+  let globalIndex = 0;
 
-  return index.sentences.map((sentence) => ({
-    archiveId: SINGLE_ARCHIVE_INDEX_ID,
-    chapterId,
-    kind:
-      stream === "source"
-        ? TEXT_SENTENCE_KIND.source
-        : TEXT_SENTENCE_KIND.summary,
-    sentenceIndex: sentence.globalIndex,
-    text: sentence.text,
-    wordsCount: sentence.wordsCount,
-  }));
+  for (const fragmentId of await fragments.listFragmentIds()) {
+    const fragment = await fragments.getFragment(fragmentId);
+
+    for (const sentence of fragment.sentences) {
+      yield {
+        archiveId,
+        chapterId,
+        kind:
+          stream === "source"
+            ? TEXT_SENTENCE_KIND.source
+            : TEXT_SENTENCE_KIND.summary,
+        sentenceIndex: globalIndex,
+        text: sentence.text,
+        wordsCount: sentence.wordsCount,
+      };
+      globalIndex += 1;
+    }
+  }
 }

--- a/packages/core/src/retrieval/search-index/index.ts
+++ b/packages/core/src/retrieval/search-index/index.ts
@@ -1,8 +1,10 @@
 export {
   createSearchIndexFingerprint,
   ensureSearchIndex,
+  finalizeSearchIndexReplacement,
   isSearchIndexCurrent,
   markDirtySearchIndexChapters,
+  prepareSearchIndexReplacement,
   querySearchIndex,
   readArchiveIndexSettings,
   readSearchIndexFingerprintFromDatabase,
@@ -14,6 +16,7 @@ export {
   SINGLE_ARCHIVE_INDEX_ID,
   setFtsIndexEmbedded,
   TEXT_SENTENCE_KIND,
+  writeSearchIndexBatch,
 } from "./search/index.js";
 export type {
   ArchiveIndexSettings,
@@ -25,6 +28,7 @@ export type {
   SearchIndexQueryResult,
   SearchIndexStatus,
   SearchIndexTextHit,
+  SearchIndexWriteCounters,
   SearchObjectPropertyKind,
   SearchObjectPropertyOwnerKind,
   TextSentenceKind,

--- a/packages/core/src/retrieval/search-index/search/build.ts
+++ b/packages/core/src/retrieval/search-index/search/build.ts
@@ -1,3 +1,4 @@
+import type { Database } from "../../../document/database.js";
 import type { Document } from "../../../document/index.js";
 import { createSearchTokenPlan } from "./tokenizer.js";
 import {
@@ -14,6 +15,10 @@ import { SEARCH_INDEX_VERSION } from "./types.js";
 
 export type ArchiveIndexProjection = SearchIndexInput;
 export type SearchIndexWriteBatch = SearchIndexInput;
+export interface SearchIndexWriteCounters {
+  readonly objectDone: number;
+  readonly textDone: number;
+}
 
 export async function writeArchiveIndexProjection(
   document: Document,
@@ -118,75 +123,145 @@ export async function replaceSearchIndex(
   const chaptersRevision = await document.serials.getChaptersRevision();
 
   await document.writeSearchIndexDatabase(async (database) => {
-    await database.transaction(async () => {
-      await progress?.({ phase: "clearing" });
-      await database.run("DELETE FROM text_sentence_fts");
-      await database.run("DELETE FROM search_object_properties_fts");
-      await database.run("DELETE FROM text_sentence_records");
-      await database.run("DELETE FROM search_object_properties_records");
-      await database.run("DELETE FROM index_dirty_chapters");
-      await database.run("DELETE FROM search_index_state");
+    await prepareSearchIndexReplacement(database, progress);
 
-      let textDone = 0;
-      let objectDone = 0;
-      for await (const batch of batches) {
-        for (const record of batch.textSentences) {
-          const plan = createSearchTokenPlan(record.text);
-          const rowId = await insertTextSentenceRecord(database, record);
-
-          await insertFtsRecord(database, "text_sentence_fts", rowId, plan);
-          textDone += 1;
-          await progress?.({
-            done: textDone,
-            phase: "indexing-text",
-            unit: "sentence",
-          });
-        }
-
-        for (const record of batch.objectProperties) {
-          const plan = createSearchTokenPlan(record.text);
-          const rowId = await insertSearchObjectPropertyRecord(
-            database,
-            record,
-          );
-
-          await insertFtsRecord(
-            database,
-            "search_object_properties_fts",
-            rowId,
-            plan,
-          );
-          objectDone += 1;
-          await progress?.({
-            done: objectDone,
-            phase: "indexing-objects",
-            unit: "object",
-          });
-        }
-      }
-
-      await progress?.({ phase: "finalizing" });
-      await database.run(
-        `
-          INSERT INTO search_index_state(key, value)
-          VALUES ('version', ?)
-        `,
-        [SEARCH_INDEX_VERSION],
+    let counters: SearchIndexWriteCounters = { objectDone: 0, textDone: 0 };
+    for await (const batch of batches) {
+      counters = await writeSearchIndexBatch(
+        database,
+        batch,
+        counters,
+        progress,
       );
-      await database.run(
-        `
-          INSERT INTO search_index_state(key, value)
-          VALUES ('fingerprint', ?)
-        `,
-        [fingerprint],
+    }
+
+    await finalizeSearchIndexReplacement(
+      database,
+      fingerprint,
+      chaptersRevision,
+      progress,
+    );
+  });
+}
+
+export async function prepareSearchIndexReplacement(
+  database: Database,
+  progress?: SearchIndexProgressReporter,
+): Promise<void> {
+  await database.transaction(async () => {
+    await progress?.({ phase: "clearing" });
+    await database.run("DELETE FROM text_sentence_fts");
+    await database.run("DELETE FROM search_object_properties_fts");
+    await database.run("DELETE FROM text_sentence_records");
+    await database.run("DELETE FROM search_object_properties_records");
+    await database.run("DELETE FROM index_dirty_chapters");
+    await database.run("DELETE FROM search_index_state");
+    await database.run(
+      `
+        INSERT INTO index_dirty_chapters(archive_id, chapter_id, updated_at)
+        VALUES (0, 0, ?)
+      `,
+      [Date.now()],
+    );
+  });
+}
+
+export async function writeSearchIndexBatch(
+  database: Database,
+  batch: SearchIndexWriteBatch,
+  counters: SearchIndexWriteCounters,
+  progress?: SearchIndexProgressReporter,
+): Promise<SearchIndexWriteCounters> {
+  let { objectDone, textDone } = counters;
+
+  await database.transaction(async () => {
+    for (const record of batch.textSentences) {
+      const plan = createSearchTokenPlan(record.text);
+      const rowId = await insertReplacementTextSentenceRecord(database, record);
+
+      await insertFtsRecord(database, "text_sentence_fts", rowId, plan);
+      textDone += 1;
+      await progress?.({
+        done: textDone,
+        phase: "indexing-text",
+        unit: "sentence",
+      });
+    }
+
+    for (const record of batch.objectProperties) {
+      const plan = createSearchTokenPlan(record.text);
+      const rowId = await insertSearchObjectPropertyRecord(database, record);
+
+      await insertFtsRecord(
+        database,
+        "search_object_properties_fts",
+        rowId,
+        plan,
       );
-      await database.run(
-        `
-          INSERT INTO search_index_state(key, value)
-          VALUES ('chaptersRevision', ?)
-        `,
-        [String(chaptersRevision)],
-      );
-    });
+      objectDone += 1;
+      await progress?.({
+        done: objectDone,
+        phase: "indexing-objects",
+        unit: "object",
+      });
+    }
+  });
+
+  return { objectDone, textDone };
+}
+
+async function insertReplacementTextSentenceRecord(
+  database: Database,
+  record: SearchIndexWriteBatch["textSentences"][number],
+): Promise<number> {
+  await database.run(
+    `
+      INSERT INTO text_sentence_records (
+        archive_id, kind, chapter_id, sentence_index, words_count, byte_offset, byte_length
+      )
+      VALUES (?, ?, ?, ?, ?, 0, 0)
+    `,
+    [
+      record.archiveId,
+      record.kind,
+      record.chapterId,
+      record.sentenceIndex,
+      record.wordsCount,
+    ],
+  );
+
+  return await database.getLastInsertRowId();
+}
+
+export async function finalizeSearchIndexReplacement(
+  database: Database,
+  fingerprint: string,
+  chaptersRevision: number,
+  progress?: SearchIndexProgressReporter,
+): Promise<void> {
+  await database.transaction(async () => {
+    await progress?.({ phase: "finalizing" });
+    await database.run("DELETE FROM index_dirty_chapters");
+    await database.run(
+      `
+        INSERT INTO search_index_state(key, value)
+        VALUES ('version', ?)
+      `,
+      [SEARCH_INDEX_VERSION],
+    );
+    await database.run(
+      `
+        INSERT INTO search_index_state(key, value)
+        VALUES ('fingerprint', ?)
+      `,
+      [fingerprint],
+    );
+    await database.run(
+      `
+        INSERT INTO search_index_state(key, value)
+        VALUES ('chaptersRevision', ?)
+      `,
+      [String(chaptersRevision)],
+    );
   });
 }

--- a/test/core/library/query.test.ts
+++ b/test/core/library/query.test.ts
@@ -458,6 +458,27 @@ describe("wiki graph library object query aggregation", () => {
     );
   });
 
+  it("bounds library query index hits by the requested page size before hydration", async () => {
+    const [{ findWikiGraphLibraryObjects }, searchIndex] = await Promise.all([
+      import("../../../packages/core/src/library/query.js"),
+      import("../../../packages/core/src/library/search-index.js"),
+    ]);
+
+    mocks.listIndexResult = {
+      objectHits: [createIndexObjectHit(1, "1")],
+      terms: ["chapter"],
+      textHits: [],
+    };
+
+    await findWikiGraphLibraryObjects(target, "chapter", { limit: 5 });
+
+    expect(searchIndex.queryWikiGraphLibrarySearchIndex).toHaveBeenCalledWith(
+      target,
+      "chapter",
+      { objectHitLimit: 100, textHitLimit: 100 },
+    );
+  });
+
   it("lists library objects from the library index instead of archive collection merge", async () => {
     const [{ listWikiGraphLibraryObjects }, archiveView] = await Promise.all([
       import("../../../packages/core/src/library/query.js"),

--- a/test/core/retrieval/query/archive-view/helpers.ts
+++ b/test/core/retrieval/query/archive-view/helpers.ts
@@ -23,6 +23,7 @@ import {
   readArchivePage,
   rebuildArchiveSearchIndex,
 } from "../../../../../packages/core/src/retrieval/query/view.js";
+import { streamArchiveIndexProjection } from "../../../../../packages/core/src/retrieval/query/archive-view/index-state.js";
 import {
   isSearchIndexCurrent,
   markDirtySearchIndexChapters,
@@ -69,6 +70,7 @@ export {
   readArchiveText,
   rebuildArchiveSearchIndex,
   SEARCH_INDEX_FTS_HIT_LIMIT,
+  streamArchiveIndexProjection,
   withTempDir,
 };
 

--- a/test/core/retrieval/query/archive-view/index.test.ts
+++ b/test/core/retrieval/query/archive-view/index.test.ts
@@ -17,6 +17,7 @@ import {
   rebuildArchiveSearchIndex,
   seedSourcedDocument,
   setupArchiveViewTestState,
+  streamArchiveIndexProjection,
   teardownArchiveViewTestState,
   withTempDir,
 } from "./helpers.js";
@@ -121,6 +122,59 @@ describe("archive/query/archive-view/index", () => {
 
         await expect(isSearchIndexCurrent(document)).resolves.toBe(true);
         await expect(countSearchIndexRows(document)).resolves.toBe(0);
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("streams archive index projection in bounded batches", async () => {
+    await withTempDir("wikigraph-archive-view-", async (path) => {
+      const document = await DirectoryDocument.open(`${path}/document`);
+
+      try {
+        await document.openSession(async (openedDocument) => {
+          await openedDocument.createSerial();
+          const draft = await openedDocument
+            .getSerialFragments(1)
+            .createDraft();
+
+          for (let index = 0; index < 1100; index += 1) {
+            draft.addSentence(`Streaming sentence ${index}.`, 3);
+          }
+          await draft.commit();
+          await openedDocument.writeToc({
+            items: [{ children: [], serialId: 1, title: "Streaming" }],
+            version: 1,
+          });
+        });
+
+        const batches = [];
+        for await (const batch of streamArchiveIndexProjection(document, 7)) {
+          batches.push(batch);
+        }
+
+        expect(batches.length).toBeGreaterThan(1);
+        for (const batch of batches) {
+          expect(
+            batch.objectProperties.length + batch.textSentences.length,
+          ).toBeLessThanOrEqual(512);
+        }
+        expect(
+          batches
+            .flatMap((batch) => batch.textSentences)
+            .map((record) => ({
+              archiveId: record.archiveId,
+              chapterId: record.chapterId,
+              sentenceIndex: record.sentenceIndex,
+            })),
+        ).toEqual(
+          Array.from({ length: 1100 }, (_, index) => ({
+            archiveId: 7,
+            chapterId: 1,
+            sentenceIndex: index,
+          })),
+        );
       } finally {
         await document.release();
       }


### PR DESCRIPTION
## Summary

Fixes oomol/wiki-graph-private#55 by making library index rebuilds stream at the archive/chapter/batch boundary instead of materializing full archive projections in memory. It also writes replacement index batches incrementally with an explicit dirty marker until finalization, and bounds library query index hits before hydration so broad library queries do not try to hydrate tens of thousands of matches for a small page.

## Changes

- Added `streamArchiveIndexProjection()` and use it for default/named library index rebuilds.
- Split replacement FTS index writes into clear -> batch writes -> finalize, leaving `index_dirty_chapters` set until the replacement is complete so interrupted rebuilds are recoverable.
- Avoided per-row SELECTs while replacing `text_sentence_records` after a full clear.
- Bounded `wikg://lib --query ... --limit N` index hit collection before archive hydration.
- Added regression coverage for bounded projection streaming and library query hit limits.

## Regression / #51 rerun notes

Commands run during this PR:

- `pnpm --filter wiki-graph test -- --run test/core/retrieval/query/archive-view/index.test.ts`
- `pnpm --filter wiki-graph test -- --run test/core/library/query.test.ts test/core/retrieval/query/archive-view/index.test.ts`
- `pnpm lint:fix`
- `pnpm typecheck`
- `pnpm test:run`
- `pnpm build`
- `pnpm format:check`
- `pnpm --filter wiki-graph dev wikg://lib/index enable --jsonl`
- `pnpm --filter wiki-graph dev maintenance upgrade wikg://lib --json`
- `pnpm --filter wiki-graph dev wikg://lib/index enable --jsonl` against a dev default library populated from 7 local `.wikg` archives copied into worktree-local state
- `pnpm --filter wiki-graph dev wikg://lib/chapter --limit 5 --json`
- `pnpm --filter wiki-graph dev wikg://lib --query "曹操" --limit 5 --json`

Final local #51-relevant result summary:

- Default library clean enable with an empty dev library succeeded.
- 7-archive default library enable succeeded without Node heap OOM and left index status `current`.
- A deliberately interrupted/timeout partial rebuild left the index dirty, and the next enable recovered to `current` without `SQLITE_READONLY`.
- `wikg://lib/chapter --limit 5 --json` returned stable JSON.
- `wikg://lib --query "曹操" --limit 5 --json` returned stable JSON with hits from `三国演义.wikg` and no `SQLITE_READONLY`.

## Still outside this PR

- Full #51 Knowledge Graph Wikimedia `fetch failed` remains an external-dependency observation unless it becomes reliably reproducible as a product retry/error-classification bug.
- Fixture gaps explicitly listed in oomol/wiki-graph-private#55 remain fixture/decision items, not product implementation blockers in this PR.
