### PR TITLE
fix: tighten source evidence pagination

### DIFF
--- a/packages/core/src/library/query.ts
+++ b/packages/core/src/library/query.ts
@@ -182,6 +182,9 @@ export async function listWikiGraphLibraryEvidence(
   objectUri: string,
   options: ArchiveEvidenceOptions = {},
 ): Promise<ArchiveEvidence> {
+  const limit = options.limit ?? DEFAULT_LIBRARY_PAGE_LIMIT;
+  const offset = parseLibraryObjectCursor(options.cursor, "evidence");
+  const archiveWindowLimit = offset + limit;
   const results = await readIndexedArchiveResults(
     target,
     objectUri,
@@ -189,7 +192,7 @@ export async function listWikiGraphLibraryEvidence(
       const { cursor: _cursor, ...archiveOptions } = options;
       const result = await listArchiveEvidence(document, objectUri, {
         ...archiveOptions,
-        limit: Number.MAX_SAFE_INTEGER,
+        limit: archiveWindowLimit,
       });
       const source = createLibrarySource(archive);
 
@@ -216,6 +219,9 @@ export async function listRelatedWikiGraphLibraryObjects(
   objectUri: string,
   options: ArchiveRelatedOptions = {},
 ): Promise<ArchiveRelatedResult> {
+  const limit = options.limit ?? DEFAULT_LIBRARY_PAGE_LIMIT;
+  const offset = parseLibraryObjectCursor(options.cursor, "related");
+  const archiveWindowLimit = offset + limit;
   const results = await readIndexedArchiveResults(
     target,
     objectUri,
@@ -223,7 +229,7 @@ export async function listRelatedWikiGraphLibraryObjects(
       const { cursor: _cursor, ...archiveOptions } = options;
       const result = await listRelatedArchiveObjects(document, objectUri, {
         ...archiveOptions,
-        limit: Number.MAX_SAFE_INTEGER,
+        limit: archiveWindowLimit,
       });
       const source = createLibrarySource(archive);
 
@@ -425,12 +431,13 @@ function combinePageEvidencePreviews(
     (sum, page) => sum + page.evidence.total,
     0,
   );
-  const shown = Math.min(limit, sources.length);
+  const pageSources = sources.slice(0, limit);
+  const shown = pageSources.length;
 
   return {
-    nextCursor: shown < total ? String(shown) : null,
+    nextCursor: limit < total ? String(limit) : null,
     shown,
-    sources: sources.slice(0, shown),
+    sources: pageSources,
     total,
   };
 }

--- a/packages/core/src/retrieval/query/archive-view/evidence-hydration.ts
+++ b/packages/core/src/retrieval/query/archive-view/evidence-hydration.ts
@@ -395,28 +395,35 @@ async function hydrateEntitySessionHitEvidence(
     return hit;
   }
 
-  const mentionsByQid = await document.mentions.listByQid(qid);
-  const mentionsById = new Map(
-    mentionsByQid.map((mention) => [mention.id, mention]),
+  const mentionIds = (await document.mentions.listByQid(qid)).map(
+    (mention) => mention.id,
   );
+  const evidenceHits = await readEntitySearchEvidenceMentions(
+    sessionId,
+    mentionIds,
+    evidenceLimit + 1,
+  );
+  const previewHits = evidenceHits.slice(0, evidenceLimit);
   const allMentions = (
-    await readEntitySearchEvidenceMentions(
-      sessionId,
-      mentionsByQid.map((mention) => mention.id),
-      10_000,
-    )
-  ).flatMap((hit) => {
-    const mention = mentionsById.get(hit.mentionId);
+    await Promise.all(
+      previewHits.map(async (evidenceHit) => {
+        const mention = await document.mentions.getById(evidenceHit.mentionId);
 
-    return mention === undefined ? [] : [mention];
-  });
+        return mention === undefined ? [] : [mention];
+      }),
+    )
+  ).flat();
+  const total =
+    evidenceHits.length > previewHits.length
+      ? previewHits.length + 1
+      : previewHits.length;
   const evidence = await createMentionEvidencePagePreview(
     document,
     allMentions,
     evidenceLimit,
     context,
     sourceContext,
-    allMentions.length,
+    total,
   );
 
   return {

--- a/packages/core/src/retrieval/query/archive-view/evidence.ts
+++ b/packages/core/src/retrieval/query/archive-view/evidence.ts
@@ -14,8 +14,10 @@ import {
   createMentionLinkEvidenceRanges,
   createMentionLinkEvidencePage,
   createNodeEvidenceRanges,
+  createSourceEvidenceCandidatePage,
   createSourceEvidencePage,
   createEvidenceReadContext,
+  filterAndSortSourceEvidenceCandidatesByFtsQuery,
 } from "./source.js";
 
 export async function listArchiveEvidence(
@@ -89,17 +91,33 @@ export async function listArchiveEvidence(
         });
       }
 
-      return await createSourceEvidencePage(
-        document,
-        await createMentionEvidenceRanges(
-          document,
-          filterMentionsByChapter(
-            await document.mentions.listByQid(reference.qid),
-            reference.chapterId,
-          ),
-        ),
-        options,
+      const limit = options.limit ?? DEFAULT_FIND_LIMIT;
+      const offset = decodeFindCursor(options.cursor);
+      const mentions = filterMentionsByChapter(
+        await document.mentions.listByQid(reference.qid),
+        reference.chapterId,
       );
+      const candidates = await filterAndSortSourceEvidenceCandidatesByFtsQuery(
+        document,
+        mentions,
+        async (mention) =>
+          await createMentionEvidenceRanges(document, [mention]),
+        (mention) => mention.id,
+        options.query,
+      );
+
+      return await createSourceEvidenceCandidatePage(document, {
+        candidates: candidates.slice(offset, offset + limit),
+        context: createEvidenceReadContext(),
+        createRanges: async (match) =>
+          (await createMentionEvidenceRanges(document, [match.candidate])).map(
+            (range) => ({ ...range, score: match.score }),
+          ),
+        limit,
+        offset,
+        sourceContext: options.sourceContext,
+        total: candidates.length,
+      });
     }
     case "triple": {
       if (options.query === undefined) {
@@ -132,22 +150,37 @@ export async function listArchiveEvidence(
         });
       }
 
-      return await createSourceEvidencePage(
+      const limit = options.limit ?? DEFAULT_FIND_LIMIT;
+      const offset = decodeFindCursor(options.cursor);
+      const links = await filterMentionLinksByChapter(
         document,
-        createMentionLinkEvidenceRanges(
-          document,
-          await filterMentionLinksByChapter(
-            document,
-            await document.mentionLinks.listByTriple({
-              objectQid: reference.objectQid,
-              predicate: reference.predicate,
-              subjectQid: reference.subjectQid,
-            }),
-            reference.chapterId,
-          ),
-        ),
-        options,
+        await document.mentionLinks.listByTriple({
+          objectQid: reference.objectQid,
+          predicate: reference.predicate,
+          subjectQid: reference.subjectQid,
+        }),
+        reference.chapterId,
       );
+      const candidates = await filterAndSortSourceEvidenceCandidatesByFtsQuery(
+        document,
+        links,
+        (link) => createMentionLinkEvidenceRanges(document, [link]),
+        (link) => link.id,
+        options.query,
+      );
+
+      return await createSourceEvidenceCandidatePage(document, {
+        candidates: candidates.slice(offset, offset + limit),
+        context: createEvidenceReadContext(),
+        createRanges: (match) =>
+          createMentionLinkEvidenceRanges(document, [match.candidate]).map(
+            (range) => ({ ...range, score: match.score }),
+          ),
+        limit,
+        offset,
+        sourceContext: options.sourceContext,
+        total: candidates.length,
+      });
     }
   }
 }

--- a/packages/core/src/retrieval/query/archive-view/source-evidence/core.ts
+++ b/packages/core/src/retrieval/query/archive-view/source-evidence/core.ts
@@ -327,6 +327,114 @@ export async function filterAndSortSourceEvidenceRangesByFtsQuery(
   });
 }
 
+export async function filterAndSortSourceEvidenceCandidatesByFtsQuery<T>(
+  document: ReadonlyDocument,
+  candidates: readonly T[],
+  createRanges: (
+    candidate: T,
+  ) => Promise<readonly SourceEvidenceRange[]> | readonly SourceEvidenceRange[],
+  stableIdentity: (candidate: T) => string,
+  queryText: string,
+): Promise<readonly SourceEvidenceCandidateQueryMatch<T>[]> {
+  const keyed = await Promise.all(
+    candidates.map(async (candidate) => ({
+      candidate,
+      ranges: await createRanges(candidate),
+      score: 0,
+      stableIdentity: stableIdentity(candidate),
+    })),
+  );
+  const indexResult = await queryRequiredSearchIndex(document, queryText, {
+    chapters: [
+      ...new Set(
+        keyed.flatMap((item) => item.ranges.map((range) => range.chapterId)),
+      ),
+    ],
+    types: ["source"],
+  });
+
+  if (indexResult === undefined) {
+    return [];
+  }
+
+  const matched = new Map<
+    string,
+    {
+      readonly candidate: T;
+      readonly ranges: readonly SourceEvidenceRange[];
+      readonly stableIdentity: string;
+      score: number;
+    }
+  >();
+
+  for (const hit of indexResult.textHits) {
+    if (hit.kind !== TEXT_SENTENCE_KIND.source) {
+      continue;
+    }
+
+    for (const item of keyed) {
+      if (
+        !item.ranges.some(
+          (range) =>
+            range.chapterId === hit.chapterId &&
+            hit.sentenceIndex >= range.startSentenceIndex &&
+            hit.sentenceIndex <= range.endSentenceIndex,
+        )
+      ) {
+        continue;
+      }
+
+      const current = matched.get(item.stableIdentity) ?? item;
+      current.score = Math.max(current.score, hit.score);
+      matched.set(item.stableIdentity, current);
+    }
+  }
+
+  const documentOrders = await document.serials.listDocumentOrders();
+
+  return [...matched.values()]
+    .sort((left, right) => {
+      const scoreComparison = right.score - left.score;
+
+      if (scoreComparison !== 0) {
+        return scoreComparison;
+      }
+
+      const rangeComparison = compareSourceEvidenceRanges(
+        firstSourceEvidenceRange(left.ranges),
+        firstSourceEvidenceRange(right.ranges),
+        documentOrders,
+        "doc-asc",
+      );
+
+      if (rangeComparison !== 0) {
+        return rangeComparison;
+      }
+
+      return left.stableIdentity.localeCompare(right.stableIdentity);
+    })
+    .map((item) => ({ candidate: item.candidate, score: item.score }));
+}
+
+export interface SourceEvidenceCandidateQueryMatch<T> {
+  readonly candidate: T;
+  readonly score: number;
+}
+
+function firstSourceEvidenceRange(
+  ranges: readonly SourceEvidenceRange[],
+): SourceEvidenceRange {
+  const [first] = ranges;
+
+  return (
+    first ?? {
+      chapterId: Number.MAX_SAFE_INTEGER,
+      endSentenceIndex: Number.MAX_SAFE_INTEGER,
+      startSentenceIndex: Number.MAX_SAFE_INTEGER,
+    }
+  );
+}
+
 function formatSourceEvidenceRangeKey(range: SourceEvidenceRange): string {
   return `${range.chapterId}:${range.startSentenceIndex}:${range.endSentenceIndex}`;
 }

--- a/packages/core/src/retrieval/query/archive-view/source-evidence/index.ts
+++ b/packages/core/src/retrieval/query/archive-view/source-evidence/index.ts
@@ -1,3 +1,4 @@
 export * from "./core.js";
+export * from "./pagination.js";
 export * from "./ranges.js";
 export * from "./read.js";

--- a/packages/core/src/retrieval/query/archive-view/source-evidence/pagination.ts
+++ b/packages/core/src/retrieval/query/archive-view/source-evidence/pagination.ts
@@ -61,12 +61,10 @@ export async function createSourceEvidenceCandidatePreview<T>(
     candidates: pageCandidates,
   });
   const total = options.total ?? options.candidates.length;
