### PR TITLE
feat: add shared state lock coordination

### DIFF
--- a/packages/core/src/document/home-schema-upgrade.ts
+++ b/packages/core/src/document/home-schema-upgrade.ts
@@ -306,14 +306,33 @@ async function assertCoreLocksSafe(): Promise<void> {
   });
 
   try {
-    if (!(await tableExists(database, "library_locks"))) {
+    if (await tableExists(database, "library_locks")) {
+      const rows = await database.queryAll(
+        `
+          SELECT owner_pid, heartbeat_at
+          FROM library_locks
+        `,
+        undefined,
+        (row) => ({
+          heartbeatAt: Number(row.heartbeat_at),
+          ownerPid: Number(row.owner_pid),
+        }),
+      );
+
+      if (rows.some((row) => isActiveLock(row.ownerPid, row.heartbeatAt))) {
+        throw new Error("Cannot upgrade home with active library locks.");
+      }
+    }
+
+    if (!(await tableExists(database, "state_locks"))) {
       return;
     }
 
-    const rows = await database.queryAll(
+    const stateLockRows = await database.queryAll(
       `
         SELECT owner_pid, heartbeat_at
-        FROM library_locks
+        FROM state_locks
+        WHERE scope = 'library'
       `,
       undefined,
       (row) => ({
@@ -322,7 +341,9 @@ async function assertCoreLocksSafe(): Promise<void> {
       }),
     );
 
-    if (rows.some((row) => isActiveLock(row.ownerPid, row.heartbeatAt))) {
+    if (
+      stateLockRows.some((row) => isActiveLock(row.ownerPid, row.heartbeatAt))
+    ) {
       throw new Error("Cannot upgrade home with active library locks.");
     }
   } finally {

--- a/packages/core/src/library/lock.ts
+++ b/packages/core/src/library/lock.ts
@@ -1,10 +1,15 @@
-import { randomUUID } from "crypto";
-
-import { openSharedStateDatabase, type Database } from "../document/index.js";
-import { getNumber, getString } from "../document/database.js";
+import { getNumber, getString, type Database } from "../document/database.js";
+import { openSharedStateDatabase } from "../document/index.js";
 import { resolveWikiGraphCoreDatabasePath } from "../runtime/common/wiki-graph/dir.js";
+import {
+  acquireStateLock,
+  isStateLocked,
+  withStateLock,
+  type StateLockMode,
+} from "../state-lock.js";
+import { isNodeError } from "../utils/node-error.js";
 
-const LIBRARY_LOCK_SCHEMA_SQL = `
+const LEGACY_LIBRARY_LOCK_SCHEMA_SQL = `
   CREATE TABLE IF NOT EXISTS library_locks (
     library_id INTEGER PRIMARY KEY,
     mode TEXT NOT NULL,
@@ -14,90 +19,121 @@ const LIBRARY_LOCK_SCHEMA_SQL = `
     created_at INTEGER NOT NULL
   );
 `;
-
-const LIBRARY_LOCK_HEARTBEAT_INTERVAL_MS = 15_000;
+const LIBRARY_LOCK_SCOPE = "library";
 const LIBRARY_LOCK_STALE_MS = 5 * 60 * 1000;
 
-export type LibraryLockMode = "read" | "write";
+export type LibraryLockMode = StateLockMode;
 
 export async function withWikiGraphLibraryLock<T>(
   libraryId: number,
   mode: LibraryLockMode,
-  operation: () => Promise<T>,
+  operation: () => Promise<T> | T,
 ): Promise<T> {
-  const release = await acquireWikiGraphLibraryLock(libraryId, mode);
-
-  try {
-    return await operation();
-  } finally {
-    await release();
-  }
+  return await withStateLock(
+    createLibraryLockOptions(libraryId, mode),
+    operation,
+  );
 }
 
 export async function acquireWikiGraphLibraryLock(
   libraryId: number,
   mode: LibraryLockMode,
 ): Promise<() => Promise<void>> {
-  const ownerId = `${process.pid}-${randomUUID()}`;
-  const database = await openLibraryLockDatabase();
+  const release = await acquireStateLock(
+    createLibraryLockOptions(libraryId, mode),
+  );
+
+  if (release === undefined) {
+    throw new Error("Wiki Graph library lock was not acquired.");
+  }
+
+  return release;
+}
+
+export async function tryAcquireWikiGraphLibraryLock(
+  libraryId: number,
+  mode: LibraryLockMode,
+): Promise<(() => Promise<void>) | undefined> {
+  return await acquireStateLock({
+    ...createLibraryLockOptions(libraryId, mode),
+    wait: false,
+  });
+}
+
+export async function isWikiGraphLibraryLocked(
+  libraryId: number,
+): Promise<boolean> {
+  return (
+    (await isStateLocked({
+      databasePath: resolveWikiGraphCoreDatabasePath(),
+      resourceKey: formatLibraryResourceKey(libraryId),
+      scope: LIBRARY_LOCK_SCOPE,
+      staleMs: LIBRARY_LOCK_STALE_MS,
+    })) || (await isLegacyWikiGraphLibraryLocked(libraryId))
+  );
+}
+
+function createLibraryLockOptions(libraryId: number, mode: LibraryLockMode) {
+  return {
+    databasePath: resolveWikiGraphCoreDatabasePath(),
+    mode,
+    resourceKey: formatLibraryResourceKey(libraryId),
+    scope: LIBRARY_LOCK_SCOPE,
+    staleMs: LIBRARY_LOCK_STALE_MS,
+  };
+}
+
+function formatLibraryResourceKey(libraryId: number): string {
+  return String(libraryId);
+}
+
+async function isLegacyWikiGraphLibraryLocked(
+  libraryId: number,
+): Promise<boolean> {
+  const database = await openLegacyLibraryLockDatabase();
 
   try {
-    await database.transaction(async () => {
-      const existing = await database.queryOne(
-        "SELECT mode, owner_id, owner_pid, heartbeat_at FROM library_locks WHERE library_id = ?",
-        [libraryId],
-        (row) => ({
-          heartbeatAt: getNumber(row, "heartbeat_at"),
-          mode: getString(row, "mode"),
-          ownerId: getString(row, "owner_id"),
-          ownerPid: getNumber(row, "owner_pid"),
-        }),
-      );
+    const existing = await database.queryOne(
+      "SELECT owner_pid, heartbeat_at FROM library_locks WHERE library_id = ?",
+      [libraryId],
+      (row) => ({
+        heartbeatAt: getNumber(row, "heartbeat_at"),
+        ownerPid: getNumber(row, "owner_pid"),
+      }),
+    );
 
-      if (existing !== undefined) {
-        if (isLockActive(existing)) {
-          throw new Error(
-            `Wiki Graph library is locked for ${existing.mode}: ${libraryId}.`,
-          );
-        }
-        await database.run(
-          "DELETE FROM library_locks WHERE library_id = ? AND owner_id = ?",
-          [libraryId, existing.ownerId],
-        );
-      }
-
-      await database.run(
-        `
-          INSERT INTO library_locks (
-            library_id, mode, owner_id, owner_pid, heartbeat_at, created_at
-          )
-          VALUES (?, ?, ?, ?, ?, ?)
-        `,
-        [libraryId, mode, ownerId, process.pid, Date.now(), Date.now()],
-      );
-    });
+    return existing !== undefined && isLockActive(existing);
   } finally {
     await database.close();
   }
+}
 
-  const heartbeat = setInterval(() => {
-    void updateLibraryLockHeartbeat(libraryId, ownerId).catch(() => undefined);
-  }, LIBRARY_LOCK_HEARTBEAT_INTERVAL_MS);
-  heartbeat.unref?.();
+async function openLegacyLibraryLockDatabase(): Promise<Database> {
+  const database = await openSharedStateDatabase(
+    resolveWikiGraphCoreDatabasePath(),
+    LEGACY_LIBRARY_LOCK_SCHEMA_SQL,
+  );
 
-  return async () => {
-    clearInterval(heartbeat);
-    const releaseDatabase = await openLibraryLockDatabase();
+  await ensureLegacyLibraryLockColumns(database);
+  return database;
+}
 
-    try {
-      await releaseDatabase.run(
-        "DELETE FROM library_locks WHERE library_id = ? AND owner_id = ?",
-        [libraryId, ownerId],
-      );
-    } finally {
-      await releaseDatabase.close();
-    }
-  };
+async function ensureLegacyLibraryLockColumns(
+  database: Database,
+): Promise<void> {
+  const columns = new Set(
+    await database.queryAll(
+      "PRAGMA table_info(library_locks)",
+      undefined,
+      (row) => getString(row, "name"),
+    ),
+  );
+
+  if (!columns.has("heartbeat_at")) {
+    await database.run(
+      "ALTER TABLE library_locks ADD COLUMN heartbeat_at INTEGER NOT NULL DEFAULT 0",
+    );
+  }
 }
 
 function isLockActive(lock: {
@@ -115,87 +151,10 @@ function isProcessAlive(pid: number): boolean {
     process.kill(pid, 0);
     return true;
   } catch (error) {
-    return !(
-      typeof error === "object" &&
-      error !== null &&
-      "code" in error &&
-      error.code === "ESRCH"
-    );
-  }
-}
-
-export async function isWikiGraphLibraryLocked(
-  libraryId: number,
-): Promise<boolean> {
-  return await withLibraryLockDatabase(async (database) => {
-    const existing = await database.queryOne(
-      "SELECT owner_pid, heartbeat_at FROM library_locks WHERE library_id = ?",
-      [libraryId],
-      (row) => ({
-        heartbeatAt: getNumber(row, "heartbeat_at"),
-        ownerPid: getNumber(row, "owner_pid"),
-      }),
-    );
-
-    return existing !== undefined && isLockActive(existing);
-  });
-}
-
-async function updateLibraryLockHeartbeat(
-  libraryId: number,
-  ownerId: string,
-): Promise<void> {
-  await withLibraryLockDatabase(async (database) => {
-    await database.run(
-      `
-UPDATE library_locks
-SET heartbeat_at = ?
-WHERE library_id = ?
-  AND owner_id = ?
-`,
-      [Date.now(), libraryId, ownerId],
-    );
-  });
-}
-
-async function withLibraryLockDatabase<T>(
-  operation: (database: Database) => Promise<T>,
-): Promise<T> {
-  const database = await openLibraryLockDatabase();
-
-  try {
-    return await operation(database);
-  } finally {
-    await database.close();
-  }
-}
-
-async function openLibraryLockDatabase(): Promise<Database> {
-  const database = await openSharedStateDatabase(
-    resolveWikiGraphCoreDatabasePath(),
-    LIBRARY_LOCK_SCHEMA_SQL,
-  );
-
-  await ensureLibraryLockColumns(database);
-  return database;
-}
-
-async function ensureLibraryLockColumns(database: Database): Promise<void> {
-  await database.transaction(async () => {
-    const columns = new Set(
-      (
-        await database.queryAll(
-          "PRAGMA table_info(library_locks)",
-          undefined,
-          (row) => getString(row, "name"),
-        )
-      ).values(),
-    );
-
-    if (!columns.has("heartbeat_at")) {
-      await database.run(
-        "ALTER TABLE library_locks ADD COLUMN heartbeat_at INTEGER NOT NULL DEFAULT 0",
-      );
+    if (isNodeError(error) && error.code === "ESRCH") {
+      return false;
     }
-  });
+
+    return true;
+  }
 }

--- a/packages/core/src/library/membership.test.ts
+++ b/packages/core/src/library/membership.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it } from "vitest";
 import {
   addWikiGraphLibraryArchive,
   createWikiGraphLibrary,
+  disableWikiGraphLibraryIndex,
   ensureDefaultWikiGraphLibrary,
   getWikiGraphLibraryMetadata,
   isWikiGraphLibraryUri,
@@ -21,16 +22,21 @@ import {
   parseLocatedWikiGraphUri,
   parseWikiGraphLibraryUri,
   putWikiGraphLibraryMetadata,
+  queryWikiGraphLibrarySearchIndex,
   rebindWikiGraphLibrary,
+  rebuildWikiGraphLibraryIndex,
   removeWikiGraphLibrary,
   removeWikiGraphLibraryArchive,
   resolveWikiGraphLibraryArchivePath,
   resolveWikiGraphLibrary,
   scanWikiGraphLibrary,
 } from "../index.js";
+import { Database } from "../document/database.js";
 import { withWikiGraphStateDirectoryPathForTesting } from "../runtime/common/wiki-graph/dir.js";
+import { resolveWikiGraphCoreDatabasePath } from "../runtime/common/wiki-graph/dir.js";
 import { writeWikgArchive } from "../storage/wikg/index.js";
 import { acquireWikiGraphLibraryLock } from "./lock.js";
+import { listWikiGraphLibrarySearchIndex } from "./search-index.js";
 
 describe("library archive membership", () => {
   it("scans nested .wikg files and reports missing registered files", async () => {
@@ -191,7 +197,7 @@ describe("library archive membership", () => {
     });
   });
 
-  it("requires the library write lock when removing a library registry", async () => {
+  it("waits for the library write lock when removing a library registry", async () => {
     await withLibraryTestState(async (tempDir) => {
       const library = await createWikiGraphLibrary({
         folderPath: join(tempDir, "locked-library"),
@@ -199,18 +205,123 @@ describe("library archive membership", () => {
       const target = parseWikiGraphLibraryUri(library.uri);
       expect(target).toBeDefined();
       const release = await acquireWikiGraphLibraryLock(library.id, "write");
+      const removal = removeWikiGraphLibrary(target!);
+      let settled = false;
+      void removal.finally(() => {
+        settled = true;
+      });
 
       try {
-        await expect(removeWikiGraphLibrary(target!)).rejects.toThrow(
-          `Wiki Graph library is locked for write: ${library.id}.`,
-        );
+        await delay(20);
+        expect(settled).toBe(false);
       } finally {
         await release();
       }
 
-      await expect(removeWikiGraphLibrary(target!)).resolves.toMatchObject({
+      await expect(removal).resolves.toMatchObject({
         id: library.id,
       });
+    });
+  });
+
+  it("allows concurrent library read locks", async () => {
+    await withLibraryTestState(async (tempDir) => {
+      const library = await createWikiGraphLibrary({
+        folderPath: join(tempDir, "readable-library"),
+      });
+      const firstRelease = await acquireWikiGraphLibraryLock(
+        library.id,
+        "read",
+      );
+
+      try {
+        const secondRelease = await acquireWikiGraphLibraryLock(
+          library.id,
+          "read",
+        );
+        await secondRelease();
+      } finally {
+        await firstRelease();
+      }
+    });
+  });
+
+  it("allows concurrent library index read and query operations", async () => {
+    await withLibraryTestState(async () => {
+      const target = parseWikiGraphLibraryUri("wikg://lib");
+      expect(target).toBeDefined();
+      await rebuildWikiGraphLibraryIndex(target!);
+
+      await expect(
+        Promise.all([
+          listWikiGraphLibrarySearchIndex(target!),
+          queryWikiGraphLibrarySearchIndex(target!, "anything"),
+        ]),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  it("waits for foreground library index reads behind a write coordination window", async () => {
+    await withLibraryTestState(async () => {
+      const target = parseWikiGraphLibraryUri("wikg://lib");
+      expect(target).toBeDefined();
+      const library = await ensureDefaultWikiGraphLibrary();
+      await rebuildWikiGraphLibraryIndex(target!);
+      const release = await acquireWikiGraphLibraryLock(library.id, "write");
+      const query = queryWikiGraphLibrarySearchIndex(target!, "anything");
+      let settled = false;
+      void query.finally(() => {
+        settled = true;
+      });
+
+      try {
+        await delay(20);
+        expect(settled).toBe(false);
+      } finally {
+        await release();
+      }
+
+      await expect(query).resolves.toBeDefined();
+    });
+  });
+
+  it("coordinates library index disable behind active read paths", async () => {
+    await withLibraryTestState(async () => {
+      const target = parseWikiGraphLibraryUri("wikg://lib");
+      expect(target).toBeDefined();
+      const library = await ensureDefaultWikiGraphLibrary();
+      await rebuildWikiGraphLibraryIndex(target!);
+      const release = await acquireWikiGraphLibraryLock(library.id, "read");
+      const disable = disableWikiGraphLibraryIndex(target!);
+      let settled = false;
+      void disable.finally(() => {
+        settled = true;
+      });
+
+      try {
+        await delay(20);
+        expect(settled).toBe(false);
+      } finally {
+        await release();
+      }
+
+      await expect(disable).resolves.toMatchObject({ status: "disabled" });
+      await expect(
+        queryWikiGraphLibrarySearchIndex(target!, "anything"),
+      ).rejects.toThrow("Wiki Graph library index is disabled");
+    });
+  });
+
+  it("cleans stale library state locks before acquiring a foreground lock", async () => {
+    await withLibraryTestState(async (tempDir) => {
+      const library = await createWikiGraphLibrary({
+        folderPath: join(tempDir, "stale-library"),
+      });
+      await insertStaleStateLock(library.id);
+
+      const release = await acquireWikiGraphLibraryLock(library.id, "write");
+
+      await release();
     });
   });
 
@@ -653,4 +764,42 @@ async function createTestWikgArchive(
   const sourceDir = await mkdtemp(join(tempDir, "wikg-source-"));
   await writeFile(join(sourceDir, "database.db"), "test", "utf8");
   await writeWikgArchive(sourceDir, path);
+}
+
+async function insertStaleStateLock(libraryId: number): Promise<void> {
+  const database = await Database.open(
+    resolveWikiGraphCoreDatabasePath(),
+    `
+      CREATE TABLE IF NOT EXISTS state_locks (
+        scope TEXT NOT NULL,
+        resource_key TEXT NOT NULL,
+        mode TEXT NOT NULL,
+        owner_id TEXT NOT NULL,
+        owner_pid INTEGER NOT NULL,
+        heartbeat_at INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        PRIMARY KEY (scope, resource_key, owner_id)
+      );
+    `,
+  );
+
+  try {
+    const staleAt = Date.now() - 10 * 60 * 1000;
+    await database.run(
+      `
+        INSERT INTO state_locks (
+          scope, resource_key, mode, owner_id, owner_pid, heartbeat_at, created_at
+        ) VALUES ('library', ?, 'write', 'stale-owner', 999999, ?, ?)
+      `,
+      [String(libraryId), staleAt, staleAt],
+    );
+  } finally {
+    await database.close();
+  }
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise<void>((resolveDelay) => {
+    setTimeout(resolveDelay, ms);
+  });
 }

--- a/packages/core/src/state-lock.test.ts
+++ b/packages/core/src/state-lock.test.ts
@@ -1,0 +1,151 @@
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { describe, expect, it } from "vitest";
+
+import { Database } from "./document/database.js";
+import {
+  acquireStateLock,
+  withStateLock,
+  type StateLockMode,
+} from "./state-lock.js";
+
+const STATE_LOCK_TEST_SCHEMA_SQL = `
+  CREATE TABLE IF NOT EXISTS state_locks (
+    scope TEXT NOT NULL,
+    resource_key TEXT NOT NULL,
+    mode TEXT NOT NULL,
+    owner_id TEXT NOT NULL,
+    owner_pid INTEGER NOT NULL,
+    heartbeat_at INTEGER NOT NULL,
+    created_at INTEGER NOT NULL,
+    PRIMARY KEY (scope, resource_key, owner_id)
+  );
+`;
+
+describe("state lock coordination", () => {
+  it("shares read locks and rejects opportunistic writes while a reader is active", async () => {
+    await withStateLockTestDatabase(async (databasePath) => {
+      const firstReader = await acquireTestLock(databasePath, "read");
+
+      try {
+        const secondReader = await acquireTestLock(databasePath, "read", {
+          wait: false,
+        });
+        const writer = await acquireTestLock(databasePath, "write", {
+          wait: false,
+        });
+
+        expect(secondReader).toBeDefined();
+        expect(writer).toBeUndefined();
+        await secondReader?.();
+      } finally {
+        await firstReader?.();
+      }
+    });
+  });
+
+  it("releases locks when a closure throws", async () => {
+    await withStateLockTestDatabase(async (databasePath) => {
+      await expect(
+        withStateLock(createTestLockOptions(databasePath, "write"), () => {
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+
+      const release = await acquireTestLock(databasePath, "write", {
+        wait: false,
+      });
+      expect(release).toBeDefined();
+      await release?.();
+    });
+  });
+
+  it("cleans stale owner rows before acquiring a foreground lock", async () => {
+    await withStateLockTestDatabase(async (databasePath) => {
+      await insertStateLock(databasePath, {
+        heartbeatAt: Date.now(),
+        mode: "write",
+        ownerId: "dead-owner",
+        ownerPid: 999999,
+      });
+
+      const release = await acquireTestLock(databasePath, "write", {
+        wait: false,
+      });
+
+      expect(release).toBeDefined();
+      await release?.();
+    });
+  });
+});
+
+async function withStateLockTestDatabase(
+  operation: (databasePath: string) => Promise<void>,
+): Promise<void> {
+  const tempDir = await mkdtemp(join(tmpdir(), "wikigraph-state-lock-test-"));
+
+  try {
+    await operation(join(tempDir, "state.sqlite"));
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+}
+
+function createTestLockOptions(databasePath: string, mode: StateLockMode) {
+  return {
+    databasePath,
+    heartbeatMs: 10,
+    mode,
+    pollMs: 10,
+    resourceKey: "resource",
+    scope: "test",
+    staleMs: 60_000,
+  };
+}
+
+async function acquireTestLock(
+  databasePath: string,
+  mode: StateLockMode,
+  options: { readonly wait?: boolean } = {},
+): Promise<(() => Promise<void>) | undefined> {
+  return await acquireStateLock({
+    ...createTestLockOptions(databasePath, mode),
+    ...options,
+  });
+}
+
+async function insertStateLock(
+  databasePath: string,
+  input: {
+    readonly heartbeatAt: number;
+    readonly mode: StateLockMode;
+    readonly ownerId: string;
+    readonly ownerPid: number;
+  },
+): Promise<void> {
+  const database = await Database.open(
+    databasePath,
+    STATE_LOCK_TEST_SCHEMA_SQL,
+  );
+
+  try {
+    await database.run(
+      `
+        INSERT INTO state_locks (
+          scope, resource_key, mode, owner_id, owner_pid, heartbeat_at, created_at
+        ) VALUES ('test', 'resource', ?, ?, ?, ?, ?)
+      `,
+      [
+        input.mode,
+        input.ownerId,
+        input.ownerPid,
+        input.heartbeatAt,
+        input.heartbeatAt,
+      ],
+    );
+  } finally {
+    await database.close();
+  }
+}

--- a/packages/core/src/state-lock.ts
+++ b/packages/core/src/state-lock.ts
@@ -1,0 +1,322 @@
+import { randomUUID } from "crypto";
+
+import {
+  getNumber,
+  getString,
+  type Database,
+  type SqlRow,
+} from "./document/database.js";
+import { openSharedStateDatabase } from "./document/index.js";
+import { isNodeError } from "./utils/node-error.js";
+
+const STATE_LOCK_SCHEMA_SQL = `
+  CREATE TABLE IF NOT EXISTS state_locks (
+    scope TEXT NOT NULL,
+    resource_key TEXT NOT NULL,
+    mode TEXT NOT NULL,
+    owner_id TEXT NOT NULL,
+    owner_pid INTEGER NOT NULL,
+    heartbeat_at INTEGER NOT NULL,
+    created_at INTEGER NOT NULL,
+    PRIMARY KEY (scope, resource_key, owner_id)
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_state_locks_resource
+  ON state_locks(scope, resource_key);
+`;
+const DEFAULT_STATE_LOCK_POLL_MS = 100;
+const DEFAULT_STATE_LOCK_STALE_MS = 5 * 60 * 1000;
+const DEFAULT_STATE_LOCK_HEARTBEAT_MS = 15_000;
+
+export type StateLockMode = "read" | "write";
+
+export interface StateLockOptions {
+  readonly databasePath: string;
+  readonly heartbeatMs?: number;
+  readonly mode: StateLockMode;
+  readonly pollMs?: number;
+  readonly resourceKey: string;
+  readonly scope: string;
+  readonly staleMs?: number;
+  readonly wait?: boolean;
+}
+
+interface StateLockRow {
+  readonly heartbeatAt: number;
+  readonly mode: StateLockMode;
+  readonly ownerId: string;
+  readonly ownerPid: number;
+}
+
+export async function withStateLock<T>(
+  options: StateLockOptions,
+  operation: () => Promise<T> | T,
+): Promise<T> {
+  const release = await acquireStateLock({ ...options, wait: true });
+
+  if (release === undefined) {
+    throw new Error("State lock was not acquired.");
+  }
+
+  try {
+    return await operation();
+  } finally {
+    await release();
+  }
+}
+
+export async function acquireStateLock(
+  options: StateLockOptions,
+): Promise<(() => Promise<void>) | undefined> {
+  const ownerId = `${process.pid}-${randomUUID()}`;
+  const pollMs = options.pollMs ?? DEFAULT_STATE_LOCK_POLL_MS;
+
+  while (true) {
+    const acquired = await tryInsertStateLock(options, ownerId);
+
+    if (acquired) {
+      return createStateLockRelease(options, ownerId);
+    }
+
+    if (options.wait === false) {
+      return undefined;
+    }
+
+    await delay(pollMs);
+  }
+}
+
+export async function isStateLocked(options: {
+  readonly databasePath: string;
+  readonly resourceKey: string;
+  readonly scope: string;
+  readonly staleMs?: number;
+}): Promise<boolean> {
+  const database = await openStateLockDatabase(options.databasePath);
+
+  try {
+    await cleanupStaleStateLocks(database, options);
+    const active = await database.queryOne(
+      `
+        SELECT 1 AS active
+        FROM state_locks
+        WHERE scope = ? AND resource_key = ?
+        LIMIT 1
+      `,
+      [options.scope, options.resourceKey],
+      () => true,
+    );
+
+    return active === true;
+  } finally {
+    await database.close();
+  }
+}
+
+async function tryInsertStateLock(
+  options: StateLockOptions,
+  ownerId: string,
+): Promise<boolean> {
+  const database = await openStateLockDatabase(options.databasePath);
+  const now = Date.now();
+
+  try {
+    return await database.transaction(async () => {
+      await cleanupStaleStateLocks(database, options);
+      const existingLocks = await database.queryAll(
+        `
+          SELECT mode, owner_id, owner_pid, heartbeat_at
+          FROM state_locks
+          WHERE scope = ? AND resource_key = ?
+        `,
+        [options.scope, options.resourceKey],
+        mapStateLockRow,
+      );
+
+      if (
+        existingLocks.some(
+          (lock) =>
+            lock.ownerId !== ownerId && locksConflict(options.mode, lock.mode),
+        )
+      ) {
+        return false;
+      }
+
+      await database.run(
+        `
+          INSERT INTO state_locks (
+            scope, resource_key, mode, owner_id, owner_pid, heartbeat_at, created_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        `,
+        [
+          options.scope,
+          options.resourceKey,
+          options.mode,
+          ownerId,
+          process.pid,
+          now,
+          now,
+        ],
+      );
+      return true;
+    });
+  } finally {
+    await database.close();
+  }
+}
+
+function createStateLockRelease(
+  options: StateLockOptions,
+  ownerId: string,
+): () => Promise<void> {
+  const heartbeatMs = options.heartbeatMs ?? DEFAULT_STATE_LOCK_HEARTBEAT_MS;
+  const heartbeat = setInterval(() => {
+    void updateStateLockHeartbeat(options, ownerId).catch(() => undefined);
+  }, heartbeatMs);
+  heartbeat.unref?.();
+
+  return async () => {
+    clearInterval(heartbeat);
+    const database = await openStateLockDatabase(options.databasePath);
+
+    try {
+      await database.run(
+        `
+          DELETE FROM state_locks
+          WHERE scope = ? AND resource_key = ? AND owner_id = ?
+        `,
+        [options.scope, options.resourceKey, ownerId],
+      );
+    } finally {
+      await database.close();
+    }
+  };
+}
+
+async function updateStateLockHeartbeat(
+  options: StateLockOptions,
+  ownerId: string,
+): Promise<void> {
+  const database = await openStateLockDatabase(options.databasePath);
+
+  try {
+    await database.run(
+      `
+        UPDATE state_locks
+        SET heartbeat_at = ?, owner_pid = ?
+        WHERE scope = ? AND resource_key = ? AND owner_id = ?
+      `,
+      [Date.now(), process.pid, options.scope, options.resourceKey, ownerId],
+    );
+  } finally {
+    await database.close();
+  }
+}
+
+async function cleanupStaleStateLocks(
+  database: Database,
+  options: {
+    readonly resourceKey?: string;
+    readonly scope?: string;
+    readonly staleMs?: number;
+  },
+): Promise<void> {
+  const clauses: string[] = [];
+  const parameters: string[] = [];
+
+  if (options.scope !== undefined) {
+    clauses.push("scope = ?");
+    parameters.push(options.scope);
+  }
+  if (options.resourceKey !== undefined) {
+    clauses.push("resource_key = ?");
+    parameters.push(options.resourceKey);
+  }
+
+  const rows = await database.queryAll(
+    `
+      SELECT scope, resource_key, mode, owner_id, owner_pid, heartbeat_at
+      FROM state_locks
+      ${clauses.length === 0 ? "" : `WHERE ${clauses.join(" AND ")}`}
+    `,
+    parameters,
+    (row) => ({
+      lock: mapStateLockRow(row),
+      resourceKey: getString(row, "resource_key"),
+      scope: getString(row, "scope"),
+    }),
+  );
+
+  for (const { lock, resourceKey, scope } of rows) {
+    if (!isStateLockStale(lock, options.staleMs)) {
+      continue;
+    }
+
+    await database.run(
+      `
+        DELETE FROM state_locks
+        WHERE scope = ?
+          AND resource_key = ?
+          AND owner_id = ?
+          AND heartbeat_at = ?
+      `,
+      [scope, resourceKey, lock.ownerId, lock.heartbeatAt],
+    );
+  }
+}
+
+async function openStateLockDatabase(databasePath: string): Promise<Database> {
+  return await openSharedStateDatabase(databasePath, STATE_LOCK_SCHEMA_SQL);
+}
+
+function mapStateLockRow(row: SqlRow): StateLockRow {
+  return {
+    heartbeatAt: getNumber(row, "heartbeat_at"),
+    mode: getStateLockMode(getString(row, "mode")),
+    ownerId: getString(row, "owner_id"),
+    ownerPid: getNumber(row, "owner_pid"),
+  };
+}
+
+function getStateLockMode(value: string): StateLockMode {
+  if (value === "read" || value === "write") {
+    return value;
+  }
+
+  return "write";
+}
+
+function locksConflict(
+  requested: StateLockMode,
+  existing: StateLockMode,
+): boolean {
+  return requested === "write" || existing === "write";
+}
+
+function isStateLockStale(
+  lock: Pick<StateLockRow, "heartbeatAt" | "ownerPid">,
+  staleMs = DEFAULT_STATE_LOCK_STALE_MS,
+): boolean {
+  return (
+    Date.now() - lock.heartbeatAt > staleMs || !isProcessAlive(lock.ownerPid)
+  );
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ESRCH") {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise<void>((resolveDelay) => {
+    setTimeout(resolveDelay, ms);
+  });
+}

--- a/test/core/runtime/gc/gc.test.ts
+++ b/test/core/runtime/gc/gc.test.ts
@@ -165,14 +165,18 @@ describe("gc", () => {
       const validPath = join(library.stagingPath, "index");
       const orphanPath = join(path, "state", "staging", "library", "999");
       const lockedPath = join(path, "state", "staging", "library", "1000");
+      const stateLockedPath = join(path, "state", "staging", "library", "1001");
 
       await mkdir(validPath, { recursive: true });
       await mkdir(orphanPath, { recursive: true });
       await mkdir(lockedPath, { recursive: true });
+      await mkdir(stateLockedPath, { recursive: true });
       await writeFile(join(validPath, "fts.db"), "valid", "utf8");
       await writeFile(join(orphanPath, "fts.db"), "orphan", "utf8");
       await writeFile(join(lockedPath, "fts.db"), "locked", "utf8");
+      await writeFile(join(stateLockedPath, "fts.db"), "state-locked", "utf8");
       await insertLibraryLock(1000);
+      await insertStateLibraryLock(1001);
 
       const report = await tryRunWikiGraphGc();
       const libraryIndexJob = report.jobs.find(
@@ -180,10 +184,11 @@ describe("gc", () => {
       );
 
       expect(report.skipped).toBe(false);
-      expect(libraryIndexJob).toMatchObject({ removed: 1, scanned: 3 });
+      expect(libraryIndexJob).toMatchObject({ removed: 1, scanned: 4 });
       await expect(stat(validPath)).resolves.toBeDefined();
       await expect(stat(orphanPath)).rejects.toThrow();
       await expect(stat(lockedPath)).resolves.toBeDefined();
+      await expect(stat(stateLockedPath)).resolves.toBeDefined();
     });
   });
 
@@ -871,6 +876,37 @@ INSERT INTO library_locks (
 ) VALUES (?, 'write', 'test-owner', ?, ?, ?)
 `,
       [libraryId, process.pid, Date.now(), Date.now()],
+    );
+  } finally {
+    await database.close();
+  }
+}
+
+async function insertStateLibraryLock(libraryId: number): Promise<void> {
+  const database = await openStateDatabase(
+    "core.sqlite",
+    `
+CREATE TABLE IF NOT EXISTS state_locks (
+  scope TEXT NOT NULL,
+  resource_key TEXT NOT NULL,
+  mode TEXT NOT NULL,
+  owner_id TEXT NOT NULL,
+  owner_pid INTEGER NOT NULL,
+  heartbeat_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (scope, resource_key, owner_id)
+);
+`,
+  );
+
+  try {
+    await database.run(
+      `
+INSERT INTO state_locks (
+  scope, resource_key, mode, owner_id, owner_pid, heartbeat_at, created_at
+) VALUES ('library', ?, 'write', 'test-owner', ?, ?, ?)
+`,
+      [String(libraryId), process.pid, Date.now(), Date.now()],
     );
   } finally {
     await database.close();

--- a/test/core/storage/schema-upgrade/index.test.ts
+++ b/test/core/storage/schema-upgrade/index.test.ts
@@ -447,7 +447,7 @@ describe("schema-upgrade", () => {
           "libraries",
           "library_metadata",
           "library_archives",
-          "library_locks",
+          "state_locks",
         ]) {
           await expect(hasTable(database, tableName)).resolves.toBe(true);
         }


### PR DESCRIPTION
## Summary
- Add a generic SQLite-backed state lock coordination primitive for long-lived local state (`state_locks`) with read/write conflict rules, waiting acquire, try-lock, heartbeat leases, stale owner cleanup, and closure-style helpers.
- Refactor library locking to use the shared primitive so foreground library read/query paths wait instead of exposing `Wiki Graph library is locked...`, while preserving legacy `library_locks` visibility for GC/schema safety.
- Extend coverage for library index read/query concurrency, write/read waiting, index disable lifecycle, stale locks, GC skip behavior, and schema upgrade expectations.

## Acceptance coverage
- Multiple concurrent library index read/query operations share read locks and do not fail with `library is locked`.
- Foreground library reads/queries wait behind write coordination and return product state errors (e.g. disabled index) instead of low-level lock errors.
- Index disable is coordinated behind active read paths and leaves subsequent queries with a clear disabled-index product error.
- Stale/dead state lock owners are cleaned before foreground acquisition.
- GC continues to safely skip locked library staging, including locks held via the new `state_locks` table.
- The shared state-lock module is independent of `.wikg` archive key, entry path, overlay, settlement, writeback, or archive session semantics.

## Verification
- `pnpm exec vitest run packages/core/src/state-lock.test.ts packages/core/src/library/membership.test.ts test/core/runtime/gc/gc.test.ts test/core/storage/schema-upgrade/index.test.ts` — 73 tests passed.
- `pnpm run test:run` — 129 test files / 825 tests passed.
- `pnpm run typecheck` — passed.
- `pnpm run lint` — passed.
- `pnpm run format:check` — passed.
- `pnpm run build` — passed.

Closes https://github.com/oomol-lab/wiki-graph/issues/178
