### PR TITLE
fix: align library help move wording

### DIFF
--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -821,6 +821,8 @@ describe("cli/args/help", () => {
       "wg wikg://lib rebind",
     );
     expect(renderHelpTopicText("library")).not.toContain("move --to");
+    expect(renderHelpTopicText("library")).not.toContain("`move`");
+    expect(renderHelpTopicText("readiness")).not.toContain("archive `move`");
     expect(renderHelpTopicText("library")).not.toContain(
       "wikg://lib/<archive-id>/",
     );

--- a/packages/core/data/help/topics/library.jinja
+++ b/packages/core/data/help/topics/library.jinja
@@ -43,7 +43,7 @@ Library archive shortcuts:
     {{ commandName }} wikg://lib/arc/<archive-id>/entity --query "term"
     {{ commandName }} wikg://lib/arc/<archive-id>/triple --query "term"
   - Run `{{ commandName }} wikg://lib/arc/<archive-id> inspect` to inspect that one managed archive's readiness; this is not a library-level health report.
-  - `{{ commandName }} <library-archive-uri> --help` explains membership actions such as `move` and `remove`.
+  - `{{ commandName }} <library-archive-uri> --help` explains membership actions such as `path set` and `remove`.
   - `{{ commandName }} <library-archive-uri>/entity --help` explains the archive object scope reached through that library shortcut.
 
 Library-wide query:
@@ -60,7 +60,7 @@ Library index lifecycle:
   - `{{ commandName }} <library-uri>/index enable` rebuilds the aggregate index from registered present archives.
   - `{{ commandName }} <library-uri>/index disable` removes the local library index materialization.
   - Library indexes are local derived state under Wiki Graph staging, not files inside the library folder.
-  - `scan`, `add`, archive `move`, archive `remove`, and archive writes can make the aggregate index dirty.
+  - `scan`, `add`, archive `path set`, archive `remove`, and archive writes can make the aggregate index dirty.
   - Enable the library index again when library-wide query reports that the index is missing, dirty, or stale.
   - Library indexes do not support archive-style `embed` or `external` modes.
 

--- a/packages/core/data/help/topics/readiness.jinja
+++ b/packages/core/data/help/topics/readiness.jinja
@@ -43,7 +43,7 @@ Library index readiness:
     The index is local derived state under Wiki Graph staging, not a file inside the library folder.
 
   Dirty behavior:
-    `scan`, `add`, archive `move`, archive `remove`, archive writes, and membership changes can mark the aggregate index dirty.
+    `scan`, `add`, archive `path set`, archive `remove`, archive writes, and membership changes can mark the aggregate index dirty.
     Re-enable the library index when library-wide query reports that it is missing, dirty, or stale.
     Library indexes do not support archive-style `embed` or `external` modes.
 


### PR DESCRIPTION
## Summary
- Replace ambiguous library/readiness help references to archive `move` with the current `path set` predicate.
- Keep archive membership help aligned with `wikg://lib/arc/<archive-id>/path set` and `remove`.
- Add tests preventing library/readiness help from reintroducing archive `move` / `move --to` wording.

Follow-up for https://github.com/oomol-lab/wiki-graph/issues/193.

## Acceptance evidence
- `wg help library` now routes membership movement through `path set`, not a non-existent archive `move` predicate.
- `wg help readiness` describes dirty index triggers using archive `path set` and `remove`.
- Manual help grep found no `.lib`, `wikg://lib/<archive-id>`, `wikg://lib add/scan/rebind/create`, `move --to`, or archive `move` suspicious library paths in the checked help pages.

## Verification
- `pnpm test:run packages/cli/src/args/help.test.ts test/cli/library.test.ts` — passed (16 tests).
- `pnpm run lint` — passed.
- `pnpm run typecheck` — passed.
- `pnpm run format:check` — passed.
- `pnpm test:run` — passed (129 files, 853 tests).
- `pnpm run build` — passed.

## Review
Attempted blind text-only reviewer twice with explicit Kanban/tool prohibitions. Both reviewer runs failed before doing work because the delegate model/API returned HTTP 503 after 3 retries (`deleg_1dca6ac3`, `deleg_c3295c24`). Per task fallback rules, completed non-blind fallback review against the issue acceptance rubric; verdict: pass. The change is help/test-only and does not touch schema, migrations, persistent data formats, permissions, production data, or public compatibility behavior.