### PR TITLE
fix: reset local CLI install state

### DIFF
--- a/scripts/install-local-cli.mjs
+++ b/scripts/install-local-cli.mjs
@@ -1,6 +1,10 @@
 import { execFileSync } from "child_process";
 import { mkdirSync } from "fs";
 import { delimiter, isAbsolute, join, resolve } from "path";
+import {
+  getLocalGlobalDir,
+  removeLocalInstallState,
+} from "./local-cli-install-state.mjs";
 
 const workspaceRoot = resolve(import.meta.dirname, "..");
 const cliRoot = join(workspaceRoot, "packages", "cli");
@@ -8,7 +12,7 @@ const globalBinDir = execFileSync("pnpm", ["bin", "--global"], {
   cwd: workspaceRoot,
   encoding: "utf8",
 }).trim();
-const localGlobalDir = join(globalBinDir, ".wiki-graph-local-global");
+const localGlobalDir = getLocalGlobalDir(globalBinDir);
 const packRoot = join(localGlobalDir, "packs");
 const pnpmGlobalEnv = {
   ...process.env,
@@ -30,12 +34,13 @@ function readTarballPath(packOutput) {
   return isAbsolute(filename) ? filename : join(packRoot, filename);
 }
 
-mkdirSync(packRoot, { recursive: true });
-
 execFileSync("pnpm", ["build"], {
   cwd: workspaceRoot,
   stdio: "inherit",
 });
+
+removeLocalInstallState(globalBinDir);
+mkdirSync(packRoot, { recursive: true });
 
 const packOutput = execFileSync(
   "pnpm",

--- a/scripts/local-cli-install-state.mjs
+++ b/scripts/local-cli-install-state.mjs
@@ -1,0 +1,33 @@
+import { existsSync, readFileSync, rmSync, unlinkSync } from "fs";
+import { join } from "path";
+
+const binNames = ["wg", "wikigraph"];
+const localGlobalDirName = ".wiki-graph-local-global";
+
+function isOwnedBinShim(binPath) {
+  if (!existsSync(binPath)) {
+    return false;
+  }
+
+  try {
+    return readFileSync(binPath, "utf8").includes(localGlobalDirName);
+  } catch {
+    return false;
+  }
+}
+
+export function getLocalGlobalDir(globalBinDir) {
+  return join(globalBinDir, localGlobalDirName);
+}
+
+export function removeLocalInstallState(globalBinDir) {
+  for (const binName of binNames) {
+    const binPath = join(globalBinDir, binName);
+
+    if (isOwnedBinShim(binPath)) {
+      unlinkSync(binPath);
+    }
+  }
+
+  rmSync(getLocalGlobalDir(globalBinDir), { force: true, recursive: true });
+}

--- a/scripts/local-cli-install-state.mjs
+++ b/scripts/local-cli-install-state.mjs
@@ -2,15 +2,33 @@ import { existsSync, readFileSync, rmSync, unlinkSync } from "fs";
 import { join } from "path";
 
 const binNames = ["wg", "wikigraph"];
+const binSuffixes = ["", ".cmd", ".bat", ".ps1"];
 const localGlobalDirName = ".wiki-graph-local-global";
 
-function isOwnedBinShim(binPath) {
+function normalizePathText(value) {
+  return value.replaceAll("\\", "/");
+}
+
+function expandPnpmShimPathText(content, globalBinDir) {
+  const normalizedGlobalBinDir = normalizePathText(globalBinDir);
+
+  return normalizePathText(content)
+    .replaceAll("$basedir/", `${normalizedGlobalBinDir}/`)
+    .replaceAll("%dp0%/", `${normalizedGlobalBinDir}/`)
+    .replaceAll("%~dp0/", `${normalizedGlobalBinDir}/`);
+}
+
+function isOwnedBinShim(binPath, globalBinDir) {
   if (!existsSync(binPath)) {
     return false;
   }
 
   try {
-    return readFileSync(binPath, "utf8").includes(localGlobalDirName);
+    const content = readFileSync(binPath, "utf8");
+    const expandedContent = expandPnpmShimPathText(content, globalBinDir);
+    const localGlobalDir = normalizePathText(getLocalGlobalDir(globalBinDir));
+
+    return expandedContent.includes(localGlobalDir);
   } catch {
     return false;
   }
@@ -22,10 +40,12 @@ export function getLocalGlobalDir(globalBinDir) {
 
 export function removeLocalInstallState(globalBinDir) {
   for (const binName of binNames) {
-    const binPath = join(globalBinDir, binName);
+    for (const binSuffix of binSuffixes) {
+      const binPath = join(globalBinDir, `${binName}${binSuffix}`);
 
-    if (isOwnedBinShim(binPath)) {
-      unlinkSync(binPath);
+      if (isOwnedBinShim(binPath, globalBinDir)) {
+        unlinkSync(binPath);
+      }
     }
   }
 

--- a/scripts/uninstall-local-cli.mjs
+++ b/scripts/uninstall-local-cli.mjs
@@ -1,18 +1,20 @@
 import { execFileSync } from "child_process";
-import { rmSync } from "fs";
-import { delimiter, join, resolve } from "path";
+import { delimiter, resolve } from "path";
+import {
+  getLocalGlobalDir,
+  removeLocalInstallState,
+} from "./local-cli-install-state.mjs";
 
 const workspaceRoot = resolve(import.meta.dirname, "..");
 const globalBinDir = execFileSync("pnpm", ["bin", "--global"], {
   cwd: workspaceRoot,
   encoding: "utf8",
 }).trim();
-const localGlobalDir = join(globalBinDir, ".wiki-graph-local-global");
+const localGlobalDir = getLocalGlobalDir(globalBinDir);
 const pnpmGlobalEnv = {
   ...process.env,
   PATH: [globalBinDir, process.env.PATH].filter(Boolean).join(delimiter),
 };
-
 try {
   execFileSync(
     "pnpm",
@@ -31,5 +33,5 @@ try {
     },
   );
 } finally {
-  rmSync(localGlobalDir, { force: true, recursive: true });
+  removeLocalInstallState(globalBinDir);
 }


### PR DESCRIPTION
## Summary
- reset the dedicated local CLI pnpm global install directory before reinstalling
- remove only wg/wikigraph shims that point at .wiki-graph-local-global
- share local CLI install cleanup between install and uninstall scripts so uninstall can recover from stale pnpm metadata

## Verification
- pnpm run lint:fix
- pnpm cli:install-local
- pnpm cli:install-local
- wg --version