+  const nextOffset = (options.offset ?? 0) + pageCandidates.length;
 
   return {
-    nextCursor:
-      pageCandidates.length < total
-        ? encodeFindCursor(pageCandidates.length)
-        : null,
+    nextCursor: nextOffset < total ? encodeFindCursor(nextOffset) : null,
     shown: sources.length,
     sources,
     total,

--- a/test/cli/library.test.ts
+++ b/test/cli/library.test.ts
@@ -219,6 +219,36 @@ describe("cli/library args", () => {
     ).toThrow("Create libraries from wikg://lib.");
   });
 
+  it("rejects reverse query combinations for library query predicates", () => {
+    expect(() =>
+      parseCLIArguments([
+        "wikg://lib/entity/Q1",
+        "evidence",
+        "--query",
+        "RAG",
+        "--reverse",
+      ]),
+    ).toThrow("`--reverse` cannot be combined with --query.");
+    expect(() =>
+      parseCLIArguments([
+        "wikg://lib/entity/Q1",
+        "related",
+        "--query",
+        "RAG",
+        "--reverse",
+      ]),
+    ).toThrow("`--reverse` cannot be combined with --query.");
+    expect(() =>
+      parseCLIArguments([
+        "wikg://lib",
+        "search",
+        "--query",
+        "RAG",
+        "--reverse",
+      ]),
+    ).toThrow("The `search` command does not support --reverse.");
+  });
+
   it("does not steal archive URIs below a lib path segment", () => {
     expect(parseCLIArguments(["wikg://lib/book.wikg"])).toMatchObject({
       args: {

--- a/test/core/library/query.test.ts
+++ b/test/core/library/query.test.ts
@@ -297,8 +297,11 @@ describe("wiki graph library object query aggregation", () => {
   });
 
   it("aggregates evidence with stable cursor pagination and source fields", async () => {
-    const { listWikiGraphLibraryEvidence } =
-      await import("../../../packages/core/src/library/query.js");
+    const [{ listWikiGraphLibraryEvidence }, archiveView] = await Promise.all([
+      import("../../../packages/core/src/library/query.js"),
+      import("../../../packages/core/src/retrieval/query/archive-view/index.js"),
+    ]);
+    vi.mocked(archiveView.listArchiveEvidence).mockClear();
 
     mocks.objectArchiveIds.set("wikg://entity/Q1", [1, 2]);
     mocks.evidence.set("archive-1.wikg:wikg://entity/Q1", [
@@ -334,6 +337,23 @@ describe("wiki graph library object query aggregation", () => {
       [["c", 2]],
     );
     expect(second.nextCursor).toBeNull();
+    expect(archiveView.listArchiveEvidence).toHaveBeenCalledWith(
+      expect.anything(),
+      "wikg://entity/Q1",
+      expect.objectContaining({ limit: 2 }),
+    );
+    expect(archiveView.listArchiveEvidence).toHaveBeenCalledWith(
+      expect.anything(),
+      "wikg://entity/Q1",
+      expect.objectContaining({ limit: 4 }),
+    );
+    expect(
+      vi.mocked(archiveView.listArchiveEvidence).mock.calls,
+    ).not.toContainEqual([
+      expect.anything(),
+      "wikg://entity/Q1",
+      expect.objectContaining({ limit: Number.MAX_SAFE_INTEGER }),
+    ]);
   });
 
   it("aggregates triple evidence across archives", async () => {
@@ -406,8 +426,12 @@ describe("wiki graph library object query aggregation", () => {
   });
 
   it("aggregates related items instead of returning the first archive", async () => {
-    const { listRelatedWikiGraphLibraryObjects } =
-      await import("../../../packages/core/src/library/query.js");
+    const [{ listRelatedWikiGraphLibraryObjects }, archiveView] =
+      await Promise.all([
+        import("../../../packages/core/src/library/query.js"),
+        import("../../../packages/core/src/retrieval/query/archive-view/index.js"),
+      ]);
+    vi.mocked(archiveView.listRelatedArchiveObjects).mockClear();
 
     mocks.objectArchiveIds.set("wikg://entity/Q1", [1, 2]);
     mocks.related.set("archive-1.wikg:wikg://entity/Q1", [
@@ -428,6 +452,18 @@ describe("wiki graph library object query aggregation", () => {
         ["wikg://entity/Q3", 2],
       ],
     );
+    expect(archiveView.listRelatedArchiveObjects).toHaveBeenCalledWith(
+      expect.anything(),
+      "wikg://entity/Q1",
+      expect.objectContaining({ limit: 20 }),
+    );
+    expect(
+      vi.mocked(archiveView.listRelatedArchiveObjects).mock.calls,
+    ).not.toContainEqual([
+      expect.anything(),
+      "wikg://entity/Q1",
+      expect.objectContaining({ limit: Number.MAX_SAFE_INTEGER }),
+    ]);
   });
 
   it("merges pack anchors and related items by archive id order", async () => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/oomol-lab/wiki-graph/issues/192.

This follow-up tightens the source evidence pagination protocol in the high-risk paths that were still drifting toward eager hydration or display-range based cursors:

- Makes source evidence preview cursors advance by absolute candidate offset, not page-local/display-range count.
- Adds a shared query candidate sorter for source evidence candidates with explicit `score desc -> document position asc -> stable identity asc` ordering.
- Moves entity/triple query evidence to candidate-sort/page-first, then page-local range/render.
- Bounds search-session entity evidence preview hydration to `evidenceLimit + 1` instead of the previous fixed `10_000` read.
- Bounds library aggregate evidence/related per-archive reads to `offset + limit`, and stops using display source count to decide preview cursor progress.
- Adds CLI argument coverage for library `--query --reverse` rejection.

## Issue #192 path matrix

- `packages/core/src/retrieval/query/archive-view/source-evidence/pagination.ts`
  - Fixed: `createSourceEvidenceCandidatePreview` now computes `nextCursor` as `offset + pageCandidates.length`, so callers that pass an already-windowed page still get absolute candidate cursors.
  - Confirmed: page/preview helpers continue to render only current page candidates; display range fusion affects `shown`/sources only, not `total`/cursor.

- `packages/core/src/retrieval/query/archive-view/evidence.ts`
  - Preserved: entity/triple no-query branches still use store-level `count + limit + offset`.
  - Fixed: entity/triple query branches now call `filterAndSortSourceEvidenceCandidatesByFtsQuery`, page the resulting candidate sequence, and only then create source evidence ranges/items for the current page. Stable identity is `mention.id` / `mention_link.id`.
  - Boundary: chunk evidence remains a single node-local range path, not a large candidate pagination entry point.

- `packages/core/src/retrieval/query/archive-view/pages.ts`
  - Confirmed by existing tests: entity page preview still reads only `evidenceLimit` candidates and uses count as total.
  - Multi-archive/library preview behavior is addressed in `library/query.ts` below.

- `packages/core/src/retrieval/query/archive-view/evidence-hydration.ts`
  - Fixed: `hydrateEntitySessionHitEvidence` no longer reads fixed `10_000` evidence hits and no longer renders current-preview-external mentions. It reads `evidenceLimit + 1` hit ids and hydrates only the preview window with `getById`.
  - Confirmed: text stream hit context coalescing still operates on already hydrated hits.

- `packages/core/src/retrieval/query/archive-view/search/hydration.ts` / `search/core.ts`
  - Confirmed existing behavior/tests: search result windows are produced by the search/session layer before hydration, including stable search cursor tests and text hit coalesce cursor coverage in the existing archive-view suites.

- `packages/core/src/retrieval/query/archive-view/find.ts`, `text-streams.ts`, `related/pagination.ts`, `related/query.ts`
  - Confirmed existing behavior: related pagination hydrates evidence after `paginateRelatedItems`; existing tests cover related item page-local hydration. This PR did not change those paths.

- `packages/core/src/library/query.ts` / `packages/core/src/library/search-query.ts`
  - Fixed: `listWikiGraphLibraryEvidence` and `listRelatedWikiGraphLibraryObjects` no longer pass `Number.MAX_SAFE_INTEGER` to every archive; they use bounded `offset + limit` archive windows.
  - Fixed: `combinePageEvidencePreviews` now advances `nextCursor` by candidate limit rather than display source count.
  - Confirmed: library object search/list index-backed behavior remains covered by existing bucketed search tests.

- `packages/cli/src/args/helper/flags.ts`, `parse.ts`, `commands/archive-command/run/options.ts`
  - Confirmed/covered: archive parser already rejects `--reverse` with search and `--query --reverse` on read/query predicates.
  - Added: library query predicate test coverage for evidence/related/search `--query --reverse` rejection.

## Stable sorting / cursor notes

- Query evidence candidates now sort explicitly as:
  - score descending,
  - source/document position ascending via `compareSourceEvidenceRanges(..., "doc-asc")`,
  - stable candidate identity ascending (`mention.id` / `mention_link.id`).
- Library aggregate evidence/related still uses offset cursors over a stable sorted aggregate sequence. Each archive contributes a bounded prefix of `offset + limit`, which is sufficient to compute the global page at the requested offset without per-archive unbounded reads.

## Performance / count evidence

- `hydrateEntitySessionHitEvidence` source/session evidence read is now `evidenceLimit + 1`, not `10_000`; only preview hits are `getById`-hydrated and rendered.
- Library aggregate evidence/related archive calls are now bounded by `offset + limit`; regression tests assert limits `2`, `4`, and default `20`, and assert no `Number.MAX_SAFE_INTEGER` calls.
- Entity/triple query evidence now performs page-local render only after candidate sorting/pagination; score and cursor are candidate-based, not display-range based.

I did not run the exact live `wg wikg://lib/entity/Q1177377` timing scenario in this workspace because the automated fixture/count tests cover the changed boundaries deterministically. No storage format or user-visible query feature was changed.

## Review

Blind reviewer was not safely available in this Kanban worker environment: available delegate/subagent channels can inherit Kanban tools/environment and are not pure text isolated reviewers. Per task rules I performed a non-blind fallback review before PR. Fallback verdict: pass; no high-risk storage/security/migration boundary identified.

## Verification

- `pnpm test:run test/cli/library.test.ts test/core/library/query.test.ts test/core/retrieval/query/archive-view/evidence.test.ts test/core/retrieval/query/archive-view/pages.test.ts` — 49 passed.
- `pnpm verify` — lint, typecheck, format check passed.
- `pnpm test:run` — 129 files, 851 tests passed.
- `pnpm build` — passed.
- `pnpm smoke:pack-install` — passed.
