### PR TITLE
Fix Wanta single-archive library shortcut contract

### DIFF
--- a/packages/cli/src/args/archive-index.test.ts
+++ b/packages/cli/src/args/archive-index.test.ts
@@ -29,6 +29,32 @@ describe("cli/args/archive index", () => {
       kind: "archive-index",
     });
     expect(
+      parseCLIArguments(["wikg://lib/arc/archive123/index", "--json"]),
+    ).toStrictEqual({
+      args: {
+        action: "get",
+        archivePath: "wikg://lib/arc/archive123",
+        json: true,
+      },
+      help: false,
+      kind: "archive-index",
+    });
+    expect(
+      parseCLIArguments([
+        "wikg://lib/arc/archive123/index",
+        "enable",
+        "--jsonl",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "enable",
+        archivePath: "wikg://lib/arc/archive123",
+        jsonl: true,
+      },
+      help: false,
+      kind: "archive-index",
+    });
+    expect(
       parseCLIArguments(["wikg:///tmp/book.wikg/index", "external"]),
     ).toStrictEqual({
       args: {

--- a/packages/cli/src/args/archive.test.ts
+++ b/packages/cli/src/args/archive.test.ts
@@ -110,6 +110,26 @@ describe("cli/args/archive", () => {
       kind: "archive",
     });
     expect(
+      parseCLIArguments([
+        "wikg://lib/arc/archive123",
+        "--query",
+        "孙悟空",
+        "--limit",
+        "3",
+        "--json",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "search",
+        archivePath: "wikg://lib/arc/archive123",
+        format: "json",
+        limit: 3,
+        query: "孙悟空",
+      },
+      help: false,
+      kind: "archive",
+    });
+    expect(
       parseCLIArguments(["wikg://lib/team/arc/archive123/entity/Q23"]),
     ).toStrictEqual({
       args: {
@@ -939,6 +959,27 @@ describe("cli/args/archive", () => {
     expect(parseCLIArguments(["wikg://book.wikg/cover"])).toStrictEqual({
       args: {
         inputPath: archivePath,
+      },
+      help: false,
+      kind: "cover",
+    });
+    expect(
+      parseCLIArguments(["wikg://lib/arc/archive123/meta", "--json"]),
+    ).toStrictEqual({
+      args: {
+        action: "get",
+        archivePath: "wikg://lib/arc/archive123",
+        json: true,
+        objectPath: "",
+      },
+      help: false,
+      kind: "object-metadata",
+    });
+    expect(
+      parseCLIArguments(["wikg://lib/arc/archive123/cover"]),
+    ).toStrictEqual({
+      args: {
+        inputPath: "wikg://lib/arc/archive123",
       },
       help: false,
       kind: "cover",

--- a/packages/cli/src/args/uri/entry.ts
+++ b/packages/cli/src/args/uri/entry.ts
@@ -1,4 +1,8 @@
-import { parseLocatedWikiGraphUri } from "wiki-graph-core";
+import {
+  type ParsedWikiGraphLibraryUri,
+  parseWikiGraphLibraryUri,
+  parseLocatedWikiGraphUri,
+} from "wiki-graph-core";
 
 import {
   isUriHelpPredicate,
@@ -329,8 +333,12 @@ function parseArchiveUriTargetArguments(
   values: ArchiveArgumentValues,
 ): ParsedCLIArguments {
   const parsed = parseLocatedWikiGraphUri(uri);
-  const archivePath = parsed.archivePath;
-  const objectUri = parsed.objectUri;
+  const libraryArchiveObjectTarget = parseLibraryArchiveObjectTarget(uri);
+  const archivePath =
+    libraryArchiveObjectTarget === undefined
+      ? parsed.archivePath
+      : formatLibraryArchiveLocator(libraryArchiveObjectTarget);
+  const objectUri = libraryArchiveObjectTarget?.objectUri ?? parsed.objectUri;
   const helpRoute = isImplicitArchiveReadAction(action)
     ? formatWikiGraphHelpCommand(uri)
     : formatWikiGraphHelpCommand(uri, action);
@@ -428,6 +436,30 @@ function parseArchiveUriTargetArguments(
   }
 
   return parseArchiveArguments(action, [uri, ...tail], values, helpRoute);
+}
+
+function parseLibraryArchiveObjectTarget(
+  uri: string,
+): ParsedWikiGraphLibraryUri | undefined {
+  const target = parseWikiGraphLibraryUri(uri);
+
+  if (target?.kind === "archive" && target.objectUri !== undefined) {
+    return target;
+  }
+
+  return undefined;
+}
+
+function formatLibraryArchiveLocator(
+  target: ParsedWikiGraphLibraryUri,
+): string {
+  if (target.kind !== "archive" || target.archivePublicId === undefined) {
+    throw new Error("Internal error: expected library archive object target.");
+  }
+
+  return target.publicId === undefined
+    ? `wikg://lib/arc/${target.archivePublicId}`
+    : `wikg://lib/${target.publicId}/arc/${target.archivePublicId}`;
 }
 
 function rejectUnsupportedArchiveReverse(

--- a/packages/cli/src/args/uri/library.ts
+++ b/packages/cli/src/args/uri/library.ts
@@ -107,6 +107,18 @@ export function parseLibraryUriFirstArguments(
     );
   }
 
+  if (
+    target.kind === "archive" &&
+    target.objectUri === undefined &&
+    (action === "search" || values.query !== undefined)
+  ) {
+    return parseLibraryArchiveRootQueryArguments(
+      uri,
+      explicitAction === undefined ? [] : positionals.slice(2),
+      values,
+    );
+  }
+
   if (target.kind === "registry") {
     return parseLibraryRegistryArguments(
       uri,
@@ -872,6 +884,19 @@ function parseLibraryArchiveInspectArguments(
     [uri, ...tail],
     values,
     formatWikiGraphHelpCommand(uri, "inspect"),
+  );
+}
+
+function parseLibraryArchiveRootQueryArguments(
+  uri: string,
+  tail: readonly string[],
+  values: ArchiveArgumentValues,
+): ParsedCLIArguments {
+  return parseArchiveArguments(
+    "search",
+    [uri, ...tail],
+    values,
+    formatWikiGraphHelpCommand(uri, "search"),
   );
 }
 

--- a/packages/cli/src/commands/archive-command/maintenance.ts
+++ b/packages/cli/src/commands/archive-command/maintenance.ts
@@ -9,6 +9,7 @@ import type {
 import { writeBinaryToStdout, writeTextToStdout } from "../../support/index.js";
 import { formatCLIJSON } from "../../support/index.js";
 import { writeArchiveDocument } from "./run/document.js";
+import { resolveArchiveRuntimeLocation } from "./run/uri.js";
 
 export async function runArchiveMetaCommand(
   args: CLIArchiveMetadataArguments,
@@ -19,7 +20,8 @@ export async function runArchiveMetaCommand(
   }
 
   const app = new WikiGraph({});
-  await app.openSession(args.inputPath, async (digest) => {
+  const location = await resolveArchiveRuntimeLocation(args.inputPath);
+  await app.openSession(location.archivePath, async (digest) => {
     await writeArchiveMeta(await digest.readMeta(), {
       json: args.json ?? false,
     });
@@ -30,7 +32,8 @@ export async function runArchiveCoverCommand(
   args: CLIArchiveCoverArguments,
 ): Promise<void> {
   const app = new WikiGraph({});
-  await app.openSession(args.inputPath, async (digest) => {
+  const location = await resolveArchiveRuntimeLocation(args.inputPath);
+  await app.openSession(location.archivePath, async (digest) => {
     if (process.stdout.isTTY === true) {
       throw new Error(
         "Refusing to write binary cover data to an interactive terminal. Redirect stdout or pipe it.",

--- a/packages/cli/src/commands/archive-command/search-index.ts
+++ b/packages/cli/src/commands/archive-command/search-index.ts
@@ -14,6 +14,7 @@ import {
   type ProgressCounter,
 } from "../../runtime/index.js";
 import { writeArchiveDocument } from "./run/document.js";
+import { resolveArchiveRuntimeLocation } from "./run/uri.js";
 
 const INDEX_PROGRESS_OUTPUT_INTERVAL_MS = 6_000;
 
@@ -42,7 +43,8 @@ export async function runArchiveIndexCommand(
 async function readIndexSettings(
   args: CLIArchiveIndexArguments,
 ): Promise<void> {
-  await new WikiGraphArchiveFile(args.archivePath).readDocument(
+  const location = await resolveArchiveRuntimeLocation(args.archivePath);
+  await new WikiGraphArchiveFile(location.archivePath).readDocument(
     async (document) => {
       const settings = await readArchiveIndexSettings(document);
 
@@ -190,10 +192,13 @@ async function readSearchIndexWritebackPolicy(
   archivePath: string,
 ): Promise<"archive" | "cache"> {
   let embedded = false;
+  const location = await resolveArchiveRuntimeLocation(archivePath);
 
-  await new WikiGraphArchiveFile(archivePath).readDocument(async (document) => {
-    embedded = (await readArchiveIndexSettings(document)).ftsEmbedded;
-  });
+  await new WikiGraphArchiveFile(location.archivePath).readDocument(
+    async (document) => {
+      embedded = (await readArchiveIndexSettings(document)).ftsEmbedded;
+    },
+  );
 
   return embedded ? "archive" : "cache";
 }

--- a/packages/cli/src/commands/object-metadata.ts
+++ b/packages/cli/src/commands/object-metadata.ts
@@ -5,6 +5,7 @@ import { WikiGraphArchiveFile } from "wiki-graph-core";
 
 import type { CLIObjectMetadataArguments } from "../args/index.js";
 import { writeArchiveDocument } from "./archive-command/run/document.js";
+import { resolveArchiveRuntimeLocation } from "./archive-command/run/uri.js";
 import {
   readTextStreamFromStdin,
   writeTextToStdout,
@@ -17,8 +18,9 @@ export async function runObjectMetadataCommand(
   const target = parseObjectMetadataTarget(args.objectPath);
 
   switch (args.action) {
-    case "get":
-      await new WikiGraphArchiveFile(args.archivePath).readDocument(
+    case "get": {
+      const location = await resolveArchiveRuntimeLocation(args.archivePath);
+      await new WikiGraphArchiveFile(location.archivePath).readDocument(
         async (document) => {
           await writeMetadataMap(
             await document.metadata.getMap(args.objectPath),
@@ -27,6 +29,7 @@ export async function runObjectMetadataCommand(
         },
       );
       return;
+    }
     case "set": {
       const value = await readMetadataInput(args, { jsonRequired: true });
       const map = parseMetadataMap(value);

--- a/test/cli/archive/object.test.ts
+++ b/test/cli/archive/object.test.ts
@@ -4,6 +4,7 @@ import { runArchiveCommand } from "../../../packages/cli/src/commands/index.js";
 import { formatFindObject } from "../../../packages/cli/src/commands/archive-output/text/object.js";
 import {
   createContinuationCursor,
+  findArchiveObjects,
   readArchivePage,
 } from "../../../packages/core/src/api/index.js";
 
@@ -286,6 +287,25 @@ describe("cli/archive/object", () => {
     expect(archiveMockState.textWrites[0]).not.toContain(
       "/tmp/library/archive123.wikg",
     );
+  });
+
+  it("runs a library archive shortcut root query against the resolved archive", async () => {
+    await runArchiveCommand({
+      action: "search",
+      archivePath: "wikg://lib/arc/archive123",
+      format: "json",
+      limit: 3,
+      query: "孙悟空",
+    });
+
+    expect(archiveMockState.readCalls).toStrictEqual([
+      "/tmp/library/archive123.wikg",
+    ]);
+    expect(findArchiveObjects).toHaveBeenCalledWith({}, "孙悟空", {
+      archiveKey: "/tmp/library/archive123.wikg",
+      limit: 3,
+    });
+    expect(archiveMockState.textWrites[0]).toContain("wikg://chunk/9");
   });
 
   it("prints library archive shortcut inspect JSON with the shortcut URI", async () => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/oomol-lab/wiki-graph/issues/200.

- Route `wikg://lib/arc/<arc-id>/meta`, `/cover`, and `/index` through the single managed archive resolver instead of treating the shortcut as a filesystem path.
- Route `wikg://lib/arc/<arc-id> --query ...` as archive root search so missing/outdated indexes report archive readiness errors, not membership `get` errors.
- Preserve library archive shortcut routing for single-archive `entity` / `triple` / `chunk` queries and object-level `evidence` / `related` / `pack`.

## Acceptance coverage

- `meta --json`: added parser coverage for `<lib-arc-scope>/meta --json`; manual verification returned the same metadata as the standalone archive URI.
- `cover`: added parser coverage for `<lib-arc-scope>/cover`; manual verification produced the same 36459 bytes and sha256 `2e9d6269574b5dc53b3a481dd35146c029b5f65382e763c0364888459edc6f9a` as the standalone archive URI.
- `index --json` and `index enable --jsonl`: added parser coverage for both shortcut forms; manual verification showed matching index state and `index enable --jsonl` completed with `succeeded`.
- Root query: added parser and runtime coverage; manual verification before enabling the index returned the archive search-index readiness error instead of membership `get --query`, and after enabling the index returned 3 objects.
- `entity` / `triple` / `chunk` query: existing shortcut routing remains covered and manual verification after index enable returned objects for all three scopes.
- Object `evidence` / `related` / `pack`: existing tests remain covered; manual verification on real shortcut URIs returned valid command results without `wikg:/lib/... ENOENT`.
- Missing/readiness failure path: manual pre-enable root query confirmed archive readiness semantics; no observed command fell back to cwd `wikg:/lib/... ENOENT` after this change.
- Metadata mutation boundary: archive-root metadata read/write continues through object metadata routing; this PR fixes the shared shortcut resolution path rather than adding new metadata semantics.

## Structural review

Non-blind fallback review was performed because Hermes blind-review delegation failed once with provider HTTP 503 before reviewing. Fallback conclusion: pass.

- No old library command compatibility layer restored and no help recommendation for old commands added.
- No `.wikg` archive schema, manifest schema, object stream schema, TOC format, archive entry format, home/core database schema, or `libraries` / `library_archives` / `library_metadata` table changes.
- No schema/version constants were changed.

## Verification

Automated:

- `pnpm vitest run packages/cli/src/args/archive.test.ts packages/cli/src/args/archive-index.test.ts test/cli/archive/object.test.ts --reporter=dot` — 3 files / 38 tests passed.
- `pnpm test:run` — 130 files / 855 tests passed.
- `pnpm run lint` — passed.
- `pnpm run typecheck` — passed.
- `pnpm run format:check` — passed.
- `pnpm run build` — passed.

Manual (using `/Users/taozeyu/.local/bin/wg` installed from this worktree; an older `/Users/taozeyu/.nvm/.../bin/wg` remains on PATH on this machine):

- `wg wikg://lib/arc/c394379a27fd/meta --json` — exit 0, matched standalone metadata.
- `wg wikg://lib/arc/c394379a27fd/cover > /tmp/wikg-lib-cover-test.out` — exit 0, matched standalone bytes/hash.
- `wg wikg://lib/arc/c394379a27fd/index --json` — exit 0, matched standalone index state.
- `wg wikg://lib/arc/c394379a27fd inspect --json` — `index.fixCommand` is `wg wikg://lib/arc/c394379a27fd/index enable`.
- `wg wikg://lib/arc/c394379a27fd --query '孙悟空' --limit 3 --json` before index enable — exit 1 with archive search-index readiness error.
- `wg wikg://lib/arc/c394379a27fd/index enable --jsonl` — exit 0, completed/succeeded.
- Root/entity/triple/chunk query after index enable — exit 0.
- Object `evidence`, `related`, and `pack` via shortcut — exit 0.
