### PR TITLE
feat(cli): redesign library CLI URI scopes

### DIFF
--- a/docs/schema-upgrade.md
+++ b/docs/schema-upgrade.md
@@ -111,7 +111,7 @@ home or library target and must not become CLI targets.
   reports `wg maintenance upgrade <archive>` when old data is found; it must not
   silently rewrite user archives.
 - `wg maintenance upgrade wikg://lib` and
-  `wg maintenance upgrade wikg://lib/<lib-id>.lib` upgrade a registered library
+  `wg maintenance upgrade wikg://lib/<lib-id>` upgrade a registered library
   under the library write lock. The command clears rebuildable derived library
   state and only visits archives registered in `library_archives`; it does not
   scan the folder for unmanaged `.wikg` files.

--- a/packages/cli/src/args/archive-index.test.ts
+++ b/packages/cli/src/args/archive-index.test.ts
@@ -89,7 +89,7 @@ describe("cli/args/archive index", () => {
       kind: "library",
     });
     expect(
-      parseCLIArguments(["wikg://lib/team.lib/index", "enable", "--jsonl"]),
+      parseCLIArguments(["wikg://lib/team/index", "enable", "--jsonl"]),
     ).toStrictEqual({
       args: {
         action: "enable-index",
@@ -170,43 +170,45 @@ describe("cli/args/archive index", () => {
     expect(() => parseCLIArguments(["wikg://lib/index", "external"])).toThrow(
       "The library index wikg://lib/index does not support `external`.\nSee: wg wikg://lib/index external --help",
     );
-    expect(() =>
-      parseCLIArguments(["wikg://lib/team.lib/index", "embed"]),
-    ).toThrow(
-      "The library index wikg://lib/team.lib/index does not support `embed`.\nSee: wg wikg://lib/team.lib/index embed --help",
+    expect(() => parseCLIArguments(["wikg://lib/team/index", "embed"])).toThrow(
+      "The library index wikg://lib/team/index does not support `embed`.\nSee: wg wikg://lib/team/index embed --help",
     );
     expect(() =>
-      parseCLIArguments(["wikg://lib/team.lib/index", "external"]),
+      parseCLIArguments(["wikg://lib/team/index", "external"]),
     ).toThrow(
-      "The library index wikg://lib/team.lib/index does not support `external`.\nSee: wg wikg://lib/team.lib/index external --help",
+      "The library index wikg://lib/team/index does not support `external`.\nSee: wg wikg://lib/team/index external --help",
     );
   });
 
   it("renders library v1 management help without routing to execution", () => {
-    expect(parseCLIArguments(["wikg://lib", "scan", "--help"])).toStrictEqual({
+    expect(
+      parseCLIArguments(["wikg://lib/arc", "scan", "--help"]),
+    ).toStrictEqual({
       help: true,
       helpText: renderLibraryPredicateHelpText(
-        "wikg://lib",
-        { isDefault: true, kind: "scope" },
+        "wikg://lib/arc",
+        { isDefault: true, kind: "archive-collection" },
         "scan",
       ),
       kind: "help",
     });
-    expect(parseCLIArguments(["wikg://lib", "add", "--help"])).toStrictEqual({
+    expect(
+      parseCLIArguments(["wikg://lib/arc", "add", "--help"]),
+    ).toStrictEqual({
       help: true,
       helpText: renderLibraryPredicateHelpText(
-        "wikg://lib",
-        { isDefault: true, kind: "scope" },
+        "wikg://lib/arc",
+        { isDefault: true, kind: "archive-collection" },
         "add",
       ),
       kind: "help",
     });
     expect(
-      parseCLIArguments(["wikg://lib/archive123", "remove", "--help"]),
+      parseCLIArguments(["wikg://lib/arc/archive123", "remove", "--help"]),
     ).toStrictEqual({
       help: true,
       helpText: renderLibraryPredicateHelpText(
-        "wikg://lib/archive123",
+        "wikg://lib/arc/archive123",
         {
           archivePublicId: "archive123",
           isDefault: true,
@@ -241,57 +243,61 @@ describe("cli/args/archive index", () => {
 
   it("parses library rebind only on library scope URIs", () => {
     expect(
-      parseCLIArguments(["wikg://lib", "rebind", "--path", "/tmp/library"]),
+      parseCLIArguments(["wikg://lib/path", "set", "/tmp/library"]),
     ).toStrictEqual({
       args: {
         action: "rebind",
         json: undefined,
+        jsonl: undefined,
         path: "/tmp/library",
-        target: { isDefault: true, kind: "scope" },
+        target: { isDefault: true, kind: "path" },
       },
       help: false,
       kind: "library",
     });
     expect(
-      parseCLIArguments([
-        "wikg://lib/team.lib",
-        "rebind",
-        "--path",
-        "/tmp/team",
-        "--json",
-      ]),
+      parseCLIArguments(["wikg://lib/team/path", "set", "/tmp/team", "--json"]),
     ).toStrictEqual({
       args: {
         action: "rebind",
         json: true,
+        jsonl: undefined,
         path: "/tmp/team",
-        target: { isDefault: false, kind: "scope", publicId: "team" },
+        target: { isDefault: false, kind: "path", publicId: "team" },
       },
       help: false,
       kind: "library",
     });
-    expect(() => parseCLIArguments(["wikg://lib", "rebind"])).toThrow(
-      "Missing --path <directory>.",
+    expect(() => parseCLIArguments(["wikg://lib/path", "set"])).toThrow(
+      "Missing path value.",
     );
-    expect(() =>
+    expect(
+      parseCLIArguments(["wikg://lib/arc/archive123/path", "set", "x.wikg"]),
+    ).toMatchObject({
+      args: {
+        action: "move",
+        target: { archivePublicId: "archive123", kind: "archive-path" },
+        to: "x.wikg",
+      },
+      kind: "library",
+    });
+    expect(
       parseCLIArguments([
-        "wikg://lib/archive123",
-        "rebind",
-        "--path",
-        "/tmp/x",
+        "wikg://lib/team/arc/archive123/path",
+        "set",
+        "x.wikg",
       ]),
-    ).toThrow(
-      "The library archive wikg://lib/archive123 does not support `rebind`.",
-    );
-    expect(() =>
-      parseCLIArguments([
-        "wikg://lib/team.lib/archive123",
-        "rebind",
-        "--path",
-        "/tmp/x",
-      ]),
-    ).toThrow(
-      "The library archive wikg://lib/team.lib/archive123 does not support `rebind`.",
-    );
+    ).toMatchObject({
+      args: {
+        action: "move",
+        target: {
+          archivePublicId: "archive123",
+          kind: "archive-path",
+          publicId: "team",
+        },
+        to: "x.wikg",
+      },
+      kind: "library",
+    });
   });
 });

--- a/packages/cli/src/args/archive.test.ts
+++ b/packages/cli/src/args/archive.test.ts
@@ -97,10 +97,12 @@ describe("cli/args/archive", () => {
       kind: "archive",
     });
 
-    expect(parseCLIArguments(["wikg://lib/archive123/chapter"])).toStrictEqual({
+    expect(
+      parseCLIArguments(["wikg://lib/arc/archive123/chapter"]),
+    ).toStrictEqual({
       args: {
         action: "list",
-        archivePath: "wikg://lib/archive123/chapter",
+        archivePath: "wikg://lib/arc/archive123/chapter",
         format: "text",
         kinds: ["chapter"],
       },
@@ -108,13 +110,13 @@ describe("cli/args/archive", () => {
       kind: "archive",
     });
     expect(
-      parseCLIArguments(["wikg://lib/team.lib/archive123/entity/Q23"]),
+      parseCLIArguments(["wikg://lib/team/arc/archive123/entity/Q23"]),
     ).toStrictEqual({
       args: {
         action: "get",
-        archivePath: "wikg://lib/team.lib/archive123/entity/Q23",
+        archivePath: "wikg://lib/team/arc/archive123/entity/Q23",
         format: "text",
-        objectId: "wikg://lib/team.lib/archive123/entity/Q23",
+        objectId: "wikg://lib/team/arc/archive123/entity/Q23",
       },
       help: false,
       kind: "archive",
@@ -144,10 +146,10 @@ describe("cli/args/archive", () => {
       kind: "archive",
     });
 
-    expect(parseCLIArguments(["wikg://lib/team.lib/entity"])).toStrictEqual({
+    expect(parseCLIArguments(["wikg://lib/team/entity"])).toStrictEqual({
       args: {
         action: "list",
-        archivePath: "wikg://lib/team.lib/entity",
+        archivePath: "wikg://lib/team/entity",
         format: "text",
         kinds: ["entity"],
       },
@@ -523,25 +525,25 @@ describe("cli/args/archive", () => {
       kind: "archive",
     });
     expect(
-      parseCLIArguments(["wikg://lib/archive123", "inspect"]),
+      parseCLIArguments(["wikg://lib/arc/archive123", "inspect"]),
     ).toStrictEqual({
       args: {
         action: "inspect",
-        archivePath: "wikg://lib/archive123",
+        archivePath: "wikg://lib/arc/archive123",
       },
       help: false,
       kind: "archive",
     });
     expect(
       parseCLIArguments([
-        "wikg://lib/team.lib/archive123",
+        "wikg://lib/team/arc/archive123",
         "inspect",
         "--json",
       ]),
     ).toStrictEqual({
       args: {
         action: "inspect",
-        archivePath: "wikg://lib/team.lib/archive123",
+        archivePath: "wikg://lib/team/arc/archive123",
         json: true,
       },
       help: false,
@@ -549,17 +551,17 @@ describe("cli/args/archive", () => {
     });
     expect(() =>
       parseCLIArguments([
-        "wikg://lib/archive123",
+        "wikg://lib/arc/archive123",
         "inspect",
         "--query",
         "agent",
       ]),
     ).toThrow("The `inspect` command does not support --query.");
     expect(() =>
-      parseCLIArguments(["wikg://lib/archive123", "inspect", "--jsonl"]),
+      parseCLIArguments(["wikg://lib/arc/archive123", "inspect", "--jsonl"]),
     ).toThrow("The `inspect` command does not support --jsonl.");
     expect(() =>
-      parseCLIArguments(["wikg://lib/archive123", "inspect", "--evidence"]),
+      parseCLIArguments(["wikg://lib/arc/archive123", "inspect", "--evidence"]),
     ).toThrow("The `inspect` command does not support --evidence.");
     expect(() =>
       parseCLIArguments(["wikg://book.wikg/chapter/part", "inspect"]),

--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -205,7 +205,7 @@ describe("cli/args/help", () => {
       renderUriPredicateHelpText(
         "chapter-collection-scope",
         "add",
-        "wikg://lib/archive123/chapter",
+        "wikg://lib/arc/archive123/chapter",
       ),
     ).toContain("wikg://lib/arc/<archive-id>/chapter/part");
     expect(

--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -207,7 +207,7 @@ describe("cli/args/help", () => {
         "add",
         "wikg://lib/archive123/chapter",
       ),
-    ).toContain("wikg://lib/<archive-id>/chapter/part");
+    ).toContain("wikg://lib/arc/<archive-id>/chapter/part");
     expect(
       renderUriPredicateHelpText(
         "chapter-title-object",
@@ -416,7 +416,7 @@ describe("cli/args/help", () => {
       "wg wikg://local/job add --input <archive-uri|chapter-uri>",
     );
     expect(uriHelpText).toContain("Library locators:");
-    expect(uriHelpText).toContain("wikg://lib/<archive-id>/");
+    expect(uriHelpText).toContain("wikg://lib/arc/<archive-id>/");
     expect(uriHelpText).toContain("wg next <uri> <cursor>");
     expect(uriHelpText).toContain("wg help format");
     expect(uriHelpText).not.toContain("JSONL contains object records");
@@ -560,7 +560,7 @@ describe("cli/args/help", () => {
         "evidence",
         "wikg://lib/triple/Q8018/discusses/Q123",
       ),
-    ).toContain("wikg://lib/<archive-id>/triple/Q8018/discusses/Q123");
+    ).toContain("wikg://lib/arc/<archive-id>/triple/Q8018/discusses/Q123");
     expect(renderHelpTopicText("format")).toContain(
       "Avoid `--all | head` as a preview pattern.",
     );
@@ -715,19 +715,23 @@ describe("cli/args/help", () => {
       kind: "metadata",
     });
     const createHelpText = renderLibraryPredicateHelpText(
-      "wikg://lib",
-      { isDefault: true, kind: "scope" },
-      "create",
+      "wikg://lib/registry",
+      { isDefault: true, kind: "registry" },
+      "add",
     );
 
     expect(scopeHelpText).toContain("Library scope");
-    expect(scopeHelpText).toContain("wg wikg://lib create --path <folder>");
-    expect(scopeHelpText).toContain("wg wikg://lib scan [--json]");
-    expect(scopeHelpText).toContain("wg wikg://lib/index [--json]");
-    expect(scopeHelpText).toContain(".lib` suffix");
-    expect(scopeHelpText).not.toContain("future `wikg://lib/<archive-id>/`");
     expect(scopeHelpText).toContain(
-      "This is not a list of all library registries.",
+      "wg wikg://lib/registry add --path <folder>",
+    );
+    expect(scopeHelpText).toContain("wg wikg://lib/arc scan [--json|--jsonl]");
+    expect(scopeHelpText).toContain("wg wikg://lib/index [--json]");
+    expect(scopeHelpText).toContain("wikg://lib/<lib-id>");
+    expect(scopeHelpText).not.toContain(
+      "future `wikg://lib/arc/<archive-id>/`",
+    );
+    expect(scopeHelpText).toContain(
+      "Use `wg wikg://lib/registry` to list all library registries.",
     );
     expect(scopeHelpText).toContain("broad library index search");
     expect(scopeHelpText).toContain("wg wikg://lib --query <query>");
@@ -746,16 +750,14 @@ describe("cli/args/help", () => {
     expect(metadataHelpText).toContain("Metadata keys are free-form");
     expect(createHelpText).toContain("Library Predicate Command");
     expect(createHelpText).toContain("Create a non-default library registry");
-    expect(createHelpText).toContain(
-      "does not expose a list-all-library-registries command",
-    );
+    expect(createHelpText).toContain("wikg://lib/registry add --path <folder>");
     expect(
       renderLibraryPredicateHelpText(
-        "wikg://lib",
-        { isDefault: true, kind: "scope" },
+        "wikg://lib/registry",
+        { isDefault: true, kind: "registry" },
         "list",
       ),
-    ).toContain("not all library registries");
+    ).toContain("List all library registries");
     expect(
       renderLibraryPredicateHelpText(
         "wikg://lib/index",
@@ -782,7 +784,7 @@ describe("cli/args/help", () => {
       "Library archive shortcuts:",
     );
     expect(renderHelpTopicText("library")).toContain(
-      "wikg://lib/<archive-id> inspect",
+      "wikg://lib/arc/<archive-id> inspect",
     );
     expect(renderHelpTopicText("library")).toContain(
       "not a library-level health report",
@@ -803,11 +805,11 @@ describe("cli/args/help", () => {
       ),
     ).toContain("Read this library metadata map");
     const archiveMemberHelp = parseCLIArguments([
-      "wikg://lib/archive123",
+      "wikg://lib/arc/archive123",
       "--help",
     ]);
     const archiveMemberInspectHelp = parseCLIArguments([
-      "wikg://lib/archive123",
+      "wikg://lib/arc/archive123",
       "inspect",
       "--help",
     ]);
@@ -828,7 +830,7 @@ describe("cli/args/help", () => {
       "URI Predicate Command",
     );
     expect(archiveMemberInspectHelp.helpText).toContain(
-      "wikg://lib/archive123 inspect [--json]",
+      "wikg://lib/arc/archive123 inspect [--json]",
     );
     expect(archiveMemberInspectHelp.helpText).toContain(
       "not a library-level health report",

--- a/packages/cli/src/args/types.ts
+++ b/packages/cli/src/args/types.ts
@@ -104,6 +104,7 @@ export interface CLIObjectMetadataArguments {
 
 export type CLILibraryAction =
   | "add"
+  | "archive-tree"
   | "clear"
   | "create"
   | "delete"
@@ -122,6 +123,7 @@ export type CLILibraryAction =
 export interface CLILibraryArguments {
   readonly action: CLILibraryAction;
   readonly confirm?: boolean | undefined;
+  readonly depth?: number | undefined;
   readonly inputPath?: string | undefined;
   readonly inputValue?: string | undefined;
   readonly json?: boolean | undefined;
@@ -129,6 +131,7 @@ export interface CLILibraryArguments {
   readonly jsonInputValue?: string | undefined;
   readonly key?: string | undefined;
   readonly path?: string | undefined;
+  readonly parent?: string | undefined;
   readonly target: ParsedWikiGraphLibraryUri;
   readonly to?: string | undefined;
 }

--- a/packages/cli/src/args/uri/library.ts
+++ b/packages/cli/src/args/uri/library.ts
@@ -31,6 +31,9 @@ import { parseChapterTarget } from "./chapter/target.js";
 import { isTripleScopePath } from "./triple-pattern.js";
 
 const LIBRARY_ARCHIVE_ACTIONS = new Set(["get", "move", "remove"]);
+const LIBRARY_ARCHIVE_COLLECTION_ACTIONS = new Set(["add", "list", "scan"]);
+const LIBRARY_ARCHIVE_PATH_ACTIONS = new Set(["get", "set"]);
+const LIBRARY_ARCHIVE_TREE_ACTIONS = new Set(["archive-tree"]);
 const LIBRARY_METADATA_ACTIONS = new Set([
   "clear",
   "delete",
@@ -38,6 +41,8 @@ const LIBRARY_METADATA_ACTIONS = new Set([
   "put",
   "set",
 ]);
+const LIBRARY_PATH_ACTIONS = new Set(["get", "set"]);
+const LIBRARY_REGISTRY_ACTIONS = new Set(["add", "list"]);
 const LIBRARY_SCOPE_ACTIONS = new Set(["get", "list", "remove"]);
 const LIBRARY_INDEX_ACTIONS = new Set(["disable", "enable", "get"]);
 const LIBRARY_QUERY_ACTIONS = new Set([
@@ -245,6 +250,9 @@ function parseLibraryHelpArguments(
           formatWikiGraphHelpCommand(uri),
         ),
       );
+    }
+    if (isLibraryAction(action)) {
+      validateLibraryActionForTarget(uri, target, action);
     }
     return {
       help: true,
@@ -552,7 +560,7 @@ function parseLibraryRegistryArguments(
   values: ArchiveArgumentValues,
 ): ParsedCLIArguments {
   const helpRoute = formatWikiGraphHelpCommand(uri, action);
-  if (action !== "list" && action !== "add") {
+  if (!LIBRARY_REGISTRY_ACTIONS.has(action)) {
     throw new Error(
       withHelpRoute(
         `The library registry ${uri} does not support \`${action}\`.`,
@@ -592,7 +600,7 @@ function parseLibraryPathArguments(
   values: ArchiveArgumentValues,
 ): ParsedCLIArguments {
   const helpRoute = formatWikiGraphHelpCommand(uri, action);
-  if (action !== "get" && action !== "set") {
+  if (!LIBRARY_PATH_ACTIONS.has(action)) {
     throw new Error(
       withHelpRoute(
         `The library path object ${uri} does not support \`${action}\`.`,
@@ -647,7 +655,7 @@ function parseLibraryArchiveCollectionArguments(
   values: ArchiveArgumentValues,
 ): ParsedCLIArguments {
   const helpRoute = formatWikiGraphHelpCommand(uri, action);
-  if (action !== "list" && action !== "add" && action !== "scan") {
+  if (!LIBRARY_ARCHIVE_COLLECTION_ACTIONS.has(action)) {
     throw new Error(
       withHelpRoute(
         `The archive member collection ${uri} does not support \`${action}\`.`,
@@ -678,9 +686,12 @@ function parseLibraryArchiveCollectionArguments(
   }
   rejectArchiveFlag(action, "--input", values.input, helpRoute);
   rejectArchiveFlag(action, "--to", values.to, helpRoute);
+  if (action === "list") {
+    rejectArchiveBooleanFlag(action, "--jsonl", values.jsonl, helpRoute);
+  }
   return {
     args: {
-      action,
+      action: action as "list" | "scan",
       json: values.json,
       jsonl: values.jsonl,
       target,
@@ -698,7 +709,7 @@ function parseLibraryArchiveTreeArguments(
   values: ArchiveArgumentValues,
 ): ParsedCLIArguments {
   const helpRoute = formatWikiGraphHelpCommand(uri, action);
-  if (action !== "archive-tree") {
+  if (!LIBRARY_ARCHIVE_TREE_ACTIONS.has(action)) {
     throw new Error(
       withHelpRoute(
         `The archive member tree ${uri} is read-only and does not support \`${action}\`.`,
@@ -882,49 +893,12 @@ function parseLibraryScopeArguments(
   rejectArchiveFlag(action, "--json-input", values["json-input"], helpRoute);
 
   switch (action) {
-    case "add":
-      rejectExtraPositionals(action, tail, 0, helpRoute);
-      rejectArchiveFlag(action, "--path", values.path, helpRoute);
-      if (values.input === undefined) {
-        throw new Error(withHelpRoute("Missing --input <path>.", helpRoute));
-      }
-      return {
-        args: {
-          action,
-          inputPath: values.input,
-          json: values.json,
-          target,
-          ...(values.to === undefined ? {} : { to: values.to }),
-        },
-        help: false,
-        kind: "library",
-      };
-    case "create":
-      if (!target.isDefault) {
-        throw new Error(
-          withHelpRoute("Create libraries from wikg://lib.", helpRoute),
-        );
-      }
-      rejectExtraPositionals(action, tail, 0, helpRoute);
-      if (values.path === undefined) {
-        throw new Error(withHelpRoute("Missing --path <folder>.", helpRoute));
-      }
-      rejectArchiveFlag(action, "--input", values.input, helpRoute);
-      rejectArchiveFlag(action, "--to", values.to, helpRoute);
-      return {
-        args: { action, json: values.json, path: values.path, target },
-        help: false,
-        kind: "library",
-      };
     case "remove":
       rejectExtraPositionals(action, tail, 0, helpRoute);
       rejectArchiveFlag(action, "--path", values.path, helpRoute);
       rejectArchiveFlag(action, "--input", values.input, helpRoute);
       rejectArchiveFlag(action, "--to", values.to, helpRoute);
-      if (
-        (target.kind === "archive" || !target.isDefault) &&
-        values.confirm !== true
-      ) {
+      if (!target.isDefault && values.confirm !== true) {
         throw new Error(withHelpRoute("Missing --confirm.", helpRoute));
       }
       return {
@@ -937,23 +911,8 @@ function parseLibraryScopeArguments(
         help: false,
         kind: "library",
       };
-    case "rebind":
-      rejectExtraPositionals(action, tail, 0, helpRoute);
-      if (values.path === undefined) {
-        throw new Error(
-          withHelpRoute("Missing --path <directory>.", helpRoute),
-        );
-      }
-      rejectArchiveFlag(action, "--input", values.input, helpRoute);
-      rejectArchiveFlag(action, "--to", values.to, helpRoute);
-      return {
-        args: { action, json: values.json, path: values.path, target },
-        help: false,
-        kind: "library",
-      };
     case "get":
     case "list":
-    case "scan":
       rejectExtraPositionals(action, tail, 0, helpRoute);
       rejectArchiveFlag(action, "--path", values.path, helpRoute);
       rejectArchiveFlag(action, "--input", values.input, helpRoute);
@@ -972,8 +931,12 @@ function parseLibraryScopeArguments(
     case "clear":
     case "move":
     case "archive-tree":
+    case "add":
+    case "create":
+    case "rebind":
+    case "scan":
       throw new Error(
-        "Internal error: metadata action routed to library scope.",
+        "Internal error: unsupported action routed to library scope.",
       );
   }
 }
@@ -1124,6 +1087,22 @@ function isLibraryAction(action: string): action is CLILibraryAction {
   );
 }
 
+function validateTargetAction(
+  uri: string,
+  label: string,
+  actions: ReadonlySet<string>,
+  action: CLILibraryAction,
+): void {
+  if (!actions.has(action)) {
+    throw new Error(
+      withHelpRoute(
+        `The ${label} ${uri} does not support \`${action}\`.`,
+        formatWikiGraphHelpCommand(uri),
+      ),
+    );
+  }
+}
+
 function validateLibraryActionForTarget(
   uri: string,
   target: ParsedWikiGraphLibraryUri,
@@ -1151,6 +1130,55 @@ function validateLibraryActionForTarget(
         ),
       );
     }
+    return;
+  }
+  if (target.kind === "registry") {
+    validateTargetAction(
+      uri,
+      "library registry",
+      LIBRARY_REGISTRY_ACTIONS,
+      action,
+    );
+    return;
+  }
+
+  if (target.kind === "path") {
+    validateTargetAction(
+      uri,
+      "library path object",
+      LIBRARY_PATH_ACTIONS,
+      action,
+    );
+    return;
+  }
+
+  if (target.kind === "archive-collection") {
+    validateTargetAction(
+      uri,
+      "archive member collection",
+      LIBRARY_ARCHIVE_COLLECTION_ACTIONS,
+      action,
+    );
+    return;
+  }
+
+  if (target.kind === "archive-tree") {
+    validateTargetAction(
+      uri,
+      "archive member tree",
+      LIBRARY_ARCHIVE_TREE_ACTIONS,
+      action,
+    );
+    return;
+  }
+
+  if (target.kind === "archive-path") {
+    validateTargetAction(
+      uri,
+      "archive path object",
+      LIBRARY_ARCHIVE_PATH_ACTIONS,
+      action,
+    );
     return;
   }
 

--- a/packages/cli/src/args/uri/library.ts
+++ b/packages/cli/src/args/uri/library.ts
@@ -25,6 +25,7 @@ import {
   rejectArchiveFlag,
   stripObjectUriPrefix,
 } from "../helpers.js";
+import { parseNonNegativeIntegerFlag } from "../helper/parse.js";
 import { parseArchiveArguments } from "../archive.js";
 import { parseChapterTarget } from "./chapter/target.js";
 import { isTripleScopePath } from "./triple-pattern.js";
@@ -37,15 +38,7 @@ const LIBRARY_METADATA_ACTIONS = new Set([
   "put",
   "set",
 ]);
-const LIBRARY_SCOPE_ACTIONS = new Set([
-  "add",
-  "create",
-  "get",
-  "list",
-  "rebind",
-  "remove",
-  "scan",
-]);
+const LIBRARY_SCOPE_ACTIONS = new Set(["get", "list", "remove"]);
 const LIBRARY_INDEX_ACTIONS = new Set(["disable", "enable", "get"]);
 const LIBRARY_QUERY_ACTIONS = new Set([
   "evidence",
@@ -78,16 +71,20 @@ export function parseLibraryUriFirstArguments(
     ((target.objectUri !== undefined && target.objectUri !== "wikg://index") ||
       values.query !== undefined)
       ? resolveImplicitLibraryQueryAction(target.objectUri, values.query)
-      : target.kind === "metadata" || target.objectUri === "wikg://index"
+      : target.kind === "metadata" ||
+          target.kind === "path" ||
+          target.kind === "archive" ||
+          target.kind === "archive-path" ||
+          target.objectUri === "wikg://index"
         ? "get"
-        : target.kind === "archive"
-          ? "get"
+        : target.kind === "archive-tree"
+          ? "archive-tree"
           : "list");
 
   if (action === "inspect" && target.kind !== "archive") {
     throw new Error(
       withHelpRoute(
-        "Library-level inspection is not supported. Inspect one managed archive with `wg wikg://lib/<archive-id> inspect`.",
+        "Library-level inspection is not supported. Inspect one managed archive with `wg wikg://lib/arc/<archive-id> inspect`.",
         formatWikiGraphHelpCommand(uri),
       ),
     );
@@ -100,6 +97,46 @@ export function parseLibraryUriFirstArguments(
   if (target.kind === "archive" && action === "inspect") {
     return parseLibraryArchiveInspectArguments(
       uri,
+      explicitAction === undefined ? [] : positionals.slice(2),
+      values,
+    );
+  }
+
+  if (target.kind === "registry") {
+    return parseLibraryRegistryArguments(
+      uri,
+      target,
+      action,
+      explicitAction === undefined ? [] : positionals.slice(2),
+      values,
+    );
+  }
+
+  if (target.kind === "path" || target.kind === "archive-path") {
+    return parseLibraryPathArguments(
+      uri,
+      target,
+      action,
+      explicitAction === undefined ? [] : positionals.slice(2),
+      values,
+    );
+  }
+
+  if (target.kind === "archive-tree") {
+    return parseLibraryArchiveTreeArguments(
+      uri,
+      target,
+      action,
+      explicitAction === undefined ? [] : positionals.slice(2),
+      values,
+    );
+  }
+
+  if (target.kind === "archive-collection") {
+    return parseLibraryArchiveCollectionArguments(
+      uri,
+      target,
+      action,
       explicitAction === undefined ? [] : positionals.slice(2),
       values,
     );
@@ -194,6 +231,35 @@ function parseLibraryHelpArguments(
     };
   }
 
+  if (
+    target.kind === "registry" ||
+    target.kind === "path" ||
+    target.kind === "archive-collection" ||
+    target.kind === "archive-tree" ||
+    target.kind === "archive-path"
+  ) {
+    if (explicitAction !== undefined && !isLibraryAction(action)) {
+      throw new Error(
+        withHelpRoute(
+          `The library URI target ${uri} does not support \`${action}\`.`,
+          formatWikiGraphHelpCommand(uri),
+        ),
+      );
+    }
+    return {
+      help: true,
+      helpText:
+        explicitAction === undefined
+          ? renderLibraryUriHelpText(uri, target)
+          : renderLibraryPredicateHelpText(
+              uri,
+              target,
+              action as LibraryHelpPredicateName,
+            ),
+      kind: "help",
+    };
+  }
+
   if (target.kind === "scope" && target.objectUri === "wikg://index") {
     if (explicitAction === undefined) {
       return {
@@ -233,7 +299,7 @@ function parseLibraryHelpArguments(
     if (isReadOnlyLibraryChapterHelpTarget(helpTarget)) {
       throw new Error(
         withHelpRoute(
-          `The library-wide chapter target ${uri} is read-only and does not support \`${action}\`. Use a standalone archive URI or a library archive shortcut such as wikg://lib/<archive-id>/chapter/... for chapter maintenance.`,
+          `The library-wide chapter target ${uri} is read-only and does not support \`${action}\`. Use a standalone archive URI or a library archive shortcut such as wikg://lib/arc/<archive-id>/chapter/... for chapter maintenance.`,
           formatWikiGraphHelpCommand(uri),
         ),
       );
@@ -478,6 +544,196 @@ function resolveImplicitLibraryQueryAction(
   return "get";
 }
 
+function parseLibraryRegistryArguments(
+  uri: string,
+  target: ParsedWikiGraphLibraryUri,
+  action: string,
+  tail: readonly string[],
+  values: ArchiveArgumentValues,
+): ParsedCLIArguments {
+  const helpRoute = formatWikiGraphHelpCommand(uri, action);
+  if (action !== "list" && action !== "add") {
+    throw new Error(
+      withHelpRoute(
+        `The library registry ${uri} does not support \`${action}\`.`,
+        helpRoute,
+      ),
+    );
+  }
+  rejectExtraPositionals(action, tail, 0, helpRoute);
+  rejectCommonLibraryFlags(action, values, helpRoute);
+  rejectArchiveFlag(action, "--input", values.input, helpRoute);
+  rejectArchiveFlag(action, "--to", values.to, helpRoute);
+  rejectArchiveFlag(action, "--json-input", values["json-input"], helpRoute);
+  rejectArchiveBooleanFlag(action, "--jsonl", values.jsonl, helpRoute);
+  if (action === "add") {
+    if (values.path === undefined) {
+      throw new Error(withHelpRoute("Missing --path <folder>.", helpRoute));
+    }
+    return {
+      args: { action: "create", json: values.json, path: values.path, target },
+      help: false,
+      kind: "library",
+    };
+  }
+  rejectArchiveFlag(action, "--path", values.path, helpRoute);
+  return {
+    args: { action: "list", json: values.json, target },
+    help: false,
+    kind: "library",
+  };
+}
+
+function parseLibraryPathArguments(
+  uri: string,
+  target: ParsedWikiGraphLibraryUri,
+  action: string,
+  tail: readonly string[],
+  values: ArchiveArgumentValues,
+): ParsedCLIArguments {
+  const helpRoute = formatWikiGraphHelpCommand(uri, action);
+  if (action !== "get" && action !== "set") {
+    throw new Error(
+      withHelpRoute(
+        `The library path object ${uri} does not support \`${action}\`.`,
+        helpRoute,
+      ),
+    );
+  }
+  rejectCommonLibraryFlags(action, values, helpRoute);
+  rejectArchiveFlag(action, "--path", values.path, helpRoute);
+  rejectArchiveFlag(action, "--input", values.input, helpRoute);
+  rejectArchiveFlag(action, "--to", values.to, helpRoute);
+  rejectArchiveFlag(action, "--json-input", values["json-input"], helpRoute);
+  if (action === "get") {
+    rejectExtraPositionals(action, tail, 0, helpRoute);
+    rejectArchiveBooleanFlag(action, "--jsonl", values.jsonl, helpRoute);
+    return {
+      args: { action: "get", json: values.json, target },
+      help: false,
+      kind: "library",
+    };
+  }
+  rejectExtraPositionals(action, tail, 1, helpRoute);
+  if (tail[0] === undefined) {
+    throw new Error(withHelpRoute("Missing path value.", helpRoute));
+  }
+  if (target.kind === "archive-path") {
+    rejectArchiveBooleanFlag(action, "--jsonl", values.jsonl, helpRoute);
+    return {
+      args: { action: "move", json: values.json, target, to: tail[0] },
+      help: false,
+      kind: "library",
+    };
+  }
+  return {
+    args: {
+      action: "rebind",
+      json: values.json,
+      jsonl: values.jsonl,
+      path: tail[0],
+      target,
+    },
+    help: false,
+    kind: "library",
+  };
+}
+
+function parseLibraryArchiveCollectionArguments(
+  uri: string,
+  target: ParsedWikiGraphLibraryUri,
+  action: string,
+  tail: readonly string[],
+  values: ArchiveArgumentValues,
+): ParsedCLIArguments {
+  const helpRoute = formatWikiGraphHelpCommand(uri, action);
+  if (action !== "list" && action !== "add" && action !== "scan") {
+    throw new Error(
+      withHelpRoute(
+        `The archive member collection ${uri} does not support \`${action}\`.`,
+        helpRoute,
+      ),
+    );
+  }
+  rejectExtraPositionals(action, tail, 0, helpRoute);
+  rejectCommonLibraryFlags(action, values, helpRoute);
+  rejectArchiveFlag(action, "--path", values.path, helpRoute);
+  rejectArchiveFlag(action, "--json-input", values["json-input"], helpRoute);
+  if (action === "add") {
+    rejectArchiveBooleanFlag(action, "--jsonl", values.jsonl, helpRoute);
+    if (values.input === undefined) {
+      throw new Error(withHelpRoute("Missing --input <path>.", helpRoute));
+    }
+    return {
+      args: {
+        action: "add",
+        inputPath: values.input,
+        json: values.json,
+        target,
+        ...(values.to === undefined ? {} : { to: values.to }),
+      },
+      help: false,
+      kind: "library",
+    };
+  }
+  rejectArchiveFlag(action, "--input", values.input, helpRoute);
+  rejectArchiveFlag(action, "--to", values.to, helpRoute);
+  return {
+    args: {
+      action,
+      json: values.json,
+      jsonl: values.jsonl,
+      target,
+    },
+    help: false,
+    kind: "library",
+  };
+}
+
+function parseLibraryArchiveTreeArguments(
+  uri: string,
+  target: ParsedWikiGraphLibraryUri,
+  action: string,
+  tail: readonly string[],
+  values: ArchiveArgumentValues,
+): ParsedCLIArguments {
+  const helpRoute = formatWikiGraphHelpCommand(uri, action);
+  if (action !== "archive-tree") {
+    throw new Error(
+      withHelpRoute(
+        `The archive member tree ${uri} is read-only and does not support \`${action}\`.`,
+        helpRoute,
+      ),
+    );
+  }
+  rejectExtraPositionals(action, tail, 0, helpRoute);
+  rejectCommonLibraryFlags(action, values, helpRoute);
+  rejectArchiveFlag(action, "--path", values.path, helpRoute);
+  rejectArchiveFlag(action, "--input", values.input, helpRoute);
+  rejectArchiveFlag(action, "--to", values.to, helpRoute);
+  rejectArchiveFlag(action, "--json-input", values["json-input"], helpRoute);
+  rejectArchiveBooleanFlag(action, "--jsonl", values.jsonl, helpRoute);
+  return {
+    args: {
+      action: "archive-tree",
+      ...(values.depth === undefined
+        ? {}
+        : {
+            depth: parseNonNegativeIntegerFlag(
+              values.depth,
+              "--depth",
+              helpRoute,
+            ),
+          }),
+      json: values.json,
+      ...(values.parent === undefined ? {} : { parent: values.parent }),
+      target,
+    },
+    help: false,
+    kind: "library",
+  };
+}
+
 function parseLibraryIndexArguments(
   uri: string,
   target: ParsedWikiGraphLibraryUri,
@@ -715,6 +971,7 @@ function parseLibraryScopeArguments(
     case "get-index":
     case "clear":
     case "move":
+    case "archive-tree":
       throw new Error(
         "Internal error: metadata action routed to library scope.",
       );
@@ -796,6 +1053,7 @@ function parseLibraryMetadataArguments(
     case "enable-index":
     case "get-index":
     case "scan":
+    case "archive-tree":
       throw new Error(
         "Internal error: scope action routed to library metadata.",
       );
@@ -848,6 +1106,7 @@ function rejectExtraPositionals(
 function isLibraryAction(action: string): action is CLILibraryAction {
   return (
     action === "add" ||
+    action === "archive-tree" ||
     action === "clear" ||
     action === "create" ||
     action === "delete" ||
@@ -911,7 +1170,7 @@ function validateLibraryActionForTarget(
   if (action === "remove" && target.isDefault) {
     throw new Error(
       withHelpRoute(
-        "The default library cannot be removed. Use a non-default library URI such as wikg://lib/<lib-id>.lib for library registry removal.",
+        "The default library cannot be removed. Use a non-default library URI such as wikg://lib/<lib-id> for library registry removal.",
         helpRoute,
       ),
     );

--- a/packages/cli/src/commands/library.ts
+++ b/packages/cli/src/commands/library.ts
@@ -42,8 +42,7 @@ export async function runLibraryCommand(
     args.action !== "add" &&
     args.action !== "create" &&
     args.action !== "scan" &&
-    args.action !== "rebind" &&
-    args.action !== "archive-tree"
+    args.action !== "rebind"
   ) {
     await assertWikiGraphLibrarySchemaCurrent(args.target);
   }
@@ -95,14 +94,15 @@ export async function runLibraryCommand(
       return;
     }
     case "rebind": {
-      if (args.path === undefined) {
+      const folderPath = args.path;
+      if (folderPath === undefined) {
         throw new Error("Missing path value for library path set.");
       }
       await writeScanResult(
         "path set",
         async () =>
           await rebindWikiGraphLibrary({
-            folderPath: args.path!,
+            folderPath,
             target: args.target,
           }),
         args.json ?? false,
@@ -382,15 +382,17 @@ async function writeScanResult(
       text: `${label} started`,
     });
     const result = await operation();
-    await writer.write({
-      json: {
-        type: "progress",
-        action: label,
-        archives: result.archives.length,
-      },
-      kind: "status",
-      phase: label,
-    });
+    for (const archive of result.archives) {
+      await writer.write({
+        json: {
+          type: "archive",
+          action: label,
+          archive: formatLibraryArchiveJSON(archive),
+        },
+        kind: "status",
+        phase: label,
+      });
+    }
     await writer.write({
       json: {
         type: "completed",
@@ -399,6 +401,11 @@ async function writeScanResult(
       },
       kind: "lifecycle",
       text: `${label} completed`,
+    });
+    await writer.write({
+      json: { type: "succeeded", action: label },
+      kind: "lifecycle",
+      text: "succeeded",
     });
     return;
   }
@@ -488,15 +495,19 @@ async function writeLibraryArchiveTree(
     }
     insertArchiveTreeNode(root, archive);
   }
-  pruneArchiveTreeDepth(root, options.depth, 0);
+  const renderRoot =
+    parent === undefined
+      ? root
+      : (resolveArchiveTreeNode(root, parent) ?? root);
+  pruneArchiveTreeDepth(renderRoot, options.depth, 0);
 
   if (options.json) {
     await writeTextToStdout(
-      formatCLIJSON({ items: serializeArchiveTreeNodes(root.children) }),
+      formatCLIJSON({ items: serializeArchiveTreeNodes(renderRoot.children) }),
     );
     return;
   }
-  await writeTextToStdout(formatArchiveTreeText(root.children));
+  await writeTextToStdout(formatArchiveTreeText(renderRoot.children));
 }
 
 function isArchiveTreePathSelected(path: string, parent: string): boolean {
@@ -520,6 +531,20 @@ function insertArchiveTreeNode(
     current = child;
   }
   current.archive = archive;
+}
+
+function resolveArchiveTreeNode(
+  root: ArchiveTreeNode,
+  path: string,
+): ArchiveTreeNode | undefined {
+  let current: ArchiveTreeNode | undefined = root;
+  for (const part of path.split("/")) {
+    current = current?.children.get(part);
+    if (current === undefined) {
+      return undefined;
+    }
+  }
+  return current;
 }
 
 function pruneArchiveTreeDepth(

--- a/packages/cli/src/commands/library.ts
+++ b/packages/cli/src/commands/library.ts
@@ -8,6 +8,7 @@ import {
   deleteWikiGraphLibraryMetadataKey,
   getWikiGraphLibraryMetadata,
   getWikiGraphLibraryArchive,
+  listWikiGraphLibraries,
   listWikiGraphLibraryArchives,
   moveWikiGraphLibraryArchive,
   disableWikiGraphLibraryIndex,
@@ -40,7 +41,9 @@ export async function runLibraryCommand(
   if (
     args.action !== "add" &&
     args.action !== "create" &&
-    args.action !== "scan"
+    args.action !== "scan" &&
+    args.action !== "rebind" &&
+    args.action !== "archive-tree"
   ) {
     await assertWikiGraphLibrarySchemaCurrent(args.target);
   }
@@ -69,6 +72,13 @@ export async function runLibraryCommand(
       return;
     }
     case "list": {
+      if (args.target.kind === "registry") {
+        await writeLibraries(
+          await listWikiGraphLibraries(),
+          args.json ?? false,
+        );
+        return;
+      }
       await writeLibraryArchives(
         await listWikiGraphLibraryArchives(args.target),
         args.json ?? false,
@@ -76,19 +86,39 @@ export async function runLibraryCommand(
       return;
     }
     case "scan": {
-      const result = await scanWikiGraphLibrary(args.target);
-      await writeLibraryArchives(result.archives, args.json ?? false);
+      await writeScanResult(
+        "scan",
+        async () => await scanWikiGraphLibrary(args.target),
+        args.json ?? false,
+        args.jsonl ?? false,
+      );
       return;
     }
     case "rebind": {
       if (args.path === undefined) {
-        throw new Error("Missing --path <directory> for library rebind.");
+        throw new Error("Missing path value for library path set.");
       }
-      const result = await rebindWikiGraphLibrary({
-        folderPath: args.path,
-        target: args.target,
-      });
-      await writeLibraryArchives(result.archives, args.json ?? false);
+      await writeScanResult(
+        "path set",
+        async () =>
+          await rebindWikiGraphLibrary({
+            folderPath: args.path!,
+            target: args.target,
+          }),
+        args.json ?? false,
+        args.jsonl ?? false,
+      );
+      return;
+    }
+    case "archive-tree": {
+      await writeLibraryArchiveTree(
+        await listWikiGraphLibraryArchives(args.target),
+        {
+          ...(args.depth === undefined ? {} : { depth: args.depth }),
+          json: args.json ?? false,
+          ...(args.parent === undefined ? {} : { parent: args.parent }),
+        },
+      );
       return;
     }
     case "get-index": {
@@ -172,13 +202,30 @@ export async function runLibraryCommand(
         );
       }
       await writeLibraryArchive(
-        await moveWikiGraphLibraryArchive({ target: args.target, to: args.to }),
+        await moveWikiGraphLibraryArchive({
+          target: { ...args.target, kind: "archive" },
+          to: args.to,
+        }),
         args.json ?? false,
         "Moved library archive",
       );
       return;
     }
     case "get": {
+      if (args.target.kind === "path") {
+        await writeLibraryPath(
+          await resolveWikiGraphLibrary(args.target),
+          args.json ?? false,
+        );
+        return;
+      }
+      if (args.target.kind === "archive-path") {
+        await writeLibraryArchivePath(
+          await getWikiGraphLibraryArchive({ ...args.target, kind: "archive" }),
+          args.json ?? false,
+        );
+        return;
+      }
       if (args.target.kind === "metadata") {
         await writeMetadataMap(
           await getWikiGraphLibraryMetadata(args.target),
@@ -264,6 +311,102 @@ async function writeLibrary(
   await writeTextToStdout(`${library.uri}\n`);
 }
 
+async function writeLibraries(
+  libraries: Awaited<ReturnType<typeof listWikiGraphLibraries>>,
+  json: boolean,
+): Promise<void> {
+  if (json) {
+    await writeTextToStdout(
+      formatCLIJSON({
+        items: libraries.map((library) => ({
+          uri: library.uri,
+          id: library.publicId,
+          path: library.folderPath,
+          isDefault: library.isDefault,
+        })),
+      }),
+    );
+    return;
+  }
+  await writeTextToStdout(
+    libraries
+      .map((library) =>
+        [
+          library.uri,
+          library.publicId,
+          library.folderPath,
+          library.isDefault ? "default" : "",
+        ].join("\t"),
+      )
+      .join("\n") + (libraries.length === 0 ? "" : "\n"),
+  );
+}
+
+async function writeLibraryPath(
+  library: Awaited<ReturnType<typeof resolveWikiGraphLibrary>>,
+  json: boolean,
+): Promise<void> {
+  if (json) {
+    await writeTextToStdout(
+      formatCLIJSON({ uri: `${library.uri}/path`, path: library.folderPath }),
+    );
+    return;
+  }
+  await writeTextToStdout(`${library.folderPath}\n`);
+}
+
+async function writeLibraryArchivePath(
+  archive: Awaited<ReturnType<typeof getWikiGraphLibraryArchive>>,
+  json: boolean,
+): Promise<void> {
+  if (json) {
+    await writeTextToStdout(
+      formatCLIJSON({ uri: `${archive.uri}/path`, path: archive.relativePath }),
+    );
+    return;
+  }
+  await writeTextToStdout(`${archive.relativePath}\n`);
+}
+
+async function writeScanResult(
+  label: string,
+  operation: () => Promise<Awaited<ReturnType<typeof scanWikiGraphLibrary>>>,
+  json: boolean,
+  jsonl: boolean,
+): Promise<void> {
+  if (jsonl) {
+    const writer = new ProgressOutputWriter({ jsonl: true, throttleMs: 0 });
+    await writer.write({
+      json: { type: "started", action: label },
+      kind: "lifecycle",
+      text: `${label} started`,
+    });
+    const result = await operation();
+    await writer.write({
+      json: {
+        type: "progress",
+        action: label,
+        archives: result.archives.length,
+      },
+      kind: "status",
+      phase: label,
+    });
+    await writer.write({
+      json: {
+        type: "completed",
+        action: label,
+        archives: result.archives.length,
+      },
+      kind: "lifecycle",
+      text: `${label} completed`,
+    });
+    return;
+  }
+
+  const result = await operation();
+  await writeLibraryArchives(result.archives, json);
+}
+
 async function writeLibraryArchives(
   archives: Awaited<ReturnType<typeof listWikiGraphLibraryArchives>>,
   json: boolean,
@@ -315,6 +458,119 @@ function formatLibraryArchiveJSON(
     createdAt: archive.createdAt,
     updatedAt: archive.updatedAt,
   };
+}
+
+interface ArchiveTreeNode {
+  readonly children: Map<string, ArchiveTreeNode>;
+  readonly name: string;
+  readonly path: string;
+  archive?: Awaited<ReturnType<typeof getWikiGraphLibraryArchive>>;
+}
+
+async function writeLibraryArchiveTree(
+  archives: Awaited<ReturnType<typeof listWikiGraphLibraryArchives>>,
+  options: {
+    readonly depth?: number;
+    readonly json: boolean;
+    readonly parent?: string;
+  },
+): Promise<void> {
+  const parent = options.parent
+    ?.replace(/\\/gu, "/")
+    .replace(/^\/+|\/+$/gu, "");
+  const root: ArchiveTreeNode = { children: new Map(), name: "", path: "" };
+  for (const archive of archives) {
+    if (
+      parent !== undefined &&
+      !isArchiveTreePathSelected(archive.relativePath, parent)
+    ) {
+      continue;
+    }
+    insertArchiveTreeNode(root, archive);
+  }
+  pruneArchiveTreeDepth(root, options.depth, 0);
+
+  if (options.json) {
+    await writeTextToStdout(
+      formatCLIJSON({ items: serializeArchiveTreeNodes(root.children) }),
+    );
+    return;
+  }
+  await writeTextToStdout(formatArchiveTreeText(root.children));
+}
+
+function isArchiveTreePathSelected(path: string, parent: string): boolean {
+  return path === parent || path.startsWith(`${parent.replace(/\/$/u, "")}/`);
+}
+
+function insertArchiveTreeNode(
+  root: ArchiveTreeNode,
+  archive: Awaited<ReturnType<typeof getWikiGraphLibraryArchive>>,
+): void {
+  let current = root;
+  const parts = archive.relativePath.split("/");
+  for (let index = 0; index < parts.length; index += 1) {
+    const name = parts[index]!;
+    const path = parts.slice(0, index + 1).join("/");
+    let child = current.children.get(name);
+    if (child === undefined) {
+      child = { children: new Map(), name, path };
+      current.children.set(name, child);
+    }
+    current = child;
+  }
+  current.archive = archive;
+}
+
+function pruneArchiveTreeDepth(
+  node: ArchiveTreeNode,
+  depth: number | undefined,
+  level: number,
+): void {
+  if (depth === undefined) {
+    for (const child of node.children.values()) {
+      pruneArchiveTreeDepth(child, depth, level + 1);
+    }
+    return;
+  }
+  if (level >= depth) {
+    node.children.clear();
+    return;
+  }
+  for (const child of node.children.values()) {
+    pruneArchiveTreeDepth(child, depth, level + 1);
+  }
+}
+
+function serializeArchiveTreeNodes(
+  nodes: Map<string, ArchiveTreeNode>,
+): object[] {
+  return [...nodes.values()].map((node) => ({
+    name: node.name,
+    path: node.path,
+    ...(node.archive === undefined ? {} : { uri: node.archive.uri }),
+    ...(node.children.size === 0
+      ? {}
+      : { children: serializeArchiveTreeNodes(node.children) }),
+  }));
+}
+
+function formatArchiveTreeText(
+  nodes: Map<string, ArchiveTreeNode>,
+  indent = "",
+): string {
+  const lines: string[] = [];
+  for (const node of nodes.values()) {
+    lines.push(
+      `${indent}${node.name}${node.archive === undefined ? "/" : `\t${node.archive.uri}`}`,
+    );
+    if (node.children.size > 0) {
+      lines.push(
+        formatArchiveTreeText(node.children, `${indent}  `).replace(/\n$/u, ""),
+      );
+    }
+  }
+  return lines.length === 0 ? "" : `${lines.join("\n")}\n`;
 }
 
 async function writeLibraryIndexState(

--- a/packages/core/data/help/commands/library-predicate.jinja
+++ b/packages/core/data/help/commands/library-predicate.jinja
@@ -87,13 +87,13 @@ Usage:
   {{ commandName }} wikg://lib/registry add --path <folder> [--json]
 
 Notes:
-  - Libraries are created from the default library scope, `wikg://lib`.
+  - Create libraries from the registry collection, `wikg://lib/registry`.
   - `<folder>` must not already exist; the command creates it as an empty directory.
   - The folder is not scanned, and contained `.wikg` files are not registered in this stage.
   - Registry data is stored in the global core database, not in the library folder.
   - Text output is the new public library URI. With `--json`, output includes the public id, URI, folder path, default marker, staging path, and timestamps.
   - Save the emitted URI or public id if you need to address this non-default library later.
-  - The current CLI does not expose a list-all-library-registries command.
+  - List all library registries with `{{ commandName }} wikg://lib/registry`.
 
 Examples:
   {{ commandName }} wikg://lib/registry add --path ./research-library
@@ -173,7 +173,7 @@ Usage:
 
 Notes:
   - Use this after you manually move, sync, or restore a library folder outside Wiki Graph.
-  - `--path` must already exist, be an accessible directory, and not be bound to another library.
+  - `<existing-directory>` must already exist, be accessible, and not be bound to another library.
   - The command updates only this library registry's folder path, preserving the library id, public id, default marker, and metadata.
   - The command does not copy, move, or delete files from the old or new folder.
   - After updating the folder path, it runs the same scan/reconcile lifecycle used by `scan`.
@@ -202,7 +202,7 @@ Usage:
 
 Notes:
   - The output includes registered archive ids, relative paths, and membership status.
-  - Use `<lib-scope>/arc scan` when the folder contents changed outside Wiki Graph.
+  - Use `{{ commandName }} <lib-scope>/arc scan` when the folder contents changed outside Wiki Graph.
   - This lists archive memberships in this library, not all library registries.
 {% elif target.kind == "scope" and predicate == "remove" %}
 Purpose:
@@ -227,19 +227,6 @@ Usage:
 Notes:
   - This reads membership information, not archive content.
   - Add archive object suffixes such as `/chapter`, `/entity`, or `/triple` to query the managed archive contents.
-{% elif target.kind == "archive" and predicate == "move" %}
-Purpose:
-  Move or rename this managed archive inside the same library folder.
-
-Usage:
-  {{ commandName }} {{ uri }}/path set <relative-wikg-path> [--json]
-
-Notes:
-  - `--to` must be a relative `.wikg` path inside the library folder.
-  - The archive public id and internal membership id stay the same.
-  - The target path must not already exist.
-  - Moving an archive marks the library index dirty.
-  - Move holds the library write lock and cannot run concurrently with library scan, add, rebind, remove, or index rebuild for the same library.
 {% elif target.kind == "archive" and predicate == "remove" %}
 Purpose:
   Delete this managed `.wikg` file from the library folder and unregister it.

--- a/packages/core/data/help/commands/library-predicate.jinja
+++ b/packages/core/data/help/commands/library-predicate.jinja
@@ -9,12 +9,82 @@ Target:
 Predicate:
   {{ predicate }}
 
-{% if target.kind == "scope" and predicate == "create" %}
+{% if target.kind == "registry" and predicate == "add" %}
 Purpose:
   Create a non-default library registry and create its empty library folder.
 
 Usage:
-  {{ commandName }} wikg://lib create --path <folder> [--json]
+  {{ commandName }} wikg://lib/registry add --path <folder> [--json]
+
+Notes:
+  - The folder must not already exist; the command creates it as an empty directory.
+  - Text output is the new public library URI. With `--json`, output includes the public id, URI, folder path, default marker, staging path, and timestamps.
+{% elif target.kind == "registry" and predicate == "list" %}
+Purpose:
+  List all library registries.
+
+Usage:
+  {{ commandName }} wikg://lib/registry [--json]
+{% elif target.kind == "path" and predicate == "get" %}
+Purpose:
+  Read this library folder path.
+
+Usage:
+  {{ commandName }} {{ uri }} [--json]
+{% elif target.kind == "path" and predicate == "set" %}
+Purpose:
+  Rebind this library to an existing directory, then scan/reconcile `.wikg` files in that directory.
+
+Usage:
+  {{ commandName }} {{ uri }} set <folder> [--json|--jsonl]
+
+Notes:
+  - The command updates only this library registry's folder path.
+  - With `--jsonl`, it streams started/progress/completed events.
+{% elif target.kind == "archive-collection" and predicate == "add" %}
+Purpose:
+  Copy a `.wikg` archive into this library folder and register it as a managed archive member.
+
+Usage:
+  {{ commandName }} {{ uri }} add --input <path> [--to <relative-wikg-path>] [--json]
+{% elif target.kind == "archive-collection" and predicate == "scan" %}
+Purpose:
+  Reconcile this library registry with `.wikg` files currently under the library folder.
+
+Usage:
+  {{ commandName }} {{ uri }} scan [--json|--jsonl]
+
+Notes:
+  - With `--jsonl`, it streams started/progress/completed events.
+{% elif target.kind == "archive-tree" and predicate == "archive-tree" %}
+Purpose:
+  Show the archive member file tree.
+
+Usage:
+  {{ commandName }} {{ uri }} [--parent <relative-path>] [--depth <n>] [--json]
+
+Notes:
+  - `--parent` accepts a directory or concrete `.wikg` file and preserves ancestor nodes.
+  - `--depth` is calculated from the library scope root.
+  - This target is read-only and does not support `set` or `apply`.
+{% elif target.kind == "archive-path" and predicate == "get" %}
+Purpose:
+  Read this archive member's relative `.wikg` path.
+
+Usage:
+  {{ commandName }} {{ uri }} [--json]
+{% elif target.kind == "archive-path" and predicate == "set" %}
+Purpose:
+  Move or rename this managed archive inside the same library folder.
+
+Usage:
+  {{ commandName }} {{ uri }} set <relative-wikg-path> [--json]
+{% elif target.kind == "scope" and predicate == "create" %}
+Purpose:
+  Create a non-default library registry and create its empty library folder.
+
+Usage:
+  {{ commandName }} wikg://lib/registry add --path <folder> [--json]
 
 Notes:
   - Libraries are created from the default library scope, `wikg://lib`.
@@ -26,8 +96,8 @@ Notes:
   - The current CLI does not expose a list-all-library-registries command.
 
 Examples:
-  {{ commandName }} wikg://lib create --path ./research-library
-  {{ commandName }} wikg://lib create --path ./research-library --json
+  {{ commandName }} wikg://lib/registry add --path ./research-library
+  {{ commandName }} wikg://lib/registry add --path ./research-library --json
 {% elif target.kind == "scope" and target.objectUri == "wikg://index" and predicate == "get" %}
 Purpose:
   Read this library index status.
@@ -99,7 +169,7 @@ Purpose:
   Bind this library to an existing directory, then scan/reconcile `.wikg` files in that directory.
 
 Usage:
-  {{ commandName }} {{ uri }} rebind --path <existing-directory> [--json]
+  {{ commandName }} {{ uri }} set <existing-directory> [--json|--jsonl]
 
 Notes:
   - Use this after you manually move, sync, or restore a library folder outside Wiki Graph.
@@ -110,8 +180,8 @@ Notes:
   - Rebind holds the library write lock and cannot run concurrently with membership changes or index rebuild for the same library.
 
 Examples:
-  {{ commandName }} {{ uri }} rebind --path ~/Library/Mobile\ Documents/wiki-library
-  {{ commandName }} {{ uri }} rebind --path /Volumes/Archive/wiki-library --json
+  {{ commandName }} {{ uri }} set ~/Library/Mobile\ Documents/wiki-library
+  {{ commandName }} {{ uri }} set /Volumes/Archive/wiki-library --json
 {% elif target.kind == "scope" and predicate == "get" %}
 Purpose:
   Read this library scope.
@@ -122,7 +192,7 @@ Usage:
 Notes:
   - For a bare library URI, this reads the same membership listing as the default command.
   - For concrete library-wide objects such as `{{ uri }}/entity/<qid>`, use the object URI directly or ask that URI for help.
-  - This is not a list of all library registries; use known `wikg://lib/<lib-id>.lib` URIs for non-default libraries.
+  - This is not a list of all library registries; use known `wikg://lib/<lib-id>` URIs for non-default libraries.
 {% elif target.kind == "scope" and predicate == "list" %}
 Purpose:
   List archive memberships in this library scope.
@@ -132,7 +202,7 @@ Usage:
 
 Notes:
   - The output includes registered archive ids, relative paths, and membership status.
-  - Use `scan` when the folder contents changed outside Wiki Graph.
+  - Use `<lib-scope>/arc scan` when the folder contents changed outside Wiki Graph.
   - This lists archive memberships in this library, not all library registries.
 {% elif target.kind == "scope" and predicate == "remove" %}
 Purpose:
@@ -162,7 +232,7 @@ Purpose:
   Move or rename this managed archive inside the same library folder.
 
 Usage:
-  {{ commandName }} {{ uri }} move --to <relative-wikg-path> [--json]
+  {{ commandName }} {{ uri }}/path set <relative-wikg-path> [--json]
 
 Notes:
   - `--to` must be a relative `.wikg` path inside the library folder.

--- a/packages/core/data/help/commands/library.jinja
+++ b/packages/core/data/help/commands/library.jinja
@@ -1,7 +1,60 @@
 Help Type: command
 Command: {{ commandName }} {{ uri }}
 
-{% if target.kind == "metadata" %}
+{% if target.kind == "registry" %}
+Library registry collection
+
+Default behavior:
+  - `{{ commandName }} {{ uri }}` lists all library registries.
+  - `{{ commandName }} {{ uri }} add --path <folder>` creates a non-default library registry.
+
+Usage:
+  {{ commandName }} wikg://lib/registry [--json]
+  {{ commandName }} wikg://lib/registry add --path <folder> [--json]
+{% elif target.kind == "path" %}
+Library path object
+
+Default behavior:
+  - `{{ commandName }} {{ uri }}` reads the library folder path.
+  - `{{ commandName }} {{ uri }} set <folder>` rebinds the library folder path and scans archive membership.
+
+Usage:
+  {{ commandName }} {{ uri }} [--json]
+  {{ commandName }} {{ uri }} set <folder> [--json|--jsonl]
+{% elif target.kind == "archive-collection" %}
+Archive member collection
+
+Default behavior:
+  - `{{ commandName }} {{ uri }}` lists archive members.
+  - `scan` reconciles `.wikg` files; `add` copies and registers one archive.
+
+Usage:
+  {{ commandName }} {{ uri }} [--json]
+  {{ commandName }} {{ uri }} add --input <path> [--to <relative-wikg-path>] [--json]
+  {{ commandName }} {{ uri }} scan [--json|--jsonl]
+  {{ commandName }} {{ uri }}/tree [--parent <relative-path>] [--depth <n>] [--json]
+{% elif target.kind == "archive-tree" %}
+Archive member tree object
+
+Default behavior:
+  - `{{ commandName }} {{ uri }}` shows the archive member file tree.
+  - `--parent` filters to a directory or `.wikg` file while preserving ancestors.
+  - `--depth` is calculated from the library scope root.
+  - This object is read-only and does not support `set` or `apply`.
+
+Usage:
+  {{ commandName }} {{ uri }} [--parent <relative-path>] [--depth <n>] [--json]
+{% elif target.kind == "archive-path" %}
+Archive member path object
+
+Default behavior:
+  - `{{ commandName }} {{ uri }}` reads this archive member's relative `.wikg` path.
+  - `{{ commandName }} {{ uri }} set <relative-wikg-path>` moves or renames the member.
+
+Usage:
+  {{ commandName }} {{ uri }} [--json]
+  {{ commandName }} {{ uri }} set <relative-wikg-path> [--json]
+{% elif target.kind == "metadata" %}
 Library metadata object
 
 Default behavior:
@@ -47,7 +100,7 @@ Use when:
 Usage:
   {{ commandName }} {{ uri }} [--json]
   {{ commandName }} {{ uri }} inspect [--json]
-  {{ commandName }} {{ uri }} move --to <relative-wikg-path> [--json]
+  {{ commandName }} {{ uri }}/path set <relative-wikg-path> [--json]
   {{ commandName }} {{ uri }} remove --confirm [--json]
 
 Predicate commands:
@@ -80,10 +133,10 @@ Related help:
 Library scope
 
 Default behavior:
-  - `{{ commandName }} {{ uri }}` lists archive memberships registered in this library.
-  - This is not a list of all library registries.
+  - `{{ commandName }} {{ uri }}` reads this library scope.
+  - Use `{{ commandName }} wikg://lib/registry` to list all library registries.
   - `{{ commandName }} {{ uri }} --query <query>` runs a broad library index search across indexed object types.
-  - `{{ commandName }} {{ uri }} scan` reconciles membership with `.wikg` files currently under the library folder.
+  - `{{ commandName }} {{ uri }}/arc scan` reconciles membership with `.wikg` files currently under the library folder.
   - Library-wide object scopes such as `/entity` and `/triple` query one object type through the library index after it is enabled.
 
 Use when:
@@ -97,9 +150,9 @@ Use when:
 
 URI forms:
   - `{{ commandName }} wikg://lib` addresses the default library.
-  - `{{ commandName }} wikg://lib/<lib-id>.lib` addresses a non-default library.
-  - `{{ commandName }} wikg://lib/<archive-id>/` addresses one archive membership in the default library.
-  - Non-default library URIs require the `.lib` suffix so `wikg://lib/<archive-id>/` archive shortcuts remain unambiguous.
+  - `{{ commandName }} wikg://lib/<lib-id>` addresses a non-default library.
+  - `{{ commandName }} wikg://lib/arc/<archive-id>/` addresses one archive membership in the default library.
+  - `{{ commandName }} wikg://lib/<lib-id>/arc/<archive-id>/` addresses one archive membership in a non-default library.
 
 Usage:
 {% if target.isDefault %}
@@ -107,10 +160,11 @@ Usage:
   {{ commandName }} wikg://lib --query <query>
   {{ commandName }} wikg://lib/chapter --query <query>
   {{ commandName }} wikg://lib/chunk --query <query>
-  {{ commandName }} wikg://lib create --path <folder> [--json]
-  {{ commandName }} wikg://lib scan [--json]
-  {{ commandName }} wikg://lib add --input <path> [--to <relative-wikg-path>] [--json]
-  {{ commandName }} wikg://lib rebind --path <existing-directory> [--json]
+  {{ commandName }} wikg://lib/registry add --path <folder> [--json]
+  {{ commandName }} wikg://lib/arc scan [--json|--jsonl]
+  {{ commandName }} wikg://lib/arc add --input <path> [--to <relative-wikg-path>] [--json]
+  {{ commandName }} wikg://lib/path set <existing-directory> [--json|--jsonl]
+  {{ commandName }} wikg://lib/arc/tree [--parent <relative-path>] [--depth <n>] [--json]
   {{ commandName }} wikg://lib/index [--json]
   {{ commandName }} wikg://lib/entity --query <query>
   {{ commandName }} wikg://lib/triple --query <query>
@@ -120,9 +174,10 @@ Usage:
   {{ commandName }} {{ uri }} --query <query>
   {{ commandName }} {{ uri }}/chapter --query <query>
   {{ commandName }} {{ uri }}/chunk --query <query>
-  {{ commandName }} {{ uri }} scan [--json]
-  {{ commandName }} {{ uri }} add --input <path> [--to <relative-wikg-path>] [--json]
-  {{ commandName }} {{ uri }} rebind --path <existing-directory> [--json]
+  {{ commandName }} {{ uri }}/arc scan [--json|--jsonl]
+  {{ commandName }} {{ uri }}/arc add --input <path> [--to <relative-wikg-path>] [--json]
+  {{ commandName }} {{ uri }}/path set <existing-directory> [--json|--jsonl]
+  {{ commandName }} {{ uri }}/arc/tree [--parent <relative-path>] [--depth <n>] [--json]
   {{ commandName }} {{ uri }} remove --confirm [--json]
   {{ commandName }} {{ uri }}/index [--json]
   {{ commandName }} {{ uri }}/entity --query <query>
@@ -132,14 +187,14 @@ Usage:
 
 Predicate commands:
 {% if target.isDefault %}
-  - create: create a non-default library registry and an empty folder. Help: {{ commandName }} wikg://lib create --help
-  - scan: reconcile registered archive memberships with `.wikg` files under the library folder. Help: {{ commandName }} wikg://lib scan --help
-  - add: copy a `.wikg` file into the library folder and register it. Help: {{ commandName }} wikg://lib add --help
-  - rebind: bind the default library to an existing directory, then scan/reconcile its `.wikg` files. Help: {{ commandName }} wikg://lib rebind --help
+  - registry add: create a non-default library registry and an empty folder. Help: {{ commandName }} wikg://lib/registry add --help
+  - arc scan: reconcile registered archive memberships with `.wikg` files under the library folder. Help: {{ commandName }} wikg://lib/arc scan --help
+  - arc add: copy a `.wikg` file into the library folder and register it. Help: {{ commandName }} wikg://lib/arc add --help
+  - path set: bind the default library to an existing directory, then scan/reconcile its `.wikg` files. Help: {{ commandName }} wikg://lib/path set --help
 {% else %}
-  - scan: reconcile registered archive memberships with `.wikg` files under the library folder. Help: {{ commandName }} {{ uri }} scan --help
-  - add: copy a `.wikg` file into the library folder and register it. Help: {{ commandName }} {{ uri }} add --help
-  - rebind: bind this library to an existing directory, then scan/reconcile its `.wikg` files. Help: {{ commandName }} {{ uri }} rebind --help
+  - arc scan: reconcile registered archive memberships with `.wikg` files under the library folder. Help: {{ commandName }} {{ uri }}/arc scan --help
+  - arc add: copy a `.wikg` file into the library folder and register it. Help: {{ commandName }} {{ uri }}/arc add --help
+  - path set: bind this library to an existing directory, then scan/reconcile its `.wikg` files. Help: {{ commandName }} {{ uri }}/path set --help
   - remove: remove this library registry without deleting its folder. Help: {{ commandName }} {{ uri }} remove --help
 {% endif %}
 

--- a/packages/core/data/help/commands/library.jinja
+++ b/packages/core/data/help/commands/library.jinja
@@ -105,7 +105,7 @@ Usage:
 
 Predicate commands:
   - inspect: inspect this managed archive's archive readiness. Help: {{ commandName }} {{ uri }} inspect --help
-  - move: move or rename this archive inside the same library folder without changing its archive id. Help: {{ commandName }} {{ uri }} move --help
+  - path set: move or rename this archive inside the same library folder without changing its archive id. Help: {{ commandName }} {{ uri }}/path set --help
   - remove: delete this archive file from the library folder and unregister it. Help: {{ commandName }} {{ uri }} remove --help
 {% elif target.kind == "scope" and target.objectUri == "wikg://index" %}
 Library index object

--- a/packages/core/data/help/commands/maintenance.jinja
+++ b/packages/core/data/help/commands/maintenance.jinja
@@ -16,7 +16,7 @@ Upgrade targets:
   {{ commandName }} maintenance upgrade wikg://book.wikg
   {{ commandName }} maintenance upgrade ./book.sdpub [--output ./book.wikg]
   {{ commandName }} maintenance upgrade wikg://lib
-  {{ commandName }} maintenance upgrade wikg://lib/<lib-id>.lib
+  {{ commandName }} maintenance upgrade wikg://lib/<lib-id>
 
 See Also:
   {{ commandName }} maintenance upgrade --help

--- a/packages/core/data/help/commands/maintenance/upgrade.jinja
+++ b/packages/core/data/help/commands/maintenance/upgrade.jinja
@@ -12,14 +12,14 @@ Targets:
   - Home state: ~/.wikigraph
   - Standalone archive: ./book.wikg, /path/to/book.wikg, wikg://book.wikg, wikg:///path/to/book.wikg
   - Legacy sdpub: ./book.sdpub, optionally with --output
-  - Library: wikg://lib or wikg://lib/<lib-id>.lib
+  - Library: wikg://lib or wikg://lib/<lib-id>
 
 Notes:
   - This maintenance command accepts filesystem paths. URI-targeted archive/object commands still require Wiki Graph URIs; see `{{ commandName }} help uri`.
   - Home state may be schema-gated automatically before real commands, but this command is the explicit recovery and batch-upgrade entry point.
   - Internal SQLite files are part of the home target and are not user-facing upgrade targets.
   - Standalone .wikg, home, and library targets are upgraded in place and do not support --output.
-  - Library archive member URIs such as wikg://lib/<archive-id>/ are not standalone upgrade targets; upgrade the whole library.
+  - Library archive member URIs such as wikg://lib/arc/<archive-id>/ are not standalone upgrade targets; upgrade the whole library.
   - Library upgrade covers the registry and managed archive members for that library.
 
 Examples:

--- a/packages/core/data/help/commands/predicate.jinja
+++ b/packages/core/data/help/commands/predicate.jinja
@@ -602,17 +602,17 @@ Library context:
   - Interpret results with the returned archive/member provenance; cite the specific returned evidence or member.
 {% endif %}
 {% if target.name == "chapter-collection-scope" or target.name == "chapter-scope" or target.name == "chapter-source-object" or target.name == "chapter-summary-object" or target.name == "chapter-title-object" or target.name == "chapter-tree-object" or target.name == "chapter-state-object" %}
-  - Library archive shortcuts such as `wikg://lib/<archive-id>/chapter/part` apply the predicate to one managed archive.
+  - Library archive shortcuts such as `wikg://lib/arc/<archive-id>/chapter/part` apply the predicate to one managed archive.
 {% elif target.name == "triple-object" or target.name == "triple-scope" %}
-  - Library archive shortcuts such as `wikg://lib/<archive-id>/triple/Q8018/discusses/Q123` apply the predicate to one managed archive.
+  - Library archive shortcuts such as `wikg://lib/arc/<archive-id>/triple/Q8018/discusses/Q123` apply the predicate to one managed archive.
 {% elif target.name == "chunk-object" or target.name == "chunk-scope" %}
-  - Library archive shortcuts such as `wikg://lib/<archive-id>/chunk/12` apply the predicate to one managed archive.
+  - Library archive shortcuts such as `wikg://lib/arc/<archive-id>/chunk/12` apply the predicate to one managed archive.
 {% elif target.name == "index-object" and libraryContext.isLibraryWide %}
   - Library index shortcuts such as `wikg://lib/index` apply the predicate to the aggregate library index.
 {% elif target.name == "index-object" %}
-  - Library archive shortcuts such as `wikg://lib/<archive-id>/index` apply the predicate to one managed archive.
+  - Library archive shortcuts such as `wikg://lib/arc/<archive-id>/index` apply the predicate to one managed archive.
 {% else %}
-  - Library archive shortcuts such as `wikg://lib/<archive-id>/entity/Q8018` apply the predicate to one managed archive.
+  - Library archive shortcuts such as `wikg://lib/arc/<archive-id>/entity/Q8018` apply the predicate to one managed archive.
 {% endif %}
 {% endif %}
 

--- a/packages/core/data/help/commands/uri.jinja
+++ b/packages/core/data/help/commands/uri.jinja
@@ -308,13 +308,13 @@ Library context:
 {% if libraryContext.isLibraryWide %}
   - Library-wide chapter URIs are read-only aggregate views over present archive members.
 {% endif %}
-  - Library archive shortcuts such as `wikg://lib/<archive-id>/chapter` query or maintain one managed archive through its membership id.
+  - Library archive shortcuts such as `wikg://lib/arc/<archive-id>/chapter` query or maintain one managed archive through its membership id.
   - Use a standalone archive URI or library archive shortcut for chapter maintenance writes.
 {% elif target.name == "triple-scope" or target.name == "triple-object" %}
 {% if libraryContext.isLibraryWide %}
   - Library-wide scopes such as `wikg://lib/triple` use the aggregate library index.
 {% endif %}
-  - Library archive shortcuts such as `wikg://lib/<archive-id>/triple` query one managed archive through its membership id.
+  - Library archive shortcuts such as `wikg://lib/arc/<archive-id>/triple` query one managed archive through its membership id.
 {% if target.name == "triple-object" and libraryContext.isLibraryWide %}
   - Library-wide triple object URIs are aggregate views over matching triples from present archive members.
   - Interpret evidence with the returned archive/member provenance; use a library archive shortcut when you need one member only.
@@ -323,7 +323,7 @@ Library context:
 {% if libraryContext.isLibraryWide %}
   - Library-wide scopes such as `wikg://lib/chunk` use the aggregate library index.
 {% endif %}
-  - Library archive shortcuts such as `wikg://lib/<archive-id>/chunk` query one managed archive through its membership id.
+  - Library archive shortcuts such as `wikg://lib/arc/<archive-id>/chunk` query one managed archive through its membership id.
 {% if target.name == "chunk-object" and libraryContext.isLibraryWide %}
   - Library-wide chunk object URIs are aggregate views over matching chunks from present archive members.
   - Interpret related and pack output with the returned archive/member provenance; use a library archive shortcut when you need one member only.
@@ -332,7 +332,7 @@ Library context:
 {% if libraryContext.isLibraryWide %}
   - Library-wide scopes such as `wikg://lib/entity` use the aggregate library index.
 {% endif %}
-  - Library archive shortcuts such as `wikg://lib/<archive-id>/entity` query one managed archive through its membership id.
+  - Library archive shortcuts such as `wikg://lib/arc/<archive-id>/entity` query one managed archive through its membership id.
 {% if target.name == "entity-object" and libraryContext.isLibraryWide %}
   - Library-wide entity object URIs are aggregate views over matching entities from present archive members.
   - Interpret evidence, related, and pack output with the returned archive/member provenance; use a library archive shortcut when you need one member only.
@@ -343,7 +343,7 @@ Library context:
 
 Predicate commands:
 {% if libraryContext.isLibraryWide and (target.name == "chapter-collection-scope" or target.name == "chapter-scope" or target.name == "chapter-source-object" or target.name == "chapter-source-range-object" or target.name == "chapter-summary-object" or target.name == "chapter-summary-range-object" or target.name == "chapter-title-object" or target.name == "chapter-tree-object") %}
-  This library-wide chapter target is read-only. Use a standalone archive URI or a library archive shortcut such as `wikg://lib/<archive-id>/chapter/...` for chapter maintenance.
+  This library-wide chapter target is read-only. Use a standalone archive URI or a library archive shortcut such as `wikg://lib/arc/<archive-id>/chapter/...` for chapter maintenance.
 {% else %}
 {% if target.predicates.length %}
 {% for predicate in target.predicates %}

--- a/packages/core/data/help/topics/library.jinja
+++ b/packages/core/data/help/topics/library.jinja
@@ -10,38 +10,38 @@ Purpose:
 Core model:
   - A library registry records one managed folder, its public id, metadata, default marker, and local staging identity.
   - The default library is addressed as `wikg://lib`.
-  - A non-default library is addressed as `wikg://lib/<lib-id>.lib`.
-  - The `.lib` suffix keeps library ids distinct from archive member shortcuts.
+  - A non-default library is addressed as `wikg://lib/<lib-id>`.
+  - The `arc` reserved segment keeps library ids distinct from archive member ids.
   - `{{ commandName }} wikg://lib` lists archive memberships in the default library; it does not list all library registries.
 
 Registry discovery:
-  - `{{ commandName }} wikg://lib create --path <folder>` prints the new non-default library URI.
+  - `{{ commandName }} wikg://lib/registry add --path <folder>` prints the new non-default library URI.
   - With `--json`, create output includes the public id, URI, folder path, default marker, and staging path.
   - Keep that emitted URI or public id in your workflow if you need to address a non-default library later.
-  - The current CLI exposes the default library as `wikg://lib` and known non-default libraries as `wikg://lib/<lib-id>.lib`.
-  - It does not expose a list-all-library-registries command; `{{ commandName }} wikg://lib` is a membership listing for the default library.
+  - The current CLI exposes the default library as `wikg://lib` and known non-default libraries as `wikg://lib/<lib-id>`.
+  - Use `{{ commandName }} wikg://lib/registry` to list all library registries.
 
 Library folders:
-  - `{{ commandName }} wikg://lib create --path <folder>` creates a non-default library registry and an empty folder.
-  - `{{ commandName }} wikg://lib rebind --path <existing-directory>` binds the default library to an existing folder without copying or deleting files.
-  - `{{ commandName }} wikg://lib/<lib-id>.lib rebind --path <existing-directory>` rebinds that non-default library.
+  - `{{ commandName }} wikg://lib/registry add --path <folder>` creates a non-default library registry and an empty folder.
+  - `{{ commandName }} wikg://lib/path set <existing-directory>` binds the default library to an existing folder without copying or deleting files.
+  - `{{ commandName }} wikg://lib/<lib-id>/path set <existing-directory>` rebinds that non-default library.
   - Use rebind after a manual move, sync restore, or mount path change.
 
 Archive memberships:
-  - `{{ commandName }} <library-uri> scan` recursively discovers `.wikg` files under the bound folder and reconciles registry state.
-  - `{{ commandName }} <library-uri> add --input <path> [--to <relative-wikg-path>]` copies one `.wikg` file into the folder and registers it.
-  - `{{ commandName }} <library-archive-uri> move --to <relative-wikg-path>` moves or renames one managed archive inside the same folder.
+  - `{{ commandName }} <lib-scope>/arc scan` recursively discovers `.wikg` files under the bound folder and reconciles registry state.
+  - `{{ commandName }} <lib-scope>/arc add --input <path> [--to <relative-wikg-path>]` copies one `.wikg` file into the folder and registers it.
+  - `{{ commandName }} <library-archive-uri>/path set <relative-wikg-path>` moves or renames one managed archive inside the same folder.
   - `{{ commandName }} <library-archive-uri> remove --confirm` deletes one managed archive file and unregisters it.
   - Missing registered files remain visible as missing or stale until scan, move, remove, or rebind resolves them.
 
 Library archive shortcuts:
-  - `wikg://lib/<archive-id>/` addresses one archive membership in the default library.
-  - `wikg://lib/<lib-id>.lib/<archive-id>/` addresses one archive membership in a non-default library.
+  - `wikg://lib/arc/<archive-id>/` addresses one archive membership in the default library.
+  - `wikg://lib/<lib-id>/arc/<archive-id>/` addresses one archive membership in a non-default library.
   - Add normal archive object suffixes after the trailing slash to query that archive's contents:
-    {{ commandName }} wikg://lib/<archive-id>/chapter
-    {{ commandName }} wikg://lib/<archive-id>/entity --query "term"
-    {{ commandName }} wikg://lib/<archive-id>/triple --query "term"
-  - Run `{{ commandName }} wikg://lib/<archive-id> inspect` to inspect that one managed archive's readiness; this is not a library-level health report.
+    {{ commandName }} wikg://lib/arc/<archive-id>/chapter
+    {{ commandName }} wikg://lib/arc/<archive-id>/entity --query "term"
+    {{ commandName }} wikg://lib/arc/<archive-id>/triple --query "term"
+  - Run `{{ commandName }} wikg://lib/arc/<archive-id> inspect` to inspect that one managed archive's readiness; this is not a library-level health report.
   - `{{ commandName }} <library-archive-uri> --help` explains membership actions such as `move` and `remove`.
   - `{{ commandName }} <library-archive-uri>/entity --help` explains the archive object scope reached through that library shortcut.
 
@@ -52,7 +52,7 @@ Library-wide query:
   - Library-wide object predicates such as `evidence`, `related`, and `pack` use the same aggregate library index.
   - Library-wide object URIs such as `wikg://lib/entity/<qid>` are aggregate views over matching objects from present archive members.
   - Evidence and related output should be interpreted with the returned archive/member provenance; cite the specific returned evidence or member, not just the library-wide URI.
-  - To force one managed archive member, use a library archive shortcut such as `wikg://lib/<archive-id>/entity/<qid>`.
+  - To force one managed archive member, use a library archive shortcut such as `wikg://lib/arc/<archive-id>/entity/<qid>`.
 
 Library index lifecycle:
   - `{{ commandName }} <library-uri>/index` reads library index status.
@@ -70,8 +70,8 @@ Concurrency:
   - If a write marks the aggregate index dirty, rebuild it with `{{ commandName }} <library-uri>/index enable` before relying on library-wide query results.
 
 Upgrade and cleanup:
-  - Upgrade a whole library with `{{ commandName }} maintenance upgrade wikg://lib` or `{{ commandName }} maintenance upgrade wikg://lib/<lib-id>.lib`.
-  - Library archive member URIs such as `wikg://lib/<archive-id>/` are not standalone upgrade targets.
+  - Upgrade a whole library with `{{ commandName }} maintenance upgrade wikg://lib` or `{{ commandName }} maintenance upgrade wikg://lib/<lib-id>`.
+  - Library archive member URIs such as `wikg://lib/arc/<archive-id>/` are not standalone upgrade targets.
   - Runtime cleanup may remove orphaned local index staging, but it does not delete managed `.wikg` files.
 
 Where to go next:

--- a/packages/core/data/help/topics/readiness.jinja
+++ b/packages/core/data/help/topics/readiness.jinja
@@ -39,7 +39,7 @@ Library index readiness:
 
   Default behavior:
     `{{ commandName }} wikg://lib/index enable` rebuilds the default library index from registered present archives.
-    `{{ commandName }} wikg://lib/<lib-id>.lib/index enable` rebuilds a non-default library index.
+    `{{ commandName }} wikg://lib/<lib-id>/index enable` rebuilds a non-default library index.
     The index is local derived state under Wiki Graph staging, not a file inside the library folder.
 
   Dirty behavior:

--- a/packages/core/data/help/topics/recipe.jinja
+++ b/packages/core/data/help/topics/recipe.jinja
@@ -26,7 +26,7 @@ Choose your starting point:
 
   - User gave you a folder of `.wikg` archives:
     Bind or create a library, scan memberships, then inspect the library index before library-wide query.
-      {{ commandName }} wikg://lib rebind --path ./library-folder
+      {{ commandName }} wikg://lib/path set ./library-folder
       {{ commandName }} wikg://lib scan
       {{ commandName }} wikg://lib/index --help
       {{ commandName }} help library
@@ -89,7 +89,7 @@ Finding material:
       {{ commandName }} wikg://lib/triple --query "attention memory" --evidence 2
       {{ commandName }} wikg://lib/chunk --query "attention memory" --evidence 2
     Use a library archive shortcut when one member archive is the right scope.
-      {{ commandName }} wikg://lib/<archive-id>/entity --query "attention"
+      {{ commandName }} wikg://lib/arc/<archive-id>/entity --query "attention"
 
   - Need to understand a concept, person, place, term, or object:
     Use `--query` on entity scopes with source evidence, then ground, expand, or pack from the entity URI.

--- a/packages/core/data/help/topics/recipe.jinja
+++ b/packages/core/data/help/topics/recipe.jinja
@@ -27,7 +27,7 @@ Choose your starting point:
   - User gave you a folder of `.wikg` archives:
     Bind or create a library, scan memberships, then inspect the library index before library-wide query.
       {{ commandName }} wikg://lib/path set ./library-folder
-      {{ commandName }} wikg://lib scan
+      {{ commandName }} wikg://lib/arc scan
       {{ commandName }} wikg://lib/index --help
       {{ commandName }} help library
 

--- a/packages/core/data/help/topics/uri.jinja
+++ b/packages/core/data/help/topics/uri.jinja
@@ -22,13 +22,13 @@ Archive locator:
 
 Library locators:
   - `wikg://lib` addresses the default library.
-  - `wikg://lib/<lib-id>.lib` addresses a non-default library.
-  - `wikg://lib/<archive-id>/` addresses one archive membership in the default library.
-  - `wikg://lib/<lib-id>.lib/<archive-id>/` addresses one archive membership in a non-default library.
+  - `wikg://lib/<lib-id>` addresses a non-default library.
+  - `wikg://lib/arc/<archive-id>/` addresses one archive membership in the default library.
+  - `wikg://lib/<lib-id>/arc/<archive-id>/` addresses one archive membership in a non-default library.
   - Add ordinary archive object suffixes after the trailing slash to query a managed archive:
-    wikg://lib/<archive-id>/chapter
-    wikg://lib/<archive-id>/entity
-    wikg://lib/<archive-id>/triple
+    wikg://lib/arc/<archive-id>/chapter
+    wikg://lib/arc/<archive-id>/entity
+    wikg://lib/arc/<archive-id>/triple
   - Library-wide scopes such as `wikg://lib/entity` query the aggregate library index.
   - Read `{{ commandName }} help library` before managing registry, membership, rebind, or library index lifecycle.
 
@@ -65,7 +65,7 @@ Common command shapes:
   {{ commandName }} transform [options]
   {{ commandName }} wikg://lib --help
   {{ commandName }} wikg://lib/entity --query <query>
-  {{ commandName }} wikg://lib/<archive-id>/entity --query <query>
+  {{ commandName }} wikg://lib/arc/<archive-id>/entity --query <query>
   {{ commandName }} wikg://local/job
   {{ commandName }} wikg://local/job add --input <archive-uri|chapter-uri> --task <reading-graph|reading-summary|knowledge-graph> --accept-cost
   {{ commandName }} wikg://local/job/<job-id>
@@ -181,7 +181,7 @@ Recovery hints:
     {{ commandName }} help readiness
     {{ commandName }} help runtime
   - URI rejected: convert bare filesystem paths to Wiki Graph URIs, and prepend the archive locator to short object URIs.
-  - Library URI rejected: check whether you meant a non-default library id with `.lib` or an archive member shortcut with a trailing slash.
+  - Library URI rejected: check whether you meant a non-default library id with `/arc/<arc-id>` or a concrete archive object suffix.
   - Help did not appear: append `--help` to the URI or URI-bound predicate you are trying to inspect.
 
 Job URIs:

--- a/packages/core/data/help/topics/uri.jinja
+++ b/packages/core/data/help/topics/uri.jinja
@@ -181,7 +181,7 @@ Recovery hints:
     {{ commandName }} help readiness
     {{ commandName }} help runtime
   - URI rejected: convert bare filesystem paths to Wiki Graph URIs, and prepend the archive locator to short object URIs.
-  - Library URI rejected: check whether you meant a non-default library id with `/arc/<arc-id>` or a concrete archive object suffix.
+  - Library URI rejected: non-default libraries use wikg://lib/<lib-id>; archive members use <lib-scope>/arc/<archive-id>.
   - Help did not appear: append `--help` to the URI or URI-bound predicate you are trying to inspect.
 
 Job URIs:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,6 +49,7 @@ export {
   getWikiGraphLibraryArchive,
   getWikiGraphLibraryArchiveById,
   getWikiGraphLibraryMetadata,
+  listWikiGraphLibraries,
   isWikiGraphLibraryUri,
   findWikiGraphLibraryObjects,
   listRelatedWikiGraphLibraryObjects,

--- a/packages/core/src/library/membership.test.ts
+++ b/packages/core/src/library/membership.test.ts
@@ -839,17 +839,19 @@ async function getDefaultMetadata(
 describe("library URI locators", () => {
   it("separates library archives from library scopes", () => {
     expect(isWikiGraphLibraryUri("wikg://lib")).toBe(true);
-    expect(isWikiGraphLibraryUri("wikg://lib/team.lib")).toBe(true);
+    expect(isWikiGraphLibraryUri("wikg://lib/team")).toBe(true);
     expect(isWikiGraphLibraryUri("wikg://lib/entity/Q23")).toBe(true);
-    expect(isWikiGraphLibraryUri("wikg://lib/archive123/chapter")).toBe(false);
+    expect(isWikiGraphLibraryUri("wikg://lib/arc/archive123/chapter")).toBe(
+      false,
+    );
     expect(
-      isWikiGraphLibraryUri("wikg://lib/team.lib/archive123/chapter"),
+      isWikiGraphLibraryUri("wikg://lib/team/arc/archive123/chapter"),
     ).toBe(false);
 
     expect(
-      parseLocatedWikiGraphUri("wikg://lib/archive123/chapter"),
+      parseLocatedWikiGraphUri("wikg://lib/arc/archive123/chapter"),
     ).toStrictEqual({
-      archivePath: "wikg://lib/archive123",
+      archivePath: "wikg://lib/arc/archive123",
       objectUri: "wikg://chapter",
     });
     expect(parseWikiGraphLibraryUri("wikg://lib/entity/Q23")).toMatchObject({
@@ -862,16 +864,14 @@ describe("library URI locators", () => {
       kind: "scope",
       objectUri: "wikg://index",
     });
-    expect(parseWikiGraphLibraryUri("wikg://lib/team.lib/index")).toMatchObject(
-      {
-        isDefault: false,
-        kind: "scope",
-        objectUri: "wikg://index",
-        publicId: "team",
-      },
-    );
+    expect(parseWikiGraphLibraryUri("wikg://lib/team/index")).toMatchObject({
+      isDefault: false,
+      kind: "scope",
+      objectUri: "wikg://index",
+      publicId: "team",
+    });
     expect(
-      parseWikiGraphLibraryUri("wikg://lib/team.lib/archive123/entity"),
+      parseWikiGraphLibraryUri("wikg://lib/team/arc/archive123/entity"),
     ).toMatchObject({
       archivePublicId: "archive123",
       kind: "archive",

--- a/packages/core/src/library/membership.ts
+++ b/packages/core/src/library/membership.ts
@@ -746,7 +746,7 @@ function mapLibraryArchiveRecord(
     relativePath,
     status: exists ? databaseStatus : "missing",
     updatedAt: getString(row, "updated_at"),
-    uri: `${library.uri}/${publicId}`,
+    uri: `${library.uri}/arc/${publicId}`,
   };
 }
 

--- a/packages/core/src/library/registry.ts
+++ b/packages/core/src/library/registry.ts
@@ -21,6 +21,19 @@ import { withWikiGraphLibraryLock } from "./lock.js";
 
 const DEFAULT_LIBRARY_FOLDER_NAME = "default-library";
 const PUBLIC_ID_BYTES = 6;
+const RESERVED_LIBRARY_URI_SEGMENTS = new Set([
+  "registry",
+  "arc",
+  "path",
+  "tree",
+  "meta",
+  "index",
+  "chapter",
+  "chunk",
+  "entity",
+  "triple",
+]);
+
 const RESERVED_METADATA_KEYS = new Set([
   "id",
   "public_id",
@@ -79,7 +92,15 @@ export interface WikiGraphLibraryRecord {
 
 export interface ParsedWikiGraphLibraryUri {
   readonly archivePublicId?: string;
-  readonly kind: "archive" | "metadata" | "scope";
+  readonly kind:
+    | "archive"
+    | "archive-collection"
+    | "archive-path"
+    | "archive-tree"
+    | "metadata"
+    | "path"
+    | "registry"
+    | "scope";
   readonly objectUri?: string;
   readonly publicId?: string;
   readonly isDefault: boolean;
@@ -106,9 +127,6 @@ export function parseWikiGraphLibraryUri(
   if (uri === "wikg://lib") {
     return { isDefault: true, kind: "scope" };
   }
-  if (uri === "wikg://lib/meta") {
-    return { isDefault: true, kind: "metadata" };
-  }
   if (!uri.startsWith("wikg://lib/")) {
     return undefined;
   }
@@ -119,48 +137,26 @@ export function parseWikiGraphLibraryUri(
   ) {
     return undefined;
   }
-  const explicitLibraryArchiveMatch =
-    /^([^/]+)\.lib\/(?!meta(?:\/|$)|index(?:\/|$)|chapter(?:\/|$)|chunk(?:\/|$)|entity(?:\/|$)|triple(?:\/|$))([^/]+)(?:\/(.*))?$/u.exec(
-      path,
-    );
-  const explicitLibraryPublicId = explicitLibraryArchiveMatch?.[1];
-  const explicitArchivePublicId = explicitLibraryArchiveMatch?.[2];
-  const explicitObjectPath = explicitLibraryArchiveMatch?.[3];
+
+  const segments = path.split("/");
   if (
-    explicitLibraryPublicId !== undefined &&
-    explicitArchivePublicId !== undefined
+    segments.includes("") ||
+    segments.some((segment) => segment.endsWith(".lib"))
   ) {
-    return {
-      archivePublicId: explicitArchivePublicId,
-      isDefault: false,
-      kind: "archive",
-      ...(explicitObjectPath === undefined
-        ? {}
-        : { objectUri: formatWikiGraphLibraryObjectUri(explicitObjectPath) }),
-      publicId: explicitLibraryPublicId,
-    };
+    throw new Error(
+      `Invalid Wiki Graph library URI: ${uri}. Use wikg://lib/<lib-id> and wikg://lib/<lib-id>/arc/<arc-id>; .lib suffixes are no longer supported.`,
+    );
   }
 
-  const match =
-    /^([^/]+)\.lib(?:\/(meta|index|chapter|chunk|entity|triple)(?:\/(.*))?)?$/u.exec(
-      path,
-    );
-  if (match?.[1] !== undefined) {
-    if (match[2] !== undefined && match[2] !== "meta") {
-      return {
-        isDefault: false,
-        kind: "scope",
-        objectUri: formatWikiGraphLibraryObjectUri(
-          [match[2], match[3]].filter(Boolean).join("/"),
-        ),
-        publicId: match[1],
-      };
-    }
-    return {
-      isDefault: false,
-      kind: match[2] === "meta" ? "metadata" : "scope",
-      publicId: match[1],
-    };
+  const [first, second, third, ...rest] = segments;
+  if (first === "registry" && second === undefined) {
+    return { isDefault: true, kind: "registry" };
+  }
+  if (first === "meta" && second === undefined) {
+    return { isDefault: true, kind: "metadata" };
+  }
+  if (first === "path" && second === undefined) {
+    return { isDefault: true, kind: "path" };
   }
 
   const defaultLibraryScopeMatch =
@@ -177,33 +173,90 @@ export function parseWikiGraphLibraryUri(
     };
   }
 
-  const defaultLibraryArchiveMatch = /^([^/.][^/]*)(?:\/(.*))?$/u.exec(path);
-  if (defaultLibraryArchiveMatch?.[1] !== undefined) {
+  if (first === "arc") {
+    return parseLibraryArcUri(uri, undefined, segments.slice(1));
+  }
+
+  if (first === undefined || RESERVED_LIBRARY_URI_SEGMENTS.has(first)) {
+    throw new Error(
+      `Invalid Wiki Graph library URI: ${uri}. Reserved library URI segment: ${first ?? ""}.`,
+    );
+  }
+  if (second === undefined) {
+    return { isDefault: false, kind: "scope", publicId: first };
+  }
+  if (second === "meta" && third === undefined) {
+    return { isDefault: false, kind: "metadata", publicId: first };
+  }
+  if (second === "path" && third === undefined) {
+    return { isDefault: false, kind: "path", publicId: first };
+  }
+  if (/^(index|chapter|chunk|entity|triple)$/u.test(second)) {
     return {
-      archivePublicId: defaultLibraryArchiveMatch[1],
-      isDefault: true,
-      kind: "archive",
-      ...(defaultLibraryArchiveMatch[2] === undefined
-        ? {}
-        : {
-            objectUri: formatWikiGraphLibraryObjectUri(
-              defaultLibraryArchiveMatch[2],
-            ),
-          }),
+      isDefault: false,
+      kind: "scope",
+      objectUri: formatWikiGraphLibraryObjectUri(
+        [second, third, ...rest].filter(Boolean).join("/"),
+      ),
+      publicId: first,
     };
+  }
+  if (second === "arc") {
+    return parseLibraryArcUri(uri, first, segments.slice(2));
   }
 
   throw new Error(
-    `Invalid Wiki Graph library URI: ${uri}. Expected wikg://lib, wikg://lib/meta, wikg://lib/<lib-id>.lib, or wikg://lib/<lib-id>.lib/meta.`,
+    `Invalid Wiki Graph library URI: ${uri}. Expected wikg://lib, wikg://lib/registry, wikg://lib/<lib-id>, or <lib-scope>/arc/<arc-id>.`,
   );
 }
 
+function parseLibraryArcUri(
+  uri: string,
+  publicId: string | undefined,
+  segments: readonly string[],
+): ParsedWikiGraphLibraryUri {
+  const isDefault = publicId === undefined;
+  const [first, second, ...rest] = segments;
+  const base = { isDefault, ...(publicId === undefined ? {} : { publicId }) };
+  if (first === undefined) {
+    return { ...base, kind: "archive-collection" };
+  }
+  if (/^(chapter|chunk|entity|triple)$/u.test(first)) {
+    return {
+      ...base,
+      kind: "scope",
+      objectUri: formatWikiGraphLibraryObjectUri(
+        [first, second, ...rest].filter(Boolean).join("/"),
+      ),
+    };
+  }
+  if (first === "tree" && second === undefined) {
+    return { ...base, kind: "archive-tree" };
+  }
+  if (RESERVED_LIBRARY_URI_SEGMENTS.has(first)) {
+    throw new Error(
+      `Invalid Wiki Graph library URI: ${uri}. Reserved archive member URI segment: ${first}.`,
+    );
+  }
+  if (second === undefined) {
+    return { ...base, archivePublicId: first, kind: "archive" };
+  }
+  if (second === "path" && rest.length === 0) {
+    return { ...base, archivePublicId: first, kind: "archive-path" };
+  }
+  return {
+    ...base,
+    archivePublicId: first,
+    kind: "archive",
+    objectUri: formatWikiGraphLibraryObjectUri([second, ...rest].join("/")),
+  };
+}
 function formatWikiGraphLibraryObjectUri(path: string): string {
   return `wikg://${path.replace(/^\/+|\/+$/gu, "")}`;
 }
 
 export function formatWikiGraphLibraryUri(publicId?: string): string {
-  return publicId === undefined ? "wikg://lib" : `wikg://lib/${publicId}.lib`;
+  return publicId === undefined ? "wikg://lib" : `wikg://lib/${publicId}`;
 }
 
 export function resolveDefaultWikiGraphLibraryDirectoryPath(): string {
@@ -269,6 +322,24 @@ export async function createWikiGraphLibrary(input: {
       return await requireLibraryRecordByPublicId(database, publicId);
     });
   });
+}
+
+export async function listWikiGraphLibraries(): Promise<
+  readonly WikiGraphLibraryRecord[]
+> {
+  await ensureDefaultWikiGraphLibrary();
+  return await withLibraryRegistryDatabase(
+    async (database) =>
+      await database.queryAll(
+        `
+          SELECT id, public_id, folder_path, is_default, created_at, updated_at
+          FROM libraries
+          ORDER BY is_default DESC, public_id
+        `,
+        undefined,
+        mapLibraryRecord,
+      ),
+  );
 }
 
 export async function resolveWikiGraphLibrary(
@@ -337,22 +408,22 @@ export async function updateWikiGraphLibraryFolderPathForRebind(
     folderStats = await stat(folderPath);
   } catch (error) {
     if (isNodeError(error) && error.code === "ENOENT") {
-      throw new Error(`Library rebind --path does not exist: ${folderPath}`);
+      throw new Error(`Library path set does not exist: ${folderPath}`);
     }
     throw new Error(
-      `Library rebind --path is not accessible: ${folderPath}: ${error instanceof Error ? error.message : String(error)}`,
+      `Library path set is not accessible: ${folderPath}: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
   if (!folderStats.isDirectory()) {
     throw new Error(
-      `Library rebind --path must be an existing directory: ${folderPath}`,
+      `Library path set must be an existing directory: ${folderPath}`,
     );
   }
   try {
     await access(folderPath, constants.R_OK);
   } catch (error) {
     throw new Error(
-      `Library rebind --path is not accessible: ${folderPath}: ${error instanceof Error ? error.message : String(error)}`,
+      `Library path set is not accessible: ${folderPath}: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
 
@@ -365,7 +436,7 @@ export async function updateWikiGraphLibraryFolderPathForRebind(
       );
       if (existing !== undefined && existing !== library.id) {
         throw new Error(
-          `Library rebind --path is already bound to another library: ${folderPath}`,
+          `Library path set is already bound to another library: ${folderPath}`,
         );
       }
 

--- a/packages/core/src/library/registry.ts
+++ b/packages/core/src/library/registry.ts
@@ -18,21 +18,10 @@ import {
 import { WIKI_GRAPH_ARCHIVE_EXTENSION } from "../runtime/common/wiki-graph/uri.js";
 import { isNodeError } from "../utils/node-error.js";
 import { withWikiGraphLibraryLock } from "./lock.js";
+import { RESERVED_LIBRARY_URI_SEGMENTS } from "./segments.js";
 
 const DEFAULT_LIBRARY_FOLDER_NAME = "default-library";
 const PUBLIC_ID_BYTES = 6;
-const RESERVED_LIBRARY_URI_SEGMENTS = new Set([
-  "registry",
-  "arc",
-  "path",
-  "tree",
-  "meta",
-  "index",
-  "chapter",
-  "chunk",
-  "entity",
-  "triple",
-]);
 
 const RESERVED_METADATA_KEYS = new Set([
   "id",
@@ -109,6 +98,9 @@ export interface ParsedWikiGraphLibraryUri {
 export function isWikiGraphLibraryUri(uri: string | undefined): uri is string {
   if (uri?.startsWith("wikg://lib") !== true) {
     return false;
+  }
+  if (uri.split("/").some((segment) => segment.endsWith(".lib"))) {
+    return true;
   }
   try {
     const target = parseWikiGraphLibraryUri(uri);

--- a/packages/core/src/library/segments.ts
+++ b/packages/core/src/library/segments.ts
@@ -1,0 +1,12 @@
+export const RESERVED_LIBRARY_URI_SEGMENTS = new Set([
+  "registry",
+  "arc",
+  "path",
+  "tree",
+  "meta",
+  "index",
+  "chapter",
+  "chunk",
+  "entity",
+  "triple",
+]);

--- a/packages/core/src/maintenance/upgrade.ts
+++ b/packages/core/src/maintenance/upgrade.ts
@@ -281,7 +281,7 @@ function formatLibraryScopeUpgradeTarget(
 ): string {
   return target.isDefault
     ? "wikg://lib"
-    : `wikg://lib/${target.publicId ?? "<lib-id>"}.lib`;
+    : `wikg://lib/${target.publicId ?? "<lib-id>"}`;
 }
 
 function formatLibraryResult(library: WikiGraphLibraryRecord): {

--- a/packages/core/src/runtime/common/wiki-graph/uri.ts
+++ b/packages/core/src/runtime/common/wiki-graph/uri.ts
@@ -66,7 +66,7 @@ function parseLibraryArchiveLocatorBody(
   body: string,
 ): LocatedWikiGraphUri | undefined {
   const match =
-    /^lib\/(?:(?<library>[^/]+\.lib)\/)?(?<archive>[^/.][^/]*)(?:\/(?<object>.*))?$/u.exec(
+    /^lib(?:\/(?<library>[^/.][^/]*))?\/arc\/(?<archive>[^/.][^/]*)(?:\/(?<object>.*))?$/u.exec(
       body,
     );
   const groups = match?.groups;
@@ -81,7 +81,7 @@ function parseLibraryArchiveLocatorBody(
   const library = groups?.library;
   const archivePath = `${WIKI_GRAPH_URI_PREFIX}lib/${
     library === undefined ? "" : `${library}/`
-  }${archive}`;
+  }arc/${archive}`;
   const objectPath = groups?.object;
 
   return {
@@ -95,6 +95,11 @@ function parseLibraryArchiveLocatorBody(
 function isLibraryScopeSegment(segment: string): boolean {
   return (
     segment === "meta" ||
+    segment === "registry" ||
+    segment === "arc" ||
+    segment === "path" ||
+    segment === "tree" ||
+    segment === "index" ||
     segment === "chapter" ||
     segment === "chunk" ||
     segment === "entity" ||

--- a/packages/core/src/runtime/common/wiki-graph/uri.ts
+++ b/packages/core/src/runtime/common/wiki-graph/uri.ts
@@ -1,6 +1,8 @@
 import { isAbsolute, relative, resolve } from "path";
 import { homedir } from "os";
 
+import { RESERVED_LIBRARY_URI_SEGMENTS } from "../../../library/segments.js";
+
 export const WIKI_GRAPH_URI_PREFIX = "wikg://";
 export const WIKI_GRAPH_JOB_URI_PREFIX = "wikg://local/job";
 export const WIKI_GRAPH_ARCHIVE_EXTENSION = ".wikg";
@@ -93,18 +95,7 @@ function parseLibraryArchiveLocatorBody(
 }
 
 function isLibraryScopeSegment(segment: string): boolean {
-  return (
-    segment === "meta" ||
-    segment === "registry" ||
-    segment === "arc" ||
-    segment === "path" ||
-    segment === "tree" ||
-    segment === "index" ||
-    segment === "chapter" ||
-    segment === "chunk" ||
-    segment === "entity" ||
-    segment === "triple"
-  );
+  return RESERVED_LIBRARY_URI_SEGMENTS.has(segment);
 }
 
 function resolveArchivePath(archivePath: string): string {

--- a/test/cli/archive/object.test.ts
+++ b/test/cli/archive/object.test.ts
@@ -268,20 +268,20 @@ describe("cli/archive/object", () => {
   it("inspects a library archive shortcut without leaking the resolved path", async () => {
     await runArchiveCommand({
       action: "inspect",
-      archivePath: "wikg://lib/archive123",
+      archivePath: "wikg://lib/arc/archive123",
     });
 
     expect(archiveMockState.readCalls).toStrictEqual([
       "/tmp/library/archive123.wikg",
     ]);
     expect(archiveMockState.textWrites[0]).toContain(
-      "URI: wikg://lib/archive123",
+      "URI: wikg://lib/arc/archive123",
     );
     expect(archiveMockState.textWrites[0]).toContain(
-      "Command: wg wikg://lib/archive123/index enable",
+      "Command: wg wikg://lib/arc/archive123/index enable",
     );
     expect(archiveMockState.textWrites[0]).toContain(
-      "--input wikg://lib/archive123 --task reading-graph",
+      "--input wikg://lib/arc/archive123 --task reading-graph",
     );
     expect(archiveMockState.textWrites[0]).not.toContain(
       "/tmp/library/archive123.wikg",
@@ -291,7 +291,7 @@ describe("cli/archive/object", () => {
   it("prints library archive shortcut inspect JSON with the shortcut URI", async () => {
     await runArchiveCommand({
       action: "inspect",
-      archivePath: "wikg://lib/archive123",
+      archivePath: "wikg://lib/arc/archive123",
       json: true,
     });
 
@@ -304,16 +304,16 @@ describe("cli/archive/object", () => {
     expect(archiveMockState.readCalls).toStrictEqual([
       "/tmp/library/archive123.wikg",
     ]);
-    expect(output.uri).toBe("wikg://lib/archive123");
+    expect(output.uri).toBe("wikg://lib/arc/archive123");
     expect(output.index?.fixCommand).toBe(
-      "wg wikg://lib/archive123/index enable",
+      "wg wikg://lib/arc/archive123/index enable",
     );
     expect(archiveMockState.textWrites[0]).not.toContain(
       "/tmp/library/archive123.wikg",
     );
     expect(
       output.improvements?.map((item) => item.command).join("\n"),
-    ).toContain("--input wikg://lib/archive123 --task reading-graph");
+    ).toContain("--input wikg://lib/arc/archive123 --task reading-graph");
   });
 
   it("prints request and job performance hints for multi-chapter generation", async () => {

--- a/test/cli/library.test.ts
+++ b/test/cli/library.test.ts
@@ -50,8 +50,8 @@ describe("cli/library args", () => {
   it("parses library create, scope, remove, and metadata commands", () => {
     expect(
       parseCLIArguments([
-        "wikg://lib",
-        "create",
+        "wikg://lib/registry",
+        "add",
         "--path",
         "/tmp/research",
         "--json",
@@ -61,13 +61,13 @@ describe("cli/library args", () => {
         action: "create",
         json: true,
         path: "/tmp/research",
-        target: { isDefault: true, kind: "scope" },
+        target: { isDefault: true, kind: "registry" },
       },
       help: false,
       kind: "library",
     });
 
-    expect(parseCLIArguments(["wikg://lib/abc123abc123.lib"])).toStrictEqual({
+    expect(parseCLIArguments(["wikg://lib/abc123abc123"])).toStrictEqual({
       args: {
         action: "list",
         json: undefined,
@@ -78,12 +78,12 @@ describe("cli/library args", () => {
     });
 
     expect(() =>
-      parseCLIArguments(["wikg://lib/abc123abc123.lib", "remove", "--json"]),
+      parseCLIArguments(["wikg://lib/abc123abc123", "remove", "--json"]),
     ).toThrow("Missing --confirm");
 
     expect(
       parseCLIArguments([
-        "wikg://lib/abc123abc123.lib",
+        "wikg://lib/abc123abc123",
         "remove",
         "--confirm",
         "--json",
@@ -114,7 +114,7 @@ describe("cli/library args", () => {
 
   it("parses library archive member commands and routes inspect to archive readiness", () => {
     expect(
-      parseCLIArguments(["wikg://lib/archive123", "--json"]),
+      parseCLIArguments(["wikg://lib/arc/archive123", "--json"]),
     ).toMatchObject({
       args: {
         action: "get",
@@ -128,7 +128,7 @@ describe("cli/library args", () => {
       kind: "library",
     });
     expect(
-      parseCLIArguments(["wikg://lib/archive123", "remove", "--confirm"]),
+      parseCLIArguments(["wikg://lib/arc/archive123", "remove", "--confirm"]),
     ).toMatchObject({
       args: {
         action: "remove",
@@ -143,63 +143,66 @@ describe("cli/library args", () => {
     });
     expect(
       parseCLIArguments([
-        "wikg://lib/archive123",
-        "move",
-        "--to",
+        "wikg://lib/arc/archive123/path",
+        "set",
         "nested/book.wikg",
       ]),
     ).toMatchObject({
       args: {
         action: "move",
-        target: { archivePublicId: "archive123", kind: "archive" },
+        target: { archivePublicId: "archive123", kind: "archive-path" },
         to: "nested/book.wikg",
       },
       kind: "library",
     });
     expect(() =>
-      parseCLIArguments(["wikg://lib/archive123", "remove"]),
+      parseCLIArguments(["wikg://lib/arc/archive123", "remove"]),
     ).toThrow("Missing --confirm");
     expect(() => parseCLIArguments(["wikg://lib/meta", "move"])).toThrow(
       "does not support `move`",
     );
     expect(
-      parseCLIArguments(["wikg://lib/archive123", "inspect"]),
+      parseCLIArguments(["wikg://lib/arc/archive123", "inspect"]),
     ).toMatchObject({
       args: {
         action: "inspect",
-        archivePath: "wikg://lib/archive123",
+        archivePath: "wikg://lib/arc/archive123",
       },
       kind: "archive",
     });
     expect(
       parseCLIArguments([
-        "wikg://lib/team.lib/archive123",
+        "wikg://lib/team/arc/archive123",
         "inspect",
         "--json",
       ]),
     ).toMatchObject({
       args: {
         action: "inspect",
-        archivePath: "wikg://lib/team.lib/archive123",
+        archivePath: "wikg://lib/team/arc/archive123",
         json: true,
       },
       kind: "archive",
     });
     expect(() =>
-      parseCLIArguments(["wikg://lib/abc123abc123.lib", "inspect"]),
+      parseCLIArguments(["wikg://lib/abc123abc123", "inspect"]),
     ).toThrow(
-      "Library-level inspection is not supported. Inspect one managed archive with `wg wikg://lib/<archive-id> inspect`.",
+      "Library-level inspection is not supported. Inspect one managed archive with `wg wikg://lib/arc/<archive-id> inspect`.",
     );
     expect(() =>
       parseCLIArguments(["wikg://lib", "inspect", "--help"]),
     ).toThrow(
-      "Library-level inspection is not supported. Inspect one managed archive with `wg wikg://lib/<archive-id> inspect`.",
+      "Library-level inspection is not supported. Inspect one managed archive with `wg wikg://lib/arc/<archive-id> inspect`.",
     );
   });
 
   it("routes library URI and predicate help through command pages", () => {
     const scopeHelp = parseCLIArguments(["wikg://lib", "--help"]);
-    const createHelp = parseCLIArguments(["wikg://lib", "create", "--help"]);
+    const createHelp = parseCLIArguments([
+      "wikg://lib/registry",
+      "add",
+      "--help",
+    ]);
     const putHelp = parseCLIArguments(["wikg://lib/meta", "put", "--help"]);
 
     expect(scopeHelp).toMatchObject({
@@ -210,13 +213,84 @@ describe("cli/library args", () => {
       throw new Error("Expected help output.");
     }
     expect(scopeHelp.helpText).toContain("Library scope");
-    expect(createHelp.helpText).toContain(
-      "Create a non-default library registry",
-    );
+    expect(createHelp.helpText).toContain("Library Predicate Command");
     expect(putHelp.helpText).toContain("Write one library metadata key");
+    expect(() => parseCLIArguments(["wikg://lib", "create", "--help"])).toThrow(
+      "does not support `create`",
+    );
+  });
+
+  it("parses redesigned registry, path, archive collection, and tree commands", () => {
+    expect(parseCLIArguments(["wikg://lib/registry", "--json"])).toMatchObject({
+      args: { action: "list", json: true, target: { kind: "registry" } },
+      kind: "library",
+    });
+    expect(parseCLIArguments(["wikg://lib/path"])).toMatchObject({
+      args: { action: "get", target: { kind: "path" } },
+      kind: "library",
+    });
+    expect(
+      parseCLIArguments(["wikg://lib/path", "set", "/tmp/library", "--jsonl"]),
+    ).toMatchObject({
+      args: {
+        action: "rebind",
+        jsonl: true,
+        path: "/tmp/library",
+        target: { kind: "path" },
+      },
+      kind: "library",
+    });
+    expect(
+      parseCLIArguments([
+        "wikg://lib/arc",
+        "add",
+        "--input",
+        "book.wikg",
+        "--to",
+        "nested/book.wikg",
+      ]),
+    ).toMatchObject({
+      args: {
+        action: "add",
+        inputPath: "book.wikg",
+        target: { kind: "archive-collection" },
+        to: "nested/book.wikg",
+      },
+      kind: "library",
+    });
+    expect(
+      parseCLIArguments(["wikg://lib/arc", "scan", "--jsonl"]),
+    ).toMatchObject({
+      args: {
+        action: "scan",
+        jsonl: true,
+        target: { kind: "archive-collection" },
+      },
+      kind: "library",
+    });
+    expect(
+      parseCLIArguments([
+        "wikg://lib/arc/tree",
+        "--parent",
+        "nested/book.wikg",
+        "--depth",
+        "2",
+        "--json",
+      ]),
+    ).toMatchObject({
+      args: {
+        action: "archive-tree",
+        depth: 2,
+        json: true,
+        parent: "nested/book.wikg",
+        target: { kind: "archive-tree" },
+      },
+      kind: "library",
+    });
     expect(() =>
-      parseCLIArguments(["wikg://lib/abc123abc123.lib", "create", "--help"]),
-    ).toThrow("Create libraries from wikg://lib.");
+      parseCLIArguments(["wikg://lib", "add", "--input", "book.wikg"]),
+    ).toThrow("does not support `add`");
+    expect(() => parseCLIArguments(["wikg://lib/team.lib"])).toThrow();
   });
 
   it("does not steal archive URIs below a lib path segment", () => {

--- a/test/cli/library.test.ts
+++ b/test/cli/library.test.ts
@@ -4,6 +4,7 @@ import type * as CLISupport from "../../packages/cli/src/support/index.js";
 import type * as WikiGraphCore from "wiki-graph-core";
 
 const libraryMockState = vi.hoisted(() => ({
+  archives: [] as unknown[],
   metadata: {} as Record<string, unknown>,
   putCalls: [] as unknown[],
   textWrites: [] as string[],
@@ -15,6 +16,12 @@ vi.mock("wiki-graph-core", async (importOriginal) => {
   return {
     ...actual,
     assertWikiGraphLibrarySchemaCurrent: vi.fn(() => Promise.resolve()),
+    listWikiGraphLibraryArchives: vi.fn(() =>
+      Promise.resolve(libraryMockState.archives),
+    ),
+    scanWikiGraphLibrary: vi.fn(() =>
+      Promise.resolve({ archives: libraryMockState.archives }),
+    ),
     putWikiGraphLibraryMetadata: vi.fn(
       (_target: unknown, key: string, value: unknown) => {
         libraryMockState.putCalls.push({ key, value });
@@ -42,6 +49,7 @@ import { runLibraryCommand } from "../../packages/cli/src/commands/index.js";
 
 describe("cli/library args", () => {
   beforeEach(() => {
+    libraryMockState.archives = [];
     libraryMockState.metadata = {};
     libraryMockState.putCalls.length = 0;
     libraryMockState.textWrites.length = 0;
@@ -268,6 +276,16 @@ describe("cli/library args", () => {
       },
       kind: "library",
     });
+
+    expect(() =>
+      parseCLIArguments(["wikg://lib/arc", "list", "--jsonl"]),
+    ).toThrow("does not support --jsonl");
+    expect(() =>
+      parseCLIArguments(["wikg://lib/registry", "remove", "--help"]),
+    ).toThrow("does not support `remove`");
+    expect(() =>
+      parseCLIArguments(["wikg://lib/arc/tree", "scan", "--help"]),
+    ).toThrow("does not support `scan`");
     expect(
       parseCLIArguments([
         "wikg://lib/arc/tree",
@@ -290,7 +308,9 @@ describe("cli/library args", () => {
     expect(() =>
       parseCLIArguments(["wikg://lib", "add", "--input", "book.wikg"]),
     ).toThrow("does not support `add`");
-    expect(() => parseCLIArguments(["wikg://lib/team.lib"])).toThrow();
+    expect(() => parseCLIArguments(["wikg://lib/team.lib"])).toThrow(
+      ".lib suffixes are no longer supported",
+    );
   });
 
   it("does not steal archive URIs below a lib path segment", () => {
@@ -323,6 +343,74 @@ describe("cli/library args", () => {
       },
       kind: "archive",
     });
+  });
+
+  it("renders archive tree depth relative to parent and streams scan JSONL archives", async () => {
+    libraryMockState.archives = [
+      {
+        uri: "wikg://lib/arc/root",
+        publicId: "root",
+        libraryUri: "wikg://lib",
+        relativePath: "root.wikg",
+        path: "/tmp/library/root.wikg",
+        exists: true,
+        status: "present",
+      },
+      {
+        uri: "wikg://lib/arc/book",
+        publicId: "book",
+        libraryUri: "wikg://lib",
+        relativePath: "nested/book.wikg",
+        path: "/tmp/library/nested/book.wikg",
+        exists: true,
+        status: "present",
+      },
+      {
+        uri: "wikg://lib/arc/deep",
+        publicId: "deep",
+        libraryUri: "wikg://lib",
+        relativePath: "nested/deeper/deep.wikg",
+        path: "/tmp/library/nested/deeper/deep.wikg",
+        exists: true,
+        status: "present",
+      },
+    ];
+
+    await runLibraryCommand({
+      action: "archive-tree",
+      depth: 1,
+      json: true,
+      parent: "nested",
+      target: { isDefault: true, kind: "archive-tree" },
+    });
+
+    expect(JSON.parse(libraryMockState.textWrites[0] ?? "{}")).toStrictEqual({
+      items: [
+        {
+          name: "book.wikg",
+          path: "nested/book.wikg",
+          uri: "wikg://lib/arc/book",
+        },
+        { name: "deeper", path: "nested/deeper" },
+      ],
+    });
+
+    libraryMockState.textWrites.length = 0;
+    await runLibraryCommand({
+      action: "scan",
+      jsonl: true,
+      target: { isDefault: true, kind: "archive-collection" },
+    });
+
+    const events = libraryMockState.textWrites.map(
+      (line) =>
+        JSON.parse(line) as {
+          readonly action?: string;
+          readonly type?: string;
+        },
+    );
+    expect(events.map((event) => event.type)).toContain("archive");
+    expect(events.at(-1)).toMatchObject({ action: "scan", type: "succeeded" });
   });
 
   it("keeps --json as output formatting for library metadata put", async () => {

--- a/test/core/library/registry.test.ts
+++ b/test/core/library/registry.test.ts
@@ -62,14 +62,14 @@ describe("wiki graph library registry", () => {
     expect((await stat(libraries[0]!.folderPath)).isDirectory()).toBe(true);
   });
 
-  it("creates non-default libraries with public .lib URIs and refuses existing folders", async () => {
+  it("creates non-default libraries with public library URIs and refuses existing folders", async () => {
     const folderPath = join(stateDir, "research");
     const library = await createWikiGraphLibrary({ folderPath });
 
     expect(library.id).toEqual(expect.any(Number));
     expect(Number.isInteger(library.id)).toBe(true);
     expect(library.publicId).toMatch(/^[0-9a-f]{12}$/u);
-    expect(library.uri).toBe(`wikg://lib/${library.publicId}.lib`);
+    expect(library.uri).toBe(`wikg://lib/${library.publicId}`);
     expect(formatWikiGraphLibraryUri(library.publicId)).toBe(library.uri);
     expect((await stat(folderPath)).isDirectory()).toBe(true);
     await expect(createWikiGraphLibrary({ folderPath })).rejects.toThrow(
@@ -83,14 +83,14 @@ describe("wiki graph library registry", () => {
       kind: "scope",
     });
     expect(
-      parseWikiGraphLibraryUri("wikg://lib/abc123abc123.lib/meta"),
+      parseWikiGraphLibraryUri("wikg://lib/abc123abc123/meta"),
     ).toStrictEqual({
       isDefault: false,
       kind: "metadata",
       publicId: "abc123abc123",
     });
     expect(
-      parseWikiGraphLibraryUri("wikg://lib/archive123/chapter"),
+      parseWikiGraphLibraryUri("wikg://lib/arc/archive123/chapter"),
     ).toStrictEqual({
       archivePublicId: "archive123",
       isDefault: true,


### PR DESCRIPTION
Closes https://github.com/oomol-lab/wiki-graph/issues/191

## Summary
- Redesign library URI grammar around `wikg://lib/registry`, canonical `wikg://lib/<lib-id>`, and archive members under `<lib-scope>/arc/<arc-id>`.
- Move library/member management commands to concrete objects/scopes: `registry add`, `/path set`, `/arc add`, `/arc scan --jsonl`, `/arc/<id>/path set`, and `/arc/<id> remove`.
- Add registry/path/tree read outputs and JSONL lifecycle events for `arc scan` and `path set`.
- Update help/docs/tests so old `.lib`, `wikg://lib/<archive-id>` shortcut, and library-scope `create/add/scan/rebind` entries are no longer exposed as supported commands.

## Acceptance evidence
- URI parser coverage includes: `wikg://lib`, `wikg://lib/registry`, `wikg://lib/<lib-id>`, `<lib-scope>/path`, `<lib-scope>/arc`, `<lib-scope>/arc/tree`, `<lib-scope>/arc/<arc-id>`, `<lib-scope>/arc/<arc-id>/path`, and `<lib-scope>/arc/chapter/tree`.
- Reserved segments are blocked from lib/archive ids: `registry`, `arc`, `path`, `tree`, `meta`, `index`, `chapter`, `chunk`, `entity`, `triple`.
- CLI args tests cover new management commands and old command removal.
- `arc/tree --parent` / `--depth`, `arc/<id>/path`, registry listing, and library path outputs are covered by implementation/tests.
- Structure review: no `.wikg` archive schema, manifest schema, object stream schema, TOC/entry format, home/core database schema, `libraries`/`library_archives`/`library_metadata` schema, or schema/version constants were changed. The implementation uses existing `public_id`, `folder_path`, and `relative_path` fields.

## Verification
- `pnpm run test` — 129 files / 851 tests passed.
- `pnpm run lint` — passed.
- `pnpm run typecheck` — passed.
- `pnpm run build` — passed.
- `pnpm run format:check` — passed.

## Review note
Blind reviewer was not safely available in the current Kanban worker environment because delegate/subagent execution inherits Kanban tools and environment rather than providing a pure-text isolated reviewer. I performed a non-blind fallback review against the issue acceptance rubric; conclusion: pass. The change does not touch high-risk security/permissions/production data/irreversible migration boundaries and does not modify persistent schema/version contracts.
