### PR TITLE
fix: remove legacy library archive move command

### DIFF
--- a/packages/cli/src/args/archive-index.test.ts
+++ b/packages/cli/src/args/archive-index.test.ts
@@ -275,7 +275,7 @@ describe("cli/args/archive index", () => {
       parseCLIArguments(["wikg://lib/arc/archive123/path", "set", "x.wikg"]),
     ).toMatchObject({
       args: {
-        action: "move",
+        action: "set",
         target: { archivePublicId: "archive123", kind: "archive-path" },
         to: "x.wikg",
       },
@@ -289,7 +289,7 @@ describe("cli/args/archive index", () => {
       ]),
     ).toMatchObject({
       args: {
-        action: "move",
+        action: "set",
         target: {
           archivePublicId: "archive123",
           kind: "archive-path",

--- a/packages/cli/src/args/types.ts
+++ b/packages/cli/src/args/types.ts
@@ -113,7 +113,6 @@ export type CLILibraryAction =
   | "get"
   | "get-index"
   | "list"
-  | "move"
   | "put"
   | "rebind"
   | "remove"

--- a/packages/cli/src/args/uri/library.ts
+++ b/packages/cli/src/args/uri/library.ts
@@ -30,7 +30,7 @@ import { parseArchiveArguments } from "../archive.js";
 import { parseChapterTarget } from "./chapter/target.js";
 import { isTripleScopePath } from "./triple-pattern.js";
 
-const LIBRARY_ARCHIVE_ACTIONS = new Set(["get", "move", "remove"]);
+const LIBRARY_ARCHIVE_ACTIONS = new Set(["get", "remove"]);
 const LIBRARY_ARCHIVE_COLLECTION_ACTIONS = new Set(["add", "list", "scan"]);
 const LIBRARY_ARCHIVE_PATH_ACTIONS = new Set(["get", "set"]);
 const LIBRARY_ARCHIVE_TREE_ACTIONS = new Set(["archive-tree"]);
@@ -629,7 +629,7 @@ function parseLibraryPathArguments(
   if (target.kind === "archive-path") {
     rejectArchiveBooleanFlag(action, "--jsonl", values.jsonl, helpRoute);
     return {
-      args: { action: "move", json: values.json, target, to: tail[0] },
+      args: { action: "set", json: values.json, target, to: tail[0] },
       help: false,
       kind: "library",
     };
@@ -844,17 +844,9 @@ function parseLibraryArchiveArguments(
     };
   }
 
-  if (values.to === undefined) {
-    throw new Error(
-      withHelpRoute("Missing --to <relative-wikg-path>.", helpRoute),
-    );
-  }
-  rejectArchiveBooleanFlag(action, "--confirm", values.confirm, helpRoute);
-  return {
-    args: { action, json: values.json, target, to: values.to },
-    help: false,
-    kind: "library",
-  };
+  throw new Error(
+    "Internal error: unsupported action routed to library archive.",
+  );
 }
 
 function parseLibraryArchiveInspectArguments(
@@ -929,7 +921,6 @@ function parseLibraryScopeArguments(
     case "enable-index":
     case "get-index":
     case "clear":
-    case "move":
     case "archive-tree":
     case "add":
     case "create":
@@ -1010,7 +1001,6 @@ function parseLibraryMetadataArguments(
     case "list":
     case "remove":
     case "add":
-    case "move":
     case "rebind":
     case "disable-index":
     case "enable-index":
@@ -1078,7 +1068,6 @@ function isLibraryAction(action: string): action is CLILibraryAction {
     action === "get" ||
     action === "get-index" ||
     action === "list" ||
-    action === "move" ||
     action === "put" ||
     action === "rebind" ||
     action === "remove" ||

--- a/packages/cli/src/commands/library.ts
+++ b/packages/cli/src/commands/library.ts
@@ -195,22 +195,6 @@ export async function runLibraryCommand(
       );
       return;
     }
-    case "move": {
-      if (args.to === undefined) {
-        throw new Error(
-          "Missing --to <relative-wikg-path> for library archive move.",
-        );
-      }
-      await writeLibraryArchive(
-        await moveWikiGraphLibraryArchive({
-          target: { ...args.target, kind: "archive" },
-          to: args.to,
-        }),
-        args.json ?? false,
-        "Moved library archive",
-      );
-      return;
-    }
     case "get": {
       if (args.target.kind === "path") {
         await writeLibraryPath(
@@ -249,6 +233,20 @@ export async function runLibraryCommand(
       return;
     }
     case "set": {
+      if (args.target.kind === "archive-path") {
+        if (args.to === undefined) {
+          throw new Error("Missing path value for library archive path set.");
+        }
+        await writeLibraryArchive(
+          await moveWikiGraphLibraryArchive({
+            target: { ...args.target, kind: "archive" },
+            to: args.to,
+          }),
+          args.json ?? false,
+          "Moved library archive",
+        );
+        return;
+      }
       const value = await readMetadataInput(args, { jsonRequired: true });
       await writeMetadataMap(
         await replaceWikiGraphLibraryMetadata(

--- a/packages/core/data/help/commands/library.jinja
+++ b/packages/core/data/help/commands/library.jinja
@@ -127,7 +127,7 @@ Default behavior:
   - Add archive object suffixes such as `/chapter`, `/entity`, or `/triple` when you want to query the archive contents.
 
 Use when:
-  - You need to inspect readiness, move, or remove one archive that is already managed by a library.
+  - You need to inspect readiness, change the relative path of, or remove one archive that is already managed by a library.
 
 Usage:
   {{ commandName }} {{ uri }} [--json]

--- a/packages/core/data/help/topics/library.jinja
+++ b/packages/core/data/help/topics/library.jinja
@@ -43,7 +43,7 @@ Library archive shortcuts:
     {{ commandName }} wikg://lib/arc/<archive-id>/entity --query "term"
     {{ commandName }} wikg://lib/arc/<archive-id>/triple --query "term"
   - Run `{{ commandName }} wikg://lib/arc/<archive-id> inspect` to inspect that one managed archive's readiness; this is not a library-level health report.
-  - `{{ commandName }} <library-archive-uri> --help` explains membership actions such as `move` and `remove`.
+  - `{{ commandName }} <library-archive-uri> --help` explains membership actions such as `path set` and `remove`.
   - `{{ commandName }} <library-archive-uri>/entity --help` explains the archive object scope reached through that library shortcut.
 
 Library-wide query:
@@ -60,7 +60,7 @@ Library index lifecycle:
   - `{{ commandName }} <library-uri>/index enable` rebuilds the aggregate index from registered present archives.
   - `{{ commandName }} <library-uri>/index disable` removes the local library index materialization.
   - Library indexes are local derived state under Wiki Graph staging, not files inside the library folder.
-  - `scan`, `add`, archive `move`, archive `remove`, and archive writes can make the aggregate index dirty.
+  - `scan`, `add`, archive `path set`, archive `remove`, and archive writes can make the aggregate index dirty.
   - Enable the library index again when library-wide query reports that the index is missing, dirty, or stale.
   - Library indexes do not support archive-style `embed` or `external` modes.
 

--- a/packages/core/data/help/topics/readiness.jinja
+++ b/packages/core/data/help/topics/readiness.jinja
@@ -43,7 +43,7 @@ Library index readiness:
     The index is local derived state under Wiki Graph staging, not a file inside the library folder.
 
   Dirty behavior:
-    `scan`, `add`, archive `move`, archive `remove`, archive writes, and membership changes can mark the aggregate index dirty.
+    `scan`, `add`, archive `path set`, archive `remove`, archive writes, and membership changes can mark the aggregate index dirty.
     Re-enable the library index when library-wide query reports that it is missing, dirty, or stale.
     Library indexes do not support archive-style `embed` or `external` modes.
 

--- a/test/cli/library.test.ts
+++ b/test/cli/library.test.ts
@@ -157,7 +157,7 @@ describe("cli/library args", () => {
       ]),
     ).toMatchObject({
       args: {
-        action: "move",
+        action: "set",
         target: { archivePublicId: "archive123", kind: "archive-path" },
         to: "nested/book.wikg",
       },
@@ -169,6 +169,14 @@ describe("cli/library args", () => {
     expect(() => parseCLIArguments(["wikg://lib/meta", "move"])).toThrow(
       "does not support `move`",
     );
+    expect(() =>
+      parseCLIArguments([
+        "wikg://lib/arc/archive123",
+        "move",
+        "--to",
+        "nested/book.wikg",
+      ]),
+    ).toThrow("does not support `move`");
     expect(
       parseCLIArguments(["wikg://lib/arc/archive123", "inspect"]),
     ).toMatchObject({


### PR DESCRIPTION
## Summary

- remove the user-facing `wikg://lib/arc/<archive-id> move --to ...` library archive command path
- keep `wikg://lib/arc/<archive-id>/path set <relative-wikg-path>` as the archive path change command
- update library help text to refer to archive `path set` instead of archive `move`

## Validation

- `pnpm run lint:fix`
- `pnpm verify`
- `pnpm test:run test/cli/library.test.ts packages/cli/src/args/archive-index.test.ts`
