### PR TITLE
fix: tighten library help discovery

### DIFF
--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -329,6 +329,10 @@ describe("cli/args/help", () => {
     expect(rootHelpText).toContain("wg <archive-uri> inspect");
     expect(rootHelpText).toContain("wg transform");
     expect(rootHelpText).toContain("wg wikg://lib --help");
+    expect(rootHelpText).toContain(
+      "Library registries, managed archive folders, path binding, and aggregate indexes",
+    );
+    expect(rootHelpText).not.toContain("aggregate indexes, and rebind");
     expect(rootHelpText).not.toContain("wg import");
     expect(rootHelpText).not.toContain("wg wikg://local/job add");
     expect(rootHelpText).not.toContain("wg <archive-uri>/index build");
@@ -781,6 +785,9 @@ describe("cli/args/help", () => {
     ).toContain("aggregate index");
     expect(renderHelpTopicText("library")).toContain("Library Management");
     expect(renderHelpTopicText("library")).toContain(
+      "folder path binding, archive memberships",
+    );
+    expect(renderHelpTopicText("library")).toContain(
       "Library archive shortcuts:",
     );
     expect(renderHelpTopicText("library")).toContain(
@@ -796,6 +803,26 @@ describe("cli/args/help", () => {
     expect(renderHelpTopicText("library")).toContain("Concurrency:");
     expect(renderHelpTopicText("library")).toContain(
       "aggregate views over matching objects",
+    );
+    expect(renderHelpTopicText("library")).toContain(
+      "wg wikg://lib/registry add --path <folder>",
+    );
+    expect(renderHelpTopicText("library")).toContain("wg wikg://lib/arc scan");
+    expect(renderHelpTopicText("library")).toContain(
+      "wg wikg://lib/path set <existing-directory>",
+    );
+    expect(renderHelpTopicText("library")).not.toContain(".lib");
+    expect(renderHelpTopicText("library")).not.toContain(
+      "wg wikg://lib create",
+    );
+    expect(renderHelpTopicText("library")).not.toContain("wg wikg://lib add");
+    expect(renderHelpTopicText("library")).not.toContain("wg wikg://lib scan");
+    expect(renderHelpTopicText("library")).not.toContain(
+      "wg wikg://lib rebind",
+    );
+    expect(renderHelpTopicText("library")).not.toContain("move --to");
+    expect(renderHelpTopicText("library")).not.toContain(
+      "wikg://lib/<archive-id>/",
     );
     expect(
       renderLibraryPredicateHelpText(
@@ -835,6 +862,43 @@ describe("cli/args/help", () => {
     expect(archiveMemberInspectHelp.helpText).toContain(
       "not a library-level health report",
     );
+    const registryHelpText = renderLibraryUriHelpText("wikg://lib/registry", {
+      isDefault: true,
+      kind: "registry",
+    });
+    const pathHelpText = renderLibraryUriHelpText("wikg://lib/path", {
+      isDefault: true,
+      kind: "path",
+    });
+    const arcHelpText = renderLibraryUriHelpText("wikg://lib/arc", {
+      isDefault: true,
+      kind: "archive-collection",
+    });
+    const arcTreeHelpText = renderLibraryUriHelpText("wikg://lib/arc/tree", {
+      isDefault: true,
+      kind: "archive-tree",
+    });
+    expect(registryHelpText).toContain("Predicate commands:");
+    expect(registryHelpText).toContain("wikg://lib/registry add --help");
+    expect(pathHelpText).toContain("wikg://lib/path set --help");
+    expect(pathHelpText).toContain("binds the library folder path");
+    expect(arcHelpText).toContain("wikg://lib/arc add --help");
+    expect(arcHelpText).toContain("wikg://lib/arc scan --help");
+    expect(arcHelpText).toContain("wikg://lib/arc/tree --help");
+    expect(arcTreeHelpText).toContain("This object is read-only");
+    for (const text of [
+      scopeHelpText,
+      registryHelpText,
+      pathHelpText,
+      arcHelpText,
+    ]) {
+      expect(text).not.toContain("wikg://lib create");
+      expect(text).not.toContain("wikg://lib add");
+      expect(text).not.toContain("wikg://lib scan");
+      expect(text).not.toContain("wikg://lib rebind");
+      expect(text).not.toContain(".lib");
+      expect(text).not.toContain("move --to");
+    }
   });
 
   it("supports a first-contact recovery chain from root help to parse failures", () => {

--- a/packages/cli/src/args/help.ts
+++ b/packages/cli/src/args/help.ts
@@ -203,7 +203,7 @@ const HELP_TOPIC_METADATA: readonly {
   {
     name: "library",
     summary:
-      "Library registries, archive memberships, aggregate indexes, and rebind.",
+      "Library registries, archive memberships, path binding, and aggregate indexes.",
   },
 ] as const;
 

--- a/packages/core/data/help/commands/library-predicate.jinja
+++ b/packages/core/data/help/commands/library-predicate.jinja
@@ -33,7 +33,7 @@ Usage:
   {{ commandName }} {{ uri }} [--json]
 {% elif target.kind == "path" and predicate == "set" %}
 Purpose:
-  Rebind this library to an existing directory, then scan/reconcile `.wikg` files in that directory.
+  Bind this library to an existing directory, then scan/reconcile `.wikg` files in that directory.
 
 Usage:
   {{ commandName }} {{ uri }} set <folder> [--json|--jsonl]
@@ -122,7 +122,7 @@ Notes:
   - Progress is emitted as text by default, or line-delimited events with `--jsonl`.
   - `--json` is not supported for enable because progress is streamed.
   - Library indexes are local derived state under Wiki Graph staging, not files inside the library folder.
-  - Rebuild holds the library write lock; concurrent `scan`, `add`, `rebind`, `disable`, archive `move`, or archive `remove` commands for the same library cannot run at the same time.
+  - Rebuild holds the library write lock; concurrent `arc scan`, `arc add`, `path set`, `disable`, archive `path set`, or archive `remove` commands for the same library cannot run at the same time.
   - Archive writes can mark the aggregate index dirty; rebuild again before relying on library-wide query when status reports dirty or stale.
 {% elif target.kind == "scope" and target.objectUri == "wikg://index" and predicate == "disable" %}
 Purpose:
@@ -150,7 +150,7 @@ Notes:
   - Parent directories for `--to` are created as needed.
   - Existing target files are not overwritten.
   - Adding an archive marks the library index dirty.
-  - The command holds the library write lock and cannot run concurrently with `scan`, `rebind`, archive moves/removes, or index rebuild for the same library.
+  - The command holds the library write lock and cannot run concurrently with `arc scan`, library `path set`, archive path changes/removes, or index rebuild for the same library.
 {% elif target.kind == "scope" and predicate == "scan" %}
 Purpose:
   Reconcile this library registry with `.wikg` files currently under the library folder.
@@ -164,24 +164,6 @@ Notes:
   - When a moved archive can be matched by its stable mutation token, scan preserves its archive id and updates the relative path.
   - Scan marks the library index dirty when membership changes.
   - Scan holds the library write lock and cannot run concurrently with membership changes or index rebuild for the same library.
-{% elif target.kind == "scope" and predicate == "rebind" %}
-Purpose:
-  Bind this library to an existing directory, then scan/reconcile `.wikg` files in that directory.
-
-Usage:
-  {{ commandName }} {{ uri }} set <existing-directory> [--json|--jsonl]
-
-Notes:
-  - Use this after you manually move, sync, or restore a library folder outside Wiki Graph.
-  - `<existing-directory>` must already exist, be accessible, and not be bound to another library.
-  - The command updates only this library registry's folder path, preserving the library id, public id, default marker, and metadata.
-  - The command does not copy, move, or delete files from the old or new folder.
-  - After updating the folder path, it runs the same scan/reconcile lifecycle used by `scan`.
-  - Rebind holds the library write lock and cannot run concurrently with membership changes or index rebuild for the same library.
-
-Examples:
-  {{ commandName }} {{ uri }} set ~/Library/Mobile\ Documents/wiki-library
-  {{ commandName }} {{ uri }} set /Volumes/Archive/wiki-library --json
 {% elif target.kind == "scope" and predicate == "get" %}
 Purpose:
   Read this library scope.
@@ -239,7 +221,7 @@ Notes:
   - If the registered file is already missing, the command can still clean the registry entry.
   - This does not delete empty parent directories.
   - Removing an archive marks the library index dirty.
-  - Remove holds the library write lock and cannot run concurrently with library scan, add, rebind, move, or index rebuild for the same library.
+  - Remove holds the library write lock and cannot run concurrently with library scan, add, path binding, archive path changes, or index rebuild for the same library.
 {% elif target.kind == "metadata" and predicate == "set" %}
 Purpose:
   Replace the whole library metadata map.

--- a/packages/core/data/help/commands/library.jinja
+++ b/packages/core/data/help/commands/library.jinja
@@ -11,16 +11,30 @@ Default behavior:
 Usage:
   {{ commandName }} wikg://lib/registry [--json]
   {{ commandName }} wikg://lib/registry add --path <folder> [--json]
+
+Predicate commands:
+  - add: create a non-default library registry and an empty folder. Help: {{ commandName }} wikg://lib/registry add --help
+
+Related help:
+  - {{ commandName }} wikg://lib --help
+  - {{ commandName }} help library
 {% elif target.kind == "path" %}
 Library path object
 
 Default behavior:
   - `{{ commandName }} {{ uri }}` reads the library folder path.
-  - `{{ commandName }} {{ uri }} set <folder>` rebinds the library folder path and scans archive membership.
+  - `{{ commandName }} {{ uri }} set <folder>` binds the library folder path and scans archive membership.
 
 Usage:
   {{ commandName }} {{ uri }} [--json]
   {{ commandName }} {{ uri }} set <folder> [--json|--jsonl]
+
+Predicate commands:
+  - set: bind this library to an existing folder and reconcile `.wikg` files. Help: {{ commandName }} {{ uri }} set --help
+
+Related help:
+  - {{ commandName }} wikg://lib --help
+  - {{ commandName }} help library
 {% elif target.kind == "archive-collection" %}
 Archive member collection
 
@@ -33,6 +47,15 @@ Usage:
   {{ commandName }} {{ uri }} add --input <path> [--to <relative-wikg-path>] [--json]
   {{ commandName }} {{ uri }} scan [--json|--jsonl]
   {{ commandName }} {{ uri }}/tree [--parent <relative-path>] [--depth <n>] [--json]
+
+Predicate commands:
+  - add: copy one `.wikg` file into the library folder. Help: {{ commandName }} {{ uri }} add --help
+  - scan: reconcile registered archive memberships with files under the folder. Help: {{ commandName }} {{ uri }} scan --help
+  - tree: inspect the managed archive file tree. Help: {{ commandName }} {{ uri }}/tree --help
+
+Related help:
+  - {{ commandName }} wikg://lib --help
+  - {{ commandName }} help library
 {% elif target.kind == "archive-tree" %}
 Archive member tree object
 
@@ -44,6 +67,9 @@ Default behavior:
 
 Usage:
   {{ commandName }} {{ uri }} [--parent <relative-path>] [--depth <n>] [--json]
+
+Related help:
+  - {{ commandName }} help library
 {% elif target.kind == "archive-path" %}
 Archive member path object
 
@@ -54,6 +80,12 @@ Default behavior:
 Usage:
   {{ commandName }} {{ uri }} [--json]
   {{ commandName }} {{ uri }} set <relative-wikg-path> [--json]
+
+Predicate commands:
+  - set: move or rename this archive inside the same library folder. Help: {{ commandName }} {{ uri }} set --help
+
+Related help:
+  - {{ commandName }} help library
 {% elif target.kind == "metadata" %}
 Library metadata object
 
@@ -128,7 +160,7 @@ Predicate commands:
   - disable: remove this library index materialization. Help: {{ commandName }} {{ uri }} disable --help
 
 Related help:
-  - Library registry, membership, aggregate index, and rebind concepts: {{ commandName }} help library
+  - Library registry, membership, path binding, and aggregate index concepts: {{ commandName }} help library
 {% else %}
 Library scope
 
@@ -199,5 +231,5 @@ Predicate commands:
 {% endif %}
 
 Related help:
-  - Library registry, membership, aggregate index, and rebind concepts: {{ commandName }} help library
+  - Library registry, membership, path binding, and aggregate index concepts: {{ commandName }} help library
 {% endif %}

--- a/packages/core/data/help/commands/predicate.jinja
+++ b/packages/core/data/help/commands/predicate.jinja
@@ -351,7 +351,7 @@ Notes:
   - Progress is emitted as text by default, or line-delimited events with `--jsonl`.
   - `--json` is not supported for enable because progress is streamed.
   - Library indexes are local derived state under Wiki Graph staging, not files inside the library folder.
-  - Rebuild holds the library write lock; concurrent `scan`, `add`, `rebind`, `disable`, archive `move`, or archive `remove` commands for the same library cannot run at the same time.
+  - Rebuild holds the library write lock; concurrent `arc scan`, `arc add`, `path set`, `disable`, archive `path set`, or archive `remove` commands for the same library cannot run at the same time.
   - Archive writes can mark the aggregate index dirty; rebuild again before relying on library-wide query when status reports dirty or stale.
 {% else %}
 Purpose:

--- a/packages/core/data/help/commands/root.jinja
+++ b/packages/core/data/help/commands/root.jinja
@@ -50,7 +50,7 @@ What to learn where:
     {{ commandName }} help readiness
   - URI grammar, scope/object routing, pagination, and short URI handling:
     {{ commandName }} help uri
-  - Library registries, managed archive folders, aggregate indexes, and rebind:
+  - Library registries, managed archive folders, path binding, and aggregate indexes:
     {{ commandName }} help library
   - Input/output formats, inference, stdin, stdout, import, export, transform, JSON, and JSONL:
     {{ commandName }} help format

--- a/packages/core/data/help/commands/uri.jinja
+++ b/packages/core/data/help/commands/uri.jinja
@@ -338,7 +338,7 @@ Library context:
   - Interpret evidence, related, and pack output with the returned archive/member provenance; use a library archive shortcut when you need one member only.
 {% endif %}
 {% endif %}
-  - Read `{{ commandName }} help library` for registry, membership, aggregate index, and rebind behavior.
+  - Read `{{ commandName }} help library` for registry, membership, path binding, and aggregate index behavior.
 {% endif %}
 
 Predicate commands:

--- a/packages/core/data/help/topics/library.jinja
+++ b/packages/core/data/help/topics/library.jinja
@@ -5,7 +5,7 @@ Library Management
 
 Purpose:
   Libraries let Wiki Graph manage a folder of `.wikg` archives and query them through one aggregate index.
-  Use this page to distinguish library registries, archive memberships, library archive shortcuts, and library index lifecycle.
+  Use this page to distinguish library registries, folder path binding, archive memberships, library archive shortcuts, and library index lifecycle.
 
 Core model:
   - A library registry records one managed folder, its public id, metadata, default marker, and local staging identity.
@@ -24,15 +24,16 @@ Registry discovery:
 Library folders:
   - `{{ commandName }} wikg://lib/registry add --path <folder>` creates a non-default library registry and an empty folder.
   - `{{ commandName }} wikg://lib/path set <existing-directory>` binds the default library to an existing folder without copying or deleting files.
-  - `{{ commandName }} wikg://lib/<lib-id>/path set <existing-directory>` rebinds that non-default library.
-  - Use rebind after a manual move, sync restore, or mount path change.
+  - `{{ commandName }} wikg://lib/<lib-id>/path set <existing-directory>` binds that non-default library to an existing folder.
+  - Use `path set` after a manual move, sync restore, or mount path change.
 
 Archive memberships:
-  - `{{ commandName }} <lib-scope>/arc scan` recursively discovers `.wikg` files under the bound folder and reconciles registry state.
-  - `{{ commandName }} <lib-scope>/arc add --input <path> [--to <relative-wikg-path>]` copies one `.wikg` file into the folder and registers it.
+  - `{{ commandName }} wikg://lib/arc scan` recursively discovers `.wikg` files under the default library folder and reconciles registry state.
+  - `{{ commandName }} wikg://lib/arc add --input <path> [--to <relative-wikg-path>]` copies one `.wikg` file into the default library folder and registers it.
+  - For a non-default library, replace `wikg://lib` with `wikg://lib/<lib-id>` in those `arc` commands.
   - `{{ commandName }} <library-archive-uri>/path set <relative-wikg-path>` moves or renames one managed archive inside the same folder.
   - `{{ commandName }} <library-archive-uri> remove --confirm` deletes one managed archive file and unregisters it.
-  - Missing registered files remain visible as missing or stale until scan, move, remove, or rebind resolves them.
+  - Missing registered files remain visible as missing or stale until `arc scan`, archive `path set`, archive `remove`, or library `path set` resolves them.
 
 Library archive shortcuts:
   - `wikg://lib/arc/<archive-id>/` addresses one archive membership in the default library.
@@ -65,7 +66,7 @@ Library index lifecycle:
 
 Concurrency:
   - Library registry and membership writes hold the library write lock.
-  - `scan`, `add`, `rebind`, library archive `move`, library archive `remove`, and library index `enable` or `disable` cannot run concurrently for the same library.
+  - `arc scan`, `arc add`, library `path set`, library archive `path set`, library archive `remove`, and library index `enable` or `disable` cannot run concurrently for the same library.
   - Library-wide `--query`, naked scope enumeration, evidence, related, and pack commands read the current aggregate index.
   - If a write marks the aggregate index dirty, rebuild it with `{{ commandName }} <library-uri>/index enable` before relying on library-wide query results.
 

--- a/packages/core/data/help/topics/recipe.jinja
+++ b/packages/core/data/help/topics/recipe.jinja
@@ -170,7 +170,7 @@ When to read deeper:
     {{ commandName }} help config
   - FTS index, LLM, WikiSpine, and generated-data prerequisites:
     {{ commandName }} help readiness
-  - Library registry, membership, aggregate index, and rebind:
+  - Library registry, membership, path binding, and aggregate index:
     {{ commandName }} help library
   - Workers, cache, logs, workspaces, failures, and JSONL progress:
     {{ commandName }} help runtime

--- a/packages/core/data/help/topics/runtime.jinja
+++ b/packages/core/data/help/topics/runtime.jinja
@@ -75,5 +75,5 @@ Where to go next:
     {{ commandName }} help format
   - Need URI command routing:
     {{ commandName }} help uri
-  - Need library registry, membership, index, or rebind behavior:
+  - Need library registry, membership, path binding, or index behavior:
     {{ commandName }} help library

--- a/packages/core/data/help/topics/uri.jinja
+++ b/packages/core/data/help/topics/uri.jinja
@@ -30,7 +30,7 @@ Library locators:
     wikg://lib/arc/<archive-id>/entity
     wikg://lib/arc/<archive-id>/triple
   - Library-wide scopes such as `wikg://lib/entity` query the aggregate library index.
-  - Read `{{ commandName }} help library` before managing registry, membership, rebind, or library index lifecycle.
+  - Read `{{ commandName }} help library` before managing registry, membership, path binding, or library index lifecycle.
 
 Short and located URIs:
   Commands may return short object URIs without local file paths:
@@ -200,5 +200,5 @@ Related help:
     {{ commandName }} help format
   - Local jobs, cache, logs, and runtime debugging:
     {{ commandName }} help runtime
-  - Library registry, membership, aggregate index, and rebind:
+  - Library registry, membership, path binding, and aggregate index:
     {{ commandName }} help library


### PR DESCRIPTION
## Summary
- Tighten library help wording so root/topic/URI/predicate pages route users through the current registry/path/arc/index command surface.
- Add predicate/related-help links for registry, path, arc collection, arc tree, and archive path help pages.
- Add help tests proving first-contact library discovery and that old user-visible command shapes are not exposed.

Closes https://github.com/oomol-lab/wiki-graph/issues/193

## Acceptance evidence
- Root help points to `wg help library` and `wg wikg://lib --help` while describing library path binding instead of legacy rebind wording.
- `wg help library` exposes `wikg://lib/registry add`, `wikg://lib/path set`, `wikg://lib/arc scan/add`, library archive shortcuts with `/arc/`, and library index lifecycle.
- Concrete help pages for `wikg://lib`, `wikg://lib/registry`, `wikg://lib/arc`, `wikg://lib/path`, `wikg://lib/index`, `wikg://lib/arc/tree`, and their key predicates provide next help routes.
- Tests and source help grep verify old visible shapes such as `.lib`, direct `wikg://lib create/add/scan/rebind`, `move --to`, and `wikg://lib/<archive-id>/` are not exposed as user help paths.

## Verification
- `pnpm test:run packages/cli/src/args/help.test.ts test/cli/library.test.ts` — passed (16 tests).
- `pnpm run format:check` — passed.
- `pnpm test:run` — passed (129 files, 853 tests).
- `pnpm run lint` — passed.
- `pnpm run typecheck` — passed.
- `pnpm run build` — passed.
- Manual source help exploration via `pnpm --filter wiki-graph dev ...` for root/library/topic/concrete library help pages — passed.

## Review
Blind text-only reviewer was not safely available in this Kanban worker: the available delegate/subagent path can inherit Kanban tools/environment, which this task explicitly disallows for blind review. Completed non-blind fallback review against the issue acceptance rubric; verdict: pass. This change is help/test-only, does not touch schema, migrations, persistent data formats, permissions, or production data.