### PR TITLE
fix(cli): inspect library archive shortcuts

### DIFF
--- a/packages/cli/src/args/archive.test.ts
+++ b/packages/cli/src/args/archive.test.ts
@@ -522,6 +522,45 @@ describe("cli/args/archive", () => {
       help: false,
       kind: "archive",
     });
+    expect(
+      parseCLIArguments(["wikg://lib/archive123", "inspect"]),
+    ).toStrictEqual({
+      args: {
+        action: "inspect",
+        archivePath: "wikg://lib/archive123",
+      },
+      help: false,
+      kind: "archive",
+    });
+    expect(
+      parseCLIArguments([
+        "wikg://lib/team.lib/archive123",
+        "inspect",
+        "--json",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "inspect",
+        archivePath: "wikg://lib/team.lib/archive123",
+        json: true,
+      },
+      help: false,
+      kind: "archive",
+    });
+    expect(() =>
+      parseCLIArguments([
+        "wikg://lib/archive123",
+        "inspect",
+        "--query",
+        "agent",
+      ]),
+    ).toThrow("The `inspect` command does not support --query.");
+    expect(() =>
+      parseCLIArguments(["wikg://lib/archive123", "inspect", "--jsonl"]),
+    ).toThrow("The `inspect` command does not support --jsonl.");
+    expect(() =>
+      parseCLIArguments(["wikg://lib/archive123", "inspect", "--evidence"]),
+    ).toThrow("The `inspect` command does not support --evidence.");
     expect(() =>
       parseCLIArguments(["wikg://book.wikg/chapter/part", "inspect"]),
     ).toThrow("`chapter/<path>` inspect is not available");

