### PR TITLE
fix: paginate source evidence candidates before rendering

### DIFF
--- a/packages/core/src/document/stores/mention-link.ts
+++ b/packages/core/src/document/stores/mention-link.ts
@@ -159,6 +159,12 @@ export class MentionLinkStore implements ReadonlyMentionLinkStore {
     readonly subjectQid: string;
   }): Promise<MentionLinkRecord[]> {
     const direction = input.order === "desc" ? "DESC" : "ASC";
+    const limitClause =
+      input.limit === undefined
+        ? input.offset === undefined
+          ? ""
+          : "LIMIT -1"
+        : "LIMIT ?";
     const rows = await this.#database.queryAll(
       `
         SELECT
@@ -188,7 +194,7 @@ export class MentionLinkStore implements ReadonlyMentionLinkStore {
           source_mentions.chapter_id ${direction},
           source_mentions.sentence_index ${direction},
           mention_links.id ${direction}
-        ${input.limit === undefined ? "" : "LIMIT ?"}
+        ${limitClause}
         ${input.offset === undefined ? "" : "OFFSET ?"}
       `,
       [

--- a/packages/core/src/document/stores/mention-link.ts
+++ b/packages/core/src/document/stores/mention-link.ts
@@ -114,11 +114,51 @@ export class MentionLinkStore implements ReadonlyMentionLinkStore {
     return await this.#hydrateEvidenceMany(rows);
   }
 
+  public async countByTriple(input: {
+    readonly chapterId?: number;
+    readonly objectQid: string;
+    readonly predicate: string;
+    readonly subjectQid: string;
+  }): Promise<number> {
+    return (
+      (await this.#database.queryOne(
+        `
+          SELECT count(*) AS count
+          FROM mention_links
+          INNER JOIN mentions AS source_mentions
+            ON source_mentions.id = mention_links.source_mention_id
+          INNER JOIN mentions AS target_mentions
+            ON target_mentions.id = mention_links.target_mention_id
+          WHERE source_mentions.qid = ?
+            AND mention_links.predicate = ?
+            AND target_mentions.qid = ?
+            ${
+              input.chapterId === undefined
+                ? ""
+                : "AND source_mentions.chapter_id = ?"
+            }
+        `,
+        [
+          input.subjectQid,
+          input.predicate,
+          input.objectQid,
+          ...(input.chapterId === undefined ? [] : [input.chapterId]),
+        ],
+        (row) => getNumber(row, "count"),
+      )) ?? 0
+    );
+  }
+
   public async listByTriple(input: {
+    readonly chapterId?: number;
+    readonly limit?: number;
+    readonly offset?: number;
+    readonly order?: "asc" | "desc";
     readonly objectQid: string;
     readonly predicate: string;
     readonly subjectQid: string;
   }): Promise<MentionLinkRecord[]> {
+    const direction = input.order === "desc" ? "DESC" : "ASC";
     const rows = await this.#database.queryAll(
       `
         SELECT
@@ -133,15 +173,32 @@ export class MentionLinkStore implements ReadonlyMentionLinkStore {
           ON source_mentions.id = mention_links.source_mention_id
         INNER JOIN mentions AS target_mentions
           ON target_mentions.id = mention_links.target_mention_id
+        INNER JOIN serials AS source_serials
+          ON source_serials.id = source_mentions.chapter_id
         WHERE source_mentions.qid = ?
           AND mention_links.predicate = ?
           AND target_mentions.qid = ?
+          ${
+            input.chapterId === undefined
+              ? ""
+              : "AND source_mentions.chapter_id = ?"
+          }
         ORDER BY
-          source_mentions.chapter_id,
-          source_mentions.sentence_index,
-          mention_links.id
+          source_serials.document_order ${direction},
+          source_mentions.chapter_id ${direction},
+          source_mentions.sentence_index ${direction},
+          mention_links.id ${direction}
+        ${input.limit === undefined ? "" : "LIMIT ?"}
+        ${input.offset === undefined ? "" : "OFFSET ?"}
       `,
-      [input.subjectQid, input.predicate, input.objectQid],
+      [
+        input.subjectQid,
+        input.predicate,
+        input.objectQid,
+        ...(input.chapterId === undefined ? [] : [input.chapterId]),
+        ...(input.limit === undefined ? [] : [input.limit]),
+        ...(input.offset === undefined ? [] : [input.offset]),
+      ],
       mapMentionLinkRow,
     );
 

--- a/packages/core/src/document/stores/mention.ts
+++ b/packages/core/src/document/stores/mention.ts
@@ -119,6 +119,12 @@ export class MentionStore implements ReadonlyMentionStore {
     } = {},
   ): Promise<MentionRecord[]> {
     const direction = options.order === "desc" ? "DESC" : "ASC";
+    const limitClause =
+      options.limit === undefined
+        ? options.offset === undefined
+          ? ""
+          : "LIMIT -1"
+        : "LIMIT ?";
 
     return await this.#database.queryAll(
       `
@@ -144,7 +150,7 @@ export class MentionStore implements ReadonlyMentionStore {
           mentions.range_start ${direction},
           mentions.range_end ${direction},
           mentions.id ${direction}
-        ${options.limit === undefined ? "" : "LIMIT ?"}
+        ${limitClause}
         ${options.offset === undefined ? "" : "OFFSET ?"}
       `,
       [

--- a/packages/core/src/document/stores/mention.ts
+++ b/packages/core/src/document/stores/mention.ts
@@ -1,4 +1,5 @@
 import type { Database } from "../database.js";
+import { getNumber, getString } from "../database.js";
 import type { MentionRecord } from "../types.js";
 import { escapeLikePattern, mapMentionRow } from "./helpers.js";
 import type { ReadonlyMentionStore } from "./types.js";
@@ -90,25 +91,87 @@ export class MentionStore implements ReadonlyMentionStore {
     );
   }
 
-  public async listByQid(qid: string): Promise<MentionRecord[]> {
+  public async countByQid(
+    qid: string,
+    options: { readonly chapterId?: number } = {},
+  ): Promise<number> {
+    return (
+      (await this.#database.queryOne(
+        `
+          SELECT count(*) AS count
+          FROM mentions
+          WHERE qid = ?
+          ${options.chapterId === undefined ? "" : "AND chapter_id = ?"}
+        `,
+        options.chapterId === undefined ? [qid] : [qid, options.chapterId],
+        (row) => getNumber(row, "count"),
+      )) ?? 0
+    );
+  }
+
+  public async listByQid(
+    qid: string,
+    options: {
+      readonly chapterId?: number;
+      readonly limit?: number;
+      readonly offset?: number;
+      readonly order?: "asc" | "desc";
+    } = {},
+  ): Promise<MentionRecord[]> {
+    const direction = options.order === "desc" ? "DESC" : "ASC";
+
     return await this.#database.queryAll(
       `
         SELECT
-          id,
-          chapter_id,
-          sentence_index,
-          range_start,
-          range_end,
-          surface,
-          qid,
-          confidence,
-          note
+          mentions.id AS id,
+          mentions.chapter_id AS chapter_id,
+          mentions.sentence_index AS sentence_index,
+          mentions.range_start AS range_start,
+          mentions.range_end AS range_end,
+          mentions.surface AS surface,
+          mentions.qid AS qid,
+          mentions.confidence AS confidence,
+          mentions.note AS note
+        FROM mentions
+        INNER JOIN serials
+          ON serials.id = mentions.chapter_id
+        WHERE mentions.qid = ?
+        ${options.chapterId === undefined ? "" : "AND mentions.chapter_id = ?"}
+        ORDER BY
+          serials.document_order ${direction},
+          mentions.chapter_id ${direction},
+          mentions.sentence_index ${direction},
+          mentions.range_start ${direction},
+          mentions.range_end ${direction},
+          mentions.id ${direction}
+        ${options.limit === undefined ? "" : "LIMIT ?"}
+        ${options.offset === undefined ? "" : "OFFSET ?"}
+      `,
+      [
+        qid,
+        ...(options.chapterId === undefined ? [] : [options.chapterId]),
+        ...(options.limit === undefined ? [] : [options.limit]),
+        ...(options.offset === undefined ? [] : [options.offset]),
+      ],
+      mapMentionRow,
+    );
+  }
+
+  public async listLabelsByQid(
+    qid: string,
+    options: { readonly chapterId?: number } = {},
+  ): Promise<string[]> {
+    return await this.#database.queryAll(
+      `
+        SELECT surface
         FROM mentions
         WHERE qid = ?
-        ORDER BY chapter_id, sentence_index, range_start, range_end, id
+        ${options.chapterId === undefined ? "" : "AND chapter_id = ?"}
+        GROUP BY surface
+        ORDER BY count(*) DESC, surface
       `,
-      [qid],
-      mapMentionRow,
+      options.chapterId === undefined ? [qid] : [qid, options.chapterId],
+      (row) => getString(row, "surface"),
     );
   }
 

