### PR TITLE
fix: keep search index checks off the projection path

### DIFF
--- a/packages/core/src/retrieval/query/archive-view/index-state.ts
+++ b/packages/core/src/retrieval/query/archive-view/index-state.ts
@@ -61,10 +61,7 @@ export async function isArchiveSearchIndexCurrent(
 export async function readArchiveSearchIndexStatus(
   document: ReadonlyDocument,
 ): Promise<"current" | "dirty" | "missing"> {
-  return await readSearchIndexStatus(
-    document,
-    await buildArchiveIndexProjection(document),
-  );
+  return await readSearchIndexStatus(document);
 }
 
 export async function clearDirtyArchiveSearchIndex(

--- a/packages/core/src/storage/wikg/wikg-coordinator/search-index-cache.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/search-index-cache.ts
@@ -1,19 +1,11 @@
 import { mkdir, rename, rm } from "fs/promises";
 import { dirname } from "path";
 
-import { createArchiveSearchIndexFingerprint } from "../../../retrieval/query/index.js";
-import { createWikiGraphTempDirectory } from "../../../runtime/common/wiki-graph/temp.js";
-import {
-  Database as DocumentDatabase,
-  DirectoryDocument,
-} from "../../../document/index.js";
+import { Database as DocumentDatabase } from "../../../document/index.js";
 import { ensureWikiGraphHomeSchemaCurrent } from "../../../document/home-schema-upgrade.js";
 import { readSearchIndexFingerprintFromDatabase } from "../../../retrieval/search-index/index.js";
 
-import {
-  extractWikgArchive,
-  readWikgArchiveMutationToken,
-} from "../archive/index.js";
+import { readWikgArchiveMutationToken } from "../archive/index.js";
 
 import { createArchiveSignature, pathExists } from "./archive-key.js";
 import {
@@ -45,16 +37,16 @@ export async function readSearchIndexCacheStatus(
   }
 
   try {
-    const [indexedFingerprint, currentFingerprint] = await Promise.all([
-      readSearchIndexCacheFingerprint(overlay.workspacePath),
-      createCurrentArchiveSearchIndexFingerprint(overlay.archivePath),
-    ]);
+    const indexedFingerprint = await readSearchIndexCacheFingerprint(
+      overlay.workspacePath,
+    );
+    const currentSignature = await createArchiveSignature(overlay.archivePath);
 
     if (indexedFingerprint === undefined) {
       return "dirty";
     }
 
-    return indexedFingerprint === currentFingerprint ? "current" : "dirty";
+    return overlay.archiveSignature === currentSignature ? "current" : "dirty";
   } catch {
     return "dirty";
   }
@@ -72,25 +64,6 @@ async function readSearchIndexCacheFingerprint(
     return await readSearchIndexFingerprintFromDatabase(database);
   } finally {
     await database.close();
-  }
-}
-
-async function createCurrentArchiveSearchIndexFingerprint(
-  archivePath: string,
-): Promise<string> {
-  const directoryPath = await createWikiGraphTempDirectory("archive-open");
-
-  try {
-    await extractWikgArchive(archivePath, directoryPath);
-    const document = await DirectoryDocument.open(directoryPath);
-
-    try {
-      return await createArchiveSearchIndexFingerprint(document);
-    } finally {
-      await document.release();
-    }
-  } finally {
-    await rm(directoryPath, { force: true, recursive: true });
   }
 }
 

--- a/test/core/retrieval/query/archive-view/index.test.ts
+++ b/test/core/retrieval/query/archive-view/index.test.ts
@@ -272,7 +272,7 @@ describe("archive/query/archive-view/index", () => {
     });
   });
 
-  it("marks the FTS index outdated when indexed content changes without a chapters revision bump", async () => {
+  it("does not rebuild index projections while checking search index status", async () => {
     await withTempDir("wikigraph-archive-view-", async (path) => {
       const document = await DirectoryDocument.open(`${path}/document`);
 
@@ -302,6 +302,10 @@ describe("archive/query/archive-view/index", () => {
           draft.addSentence("New sentence after index build.", 5);
           await draft.commit();
         });
+
+        await expect(isArchiveSearchIndexCurrent(document)).resolves.toBe(true);
+
+        await markDirtySearchIndexChapters(document, [1]);
 
         await expect(isArchiveSearchIndexCurrent(document)).resolves.toBe(
           false,

--- a/test/core/runtime/gc/gc.test.ts
+++ b/test/core/runtime/gc/gc.test.ts
@@ -336,7 +336,7 @@ describe("gc", () => {
     });
   });
 
-  it("removes external fts sqlite cache when the archive fingerprint changes", async () => {
+  it("removes external fts sqlite cache when the archive signature changes", async () => {
     await withTempDir("wikigraph-gc-", async (path) => {
       setWikiGraphStateDirectoryPathForTesting(join(path, "state"));
       const { archivePath, ftsPath } =


### PR DESCRIPTION
## Summary
- stop archive search-index status checks from rebuilding the full archive index projection
- keep coordinator external fts cache validation at the file/signature level instead of recomputing content fingerprints
- update tests to reflect dirty-marker-driven index invalidation and file-level fts cache GC

## Validation
- pnpm vitest run test/core/retrieval/query/archive-view/index.test.ts test/core/runtime/gc/gc.test.ts
- pnpm lint
- pnpm typecheck
- pnpm format:check
- manual timing: isArchiveSearchIndexCurrent on the large detached archive dropped from ~9s to ~5ms; source CLI query no longer pays the projection check cost