### PR TITLE
fix: clean orphan overlays during home upgrade

### DIFF
--- a/docs/schema-upgrade.md
+++ b/docs/schema-upgrade.md
@@ -79,10 +79,11 @@ code and tests when adding new home SQLite files:
 
 For v1 -> v2, derived home data is deleted or invalidated: query/search caches,
 external cache, GC state, build queue SQLite/cache when safe, library aggregate
-indexes, and external archive search index overlays/workspaces for `fts.db` only.
-The upgrader must not delete non-`fts.db` overlays and must block when active GC,
-build job, worker lease, coordinator owner/lock/sqlite lease/commit lock, or
-non-`fts.db` overlay state is present.
+indexes, external archive search index overlays/workspaces for `fts.db`, and
+orphaned SQLite materialization cache overlays whose archive file no longer
+exists. The upgrader must block when active GC, build job, worker lease,
+coordinator owner/lock/sqlite lease/commit lock, or remaining non-derived
+overlay state is present.
 
 Pure information commands such as `wg --version` and help rendering must not open
 home SQLite and must not trigger schema upgrade.

--- a/packages/core/src/document/home-schema-upgrade.ts
+++ b/packages/core/src/document/home-schema-upgrade.ts
@@ -98,8 +98,9 @@ export async function ensureWikiGraphHomeSchemaCurrent(): Promise<void> {
     }
 
     if (schemaVersion < CURRENT_HOME_SCHEMA_VERSION) {
-      await assertHomeUpgradeSafe();
+      await assertHomeUpgradeSafeBeforeCleanup();
       await cleanupHomeDerivedData();
+      await assertNoNonDerivedCoordinatorOverlays();
       await writeHomeSchemaVersion(
         coreDatabasePath,
         CURRENT_HOME_SCHEMA_VERSION,
@@ -284,13 +285,14 @@ async function cleanupHomeDerivedData(): Promise<void> {
   const stagingDatabasePath = join(stagingDirectoryPath, "staging.sqlite");
   if (await pathExists(stagingDatabasePath)) {
     await removeArchiveSearchIndexOverlays(stagingDatabasePath);
+    await removeOrphanedSqliteCacheOverlays(stagingDatabasePath);
   }
 }
 
-async function assertHomeUpgradeSafe(): Promise<void> {
+async function assertHomeUpgradeSafeBeforeCleanup(): Promise<void> {
   await assertCoreLocksSafe();
   await assertGcLockSafe();
-  await assertCoordinatorStateSafe();
+  await assertCoordinatorActiveStateSafe();
   await assertBuildQueueSafe();
 }
 
@@ -366,7 +368,7 @@ async function assertGcLockSafe(): Promise<void> {
   }
 }
 
-async function assertCoordinatorStateSafe(): Promise<void> {
+async function assertCoordinatorActiveStateSafe(): Promise<void> {
   const stagingDatabasePath = join(
     resolveWikiGraphStagingDirectoryPath(),
     "staging.sqlite",
@@ -409,7 +411,26 @@ async function assertCoordinatorStateSafe(): Promise<void> {
         );
       }
     }
+  } finally {
+    await database.close();
+  }
+}
 
+async function assertNoNonDerivedCoordinatorOverlays(): Promise<void> {
+  const stagingDatabasePath = join(
+    resolveWikiGraphStagingDirectoryPath(),
+    "staging.sqlite",
+  );
+
+  if (!(await pathExists(stagingDatabasePath))) {
+    return;
+  }
+
+  const database = await Database.open(stagingDatabasePath, "", {
+    readonly: true,
+  });
+
+  try {
     if (!(await tableExists(database, "entry_overlays"))) {
       return;
     }
@@ -543,6 +564,54 @@ async function removeArchiveSearchIndexOverlays(
       `,
       parameters,
     );
+  } finally {
+    await database.close();
+  }
+}
+
+async function removeOrphanedSqliteCacheOverlays(
+  stagingDatabasePath: string,
+): Promise<void> {
+  const database = await Database.open(stagingDatabasePath);
+
+  try {
+    if (!(await tableExists(database, "entry_overlays"))) {
+      return;
+    }
+
+    const overlays = await database.queryAll(
+      `
+        SELECT archive_key, archive_path, entry_path, workspace_path
+        FROM entry_overlays
+        WHERE entry_path IN (?, ?)
+      `,
+      ["database.db", SEARCH_INDEX_DATABASE_PATH],
+      (row) => ({
+        archiveKey: String(row.archive_key),
+        archivePath: String(row.archive_path),
+        entryPath: String(row.entry_path),
+        workspacePath:
+          row.workspace_path === null ? undefined : String(row.workspace_path),
+      }),
+    );
+
+    for (const overlay of overlays) {
+      if (await pathExists(overlay.archivePath)) {
+        continue;
+      }
+
+      if (overlay.workspacePath !== undefined) {
+        await deletePathIfExists(overlay.workspacePath);
+      }
+
+      await database.run(
+        `
+          DELETE FROM entry_overlays
+          WHERE archive_key = ? AND entry_path = ?
+        `,
+        [overlay.archiveKey, overlay.entryPath],
+      );
+    }
   } finally {
     await database.close();
   }

--- a/test/core/storage/schema-upgrade/index.test.ts
+++ b/test/core/storage/schema-upgrade/index.test.ts
@@ -418,6 +418,7 @@ describe("schema-upgrade", () => {
 
   it("rejects a home upgrade with a non-fts overlay", async () => {
     await withBlockedHomeUpgrade("overlay", async (home) => {
+      await writeFile(join(home, "book.wikg"), "archive");
       await writeCoordinatorOverlay(home, {
         archiveKey: "archive-key",
         entryPath: "database.db",
@@ -427,6 +428,34 @@ describe("schema-upgrade", () => {
         "non-derived coordinator overlays",
       );
     });
+  });
+
+  it("removes orphaned sqlite cache overlays for missing archives during home upgrade", async () => {
+    await withLegacyHome(
+      "wikigraph-schema-orphan-sqlite-overlay-",
+      async (home) => {
+        const workspacePath = join(
+          home,
+          "staging",
+          "work",
+          "archive-key",
+          "database.db",
+        );
+        await mkdir(dirname(workspacePath), { recursive: true });
+        await writeFile(workspacePath, "materialized database cache");
+        await writeCoordinatorOverlay(home, {
+          archiveKey: "archive-key",
+          entryPath: "database.db",
+          workspacePath,
+        });
+
+        await ensureWikiGraphHomeSchemaCurrent();
+
+        await expect(readHomeSchemaVersion(home)).resolves.toBe(2);
+        await expect(stat(workspacePath)).rejects.toThrow();
+        await expect(countCoordinatorOverlays(home)).resolves.toBe(0);
+      },
+    );
   });
 
   it("keeps core registry tables and constraints available after home upgrade", async () => {
@@ -706,7 +735,11 @@ async function writeActiveCoordinatorState(
 
 async function writeCoordinatorOverlay(
   home: string,
-  input: { readonly archiveKey: string; readonly entryPath: string },
+  input: {
+    readonly archiveKey: string;
+    readonly entryPath: string;
+    readonly workspacePath?: string;
+  },
 ): Promise<void> {
   await mkdir(join(home, "staging"), { recursive: true });
   const database = await Database.open(join(home, "staging", "staging.sqlite"));
@@ -723,8 +756,33 @@ async function writeCoordinatorOverlay(
       )
     `);
     await database.run(
-      "INSERT INTO entry_overlays (archive_key, archive_path, entry_path, kind, workspace_path, updated_at) VALUES (?, ?, ?, 'file', NULL, ?)",
-      [input.archiveKey, join(home, "book.wikg"), input.entryPath, Date.now()],
+      "INSERT INTO entry_overlays (archive_key, archive_path, entry_path, kind, workspace_path, updated_at) VALUES (?, ?, ?, 'file', ?, ?)",
+      [
+        input.archiveKey,
+        join(home, "book.wikg"),
+        input.entryPath,
+        input.workspacePath ?? null,
+        Date.now(),
+      ],
+    );
+  } finally {
+    await database.close();
+  }
+}
+
+async function countCoordinatorOverlays(home: string): Promise<number> {
+  const database = await Database.open(
+    join(home, "staging", "staging.sqlite"),
+    "",
+    { readonly: true },
+  );
+  try {
+    return (
+      (await database.queryOne(
+        "SELECT COUNT(*) AS count FROM entry_overlays",
+        undefined,
+        (row) => Number(row.count),
+      )) ?? 0
     );
   } finally {
     await database.close();


### PR DESCRIPTION
## Summary
- delete orphaned SQLite materialization cache overlays during home schema upgrade when their archive path no longer exists
- keep blocking on remaining non-derived overlays that may represent real unflushed data
- document the derived-data cleanup policy and add schema-upgrade regression coverage

## Tests
- pnpm run lint:fix
- pnpm test:run test/core/storage/schema-upgrade/index.test.ts test/core/runtime/gc/gc.test.ts test/core/retrieval/query/search-cache.test.ts
- pnpm typecheck
- manual regression: restored legacy ~/.wikigraph backup, ran pnpm run cli:install-local, then wg wikg://lib/meta --json / wg wikg://lib / wg wikg://lib/index --json
- manual regression: rebound default lib to /Users/taozeyu/Documents/WIKG, ran wg maintenance upgrade wikg://lib --json and wg wikg://lib/index enable --jsonl