--- a/packages/core/src/document/stores/types.ts
+++ b/packages/core/src/document/stores/types.ts
@@ -54,18 +54,44 @@ export interface ReadonlyReadingEdgeStore {
 }
 
 export interface ReadonlyMentionStore {
+  countByQid(
+    qid: string,
+    options?: { readonly chapterId?: number },
+  ): Promise<number>;
   getById(mentionId: string): Promise<MentionRecord | undefined>;
   listAll(): Promise<MentionRecord[]>;
   listBySurfaceTerms(terms: readonly string[]): Promise<MentionRecord[]>;
   listBySurfaces(surfaces: readonly string[]): Promise<MentionRecord[]>;
-  listByQid(qid: string): Promise<MentionRecord[]>;
+  listByQid(
+    qid: string,
+    options?: {
+      readonly chapterId?: number;
+      readonly limit?: number;
+      readonly offset?: number;
+      readonly order?: "asc" | "desc";
+    },
+  ): Promise<MentionRecord[]>;
+  listLabelsByQid(
+    qid: string,
+    options?: { readonly chapterId?: number },
+  ): Promise<string[]>;
   listByChapter(chapterId: number): Promise<MentionRecord[]>;
 }
 
 export interface ReadonlyMentionLinkStore {
+  countByTriple(input: {
+    readonly chapterId?: number;
+    readonly objectQid: string;
+    readonly predicate: string;
+    readonly subjectQid: string;
+  }): Promise<number>;
   getById(linkId: string): Promise<MentionLinkRecord | undefined>;
   listAll(): Promise<MentionLinkRecord[]>;
   listByTriple(input: {
+    readonly chapterId?: number;
+    readonly limit?: number;
+    readonly offset?: number;
+    readonly order?: "asc" | "desc";
     readonly objectQid: string;
     readonly predicate: string;
     readonly subjectQid: string;

--- a/packages/core/src/library/query.ts
+++ b/packages/core/src/library/query.ts
@@ -439,20 +439,6 @@ function combinePageEvidencePreviews(
   };
 }
 
-function createPageEvidenceOptions(
-  options: Parameters<typeof readArchivePage>[2] = {},
-): ArchiveEvidenceOptions {
-  return {
-    ...(options.evidenceLimit === undefined
-      ? {}
-      : { limit: options.evidenceLimit }),
-    ...(options.order === undefined ? {} : { order: options.order }),
-    ...(options.sourceContext === undefined
-      ? {}
-      : { sourceContext: options.sourceContext }),
-  };
-}
-
 function createEvidenceResult(
   items: readonly ArchiveEvidenceItem[],
   options: ArchiveEvidenceOptions,
@@ -488,18 +474,6 @@ function createRelatedResult(
     items: pageItems,
     limit,
     nextCursor: nextOffset < sorted.length ? String(nextOffset) : null,
-  };
-}
-
-function createEvidencePreview(evidence: ArchiveEvidence, limit: number) {
-  const sources = evidence.items.slice(0, limit);
-
-  return {
-    nextCursor:
-      sources.length < evidence.items.length ? String(sources.length) : null,
-    shown: sources.length,
-    sources,
-    total: evidence.items.length,
   };
 }
 

--- a/packages/core/src/library/query.ts
+++ b/packages/core/src/library/query.ts
@@ -163,16 +163,12 @@ export async function readWikiGraphLibraryPage(
   );
 
   const page = createMultiArchivePage(pages);
-  if (
-    (page.type === "entity" || page.type === "triple") &&
-    pages.length > 1 &&
-    options.evidenceLimit !== undefined
-  ) {
+  if ((page.type === "entity" || page.type === "triple") && pages.length > 1) {
     return {
       ...page,
       evidence: combinePageEvidencePreviews(
         pages,
-        options.evidenceLimit,
+        options.evidenceLimit ?? 3,
         options.order ?? "doc-asc",
       ),
     };

--- a/packages/core/src/library/query.ts
+++ b/packages/core/src/library/query.ts
@@ -20,8 +20,10 @@ import type {
   ArchiveEvidence,
   ArchiveEvidenceItem,
   ArchiveEvidenceOptions,
+  ArchiveFindEvidencePreview,
   ArchiveFindHit,
   ArchiveFindOptions,
+  ArchiveFindOrder,
   ArchiveFindResult,
   ArchiveLibrarySource,
   ArchiveListItem,
@@ -161,15 +163,18 @@ export async function readWikiGraphLibraryPage(
   );
 
   const page = createMultiArchivePage(pages);
-  if ((page.type === "entity" || page.type === "triple") && pages.length > 1) {
-    const evidence = await listWikiGraphLibraryEvidence(target, objectUri, {
-      ...createPageEvidenceOptions(options),
-      limit: Number.MAX_SAFE_INTEGER,
-    });
-
+  if (
+    (page.type === "entity" || page.type === "triple") &&
+    pages.length > 1 &&
+    options.evidenceLimit !== undefined
+  ) {
     return {
       ...page,
-      evidence: createEvidencePreview(evidence, options.evidenceLimit ?? 3),
+      evidence: combinePageEvidencePreviews(
+        pages,
+        options.evidenceLimit,
+        options.order ?? "doc-asc",
+      ),
     };
   }
 
@@ -315,7 +320,6 @@ async function readIndexedArchiveResults<T>(
   }
 
   const results: T[] = [];
-
   for (const archiveId of archiveIds) {
     const archive = await getWikiGraphLibraryArchiveById(library, archiveId);
     if (!isReadableLibraryArchive(archive)) {
@@ -400,6 +404,39 @@ function createMultiArchivePage(pages: readonly ArchivePage[]): ArchivePage {
   } = first;
 
   return { ...page, sources };
+}
+
+function combinePageEvidencePreviews(
+  pages: readonly ArchivePage[],
+  limit: number,
+  order: ArchiveFindOrder,
+): ArchiveFindEvidencePreview {
+  const evidencePages = pages.flatMap((page) =>
+    page.type === "entity" || page.type === "triple" ? [page] : [],
+  );
+  const orderedPages =
+    order === "doc-desc" ? evidencePages.slice().reverse() : evidencePages;
+  const sources = orderedPages.flatMap((page) =>
+    page.evidence.sources.map((source) => ({
+      ...source,
+      ...(page.archiveId === undefined ? {} : { archiveId: page.archiveId }),
+      ...(page.libraryArchiveUri === undefined
+        ? {}
+        : { libraryArchiveUri: page.libraryArchiveUri }),
+    })),
+  );
+  const total = evidencePages.reduce(
+    (sum, page) => sum + page.evidence.total,
+    0,
+  );
+  const shown = Math.min(limit, sources.length);
+
+  return {
+    nextCursor: shown < total ? String(shown) : null,
+    shown,
+    sources: sources.slice(0, shown),
+    total,
+  };
 }
 
 function createPageEvidenceOptions(

--- a/packages/core/src/retrieval/query/archive-view/evidence-hydration.ts
+++ b/packages/core/src/retrieval/query/archive-view/evidence-hydration.ts
@@ -2,7 +2,6 @@ import type { ReadonlyDocument } from "../../../document/index.js";
 
 import { readEntitySearchEvidenceMentions } from "../search-cache/index.js";
 import {
-  encodeFindCursor,
   isWikiGraphObjectUri,
   mergeStringLists,
   normalizeWikiGraphObjectUri,
@@ -25,11 +24,9 @@ import {
 } from "./knowledge.js";
 import {
   createEvidenceReadContext,
-  createExpandedSourceEvidenceRanges,
+  createMentionEvidencePagePreview,
   createMentionEvidencePreview,
-  createMentionEvidenceRanges,
   createMentionLinkEvidencePreview,
-  createSourceEvidenceItem,
 } from "./source.js";
 
 export async function hydrateFindHitEvidence(
@@ -413,26 +410,13 @@ async function hydrateEntitySessionHitEvidence(
 
     return mention === undefined ? [] : [mention];
   });
-  const ranges = await createMentionEvidenceRanges(document, allMentions);
-  const mergedRanges = await createExpandedSourceEvidenceRanges(
+  const evidence = await createMentionEvidencePagePreview(
     document,
-    ranges,
-    sourceContext,
+    allMentions,
+    evidenceLimit,
     context,
-  );
-  const sources = await Promise.all(
-    mergedRanges
-      .slice(0, evidenceLimit)
-      .map(
-        async (range) =>
-          await createSourceEvidenceItem(
-            document,
-            range.chapterId,
-            range.startSentenceIndex,
-            range.endSentenceIndex,
-            context,
-          ),
-      ),
+    sourceContext,
+    allMentions.length,
   );
 
   return {
@@ -448,14 +432,6 @@ async function hydrateEntitySessionHitEvidence(
           snippet: allMentions[0].note ?? allMentions[0].surface,
           title: allMentions[0].surface,
         }),
-    evidence: {
-      nextCursor:
-        sources.length < mergedRanges.length
-          ? encodeFindCursor(sources.length)
-          : null,
-      shown: sources.length,
-      sources,
-      total: mergedRanges.length,
-    },
+    evidence,
   };
 }

--- a/packages/core/src/retrieval/query/archive-view/evidence.ts
+++ b/packages/core/src/retrieval/query/archive-view/evidence.ts
@@ -3,15 +3,19 @@ import type { ReadonlyDocument } from "../../../document/index.js";
 import { parseWikiGraphReference } from "./references.js";
 import type { ArchiveEvidence, ArchiveEvidenceOptions } from "./types.js";
 import { requireNode } from "./core.js";
+import { DEFAULT_FIND_LIMIT, decodeFindCursor } from "./helpers.js";
 import {
   filterMentionLinksByChapter,
   filterMentionsByChapter,
 } from "./knowledge.js";
 import {
   createMentionEvidenceRanges,
+  createMentionEvidencePage,
   createMentionLinkEvidenceRanges,
+  createMentionLinkEvidencePage,
   createNodeEvidenceRanges,
   createSourceEvidencePage,
+  createEvidenceReadContext,
 } from "./source.js";
 
 export async function listArchiveEvidence(
@@ -58,7 +62,33 @@ export async function listArchiveEvidence(
         options,
       );
     }
-    case "entity":
+    case "entity": {
+      if (options.query === undefined) {
+        const limit = options.limit ?? DEFAULT_FIND_LIMIT;
+        const offset = decodeFindCursor(options.cursor);
+        const chapterFilter =
+          reference.chapterId === undefined
+            ? {}
+            : { chapterId: reference.chapterId };
+        const [total, mentions] = await Promise.all([
+          document.mentions.countByQid(reference.qid, chapterFilter),
+          document.mentions.listByQid(reference.qid, {
+            ...chapterFilter,
+            limit,
+            offset,
+            order: options.order === "doc-desc" ? "desc" : "asc",
+          }),
+        ]);
+
+        return await createMentionEvidencePage(document, mentions, {
+          context: createEvidenceReadContext(),
+          limit,
+          offset,
+          sourceContext: options.sourceContext,
+          total,
+        });
+      }
+
       return await createSourceEvidencePage(
         document,
         await createMentionEvidenceRanges(
@@ -70,7 +100,38 @@ export async function listArchiveEvidence(
         ),
         options,
       );
-    case "triple":
+    }
+    case "triple": {
+      if (options.query === undefined) {
+        const limit = options.limit ?? DEFAULT_FIND_LIMIT;
+        const offset = decodeFindCursor(options.cursor);
+        const tripleQuery = {
+          ...(reference.chapterId === undefined
+            ? {}
+            : { chapterId: reference.chapterId }),
+          objectQid: reference.objectQid,
+          predicate: reference.predicate,
+          subjectQid: reference.subjectQid,
+        };
+        const [total, links] = await Promise.all([
+          document.mentionLinks.countByTriple(tripleQuery),
+          document.mentionLinks.listByTriple({
+            ...tripleQuery,
+            limit,
+            offset,
+            order: options.order === "doc-desc" ? "desc" : "asc",
+          }),
+        ]);
+
+        return await createMentionLinkEvidencePage(document, links, {
+          context: createEvidenceReadContext(),
+          limit,
+          offset,
+          sourceContext: options.sourceContext,
+          total,
+        });
+      }
+
       return await createSourceEvidencePage(
         document,
         createMentionLinkEvidenceRanges(
@@ -87,6 +148,7 @@ export async function listArchiveEvidence(
         ),
         options,
       );
+    }
   }
 }
 

--- a/packages/core/src/retrieval/query/archive-view/find.ts
+++ b/packages/core/src/retrieval/query/archive-view/find.ts
@@ -242,7 +242,6 @@ export async function findChapters(
       ...(await findTextStreamSentences(
         document,
         chapter.chapterId,
-        chapter.path,
         "summary",
         title,
         search,
@@ -253,7 +252,6 @@ export async function findChapters(
       ...(await findTextStreamSentences(
         document,
         chapter.chapterId,
-        chapter.path,
         "source",
         title,
         search,
@@ -267,7 +265,6 @@ export async function findChapters(
 async function findTextStreamSentences(
   document: ReadonlyDocument,
   chapterId: number,
-  chapterPath: string,
   stream: ArchiveTextStreamKind,
   title: string,
   search: ArchiveTextSearch,
@@ -286,7 +283,7 @@ async function findTextStreamSentences(
         chapter: chapterId,
         field: stream,
         id: formatTextStreamRangeUri(
-          chapterPath,
+          chapterId,
           stream,
           sentence.globalIndex,
           sentence.globalIndex,

--- a/packages/core/src/retrieval/query/archive-view/knowledge.ts
+++ b/packages/core/src/retrieval/query/archive-view/knowledge.ts
@@ -109,26 +109,14 @@ export async function createTriplePageLabel(
   document: ReadonlyDocument,
   reference: Extract<WikiGraphReference, { readonly type: "triple" }>,
 ): Promise<string> {
-  const [subjectMentions, objectMentions] = await Promise.all([
-    document.mentions.listByQid(reference.subjectQid),
-    document.mentions.listByQid(reference.objectQid),
+  const chapterFilter =
+    reference.chapterId === undefined ? {} : { chapterId: reference.chapterId };
+  const [subjectLabels, objectLabels] = await Promise.all([
+    document.mentions.listLabelsByQid(reference.subjectQid, chapterFilter),
+    document.mentions.listLabelsByQid(reference.objectQid, chapterFilter),
   ]);
-  const scopedSubjectMentions = filterMentionsByChapter(
-    subjectMentions,
-    reference.chapterId,
-  );
-  const scopedObjectMentions = filterMentionsByChapter(
-    objectMentions,
-    reference.chapterId,
-  );
-  const subjectLabel =
-    scopedSubjectMentions.length === 0
-      ? reference.subjectQid
-      : selectEntityLabel(scopedSubjectMentions);
-  const objectLabel =
-    scopedObjectMentions.length === 0
-      ? reference.objectQid
-      : selectEntityLabel(scopedObjectMentions);
+  const subjectLabel = subjectLabels[0] ?? reference.subjectQid;
+  const objectLabel = objectLabels[0] ?? reference.objectQid;
 
   return `${subjectLabel}(${reference.subjectQid}) ${reference.predicate} ${objectLabel}(${reference.objectQid})`;
 }

--- a/packages/core/src/retrieval/query/archive-view/pages.ts
+++ b/packages/core/src/retrieval/query/archive-view/pages.ts
@@ -24,17 +24,11 @@ import {
 } from "./core.js";
 import {
   createEvidenceReadContext,
-  createMentionEvidencePreview,
-  createMentionLinkEvidencePreview,
+  createMentionEvidencePagePreview,
+  createMentionLinkEvidencePagePreview,
 } from "./source.js";
 import { createTextStreamBacklinks } from "./backlinks.js";
-import {
-  createTriplePageLabel,
-  filterMentionLinksByChapter,
-  filterMentionsByChapter,
-  selectEntityLabel,
-  selectEntityLabels,
-} from "./knowledge.js";
+import { createTriplePageLabel } from "./knowledge.js";
 import { resolveEntityWikipage } from "./related/index.js";
 import {
   formatChapterId,
@@ -295,28 +289,38 @@ async function readWikiGraphPage(
         type: "chapter-tree",
       };
     case "entity": {
-      const mentions = filterMentionsByChapter(
-        await document.mentions.listByQid(reference.qid),
-        reference.chapterId,
-      );
+      const evidenceLimit = options.evidenceLimit ?? 3;
+      const chapterFilter =
+        reference.chapterId === undefined
+          ? {}
+          : { chapterId: reference.chapterId };
+      const [mentionCount, mentions, labels] = await Promise.all([
+        document.mentions.countByQid(reference.qid, chapterFilter),
+        document.mentions.listByQid(reference.qid, {
+          ...chapterFilter,
+          limit: evidenceLimit,
+          order: options.order === "doc-desc" ? "desc" : "asc",
+        }),
+        document.mentions.listLabelsByQid(reference.qid, chapterFilter),
+      ]);
 
-      if (mentions.length === 0) {
+      if (mentionCount === 0) {
         throw new Error(`Entity ${uri} was not found in this archive.`);
       }
 
       return {
-        evidence: await createMentionEvidencePreview(
+        evidence: await createMentionEvidencePagePreview(
           document,
           mentions,
-          options.evidenceLimit,
+          evidenceLimit,
           createEvidenceReadContext(),
           options.sourceContext ?? DEFAULT_SOURCE_CONTEXT,
-          options.order ?? "doc-asc",
+          mentionCount,
         ),
         id: displayUri,
-        label: selectEntityLabel(mentions),
-        labels: selectEntityLabels(mentions),
-        mentionCount: mentions.length,
+        label: labels[0] ?? reference.qid,
+        labels,
+        mentionCount,
         qid: reference.qid,
         type: "entity",
       };
@@ -328,31 +332,40 @@ async function readWikiGraphPage(
         type: "entity-wikipage",
       };
     case "triple": {
-      const links = await filterMentionLinksByChapter(
-        document,
-        await document.mentionLinks.listByTriple({
-          objectQid: reference.objectQid,
-          predicate: reference.predicate,
-          subjectQid: reference.subjectQid,
+      const evidenceLimit = options.evidenceLimit ?? 3;
+      const tripleQuery = {
+        ...(reference.chapterId === undefined
+          ? {}
+          : { chapterId: reference.chapterId }),
+        objectQid: reference.objectQid,
+        predicate: reference.predicate,
+        subjectQid: reference.subjectQid,
+      };
+      const [linkCount, links, label] = await Promise.all([
+        document.mentionLinks.countByTriple(tripleQuery),
+        document.mentionLinks.listByTriple({
+          ...tripleQuery,
+          limit: evidenceLimit,
+          order: options.order === "doc-desc" ? "desc" : "asc",
         }),
-        reference.chapterId,
-      );
+        createTriplePageLabel(document, reference),
+      ]);
 
-      if (links.length === 0) {
+      if (linkCount === 0) {
         throw new Error(`Triple ${uri} was not found in this archive.`);
       }
 
       return {
-        evidence: await createMentionLinkEvidencePreview(
+        evidence: await createMentionLinkEvidencePagePreview(
           document,
           links,
-          options.evidenceLimit,
+          evidenceLimit,
           createEvidenceReadContext(),
           options.sourceContext ?? DEFAULT_SOURCE_CONTEXT,
-          options.order ?? "doc-asc",
+          linkCount,
         ),
         id: displayUri,
-        label: await createTriplePageLabel(document, reference),
+        label,
         objectQid: reference.objectQid,
         predicate: reference.predicate,
         subjectQid: reference.subjectQid,

--- a/packages/core/src/retrieval/query/archive-view/related/pagination.ts
+++ b/packages/core/src/retrieval/query/archive-view/related/pagination.ts
@@ -3,7 +3,7 @@ import type { ReadonlyDocument } from "../../../../document/index.js";
 import { DEFAULT_SOURCE_CONTEXT, requireNode } from "../core.js";
 import {
   createEvidenceReadContext,
-  createMentionLinkEvidencePreview,
+  createMentionLinkEvidencePagePreview,
   createNodeEvidenceRanges,
   createSourceEvidencePreview,
 } from "../source.js";
@@ -45,13 +45,12 @@ export async function hydrateRelatedItemsEvidence(
           return item;
         }
         if (item.type === "triple") {
-          const evidence = await createMentionLinkEvidencePreview(
+          const evidence = await createMentionLinkEvidencePagePreview(
             document,
             item.evidenceLinks ?? [],
             evidenceLimit,
             context,
             options.sourceContext ?? DEFAULT_SOURCE_CONTEXT,
-            options.order ?? "doc-asc",
           );
           const { evidenceLinks: _evidenceLinks, ...publicItem } = item;
 

--- a/packages/core/src/retrieval/query/archive-view/search/hydration.ts
+++ b/packages/core/src/retrieval/query/archive-view/search/hydration.ts
@@ -296,7 +296,7 @@ export async function hydrateSearchTextHit(
     ...createArchiveScopeFields(hit.archiveId),
     field: stream,
     id: formatTextStreamRangeUri(
-      chapter.path,
+      hit.chapterId,
       stream,
       range.startSentenceIndex,
       range.endSentenceIndex,

--- a/packages/core/src/retrieval/query/archive-view/source-evidence/core.ts
+++ b/packages/core/src/retrieval/query/archive-view/source-evidence/core.ts
@@ -22,12 +22,15 @@ import type {
 } from "../types.js";
 import { DEFAULT_SOURCE_CONTEXT } from "../core.js";
 import {
-  createExpandedSourceEvidenceRanges,
   createMentionEvidenceRanges,
   createMentionLinkEvidenceRanges,
-  mergeSourceEvidenceRanges,
 } from "./ranges.js";
-import { createEvidenceReadContext, createSourceEvidenceItem } from "./read.js";
+import {
+  createSourceEvidenceCandidatePage,
+  createSourceEvidenceCandidatePreview,
+  createSourceEvidenceDisplayItems,
+} from "./pagination.js";
+import { createEvidenceReadContext } from "./read.js";
 
 export { createEvidenceReadContext, createSourceEvidenceItem } from "./read.js";
 export {
@@ -44,14 +47,95 @@ export async function createMentionEvidencePreview(
   context: EvidenceReadContext = createEvidenceReadContext(),
   sourceContext = DEFAULT_SOURCE_CONTEXT,
   order: ArchiveFindOrder = "doc-asc",
+  total?: number,
 ): Promise<ArchiveFindEvidencePreview> {
-  return await createSourceEvidencePreview(
+  return await createSourceEvidenceCandidatePreview(document, {
+    candidates: mentions,
+    context,
+    createRanges: async (mention) =>
+      await createMentionEvidenceRanges(document, [mention]),
+    limit,
+    sourceContext,
+    total,
+  });
+}
+
+export async function createMentionEvidencePagePreview(
+  document: ReadonlyDocument,
+  mentions: readonly MentionRecord[],
+  limit = 3,
+  context: EvidenceReadContext = createEvidenceReadContext(),
+  sourceContext = DEFAULT_SOURCE_CONTEXT,
+  total?: number,
+): Promise<ArchiveFindEvidencePreview> {
+  return await createSourceEvidenceCandidatePreview(document, {
+    candidates: mentions,
+    context,
+    createRanges: async (mention) =>
+      await createMentionEvidenceRanges(document, [mention]),
+    limit,
+    sourceContext,
+    total,
+  });
+}
+
+export async function createMentionEvidencePage(
+  document: ReadonlyDocument,
+  mentions: readonly MentionRecord[],
+  options: {
+    readonly context: EvidenceReadContext;
+    readonly limit: number;
+    readonly offset: number;
+    readonly sourceContext?: number | undefined;
+    readonly total: number;
+  },
+): Promise<ArchiveEvidence> {
+  return await createSourceEvidenceCandidatePage(document, {
+    candidates: mentions,
+    context: options.context,
+    createRanges: async (mention) =>
+      await createMentionEvidenceRanges(document, [mention]),
+    limit: options.limit,
+    offset: options.offset,
+    sourceContext: options.sourceContext,
+    total: options.total,
+  });
+}
+
+export async function createRangeEvidencePreview(
+  document: ReadonlyDocument,
+  ranges: readonly SourceEvidenceRange[],
+  limit = 3,
+  context: EvidenceReadContext = createEvidenceReadContext(),
+  sourceContext = DEFAULT_SOURCE_CONTEXT,
+  total?: number,
+): Promise<ArchiveFindEvidencePreview> {
+  return await createSourceEvidenceCandidatePreview(document, {
+    candidates: ranges,
+    context,
+    createRanges: (range) => [range],
+    limit,
+    sourceContext,
+    total,
+  });
+}
+
+export async function createSortedRangeEvidencePreview(
+  document: ReadonlyDocument,
+  ranges: readonly SourceEvidenceRange[],
+  limit = 3,
+  context: EvidenceReadContext = createEvidenceReadContext(),
+  sourceContext = DEFAULT_SOURCE_CONTEXT,
+  order: ArchiveFindOrder = "doc-asc",
+  total?: number,
+): Promise<ArchiveFindEvidencePreview> {
+  return await createRangeEvidencePreview(
     document,
-    await createMentionEvidenceRanges(document, mentions),
+    await sortSourceEvidenceRanges(document, ranges, order),
     limit,
     context,
     sourceContext,
-    order,
+    total,
   );
 }
 
@@ -62,14 +146,78 @@ export async function createMentionLinkEvidencePreview(
   context: EvidenceReadContext = createEvidenceReadContext(),
   sourceContext = DEFAULT_SOURCE_CONTEXT,
   order: ArchiveFindOrder = "doc-asc",
+  total?: number,
 ): Promise<ArchiveFindEvidencePreview> {
-  return await createSourceEvidencePreview(
+  return await createSourceEvidenceCandidatePreview(document, {
+    candidates: links,
+    context,
+    createRanges: (link) => createMentionLinkEvidenceRanges(document, [link]),
+    limit,
+    sourceContext,
+    total,
+  });
+}
+
+export async function createMentionLinkEvidencePagePreview(
+  document: ReadonlyDocument,
+  links: readonly MentionLinkRecord[],
+  limit = 3,
+  context: EvidenceReadContext = createEvidenceReadContext(),
+  sourceContext = DEFAULT_SOURCE_CONTEXT,
+  total?: number,
+): Promise<ArchiveFindEvidencePreview> {
+  return await createSourceEvidenceCandidatePreview(document, {
+    candidates: links,
+    context,
+    createRanges: (link) => createMentionLinkEvidenceRanges(document, [link]),
+    limit,
+    sourceContext,
+    total,
+  });
+}
+
+export async function createMentionLinkEvidencePage(
+  document: ReadonlyDocument,
+  links: readonly MentionLinkRecord[],
+  options: {
+    readonly context: EvidenceReadContext;
+    readonly limit: number;
+    readonly offset: number;
+    readonly sourceContext?: number | undefined;
+    readonly total: number;
+  },
+): Promise<ArchiveEvidence> {
+  return await createSourceEvidenceCandidatePage(document, {
+    candidates: links,
+    context: options.context,
+    createRanges: (link) => createMentionLinkEvidenceRanges(document, [link]),
+    limit: options.limit,
+    offset: options.offset,
+    sourceContext: options.sourceContext,
+    total: options.total,
+  });
+}
+
+export async function createSortedMentionLinkEvidencePreview(
+  document: ReadonlyDocument,
+  links: readonly MentionLinkRecord[],
+  limit = 3,
+  context: EvidenceReadContext = createEvidenceReadContext(),
+  sourceContext = DEFAULT_SOURCE_CONTEXT,
+  order: ArchiveFindOrder = "doc-asc",
+  total?: number,
+): Promise<ArchiveFindEvidencePreview> {
+  return await createRangeEvidencePreview(
     document,
-    createMentionLinkEvidenceRanges(document, links),
+    await sortSourceEvidenceRanges(
+      document,
+      createMentionLinkEvidenceRanges(document, links),
+      order,
+    ),
     limit,
     context,
     sourceContext,
-    order,
+    total,
   );
 }
 
@@ -87,33 +235,18 @@ export async function createSourceEvidencePage(
     options.query,
     options.order ?? "doc-asc",
   );
-  const displayRanges = await createExpandedSourceEvidenceRanges(
-    document,
-    evidenceRanges,
-    options.sourceContext ?? DEFAULT_SOURCE_CONTEXT,
-    context,
-  );
-  const pageRanges = displayRanges.slice(start, start + limit);
+  const pageRanges = evidenceRanges.slice(start, start + limit);
   const nextOffset = start + pageRanges.length;
-  const items = await Promise.all(
-    pageRanges.map(
-      async (range) =>
-        await createSourceEvidenceItem(
-          document,
-          range.chapterId,
-          range.startSentenceIndex,
-          range.endSentenceIndex,
-          context,
-          range.score,
-        ),
-    ),
-  );
+  const items = await createSourceEvidenceDisplayItems(document, pageRanges, {
+    context,
+    sourceContext: options.sourceContext,
+  });
 
   return {
     items,
     limit,
     nextCursor:
-      nextOffset < displayRanges.length ? encodeFindCursor(nextOffset) : null,
+      nextOffset < evidenceRanges.length ? encodeFindCursor(nextOffset) : null,
   };
 }
 
@@ -126,7 +259,7 @@ export async function filterAndSortSourceEvidenceRangesByFtsQuery(
   const documentOrders = await document.serials.listDocumentOrders();
 
   if (queryText === undefined) {
-    return mergeSourceEvidenceRanges(ranges).sort((left, right) =>
+    return [...ranges].sort((left, right) =>
       compareSourceEvidenceRanges(left, right, documentOrders, order),
     );
   }
@@ -214,37 +347,27 @@ export async function createSourceEvidencePreview(
   context: EvidenceReadContext = createEvidenceReadContext(),
   sourceContext = DEFAULT_SOURCE_CONTEXT,
   order: ArchiveFindOrder = "doc-asc",
+  total?: number,
 ): Promise<ArchiveFindEvidencePreview> {
+  return await createSortedRangeEvidencePreview(
+    document,
+    ranges,
+    limit,
+    context,
+    sourceContext,
+    order,
+    total,
+  );
+}
+
+async function sortSourceEvidenceRanges(
+  document: ReadonlyDocument,
+  ranges: readonly SourceEvidenceRange[],
+  order: ArchiveFindOrder,
+): Promise<readonly SourceEvidenceRange[]> {
   const documentOrders = await document.serials.listDocumentOrders();
-  const mergedRanges = mergeSourceEvidenceRanges(ranges).sort((left, right) =>
+
+  return [...ranges].sort((left, right) =>
     compareSourceEvidenceRanges(left, right, documentOrders, order),
   );
-  const displayRanges = await createExpandedSourceEvidenceRanges(
-    document,
-    mergedRanges.slice(0, limit),
-    sourceContext,
-    context,
-  );
-  const sources = await Promise.all(
-    displayRanges.map(
-      async (range) =>
-        await createSourceEvidenceItem(
-          document,
-          range.chapterId,
-          range.startSentenceIndex,
-          range.endSentenceIndex,
-          context,
-        ),
-    ),
-  );
-
-  return {
-    nextCursor:
-      Math.min(limit, mergedRanges.length) < mergedRanges.length
-        ? encodeFindCursor(Math.min(limit, mergedRanges.length))
-        : null,
-    shown: sources.length,
-    sources,
-    total: mergedRanges.length,
-  };
 }

--- a/packages/core/src/retrieval/query/archive-view/source-evidence/core.ts
+++ b/packages/core/src/retrieval/query/archive-view/source-evidence/core.ts
@@ -46,7 +46,7 @@ export async function createMentionEvidencePreview(
   limit = 3,
   context: EvidenceReadContext = createEvidenceReadContext(),
   sourceContext = DEFAULT_SOURCE_CONTEXT,
-  order: ArchiveFindOrder = "doc-asc",
+  _order: ArchiveFindOrder = "doc-asc",
   total?: number,
 ): Promise<ArchiveFindEvidencePreview> {
   return await createSourceEvidenceCandidatePreview(document, {
@@ -145,7 +145,7 @@ export async function createMentionLinkEvidencePreview(
   limit = 3,
   context: EvidenceReadContext = createEvidenceReadContext(),
   sourceContext = DEFAULT_SOURCE_CONTEXT,
-  order: ArchiveFindOrder = "doc-asc",
+  _order: ArchiveFindOrder = "doc-asc",
   total?: number,
 ): Promise<ArchiveFindEvidencePreview> {
   return await createSourceEvidenceCandidatePreview(document, {

--- a/packages/core/src/retrieval/query/archive-view/source-evidence/core.ts
+++ b/packages/core/src/retrieval/query/archive-view/source-evidence/core.ts
@@ -46,11 +46,16 @@ export async function createMentionEvidencePreview(
   limit = 3,
   context: EvidenceReadContext = createEvidenceReadContext(),
   sourceContext = DEFAULT_SOURCE_CONTEXT,
-  _order: ArchiveFindOrder = "doc-asc",
+  order: ArchiveFindOrder = "doc-asc",
   total?: number,
 ): Promise<ArchiveFindEvidencePreview> {
   return await createSourceEvidenceCandidatePreview(document, {
-    candidates: mentions,
+    candidates: await sortSourceEvidenceCandidates(
+      document,
+      mentions,
+      async (mention) => await createMentionEvidenceRanges(document, [mention]),
+      order,
+    ),
     context,
     createRanges: async (mention) =>
       await createMentionEvidenceRanges(document, [mention]),
@@ -145,11 +150,16 @@ export async function createMentionLinkEvidencePreview(
   limit = 3,
   context: EvidenceReadContext = createEvidenceReadContext(),
   sourceContext = DEFAULT_SOURCE_CONTEXT,
-  _order: ArchiveFindOrder = "doc-asc",
+  order: ArchiveFindOrder = "doc-asc",
   total?: number,
 ): Promise<ArchiveFindEvidencePreview> {
   return await createSourceEvidenceCandidatePreview(document, {
-    candidates: links,
+    candidates: await sortSourceEvidenceCandidates(
+      document,
+      links,
+      (link) => createMentionLinkEvidenceRanges(document, [link]),
+      order,
+    ),
     context,
     createRanges: (link) => createMentionLinkEvidenceRanges(document, [link]),
     limit,
@@ -319,6 +329,41 @@ export async function filterAndSortSourceEvidenceRangesByFtsQuery(
 
 function formatSourceEvidenceRangeKey(range: SourceEvidenceRange): string {
   return `${range.chapterId}:${range.startSentenceIndex}:${range.endSentenceIndex}`;
+}
+
+async function sortSourceEvidenceCandidates<T>(
+  document: ReadonlyDocument,
+  candidates: readonly T[],
+  createRanges: (
+    candidate: T,
+  ) => Promise<readonly SourceEvidenceRange[]> | readonly SourceEvidenceRange[],
+  order: ArchiveFindOrder,
+): Promise<readonly T[]> {
+  const documentOrders = await document.serials.listDocumentOrders();
+  const keyed = await Promise.all(
+    candidates.map(async (candidate) => ({
+      candidate,
+      range: (await createRanges(candidate))[0],
+    })),
+  );
+
+  return keyed
+    .sort((left, right) => {
+      if (left.range === undefined || right.range === undefined) {
+        return left.range === undefined
+          ? right.range === undefined
+            ? 0
+            : 1
+          : -1;
+      }
+      return compareSourceEvidenceRanges(
+        left.range,
+        right.range,
+        documentOrders,
+        order,
+      );
+    })
+    .map((item) => item.candidate);
 }
 
 function compareSourceEvidenceRanges(

--- a/packages/core/src/retrieval/query/archive-view/source-evidence/pagination.ts
+++ b/packages/core/src/retrieval/query/archive-view/source-evidence/pagination.ts
@@ -1,0 +1,133 @@
+import type { ReadonlyDocument } from "../../../../document/index.js";
+
+import { encodeFindCursor } from "../helpers.js";
+import type {
+  ArchiveEvidence,
+  ArchiveEvidenceItem,
+  ArchiveFindEvidencePreview,
+  EvidenceReadContext,
+  SourceEvidenceRange,
+} from "../types.js";
+import { DEFAULT_SOURCE_CONTEXT } from "../core.js";
+import {
+  createExpandedSourceEvidenceRanges,
+  mergeSourceEvidenceRangesInInputOrder,
+} from "./ranges.js";
+import { createSourceEvidenceItem } from "./read.js";
+
+export interface SourceEvidencePageDisplayOptions {
+  readonly context: EvidenceReadContext;
+  readonly sourceContext?: number | undefined;
+}
+
+export interface SourceEvidenceCandidatePageOptions<T> {
+  readonly candidates: readonly T[];
+  readonly context: EvidenceReadContext;
+  readonly createRanges: (
+    candidate: T,
+  ) => Promise<readonly SourceEvidenceRange[]> | readonly SourceEvidenceRange[];
+  readonly limit: number;
+  readonly offset?: number | undefined;
+  readonly sourceContext?: number | undefined;
+  readonly total?: number | undefined;
+}
+
+export async function createSourceEvidenceCandidatePage<T>(
+  document: ReadonlyDocument,
+  options: SourceEvidenceCandidatePageOptions<T>,
+): Promise<ArchiveEvidence> {
+  const pageCandidates = options.candidates.slice(0, options.limit);
+  const items = await createSourceEvidenceCandidateItems(document, {
+    ...options,
+    candidates: pageCandidates,
+  });
+  const nextOffset = (options.offset ?? 0) + pageCandidates.length;
+  const total = options.total ?? options.candidates.length;
+
+  return {
+    items,
+    limit: options.limit,
+    nextCursor: nextOffset < total ? encodeFindCursor(nextOffset) : null,
+  };
+}
+
+export async function createSourceEvidenceCandidatePreview<T>(
+  document: ReadonlyDocument,
+  options: SourceEvidenceCandidatePageOptions<T>,
+): Promise<ArchiveFindEvidencePreview> {
+  const pageCandidates = options.candidates.slice(0, options.limit);
+  const sources = await createSourceEvidenceCandidateItems(document, {
+    ...options,
+    candidates: pageCandidates,
+  });
+  const total = options.total ?? options.candidates.length;
+
+  return {
+    nextCursor:
+      pageCandidates.length < total
+        ? encodeFindCursor(pageCandidates.length)
+        : null,
+    shown: sources.length,
+    sources,
+    total,
+  };
+}
+
+async function createSourceEvidenceCandidateItems<T>(
+  document: ReadonlyDocument,
+  options: SourceEvidenceCandidatePageOptions<T>,
+): Promise<ArchiveEvidenceItem[]> {
+  const ranges = (
+    await Promise.all(
+      options.candidates.map(
+        async (candidate) => await options.createRanges(candidate),
+      ),
+    )
+  ).flat();
+
+  return await createSourceEvidenceDisplayItems(document, ranges, {
+    context: options.context,
+    sourceContext: options.sourceContext,
+  });
+}
+
+export async function createSourceEvidenceDisplayItems(
+  document: ReadonlyDocument,
+  ranges: readonly SourceEvidenceRange[],
+  options: SourceEvidencePageDisplayOptions,
+): Promise<ArchiveEvidenceItem[]> {
+  const displayRanges = await createSourceEvidenceDisplayRanges(
+    document,
+    ranges,
+    options,
+  );
+
+  return await Promise.all(
+    displayRanges.map(
+      async (range) =>
+        await createSourceEvidenceItem(
+          document,
+          range.chapterId,
+          range.startSentenceIndex,
+          range.endSentenceIndex,
+          options.context,
+          range.score,
+        ),
+    ),
+  );
+}
+
+export async function createSourceEvidenceDisplayRanges(
+  document: ReadonlyDocument,
+  ranges: readonly SourceEvidenceRange[],
+  options: SourceEvidencePageDisplayOptions,
+): Promise<SourceEvidenceRange[]> {
+  const expanded = await createExpandedSourceEvidenceRanges(
+    document,
+    ranges,
+    options.sourceContext ?? DEFAULT_SOURCE_CONTEXT,
+    options.context,
+  );
+
+  return mergeSourceEvidenceRangesInInputOrder(expanded);
+}

--- a/packages/core/src/retrieval/query/archive-view/source-evidence/read.ts
+++ b/packages/core/src/retrieval/query/archive-view/source-evidence/read.ts
@@ -29,7 +29,7 @@ export async function createSourceEvidenceItem(
     endSentenceIndex: range.endSentenceIndex,
     fragmentId: range.startSentenceIndex,
     id: formatTextStreamRangeUri(
-      chapter.path,
+      chapterId,
       "source",
       range.startSentenceIndex,
       range.endSentenceIndex,

--- a/packages/core/src/text/summary-build/snapshot/empty-stores.ts
+++ b/packages/core/src/text/summary-build/snapshot/empty-stores.ts
@@ -8,6 +8,13 @@ import type {
 } from "../../../document/index.js";
 
 export class EmptySnapshotMentionStore implements ReadonlyMentionStore {
+  public countByQid(
+    _qid: string,
+    _options?: { readonly chapterId?: number },
+  ): Promise<number> {
+    return Promise.resolve(0);
+  }
+
   public getById(_mentionId: string): Promise<undefined> {
     return Promise.resolve(undefined);
   }
@@ -16,7 +23,22 @@ export class EmptySnapshotMentionStore implements ReadonlyMentionStore {
     return Promise.resolve([]);
   }
 
-  public listByQid(_qid: string): Promise<MentionRecord[]> {
+  public listByQid(
+    _qid: string,
+    _options?: {
+      readonly chapterId?: number;
+      readonly limit?: number;
+      readonly offset?: number;
+      readonly order?: "asc" | "desc";
+    },
+  ): Promise<MentionRecord[]> {
+    return Promise.resolve([]);
+  }
+
+  public listLabelsByQid(
+    _qid: string,
+    _options?: { readonly chapterId?: number },
+  ): Promise<string[]> {
     return Promise.resolve([]);
   }
 
@@ -38,6 +60,15 @@ export class EmptySnapshotMentionStore implements ReadonlyMentionStore {
 }
 
 export class EmptySnapshotMentionLinkStore implements ReadonlyMentionLinkStore {
+  public countByTriple(_input: {
+    readonly chapterId?: number;
+    readonly objectQid: string;
+    readonly predicate: string;
+    readonly subjectQid: string;
+  }): Promise<number> {
+    return Promise.resolve(0);
+  }
+
   public getById(_linkId: string): Promise<undefined> {
     return Promise.resolve(undefined);
   }
@@ -47,6 +78,10 @@ export class EmptySnapshotMentionLinkStore implements ReadonlyMentionLinkStore {
   }
 
   public listByTriple(_input: {
+    readonly chapterId?: number;
+    readonly limit?: number;
+    readonly offset?: number;
+    readonly order?: "asc" | "desc";
     readonly objectQid: string;
     readonly predicate: string;
     readonly subjectQid: string;

--- a/test/core/document/stores.test.ts
+++ b/test/core/document/stores.test.ts
@@ -116,6 +116,75 @@ describe("document/stores", () => {
     });
   });
 
+  it("supports offset-only mention and mention-link pagination", async () => {
+    await withDocument(async (document) => {
+      await document.openSession(async (openedDocument) => {
+        await openedDocument.serials.createWithId(1);
+        await openedDocument.mentions.saveMany([
+          {
+            chapterId: 1,
+            id: "m1",
+            qid: "Q1",
+            rangeEnd: 2,
+            rangeStart: 0,
+            sentenceIndex: 0,
+            surface: "Alpha",
+          },
+          {
+            chapterId: 1,
+            id: "m2",
+            qid: "Q1",
+            rangeEnd: 5,
+            rangeStart: 3,
+            sentenceIndex: 1,
+            surface: "Beta",
+          },
+          {
+            chapterId: 1,
+            id: "m3",
+            qid: "Q2",
+            rangeEnd: 8,
+            rangeStart: 6,
+            sentenceIndex: 2,
+            surface: "Target",
+          },
+        ]);
+        await openedDocument.mentionLinks.saveMany([
+          {
+            evidenceSentenceIds: [[1, 0]],
+            id: "l1",
+            predicate: "mentions",
+            sourceMentionId: "m1",
+            targetMentionId: "m3",
+          },
+          {
+            evidenceSentenceIds: [[1, 1]],
+            id: "l2",
+            predicate: "mentions",
+            sourceMentionId: "m2",
+            targetMentionId: "m3",
+          },
+        ]);
+
+        expect(
+          (await openedDocument.mentions.listByQid("Q1", { offset: 1 })).map(
+            (mention) => mention.id,
+          ),
+        ).toStrictEqual(["m2"]);
+        expect(
+          (
+            await openedDocument.mentionLinks.listByTriple({
+              objectQid: "Q2",
+              offset: 1,
+              predicate: "mentions",
+              subjectQid: "Q1",
+            })
+          ).map((link) => link.id),
+        ).toStrictEqual(["l2"]);
+      });
+    });
+  });
+
   it("saves and clears mention evidence by chapter", async () => {
     await withDocument(async (document) => {
       await document.openSession(async (openedDocument) => {

--- a/test/core/library/query.test.ts
+++ b/test/core/library/query.test.ts
@@ -232,6 +232,70 @@ describe("wiki graph library object query aggregation", () => {
     });
   });
 
+  it("merges page evidence previews for multi-archive get without rescanning evidence", async () => {
+    const [{ readWikiGraphLibraryPage }, archiveView] = await Promise.all([
+      import("../../../packages/core/src/library/query.js"),
+      import("../../../packages/core/src/retrieval/query/archive-view/index.js"),
+    ]);
+    vi.mocked(archiveView.listArchiveEvidence).mockClear();
+
+    mocks.objectArchiveIds.set("wikg://entity/Q1", [1, 2]);
+    mocks.pages.set("archive-1.wikg:wikg://entity/Q1", {
+      evidence: {
+        nextCursor: "2",
+        shown: 2,
+        sources: [createEvidence("a", 1), createEvidence("b", 2)],
+        total: 4,
+      },
+      id: "wikg://entity/Q1",
+      label: "Shared",
+      labels: ["Shared"],
+      mentionCount: 4,
+      qid: "Q1",
+      type: "entity",
+    });
+    mocks.pages.set("archive-2.wikg:wikg://entity/Q1", {
+      evidence: {
+        nextCursor: "2",
+        shown: 2,
+        sources: [createEvidence("c", 1), createEvidence("d", 2)],
+        total: 3,
+      },
+      id: "wikg://entity/Q1",
+      label: "Shared",
+      labels: ["Shared"],
+      mentionCount: 3,
+      qid: "Q1",
+      type: "entity",
+    });
+
+    const page = await readWikiGraphLibraryPage(target, "wikg://entity/Q1", {
+      evidenceLimit: 2,
+    });
+
+    expect(archiveView.listArchiveEvidence).not.toHaveBeenCalled();
+    expect(page).toMatchObject({
+      evidence: {
+        nextCursor: "2",
+        shown: 2,
+        total: 7,
+      },
+      type: "entity",
+    });
+    expect(page.type === "entity" ? page.evidence.sources : []).toStrictEqual([
+      {
+        ...createEvidence("a", 1),
+        archiveId: 1,
+        libraryArchiveUri: "wikg://lib/archive-1",
+      },
+      {
+        ...createEvidence("b", 2),
+        archiveId: 1,
+        libraryArchiveUri: "wikg://lib/archive-1",
+      },
+    ]);
+  });
+
   it("aggregates evidence with stable cursor pagination and source fields", async () => {
     const { listWikiGraphLibraryEvidence } =
       await import("../../../packages/core/src/library/query.js");

--- a/test/core/retrieval/query/archive-view/collection.test.ts
+++ b/test/core/retrieval/query/archive-view/collection.test.ts
@@ -194,7 +194,7 @@ describe("archive/query/archive-view/collection", () => {
         expect(entityWithEvidence?.type).toBe("entity");
         expect(entityWithEvidence?.evidence?.shown).toBe(1);
         expect(entityWithEvidence?.evidence?.sources[0]?.id).toBe(
-          "wikg://chapter/second/source#1",
+          "wikg://chapter/2/source#1",
         );
       } finally {
         await document.release();

--- a/test/core/retrieval/query/archive-view/evidence.test.ts
+++ b/test/core/retrieval/query/archive-view/evidence.test.ts
@@ -79,6 +79,68 @@ describe("archive/query/archive-view/evidence", () => {
     });
   });
 
+  it("paginates evidence candidates before page-local range fusion", async () => {
+    await withTempDir("wikigraph-archive-view-", async (path) => {
+      const document = await DirectoryDocument.open(`${path}/document`);
+
+      try {
+        await seedSourcedDocument(document);
+        await document.openSession(async (openedDocument) => {
+          const draft = await openedDocument
+            .getSerialFragments(1)
+            .createDraft();
+
+          draft.addSentence("Fourth page-local sentence.", 4);
+          await draft.commit();
+          await openedDocument.mentions.saveMany(
+            [0, 1, 2, 3].map((sentenceIndex) => ({
+              chapterId: 1,
+              id: `page-local-${sentenceIndex}`,
+              qid: "Q999",
+              rangeEnd: sentenceIndex + 1,
+              rangeStart: sentenceIndex,
+              sentenceIndex,
+              surface: "Page Local",
+            })),
+          );
+        });
+
+        const firstPage = await listArchiveEvidence(
+          document,
+          "wikg://entity/Q999",
+          {
+            limit: 2,
+            sourceContext: 0,
+          },
+        );
+
+        expect(firstPage.items.map((item) => item.id)).toStrictEqual([
+          "wikg://chapter/1/source#1..2",
+        ]);
+        expect(firstPage.nextCursor).not.toBeNull();
+
+        const secondPage = await listArchiveEvidence(
+          document,
+          "wikg://entity/Q999",
+          {
+            ...(firstPage.nextCursor === null
+              ? {}
+              : { cursor: firstPage.nextCursor }),
+            limit: 2,
+            sourceContext: 0,
+          },
+        );
+
+        expect(secondPage.items.map((item) => item.id)).toStrictEqual([
+          "wikg://chapter/1/source#3..4",
+        ]);
+        expect(secondPage.nextCursor).toBeNull();
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
   it("reads archive objects as continuous text", async () => {
     await withTempDir("wikigraph-archive-view-", async (path) => {
       const document = await DirectoryDocument.open(`${path}/document`);
@@ -169,7 +231,7 @@ describe("archive/query/archive-view/evidence", () => {
         ).resolves.toMatchObject({
           items: [
             {
-              id: "wikg://chapter/introduction/source#1..3",
+              id: "wikg://chapter/1/source#1..3",
               source:
                 "An LLM Wiki exposes pages, links, and source fragments to agents.朱元璋知道了这个消息，随后亲自来到洪都。Source-only archives should be searchable.",
               type: "source",
@@ -183,7 +245,7 @@ describe("archive/query/archive-view/evidence", () => {
         ).resolves.toMatchObject({
           items: [
             {
-              id: "wikg://chapter/introduction/source#1",
+              id: "wikg://chapter/1/source#1",
               source:
                 "An LLM Wiki exposes pages, links, and source fragments to agents.",
               type: "source",
@@ -195,7 +257,7 @@ describe("archive/query/archive-view/evidence", () => {
         ).resolves.toMatchObject({
           items: [
             {
-              id: "wikg://chapter/introduction/source#1..3",
+              id: "wikg://chapter/1/source#1..3",
               type: "source",
             },
           ],
@@ -205,7 +267,7 @@ describe("archive/query/archive-view/evidence", () => {
         ).resolves.toMatchObject({
           items: [
             {
-              id: "wikg://chapter/introduction/source#1..3",
+              id: "wikg://chapter/1/source#1..3",
               type: "source",
             },
           ],
@@ -217,7 +279,7 @@ describe("archive/query/archive-view/evidence", () => {
             shown: 1,
             sources: [
               {
-                id: "wikg://chapter/introduction/source#1..3",
+                id: "wikg://chapter/1/source#1..3",
                 type: "source",
               },
             ],
@@ -237,7 +299,7 @@ describe("archive/query/archive-view/evidence", () => {
             shown: 1,
             sources: [
               {
-                id: "wikg://chapter/introduction/source#1..3",
+                id: "wikg://chapter/1/source#1..3",
                 type: "source",
               },
             ],
@@ -304,7 +366,7 @@ describe("archive/query/archive-view/evidence", () => {
                 shown: 1,
                 sources: [
                   {
-                    id: "wikg://chapter/introduction/source#1..3",
+                    id: "wikg://chapter/1/source#1..3",
                   },
                 ],
                 total: 1,
@@ -333,7 +395,7 @@ describe("archive/query/archive-view/evidence", () => {
         ).resolves.toMatchObject({
           items: [
             {
-              id: "wikg://chapter/introduction/source#3..6",
+              id: "wikg://chapter/1/source#3..6",
               source:
                 "Source-only archives should be searchable.First unrelated fragment sentence.Second fragment mentions Augustine.Third unrelated fragment sentence.",
               type: "source",
@@ -348,7 +410,7 @@ describe("archive/query/archive-view/evidence", () => {
         ).resolves.toMatchObject({
           items: [
             {
-              id: "wikg://chapter/introduction/source#1..5",
+              id: "wikg://chapter/1/source#1..5",
               type: "source",
             },
           ],
@@ -396,7 +458,7 @@ describe("archive/query/archive-view/evidence", () => {
         );
 
         expect(evidence.items.map((item) => item.id)).toStrictEqual([
-          "wikg://chapter/introduction/source#1..3",
+          "wikg://chapter/1/source#1..3",
         ]);
         expect(evidence.items[0]?.score).toBeGreaterThan(0);
       } finally {
@@ -518,8 +580,8 @@ describe("archive/query/archive-view/evidence", () => {
         );
 
         expect(evidence.items.map((item) => item.id)).toStrictEqual([
-          "wikg://chapter/evidence/source#3",
-          "wikg://chapter/evidence/source#1",
+          "wikg://chapter/1/source#3",
+          "wikg://chapter/1/source#1",
         ]);
       } finally {
         await document.release();

--- a/test/core/retrieval/query/archive-view/graph-search.test.ts
+++ b/test/core/retrieval/query/archive-view/graph-search.test.ts
@@ -57,7 +57,7 @@ describe("archive/query/archive-view/graph search", () => {
               shown: 1,
               sources: [
                 expect.objectContaining({
-                  id: "wikg://chapter/introduction/source#1..3",
+                  id: "wikg://chapter/1/source#1..3",
                   source:
                     "An LLM Wiki exposes pages, links, and source fragments to agents.朱元璋知道了这个消息，随后亲自来到洪都。Source-only archives should be searchable.",
                 }),
@@ -351,7 +351,7 @@ describe("archive/query/archive-view/graph search", () => {
         expect(result.items[0]).toMatchObject({
           evidence: {
             nextCursor: null,
-            total: 1,
+            total: 2,
           },
           id: "wikg://entity/Q1",
           title: "战舰",
@@ -472,7 +472,7 @@ describe("archive/query/archive-view/graph search", () => {
         expect(triple?.evidence?.total).toBe(1);
         expect(triple?.evidence?.sources).toStrictEqual([
           expect.objectContaining({
-            id: "wikg://chapter/introduction/source#1..3",
+            id: "wikg://chapter/1/source#1..3",
             source:
               "An LLM Wiki exposes pages, links, and source fragments to agents.朱元璋知道了这个消息，随后亲自来到洪都。Source-only archives should be searchable.",
           }),

--- a/test/core/retrieval/query/archive-view/graph-search.test.ts
+++ b/test/core/retrieval/query/archive-view/graph-search.test.ts
@@ -574,9 +574,7 @@ describe("archive/query/archive-view/graph search", () => {
         const sourceHit = result.items.find(
           (item) => item.type === "source" && item.field === "source",
         );
-        expect(sourceHit?.id).toMatch(
-          /^wikg:\/\/chapter\/introduction\/source#/u,
-        );
+        expect(sourceHit?.id).toMatch(/^wikg:\/\/chapter\/1\/source#/u);
         expect(sourceHit).toMatchObject({
           field: "source",
           missingTerms: [],

--- a/test/core/retrieval/query/archive-view/pages.test.ts
+++ b/test/core/retrieval/query/archive-view/pages.test.ts
@@ -227,7 +227,7 @@ describe("archive/query/archive-view/pages", () => {
 
         expect(result.items).toContainEqual(
           expect.objectContaining({
-            id: "wikg://chapter/introduction/summary#1",
+            id: "wikg://chapter/1/summary#1",
             type: "summary",
           }),
         );

--- a/test/core/retrieval/query/archive-view/pages.test.ts
+++ b/test/core/retrieval/query/archive-view/pages.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DirectoryDocument,
   createEntityWikipageMockFetch,
@@ -85,6 +85,48 @@ describe("archive/query/archive-view/pages", () => {
           publisher: "Example Press",
           title: "Root Metadata",
           type: "meta",
+        });
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("limits entity page evidence candidates at the store boundary", async () => {
+    await withTempDir("wikigraph-archive-view-", async (path) => {
+      const document = await DirectoryDocument.open(`${path}/document`);
+
+      try {
+        await seedSourcedDocument(document);
+        await document.openSession(async (openedDocument) => {
+          await openedDocument.mentions.saveMany(
+            [0, 1, 2, 3].map((sentenceIndex) => ({
+              chapterId: 1,
+              id: `limited-${sentenceIndex}`,
+              qid: "Q999",
+              rangeEnd: sentenceIndex + 1,
+              rangeStart: sentenceIndex,
+              sentenceIndex,
+              surface: "Limited Entity",
+            })),
+          );
+        });
+        const listByQid = vi.spyOn(document.mentions, "listByQid");
+
+        const page = await readArchivePage(document, "wikg://entity/Q999", {
+          evidenceLimit: 2,
+        });
+
+        expect(listByQid).toHaveBeenCalledWith("Q999", {
+          limit: 2,
+          order: "asc",
+        });
+        expect(page).toMatchObject({
+          evidence: {
+            total: 4,
+          },
+          mentionCount: 4,
+          type: "entity",
         });
       } finally {
         await document.release();
@@ -511,12 +553,12 @@ describe("archive/query/archive-view/pages", () => {
           "wikg://chapter/second-in-id-first-in-document/title",
         ]);
         expect(evidence.items.map((item) => item.id)).toStrictEqual([
-          "wikg://chapter/second-in-id-first-in-document/source#1",
-          "wikg://chapter/first-in-id-second-in-document/source#1",
+          "wikg://chapter/2/source#1",
+          "wikg://chapter/1/source#1",
         ]);
         expect(evidenceReverse.items.map((item) => item.id)).toStrictEqual([
-          "wikg://chapter/first-in-id-second-in-document/source#1",
-          "wikg://chapter/second-in-id-first-in-document/source#1",
+          "wikg://chapter/1/source#1",
+          "wikg://chapter/2/source#1",
         ]);
       } finally {
         await document.release();

--- a/test/core/retrieval/query/archive-view/search-controls.test.ts
+++ b/test/core/retrieval/query/archive-view/search-controls.test.ts
@@ -35,7 +35,7 @@ describe("archive/query/archive-view/search controls", () => {
         expect(result.items).toContainEqual(
           expect.objectContaining({
             field: "source",
-            id: "wikg://chapter/introduction/source#2",
+            id: "wikg://chapter/1/source#2",
             type: "source",
           }),
         );
@@ -64,7 +64,7 @@ describe("archive/query/archive-view/search controls", () => {
         expect(result.items).toStrictEqual([
           expect.objectContaining({
             chapter: 1,
-            id: "wikg://chapter/introduction/source#1",
+            id: "wikg://chapter/1/source#1",
             position: { chapter: 1, sentence: 0 },
             type: "source",
           }),

--- a/test/core/retrieval/query/archive-view/text-search.test.ts
+++ b/test/core/retrieval/query/archive-view/text-search.test.ts
@@ -46,7 +46,7 @@ describe("archive/query/archive-view/text search", () => {
         expect(result.items).toContainEqual(
           expect.objectContaining({
             field: "source",
-            id: "wikg://chapter/introduction/source#1",
+            id: "wikg://chapter/1/source#1..3",
             position: {
               chapter: 1,
               sentence: 0,
@@ -137,14 +137,9 @@ describe("archive/query/archive-view/text search", () => {
         expect(result.items).toStrictEqual([
           expect.objectContaining({
             field: "source",
-            id: "wikg://chapter/chapter-1/source#2",
-            snippet: "Alice studies graph retrieval.",
-            type: "source",
-          }),
-          expect.objectContaining({
-            field: "source",
-            id: "wikg://chapter/chapter-1/source#3",
-            snippet: "Bob cites Alice in a research note.",
+            id: "wikg://chapter/1/source#1..3",
+            snippet:
+              "# Test NoteAlice studies graph retrieval.Bob cites Alice in a research note.",
             type: "source",
           }),
         ]);
@@ -172,9 +167,7 @@ describe("archive/query/archive-view/text search", () => {
         const sourceHit = result.items.find(
           (item) => item.type === "source" && item.field === "source",
         );
-        expect(sourceHit?.id).toMatch(
-          /^wikg:\/\/chapter\/introduction\/source#/u,
-        );
+        expect(sourceHit?.id).toMatch(/^wikg:\/\/chapter\/1\/source#/u);
         expect(sourceHit).toMatchObject({
           field: "source",
           type: "source",
@@ -286,8 +279,8 @@ describe("archive/query/archive-view/text search", () => {
         });
 
         expect(result.items.map((item) => item.id)).toStrictEqual([
-          "wikg://chapter/ranking/source#2",
-          "wikg://chapter/ranking/source#1",
+          "wikg://chapter/1/source#2",
+          "wikg://chapter/1/source#1",
         ]);
         expect(result.items[0]?.score).toBeGreaterThan(
           result.items[1]?.score ?? 0,


### PR DESCRIPTION
## Summary
- centralize source evidence page-local rendering in a shared pagination helper
- paginate mention and mention-link evidence candidates before source range expansion/fusion/rendering
- avoid rescanning multi-archive page evidence previews and emit numeric chapter source evidence URIs

## Audit
- entity/triple page previews use store-level candidate limit/order before page-local source range display
- no-query evidence pagination uses count + offset/limit candidate pages before display fusion
- search evidence hydration and related previews reuse the shared page-local evidence display path
- remaining listByQid/listByTriple uses are label/search/related candidate discovery paths, not eager source range rendering paths

## Validation
- pnpm exec tsc -p tsconfig.json --noEmit
- pnpm exec vitest run test/core/retrieval/query/archive-view/evidence.test.ts test/core/retrieval/query/archive-view/pages.test.ts test/core/library/query.test.ts --passWithNoTests
- pnpm exec prettier --check ...
- pnpm --filter wiki-graph dev wikg://lib/e666e52258b0.lib/entity/Q1177377