### PR TITLE
fix(library): remove FTS from library archives

### DIFF
--- a/packages/cli/src/commands/archive-command/run/document.test.ts
+++ b/packages/cli/src/commands/archive-command/run/document.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
 let restoreStderrWrite: (() => void) | undefined;
 
 vi.mock("wiki-graph-core", () => ({
+  finalizeWikiGraphLibraryArchiveWrite: vi.fn(() => Promise.resolve(false)),
   markWikiGraphLibraryIndexDirty: vi.fn(),
   WikiGraphArchiveFile: class {
     public readonly archivePath: string;

--- a/packages/cli/src/commands/archive-command/run/document.ts
+++ b/packages/cli/src/commands/archive-command/run/document.ts
@@ -1,4 +1,5 @@
 import {
+  finalizeWikiGraphLibraryArchiveWrite,
   markWikiGraphLibraryIndexDirty,
   WikiGraphArchiveFile,
   type DirectoryDocument,
@@ -27,6 +28,12 @@ export async function writeArchiveDocument<T>(
   );
 
   if (location.libraryDirtyTarget !== undefined) {
+    if (location.libraryArchiveTarget !== undefined) {
+      await finalizeWikiGraphLibraryArchiveWrite({
+        target: location.libraryArchiveTarget,
+      });
+    }
+
     try {
       await markWikiGraphLibraryIndexDirty(location.libraryDirtyTarget);
     } catch (error) {

--- a/packages/cli/src/commands/archive-command/run/uri.test.ts
+++ b/packages/cli/src/commands/archive-command/run/uri.test.ts
@@ -9,15 +9,20 @@ import {
   createWikiGraphLibrary,
   DirectoryDocument,
   parseWikiGraphLibraryUri,
+  readArchiveIndexSettings,
   readWikiGraphLibraryIndexState,
+  rebuildArchiveSearchIndex,
   rebuildWikiGraphLibraryIndex,
+  setFtsIndexEmbedded,
   TOC_FILE_VERSION,
+  WikiGraphArchiveFile,
   writeWikgArchive,
 } from "wiki-graph-core";
 import {
   getWikiGraphStateDirectoryPathForTesting,
   setWikiGraphStateDirectoryPathForTesting,
 } from "../../../../../core/src/runtime/common/wiki-graph/dir.js";
+import { readWikgArchiveEntry } from "../../../../../core/src/storage/wikg/archive/index.js";
 import { runArchiveChapterCommand } from "../chapter.js";
 import { resolveArchiveCommandRuntimeArguments } from "./uri.js";
 
@@ -150,6 +155,40 @@ describe("archive-command URI runtime resolution", () => {
       readWikiGraphLibraryIndexState(target!),
     ).resolves.toMatchObject({
       status: "current",
+    });
+  });
+
+  it("removes embedded FTS from library archive URI writes without changing the policy", async () => {
+    const target = parseWikiGraphLibraryUri("wikg://lib");
+    expect(target).toBeDefined();
+    const archive = await addTestArchiveToLibrary(target!);
+
+    await new WikiGraphArchiveFile(archive.path).write(
+      async (document) => {
+        await setFtsIndexEmbedded(document, true);
+        await rebuildArchiveSearchIndex(document);
+      },
+      { searchIndexWritebackPolicy: "archive" },
+    );
+    await expect(
+      readWikgArchiveEntry(archive.path, "fts.db"),
+    ).resolves.toBeDefined();
+
+    await runArchiveChapterCommand({ action: "add", path: archive.uri });
+
+    await expect(readWikgArchiveEntry(archive.path, "fts.db")).resolves.toBe(
+      undefined,
+    );
+    await expect(
+      new WikiGraphArchiveFile(archive.path).readDocument(
+        async (document) =>
+          (await readArchiveIndexSettings(document)).ftsEmbedded,
+      ),
+    ).resolves.toBe(true);
+    await expect(
+      readWikiGraphLibraryIndexState(target!),
+    ).resolves.toMatchObject({
+      status: "dirty",
     });
   });
 });

--- a/packages/cli/src/commands/archive-command/run/uri.ts
+++ b/packages/cli/src/commands/archive-command/run/uri.ts
@@ -14,6 +14,7 @@ export interface ArchiveRuntimeLocation {
   readonly archiveKey: string;
   readonly archivePath: string;
   readonly indexScope: QueryIndexScope;
+  readonly libraryArchiveTarget?: ParsedWikiGraphLibraryUri;
   readonly libraryDirtyTarget?: ParsedWikiGraphLibraryUri;
   readonly locatedUri: string;
 }
@@ -50,6 +51,7 @@ export async function resolveArchiveRuntimeLocation(
     indexScope: { archiveKey: archivePath, archivePath, kind: "archive-index" },
     ...(libraryArchiveTarget?.kind === "archive"
       ? {
+          libraryArchiveTarget,
           libraryDirtyTarget: {
             isDefault: libraryArchiveTarget.isDefault,
             kind: "scope",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,8 @@ export {
   createWikiGraphLibrary,
   deleteWikiGraphLibraryMetadataKey,
   ensureDefaultWikiGraphLibrary,
+  ensureLibraryManagedArchiveHasNoSearchIndex,
+  finalizeWikiGraphLibraryArchiveWrite,
   formatWikiGraphLibraryUri,
   getWikiGraphLibraryArchive,
   getWikiGraphLibraryArchiveById,

--- a/packages/core/src/library/membership.test.ts
+++ b/packages/core/src/library/membership.test.ts
@@ -5,6 +5,7 @@ import {
   readFile,
   rename,
   rm,
+  stat,
   writeFile,
 } from "fs/promises";
 import { join } from "path";
@@ -16,25 +17,35 @@ import {
   createWikiGraphLibrary,
   disableWikiGraphLibraryIndex,
   ensureDefaultWikiGraphLibrary,
+  finalizeWikiGraphLibraryArchiveWrite,
   getWikiGraphLibraryMetadata,
   isWikiGraphLibraryUri,
   moveWikiGraphLibraryArchive,
   parseLocatedWikiGraphUri,
   parseWikiGraphLibraryUri,
   putWikiGraphLibraryMetadata,
+  readArchiveIndexSettings,
   queryWikiGraphLibrarySearchIndex,
+  rebuildArchiveSearchIndex,
   rebindWikiGraphLibrary,
+  setFtsIndexEmbedded,
   rebuildWikiGraphLibraryIndex,
   removeWikiGraphLibrary,
   removeWikiGraphLibraryArchive,
   resolveWikiGraphLibraryArchivePath,
   resolveWikiGraphLibrary,
   scanWikiGraphLibrary,
+  WikiGraphArchiveFile,
 } from "../index.js";
 import { Database } from "../document/database.js";
+import { DirectoryDocument } from "../document/index.js";
 import { withWikiGraphStateDirectoryPathForTesting } from "../runtime/common/wiki-graph/dir.js";
 import { resolveWikiGraphCoreDatabasePath } from "../runtime/common/wiki-graph/dir.js";
-import { writeWikgArchive } from "../storage/wikg/index.js";
+import {
+  readWikgArchiveEntry,
+  readWikgArchiveMutationToken,
+  writeWikgArchive,
+} from "../storage/wikg/index.js";
 import { acquireWikiGraphLibraryLock } from "./lock.js";
 import { listWikiGraphLibrarySearchIndex } from "./search-index.js";
 
@@ -194,6 +205,158 @@ describe("library archive membership", () => {
       });
       expect(removed.publicId).toBe(added.publicId);
       await expect(readFile(moved.path, "utf8")).rejects.toThrow();
+    });
+  });
+
+  it("removes embedded FTS entries on library add without changing the archive policy", async () => {
+    await withLibraryTestState(async (tempDir) => {
+      const target = parseWikiGraphLibraryUri("wikg://lib");
+      expect(target).toBeDefined();
+      const source = join(tempDir, "embedded.wikg");
+      await createEmbeddedSearchIndexArchive(tempDir, source);
+      const sourceToken = await readWikgArchiveMutationToken(source);
+
+      const added = await addWikiGraphLibraryArchive({
+        inputPath: source,
+        target: target!,
+        to: "embedded.wikg",
+      });
+
+      await expect(readWikgArchiveEntry(added.path, "fts.db")).resolves.toBe(
+        undefined,
+      );
+      await expect(readArchiveFtsEmbedded(added.path)).resolves.toBe(true);
+      expect(added.lastSeenMutationToken).toBe(
+        await readWikgArchiveMutationToken(added.path),
+      );
+      expect(added.lastSeenMutationToken).not.toBe(sourceToken);
+    });
+  });
+
+  it("removes embedded FTS entries during scan and records refreshed archive state", async () => {
+    await withLibraryTestState(async (tempDir) => {
+      const library = await ensureDefaultWikiGraphLibrary();
+      const target = parseWikiGraphLibraryUri("wikg://lib");
+      expect(target).toBeDefined();
+      const archivePath = join(library.folderPath, "scanned.wikg");
+      await createEmbeddedSearchIndexArchive(tempDir, archivePath);
+      const before = await inspectFileState(archivePath);
+
+      const result = await scanWikiGraphLibrary(target!);
+      const scanned = result.archives.find(
+        (archive) => archive.relativePath === "scanned.wikg",
+      );
+
+      await expect(readWikgArchiveEntry(archivePath, "fts.db")).resolves.toBe(
+        undefined,
+      );
+      await expect(readArchiveFtsEmbedded(archivePath)).resolves.toBe(true);
+      const after = await inspectFileState(archivePath);
+      expect(scanned).toMatchObject({
+        lastSeenMtimeMs: Math.round(after.mtimeMs),
+        lastSeenMutationToken: after.mutationToken,
+        lastSeenSize: after.size,
+      });
+      expect(after.mutationToken).not.toBe(before.mutationToken);
+    });
+  });
+
+  it("removes embedded FTS entries during rebind and records refreshed archive state", async () => {
+    await withLibraryTestState(async (tempDir) => {
+      await ensureDefaultWikiGraphLibrary();
+      const target = parseWikiGraphLibraryUri("wikg://lib");
+      expect(target).toBeDefined();
+      const newFolder = join(tempDir, "rebound-library");
+      await mkdir(newFolder);
+      const archivePath = join(newFolder, "rebound.wikg");
+      await createEmbeddedSearchIndexArchive(tempDir, archivePath);
+
+      const result = await rebindWikiGraphLibrary({
+        folderPath: newFolder,
+        target: target!,
+      });
+      const rebound = result.archives.find(
+        (archive) => archive.relativePath === "rebound.wikg",
+      );
+
+      await expect(readWikgArchiveEntry(archivePath, "fts.db")).resolves.toBe(
+        undefined,
+      );
+      await expect(readArchiveFtsEmbedded(archivePath)).resolves.toBe(true);
+      const after = await inspectFileState(archivePath);
+      expect(rebound).toMatchObject({
+        lastSeenMtimeMs: Math.round(after.mtimeMs),
+        lastSeenMutationToken: after.mutationToken,
+        lastSeenSize: after.size,
+      });
+    });
+  });
+
+  it("does not rewrite library archives that already have no embedded FTS entry", async () => {
+    await withLibraryTestState(async (tempDir) => {
+      const library = await ensureDefaultWikiGraphLibrary();
+      const target = parseWikiGraphLibraryUri("wikg://lib");
+      expect(target).toBeDefined();
+      const archivePath = join(library.folderPath, "plain.wikg");
+      await createTestWikgArchive(tempDir, archivePath);
+      const before = await inspectFileState(archivePath);
+
+      await scanWikiGraphLibrary(target!);
+      const after = await inspectFileState(archivePath);
+
+      expect(after).toStrictEqual(before);
+    });
+  });
+
+  it("does not rewrite a library URI write finalization when the archive has no embedded FTS entry", async () => {
+    await withLibraryTestState(async (tempDir) => {
+      const target = parseWikiGraphLibraryUri("wikg://lib");
+      expect(target).toBeDefined();
+      const source = join(tempDir, "plain-source.wikg");
+      await createTestWikgArchive(tempDir, source);
+      const added = await addWikiGraphLibraryArchive({
+        inputPath: source,
+        target: target!,
+        to: "plain-finalize.wikg",
+      });
+      const archiveTarget = parseWikiGraphLibraryUri(added.uri);
+      expect(archiveTarget?.kind).toBe("archive");
+      const before = await inspectFileState(added.path);
+
+      await expect(
+        finalizeWikiGraphLibraryArchiveWrite({ target: archiveTarget! }),
+      ).resolves.toBe(false);
+      const after = await inspectFileState(added.path);
+
+      expect(after).toStrictEqual(before);
+    });
+  });
+
+  it("builds and queries the library aggregate index from main archive data when member FTS is absent", async () => {
+    await withLibraryTestState(async (tempDir) => {
+      const target = parseWikiGraphLibraryUri("wikg://lib");
+      expect(target).toBeDefined();
+      const source = join(tempDir, "searchable.wikg");
+      await createSearchableArchiveWithoutSearchIndex(tempDir, source);
+
+      const added = await addWikiGraphLibraryArchive({
+        inputPath: source,
+        target: target!,
+        to: "searchable.wikg",
+      });
+      await expect(readWikgArchiveEntry(added.path, "fts.db")).resolves.toBe(
+        undefined,
+      );
+
+      await rebuildWikiGraphLibraryIndex(target!);
+      const result = await queryWikiGraphLibrarySearchIndex(
+        target!,
+        "Libraryless",
+      );
+
+      expect(result?.textHits).toContainEqual(
+        expect.objectContaining({ libraryArchiveUri: added.uri }),
+      );
     });
   });
 
@@ -764,6 +927,70 @@ async function createTestWikgArchive(
   const sourceDir = await mkdtemp(join(tempDir, "wikg-source-"));
   await writeFile(join(sourceDir, "database.db"), "test", "utf8");
   await writeWikgArchive(sourceDir, path);
+}
+
+async function createEmbeddedSearchIndexArchive(
+  tempDir: string,
+  path: string,
+): Promise<void> {
+  const sourceDir = await mkdtemp(join(tempDir, "wikg-source-"));
+  const document = await DirectoryDocument.open(sourceDir);
+
+  try {
+    await setFtsIndexEmbedded(document, true);
+    await rebuildArchiveSearchIndex(document);
+  } finally {
+    await document.release();
+  }
+
+  await writeWikgArchive(sourceDir, path);
+  await expect(readWikgArchiveEntry(path, "fts.db")).resolves.toBeDefined();
+}
+
+async function createSearchableArchiveWithoutSearchIndex(
+  tempDir: string,
+  path: string,
+): Promise<void> {
+  const sourceDir = await mkdtemp(join(tempDir, "wikg-source-"));
+  const document = await DirectoryDocument.open(sourceDir);
+
+  try {
+    await document.openSession(async (openedDocument) => {
+      await openedDocument.createSerial();
+      const draft = await openedDocument.getSerialFragments(1).createDraft();
+      draft.addSentence("Libraryless archive data remains searchable.", 5);
+      await draft.commit();
+      await openedDocument.writeToc({
+        items: [{ children: [], serialId: 1, title: "Libraryless" }],
+        version: 1,
+      });
+    });
+  } finally {
+    await document.release();
+  }
+
+  await writeWikgArchive(sourceDir, path);
+  await expect(readWikgArchiveEntry(path, "fts.db")).resolves.toBeUndefined();
+}
+
+async function readArchiveFtsEmbedded(path: string): Promise<boolean> {
+  return await new WikiGraphArchiveFile(path).readDocument(
+    async (document) => (await readArchiveIndexSettings(document)).ftsEmbedded,
+  );
+}
+
+async function inspectFileState(path: string): Promise<{
+  readonly mtimeMs: number;
+  readonly mutationToken?: string;
+  readonly size: number;
+}> {
+  const fileStat = await stat(path);
+  const mutationToken = await readWikgArchiveMutationToken(path);
+  return {
+    mtimeMs: fileStat.mtimeMs,
+    mutationToken,
+    size: fileStat.size,
+  };
 }
 
 async function insertStaleStateLock(libraryId: number): Promise<void> {

--- a/packages/core/src/library/membership.ts
+++ b/packages/core/src/library/membership.ts
@@ -21,7 +21,11 @@ import {
 import { openSharedStateDatabase } from "../document/index.js";
 import { resolveWikiGraphCoreDatabasePath } from "../runtime/common/wiki-graph/dir.js";
 import { WIKI_GRAPH_ARCHIVE_EXTENSION } from "../runtime/common/wiki-graph/uri.js";
-import { readWikgArchiveMutationToken } from "../storage/wikg/index.js";
+import {
+  readWikgArchiveEntry,
+  readWikgArchiveMutationToken,
+  WikiGraphArchiveFile,
+} from "../storage/wikg/index.js";
 import { isNodeError } from "../utils/node-error.js";
 import {
   parseWikiGraphLibraryUri,
@@ -34,6 +38,7 @@ import { markWikiGraphLibraryIndexDirty } from "./search-index.js";
 import { withWikiGraphLibraryLock } from "./lock.js";
 
 const PUBLIC_ID_BYTES = 6;
+const SEARCH_INDEX_ARCHIVE_ENTRY_PATH = "fts.db";
 const LIBRARY_ARCHIVES_TABLE_COLUMNS_SQL = `
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     library_id INTEGER NOT NULL,
@@ -313,7 +318,7 @@ export async function addWikiGraphLibraryArchive(input: {
     );
     await copyFile(sourcePath, targetPath, constants.COPYFILE_EXCL);
     await assertInsideLibrary(await realpath(targetPath), library.folderPath);
-    const targetFile = await inspectLibraryArchiveFile(
+    const targetFile = await ensureLibraryArchiveFileHasNoSearchIndexAndInspect(
       library.folderPath,
       targetRelativePath,
     );
@@ -337,6 +342,58 @@ export async function addWikiGraphLibraryArchive(input: {
     await markWikiGraphLibraryIndexDirty(library);
     return archive;
   });
+}
+
+export async function finalizeWikiGraphLibraryArchiveWrite(input: {
+  readonly target: ParsedWikiGraphLibraryUri;
+}): Promise<boolean> {
+  if (input.target.kind !== "archive") {
+    throw new Error("Expected a Wiki Graph library archive URI.");
+  }
+
+  const library = await resolveWikiGraphLibrary(input.target);
+  return await withWikiGraphLibraryLock(library.id, "write", async () => {
+    const archive = await resolveLibraryArchiveTarget(input.target, library);
+    const removed = await ensureLibraryManagedArchiveHasNoSearchIndex(
+      archive.path,
+    );
+    const refreshedFile = await inspectLibraryArchiveFile(
+      library.folderPath,
+      archive.relativePath,
+    );
+
+    await withLibraryArchiveMembershipDatabase(async (database) => {
+      await updateLibraryArchiveSeen(database, archive.id, refreshedFile, {
+        status: "present",
+      });
+    });
+
+    return removed;
+  });
+}
+
+export async function ensureLibraryManagedArchiveHasNoSearchIndex(
+  archivePath: string,
+): Promise<boolean> {
+  if ((await readOptionalWikgMutationToken(archivePath)) === undefined) {
+    return false;
+  }
+
+  const searchIndex = await readWikgArchiveEntry(
+    archivePath,
+    SEARCH_INDEX_ARCHIVE_ENTRY_PATH,
+  );
+  if (searchIndex === undefined) {
+    return false;
+  }
+
+  await new WikiGraphArchiveFile(archivePath).write(
+    async (document) => {
+      await document.deleteSearchIndexDatabase();
+    },
+    { searchIndexWritebackPolicy: "archive" },
+  );
+  return true;
 }
 
 export async function removeWikiGraphLibraryArchive(input: {
@@ -719,9 +776,22 @@ async function listWikgFiles(
   await walkLibraryDirectory(root, root, relativePaths);
   const files: DiscoveredLibraryArchiveFile[] = [];
   for (const relativePath of relativePaths.sort((a, b) => a.localeCompare(b))) {
-    files.push(await inspectLibraryArchiveFile(root, relativePath));
+    files.push(
+      await ensureLibraryArchiveFileHasNoSearchIndexAndInspect(
+        root,
+        relativePath,
+      ),
+    );
   }
   return files;
+}
+
+async function ensureLibraryArchiveFileHasNoSearchIndexAndInspect(
+  root: string,
+  relativePath: string,
+): Promise<DiscoveredLibraryArchiveFile> {
+  await ensureLibraryManagedArchiveHasNoSearchIndex(join(root, relativePath));
+  return await inspectLibraryArchiveFile(root, relativePath);
 }
 
 async function walkLibraryDirectory(


### PR DESCRIPTION
## Summary
- Remove materialized `fts.db` entries from library-managed `.wikg` archives at add/scan/rebind boundaries while preserving `archive_index_settings.fts_embedded`.
- Finalize `wikg://lib/...` archive writes by clearing any embedded FTS entry and refreshing membership token/size/mtime before marking the library aggregate index dirty.
- Add regression coverage for add/scan/rebind cleanup, library URI write cleanup, no-op finalization, state-isolated tests, and aggregate library indexing from member main data without member `fts.db`.

Fixes https://github.com/oomol-lab/wiki-graph/issues/183

## Acceptance coverage
- `library add`: covered by `membership.test.ts` embedded FTS add test; asserts target lacks `fts.db`, keeps `ftsEmbedded: true`, and membership token matches cleaned archive token.
- `library scan`: covered by scan cleanup test; asserts no `fts.db`, policy unchanged, and token/size/mtime refreshed after cleanup.
- `library rebind`: covered by rebind cleanup test; asserts no `fts.db`, policy unchanged, and token/size/mtime refreshed after cleanup.
- `wikg://lib/...` archive write: covered by `uri.test.ts`; recreates member embedded FTS, performs library URI write, asserts `fts.db` removed, policy unchanged, and index dirty.
- No-op: covered by scan no-op and finalization no-op tests; mutation/file state is unchanged when no `fts.db` exists.
- Library aggregate index: covered by test that builds/queries the library index from member main data when member `fts.db` is absent.
- State isolation: new/changed library tests use `withLibraryTestState` / temporary Wiki Graph state directories.

## Verification
- `pnpm vitest run packages/core/src/library/membership.test.ts packages/cli/src/commands/archive-command/run/uri.test.ts packages/cli/src/commands/archive-command/run/document.test.ts` — passed (before final extra tests: 33 tests).
- `pnpm vitest run packages/core/src/library/membership.test.ts test/core/storage/wikg/archive.test.ts test/core/retrieval/query/archive-view/index.test.ts test/cli/library.test.ts packages/cli/src/commands/archive-command/run/uri.test.ts packages/cli/src/commands/archive-command/run/document.test.ts && pnpm typecheck` — passed (before final extra tests: 60 tests + typecheck).
- `pnpm lint && pnpm format:check && pnpm typecheck && pnpm build` — passed.
- `pnpm vitest run packages/core/src/library/membership.test.ts` — passed (28 tests).
- `pnpm vitest run packages/core/src/library/membership.test.ts test/core/storage/wikg/archive.test.ts test/core/retrieval/query/archive-view/index.test.ts test/cli/library.test.ts packages/cli/src/commands/archive-command/run/uri.test.ts packages/cli/src/commands/archive-command/run/document.test.ts && pnpm build` — passed (62 tests + build).
- `pnpm test:run` — passed (129 files, 838 tests).

## Independent review
- Blind review attempt 1: `verdict: fail`; reviewer identified missing no-op finalization / aggregate-index coverage.
- Blind review attempt 2 after fixes: `verdict: pass`; no blocking risks reported.