--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -782,6 +782,12 @@ describe("cli/args/help", () => {
       "Library archive shortcuts:",
     );
     expect(renderHelpTopicText("library")).toContain(
+      "wikg://lib/<archive-id> inspect",
+    );
+    expect(renderHelpTopicText("library")).toContain(
+      "not a library-level health report",
+    );
+    expect(renderHelpTopicText("library")).toContain(
       "Library index lifecycle:",
     );
     expect(renderHelpTopicText("library")).toContain("Registry discovery:");
@@ -796,6 +802,37 @@ describe("cli/args/help", () => {
         "get",
       ),
     ).toContain("Read this library metadata map");
+    const archiveMemberHelp = parseCLIArguments([
+      "wikg://lib/archive123",
+      "--help",
+    ]);
+    const archiveMemberInspectHelp = parseCLIArguments([
+      "wikg://lib/archive123",
+      "inspect",
+      "--help",
+    ]);
+    expect(archiveMemberHelp).toMatchObject({ help: true, kind: "help" });
+    expect(archiveMemberInspectHelp).toMatchObject({
+      help: true,
+      kind: "help",
+    });
+    if (!archiveMemberHelp.help || !archiveMemberInspectHelp.help) {
+      throw new Error("Expected library archive help output.");
+    }
+    expect(archiveMemberHelp.helpText).toContain(
+      "reads the registry entry for this library archive member",
+    );
+    expect(archiveMemberHelp.helpText).toContain("inspect [--json]");
+    expect(archiveMemberHelp.helpText).toContain("not the library registry");
+    expect(archiveMemberInspectHelp.helpText).toContain(
+      "URI Predicate Command",
+    );
+    expect(archiveMemberInspectHelp.helpText).toContain(
+      "wikg://lib/archive123 inspect [--json]",
+    );
+    expect(archiveMemberInspectHelp.helpText).toContain(
+      "not a library-level health report",
+    );
   });
 
   it("supports a first-contact recovery chain from root help to parse failures", () => {

--- a/packages/cli/src/args/uri/library.ts
+++ b/packages/cli/src/args/uri/library.ts
@@ -88,6 +88,14 @@ export function parseLibraryUriFirstArguments(
     return parseLibraryHelpArguments(uri, target, action, explicitAction);
   }
 
+  if (target.kind === "archive" && action === "inspect") {
+    return parseLibraryArchiveInspectArguments(
+      uri,
+      explicitAction === undefined ? [] : positionals.slice(2),
+      values,
+    );
+  }
+
   if (target.kind === "scope" && target.objectUri === "wikg://index") {
     return parseLibraryIndexArguments(
       uri,
@@ -156,6 +164,14 @@ function parseLibraryHelpArguments(
   action: string,
   explicitAction: string | undefined,
 ): ParsedCLIArguments {
+  if (target.kind === "archive" && action === "inspect") {
+    return {
+      help: true,
+      helpText: renderUriPredicateHelpText("archive-scope", "inspect", uri),
+      kind: "help",
+    };
+  }
+
   if (
     target.kind === "scope" &&
     target.objectUri === undefined &&
@@ -563,6 +579,19 @@ function parseLibraryArchiveArguments(
     help: false,
     kind: "library",
   };
+}
+
+function parseLibraryArchiveInspectArguments(
+  uri: string,
+  tail: readonly string[],
+  values: ArchiveArgumentValues,
+): ParsedCLIArguments {
+  return parseArchiveArguments(
+    "inspect",
+    [uri, ...tail],
+    values,
+    formatWikiGraphHelpCommand(uri, "inspect"),
+  );
 }
 
 function parseLibraryScopeArguments(

--- a/packages/cli/src/args/uri/library.ts
+++ b/packages/cli/src/args/uri/library.ts
@@ -84,6 +84,15 @@ export function parseLibraryUriFirstArguments(
           ? "get"
           : "list");
 
+  if (action === "inspect" && target.kind !== "archive") {
+    throw new Error(
+      withHelpRoute(
+        "Library-level inspection is not supported. Inspect one managed archive with `wg wikg://lib/<archive-id> inspect`.",
+        formatWikiGraphHelpCommand(uri),
+      ),
+    );
+  }
+
   if (values.help === true) {
     return parseLibraryHelpArguments(uri, target, action, explicitAction);
   }

--- a/packages/cli/src/commands/archive-command/inspect.ts
+++ b/packages/cli/src/commands/archive-command/inspect.ts
@@ -103,7 +103,7 @@ async function createArchiveInspectReport(
   document: ReadonlyDocument,
   args: CLIArchiveArguments,
 ): Promise<InspectReport> {
-  const archiveUri = formatWikiGraphCommandUri(args.archivePath);
+  const archiveUri = formatArchiveInspectCommandUri(args.archivePath);
   const scopeUri =
     args.chapterId === undefined
       ? archiveUri
@@ -205,6 +205,14 @@ async function createArchiveInspectReport(
     performanceHints,
     help: { readiness: "wg help readiness" },
   };
+}
+
+function formatArchiveInspectCommandUri(archivePath: string): string {
+  if (archivePath.startsWith("wikg://lib/")) {
+    return archivePath;
+  }
+
+  return formatWikiGraphCommandUri(archivePath);
 }
 
 function formatArchiveInspectText(report: InspectReport): string {

--- a/packages/cli/src/commands/archive-command/run/uri.test.ts
+++ b/packages/cli/src/commands/archive-command/run/uri.test.ts
@@ -24,7 +24,10 @@ import {
 } from "../../../../../core/src/runtime/common/wiki-graph/dir.js";
 import { readWikgArchiveEntry } from "../../../../../core/src/storage/wikg/archive/index.js";
 import { runArchiveChapterCommand } from "../chapter.js";
-import { resolveArchiveCommandRuntimeArguments } from "./uri.js";
+import {
+  resolveArchiveCommandRuntimeArguments,
+  resolveArchiveRuntimeLocation,
+} from "./uri.js";
 
 let previousStateDir: string | undefined;
 let tempDir: string;
@@ -64,6 +67,29 @@ describe("archive-command URI runtime resolution", () => {
       archivePath: `wikg://${archive.path}/entity/Q23`,
       format: "json",
       objectId: `wikg://${archive.path}/entity/Q23`,
+    });
+  });
+
+  it("keeps library archive inspect arguments displayable while runtime resolution can find the archive", async () => {
+    const target = parseWikiGraphLibraryUri("wikg://lib");
+    expect(target).toBeDefined();
+    const archive = await addTestArchiveToLibrary(target!);
+
+    await expect(
+      resolveArchiveCommandRuntimeArguments({
+        action: "inspect",
+        archivePath: archive.uri,
+      }),
+    ).resolves.toStrictEqual({
+      action: "inspect",
+      archivePath: archive.uri,
+    });
+
+    await expect(
+      resolveArchiveRuntimeLocation(archive.uri),
+    ).resolves.toMatchObject({
+      archivePath: archive.path,
+      locatedUri: `wikg://${archive.path}`,
     });
   });
 

--- a/packages/cli/src/commands/archive-command/run/uri.ts
+++ b/packages/cli/src/commands/archive-command/run/uri.ts
@@ -71,6 +71,7 @@ export async function resolveArchiveCommandRuntimeArguments(
   if (
     args.action === "create" ||
     args.action === "export" ||
+    args.action === "inspect" ||
     args.action === "next"
   ) {
     return args;

--- a/packages/core/data/help/commands/library.jinja
+++ b/packages/core/data/help/commands/library.jinja
@@ -38,17 +38,20 @@ Library archive membership
 Default behavior:
   - `{{ commandName }} {{ uri }}` reads the registry entry for this library archive member.
   - The membership entry identifies the archive id, relative path, status, and containing library.
+  - `{{ commandName }} {{ uri }} inspect` checks readiness for this managed archive's contents, not the library registry.
   - Add archive object suffixes such as `/chapter`, `/entity`, or `/triple` when you want to query the archive contents.
 
 Use when:
-  - You need to inspect, move, or remove one archive that is already managed by a library.
+  - You need to inspect readiness, move, or remove one archive that is already managed by a library.
 
 Usage:
   {{ commandName }} {{ uri }} [--json]
+  {{ commandName }} {{ uri }} inspect [--json]
   {{ commandName }} {{ uri }} move --to <relative-wikg-path> [--json]
   {{ commandName }} {{ uri }} remove --confirm [--json]
 
 Predicate commands:
+  - inspect: inspect this managed archive's archive readiness. Help: {{ commandName }} {{ uri }} inspect --help
   - move: move or rename this archive inside the same library folder without changing its archive id. Help: {{ commandName }} {{ uri }} move --help
   - remove: delete this archive file from the library folder and unregister it. Help: {{ commandName }} {{ uri }} remove --help
 {% elif target.kind == "scope" and target.objectUri == "wikg://index" %}

--- a/packages/core/data/help/commands/predicate.jinja
+++ b/packages/core/data/help/commands/predicate.jinja
@@ -98,6 +98,9 @@ Notes:
   - Run this before broad Reading Graph, Reading Summary, or Knowledge Graph work.
   - The report includes content counts, FTS index readiness, generation coverage, retrieval guidance, recommended next commands, planning estimates, and concurrency hints.
   - Use `--json` for a machine-readable report with the same recommendations.
+{% if libraryContext.isArchiveShortcut %}
+  - This library archive shortcut inspects one managed archive's readiness; it is not a library-level health report.
+{% endif %}
 {% elif predicate == "add" and target.name == "chapter-collection-scope" %}
 Purpose:
   Add a chapter to the archive.

--- a/packages/core/data/help/topics/library.jinja
+++ b/packages/core/data/help/topics/library.jinja
@@ -41,6 +41,7 @@ Library archive shortcuts:
     {{ commandName }} wikg://lib/<archive-id>/chapter
     {{ commandName }} wikg://lib/<archive-id>/entity --query "term"
     {{ commandName }} wikg://lib/<archive-id>/triple --query "term"
+  - Run `{{ commandName }} wikg://lib/<archive-id> inspect` to inspect that one managed archive's readiness; this is not a library-level health report.
   - `{{ commandName }} <library-archive-uri> --help` explains membership actions such as `move` and `remove`.
   - `{{ commandName }} <library-archive-uri>/entity --help` explains the archive object scope reached through that library shortcut.
 

--- a/test/cli/archive/mock.ts
+++ b/test/cli/archive/mock.ts
@@ -1,5 +1,6 @@
 import { vi } from "vitest";
 import type * as CLISupport from "../../../packages/cli/src/support/index.js";
+import type * as WikiGraphCore from "wiki-graph-core";
 import type {
   ArchiveBacklinks,
   ArchiveCollectionResult,
@@ -463,6 +464,19 @@ export function parseJSONLLastLine(text: string | undefined): unknown {
 
   return JSON.parse(line) as unknown;
 }
+
+vi.mock("wiki-graph-core", async (importOriginal) => {
+  const actual = await importOriginal<typeof WikiGraphCore>();
+
+  return {
+    ...actual,
+    resolveWikiGraphLibraryArchivePath: vi.fn((uri: string) => {
+      const archiveId = uri.split("/").at(-1) ?? "archive";
+
+      return Promise.resolve(`/tmp/library/${archiveId}.wikg`);
+    }),
+  };
+});
 
 vi.mock(
   "../../../packages/core/src/storage/wikg/wiki-graph-archive-file.js",

--- a/test/cli/archive/object.test.ts
+++ b/test/cli/archive/object.test.ts
@@ -265,6 +265,57 @@ describe("cli/archive/object", () => {
     expect(archiveMockState.textWrites[0]).toContain("Archive Inspect");
   });
 
+  it("inspects a library archive shortcut without leaking the resolved path", async () => {
+    await runArchiveCommand({
+      action: "inspect",
+      archivePath: "wikg://lib/archive123",
+    });
+
+    expect(archiveMockState.readCalls).toStrictEqual([
+      "/tmp/library/archive123.wikg",
+    ]);
+    expect(archiveMockState.textWrites[0]).toContain(
+      "URI: wikg://lib/archive123",
+    );
+    expect(archiveMockState.textWrites[0]).toContain(
+      "Command: wg wikg://lib/archive123/index enable",
+    );
+    expect(archiveMockState.textWrites[0]).toContain(
+      "--input wikg://lib/archive123 --task reading-graph",
+    );
+    expect(archiveMockState.textWrites[0]).not.toContain(
+      "/tmp/library/archive123.wikg",
+    );
+  });
+
+  it("prints library archive shortcut inspect JSON with the shortcut URI", async () => {
+    await runArchiveCommand({
+      action: "inspect",
+      archivePath: "wikg://lib/archive123",
+      json: true,
+    });
+
+    const output = JSON.parse(archiveMockState.textWrites[0] ?? "") as {
+      readonly index?: { readonly fixCommand?: string };
+      readonly improvements?: readonly { readonly command?: string }[];
+      readonly uri?: string;
+    };
+
+    expect(archiveMockState.readCalls).toStrictEqual([
+      "/tmp/library/archive123.wikg",
+    ]);
+    expect(output.uri).toBe("wikg://lib/archive123");
+    expect(output.index?.fixCommand).toBe(
+      "wg wikg://lib/archive123/index enable",
+    );
+    expect(archiveMockState.textWrites[0]).not.toContain(
+      "/tmp/library/archive123.wikg",
+    );
+    expect(
+      output.improvements?.map((item) => item.command).join("\n"),
+    ).toContain("--input wikg://lib/archive123 --task reading-graph");
+  });
+
   it("prints request and job performance hints for multi-chapter generation", async () => {
     archiveMockState.inspectChapters = [
       {

--- a/test/cli/library.test.ts
+++ b/test/cli/library.test.ts
@@ -112,7 +112,7 @@ describe("cli/library args", () => {
     });
   });
 
-  it("parses library archive member commands and rejects unsupported inspect", () => {
+  it("parses library archive member commands and routes inspect to archive readiness", () => {
     expect(
       parseCLIArguments(["wikg://lib/archive123", "--json"]),
     ).toMatchObject({
@@ -162,6 +162,29 @@ describe("cli/library args", () => {
     expect(() => parseCLIArguments(["wikg://lib/meta", "move"])).toThrow(
       "does not support `move`",
     );
+    expect(
+      parseCLIArguments(["wikg://lib/archive123", "inspect"]),
+    ).toMatchObject({
+      args: {
+        action: "inspect",
+        archivePath: "wikg://lib/archive123",
+      },
+      kind: "archive",
+    });
+    expect(
+      parseCLIArguments([
+        "wikg://lib/team.lib/archive123",
+        "inspect",
+        "--json",
+      ]),
+    ).toMatchObject({
+      args: {
+        action: "inspect",
+        archivePath: "wikg://lib/team.lib/archive123",
+        json: true,
+      },
+      kind: "archive",
+    });
     expect(() =>
       parseCLIArguments(["wikg://lib/abc123abc123.lib", "inspect"]),
     ).toThrow("does not support `inspect`");

--- a/test/cli/library.test.ts
+++ b/test/cli/library.test.ts
@@ -187,7 +187,14 @@ describe("cli/library args", () => {
     });
     expect(() =>
       parseCLIArguments(["wikg://lib/abc123abc123.lib", "inspect"]),
-    ).toThrow("does not support `inspect`");
+    ).toThrow(
+      "Library-level inspection is not supported. Inspect one managed archive with `wg wikg://lib/<archive-id> inspect`.",
+    );
+    expect(() =>
+      parseCLIArguments(["wikg://lib", "inspect", "--help"]),
+    ).toThrow(
+      "Library-level inspection is not supported. Inspect one managed archive with `wg wikg://lib/<archive-id> inspect`.",
+    );
   });
 
   it("routes library URI and predicate help through command pages", () => {


### PR DESCRIPTION
## Summary
- Route `wikg://lib/<archive-id> inspect` and non-default library archive shortcuts to the existing archive inspect command.
- Preserve the user-facing library shortcut URI in text and JSON inspect reports while resolving the underlying archive through the library membership resolver.
- Update library/archive inspect help text to explain that this checks one managed archive, not library-level health.

Closes https://github.com/oomol-lab/wiki-graph/issues/187

## Acceptance coverage
- 参数解析：covered for `wikg://lib/archive123 inspect` and `wikg://lib/team.lib/archive123 inspect --json`.
- 参数拒绝：covered for `--query`, `--jsonl`, and `--evidence` using archive inspect rejection rules.
- Help：covered and manually reviewed for `wikg://lib/archive123 --help`, `wikg://lib/archive123 inspect --help`, `wikg://lib --help`, and `wg help library`.
- Help 错误提示：manually verified `wikg://lib inspect` and `wikg://lib/team.lib inspect` remain unsupported with accurate help routes.
- Command routing：covered through `runArchiveCommand`/runtime tests; library shortcuts resolve via membership resolver to the underlying archive.
- Display URI：text and JSON inspect output keep `wikg://lib/archive123` and do not leak `/tmp/library/archive123.wikg`.
- Existing behavior：membership `get`/`move`/`remove` behavior remains in library tests; no `wikg://lib inspect` support was added.

## Verification
- `pnpm vitest run packages/cli/src/args/archive.test.ts packages/cli/src/args/help.test.ts test/cli/library.test.ts test/cli/archive/object.test.ts packages/cli/src/commands/archive-command/run/uri.test.ts` — 5 files passed, 52 tests passed
- `pnpm run typecheck` — passed
- `pnpm run lint` — passed
- `pnpm run format:check` — passed
- `pnpm run build` — passed
- `pnpm run test` — 129 files passed, 846 tests passed
- `git diff --check` — passed

## Review
- Independent blind review completed after the JSON display URI coverage fix.
- Reviewer verdict: pass.
- High-risk boundary: this change is scoped to CLI parsing/routing/help/display URI behavior and does not add library-level readiness reports, caches, schema, migrations, credentials, or production data operations.
