### PR TITLE
fix: harden CLI runner SDK contract

### DIFF
--- a/packages/cli/src/app/runner.ts
+++ b/packages/cli/src/app/runner.ts
@@ -66,6 +66,7 @@ export async function runWikiGraphCLI(
     cwd: input.cwd ?? process.cwd(),
     env: environment,
     exitCode: 0,
+    signal: input.signal,
     stderr,
     stderrIsTTY: input.stderrIsTTY,
     stdin,
@@ -82,6 +83,7 @@ export async function runWikiGraphCLI(
         stdinIsTTY: context.stdinIsTTY ?? stdin.isTTY,
         stdout,
       });
+      throwIfAborted(input.signal);
       const exitCode = normalizeExitCode(getCLIExitCode(), result.exitCode);
 
       return { exitCode };

--- a/packages/cli/src/app/runner.ts
+++ b/packages/cli/src/app/runner.ts
@@ -1,6 +1,12 @@
 import { Readable, Writable } from "stream";
 
+import { withWikiGraphRuntimeEnvironment } from "wiki-graph-core";
 import { dispatchWikiGraphCLI } from "./dispatch.js";
+import {
+  getCLIExitCode,
+  withWikiGraphCLIRuntimeContext,
+  type WikiGraphCLIRuntimeContext,
+} from "../runtime/context.js";
 
 export interface RunWikiGraphCLIInput {
   /**
@@ -39,61 +45,48 @@ export interface WikiGraphCLI {
   ): Promise<RunWikiGraphCLICapturedResult>;
 }
 
-let activeRunner = false;
-
 export async function runWikiGraphCLI(
   input: RunWikiGraphCLIInput = {},
 ): Promise<RunWikiGraphCLIResult> {
   throwIfAborted(input.signal);
 
-  if (activeRunner) {
-    throw new Error(
-      "runWikiGraphCLI cannot run concurrently because it adapts process-global CLI state.",
-    );
-  }
-
-  activeRunner = true;
-
-  const originalCwd = process.cwd();
-  const originalExitCode = process.exitCode;
   const stdin = createInputStream(input.stdin ?? process.stdin);
   const stdout = input.stdout ?? process.stdout;
   const stderr = input.stderr ?? process.stderr;
-  const restore = installProcessAdapters({
-    argv: input.argv ?? process.argv.slice(2),
-    env: input.env,
+  const argv = input.argv ?? process.argv.slice(2);
+  const environment =
+    input.env === undefined
+      ? process.env
+      : {
+          ...process.env,
+          ...input.env,
+        };
+  const context: WikiGraphCLIRuntimeContext = {
+    argv,
+    cwd: input.cwd ?? process.cwd(),
+    env: environment,
+    exitCode: 0,
     stderr,
     stderrIsTTY: input.stderrIsTTY,
     stdin,
     stdinIsTTY: input.stdinIsTTY,
     stdout,
     stdoutIsTTY: input.stdoutIsTTY,
-  });
+  };
 
-  try {
-    if (input.cwd !== undefined && input.cwd !== originalCwd) {
-      process.chdir(input.cwd);
-    }
+  return await withWikiGraphRuntimeEnvironment(environment, async () =>
+    withWikiGraphCLIRuntimeContext(context, async () => {
+      const result = await dispatchWikiGraphCLI({
+        argv,
+        stderr,
+        stdinIsTTY: context.stdinIsTTY ?? stdin.isTTY,
+        stdout,
+      });
+      const exitCode = normalizeExitCode(getCLIExitCode(), result.exitCode);
 
-    process.exitCode = 0;
-
-    const result = await dispatchWikiGraphCLI({
-      argv: input.argv ?? process.argv.slice(2),
-      stderr,
-      stdinIsTTY: stdin.isTTY,
-      stdout,
-    });
-    const exitCode = normalizeExitCode(process.exitCode, result.exitCode);
-
-    return { exitCode };
-  } finally {
-    if (process.cwd() !== originalCwd) {
-      process.chdir(originalCwd);
-    }
-    process.exitCode = originalExitCode;
-    restore();
-    activeRunner = false;
-  }
+      return { exitCode };
+    }),
+  );
 }
 
 export async function runWikiGraphCLICaptured(
@@ -151,93 +144,6 @@ function createInputStream(
   return input as NodeJS.ReadableStream & { isTTY?: boolean | undefined };
 }
 
-function installProcessAdapters(input: {
-  readonly argv: readonly string[];
-  readonly env?: NodeJS.ProcessEnv | undefined;
-  readonly stderr: NodeJS.WritableStream;
-  readonly stderrIsTTY?: boolean | undefined;
-  readonly stdin: NodeJS.ReadableStream & { isTTY?: boolean | undefined };
-  readonly stdinIsTTY?: boolean | undefined;
-  readonly stdout: NodeJS.WritableStream;
-  readonly stdoutIsTTY?: boolean | undefined;
-}): () => void {
-  const processDescriptors = {
-    argv: Object.getOwnPropertyDescriptor(process, "argv"),
-    env: Object.getOwnPropertyDescriptor(process, "env"),
-    stderr: Object.getOwnPropertyDescriptor(process, "stderr"),
-    stdin: Object.getOwnPropertyDescriptor(process, "stdin"),
-    stdout: Object.getOwnPropertyDescriptor(process, "stdout"),
-  };
-  const streamDescriptors = {
-    stderrIsTTY: Object.getOwnPropertyDescriptor(input.stderr, "isTTY"),
-    stdinIsTTY: Object.getOwnPropertyDescriptor(input.stdin, "isTTY"),
-    stdoutIsTTY: Object.getOwnPropertyDescriptor(input.stdout, "isTTY"),
-  };
-
-  Object.defineProperty(input.stdin, "isTTY", {
-    configurable: true,
-    value: input.stdinIsTTY ?? input.stdin.isTTY,
-  });
-  Object.defineProperty(input.stdout, "isTTY", {
-    configurable: true,
-    value: input.stdoutIsTTY ?? getWritableIsTTY(input.stdout),
-  });
-  Object.defineProperty(input.stderr, "isTTY", {
-    configurable: true,
-    value: input.stderrIsTTY ?? getWritableIsTTY(input.stderr),
-  });
-  Object.defineProperty(process, "argv", {
-    configurable: true,
-    value: ["node", "wg", ...input.argv],
-  });
-  Object.defineProperty(process, "env", {
-    configurable: true,
-    value:
-      input.env === undefined
-        ? process.env
-        : {
-            ...process.env,
-            ...input.env,
-          },
-  });
-  Object.defineProperty(process, "stdin", {
-    configurable: true,
-    value: input.stdin,
-  });
-  Object.defineProperty(process, "stdout", {
-    configurable: true,
-    value: input.stdout,
-  });
-  Object.defineProperty(process, "stderr", {
-    configurable: true,
-    value: input.stderr,
-  });
-
-  return () => {
-    restoreDescriptor(process, "stderr", processDescriptors.stderr);
-    restoreDescriptor(process, "stdout", processDescriptors.stdout);
-    restoreDescriptor(process, "stdin", processDescriptors.stdin);
-    restoreDescriptor(process, "env", processDescriptors.env);
-    restoreDescriptor(process, "argv", processDescriptors.argv);
-    restoreDescriptor(input.stderr, "isTTY", streamDescriptors.stderrIsTTY);
-    restoreDescriptor(input.stdout, "isTTY", streamDescriptors.stdoutIsTTY);
-    restoreDescriptor(input.stdin, "isTTY", streamDescriptors.stdinIsTTY);
-  };
-}
-
-function restoreDescriptor(
-  target: object,
-  property: string,
-  descriptor: PropertyDescriptor | undefined,
-): void {
-  if (descriptor === undefined) {
-    Reflect.deleteProperty(target, property);
-    return;
-  }
-
-  Object.defineProperty(target, property, descriptor);
-}
-
 function normalizeExitCode(
   currentExitCode: NodeJS.Process["exitCode"],
   fallbackExitCode: number,
@@ -249,11 +155,6 @@ function normalizeExitCode(
   const numericExitCode = Number(currentExitCode);
 
   return Number.isFinite(numericExitCode) ? numericExitCode : 1;
-}
-
-function getWritableIsTTY(stream: NodeJS.WritableStream): boolean | undefined {
-  return (stream as NodeJS.WritableStream & { isTTY?: boolean | undefined })
-    .isTTY;
 }
 
 function throwIfAborted(signal: AbortSignal | undefined): void {

--- a/packages/cli/src/commands/local-config.ts
+++ b/packages/cli/src/commands/local-config.ts
@@ -11,6 +11,7 @@ import {
   type WikispineProvider,
 } from "wiki-graph-core";
 import { buildLLMOptions } from "../runtime/llm.js";
+import { setCLIExitCode } from "../runtime/context.js";
 import { writeTextToStderr, writeTextToStdout } from "../support/index.js";
 import { formatCLIJSON } from "../support/index.js";
 import {
@@ -159,7 +160,7 @@ async function runLLMConfigTest(args: CLILocalConfigArguments): Promise<void> {
 
     if (args.json === true) {
       await writeTextToStdout(formatCLIJSON(output));
-      process.exitCode = 1;
+      setCLIExitCode(1);
       return;
     }
 
@@ -225,7 +226,7 @@ async function runWikispineConfigTest(
 
     if (args.json === true) {
       await writeTextToStdout(formatCLIJSON(output));
-      process.exitCode = 1;
+      setCLIExitCode(1);
       return;
     }
 

--- a/packages/cli/src/commands/queue/add.ts
+++ b/packages/cli/src/commands/queue/add.ts
@@ -8,6 +8,7 @@ import { WikiGraphArchiveFile } from "wiki-graph-core";
 
 import type { CLIQueueArguments } from "../../args/index.js";
 import type { CLIConfig } from "../../runtime/config.js";
+import { getCLIEnvValue } from "../../runtime/context.js";
 import { spawnInternalChild } from "../../runtime/internal-child.js";
 import { createQueueAddEstimate } from "./estimate.js";
 import { writeArchiveAddSummary } from "./output.js";
@@ -149,7 +150,7 @@ export function assertBuildCostAccepted(args: CLIQueueArguments): void {
 }
 
 export function tryStartQueueWorker(): void {
-  if (process.env.WIKIGRAPH_QUEUE_DISABLE_AUTOSTART === "1") {
+  if (getCLIEnvValue("WIKIGRAPH_QUEUE_DISABLE_AUTOSTART") === "1") {
     return;
   }
 

--- a/packages/cli/src/runtime/context.ts
+++ b/packages/cli/src/runtime/context.ts
@@ -1,0 +1,80 @@
+import { AsyncLocalStorage } from "async_hooks";
+
+export interface WikiGraphCLIRuntimeContext {
+  readonly argv: readonly string[];
+  readonly cwd: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly stderr: NodeJS.WritableStream;
+  readonly stderrIsTTY?: boolean | undefined;
+  readonly stdin: NodeJS.ReadableStream & { isTTY?: boolean | undefined };
+  readonly stdinIsTTY?: boolean | undefined;
+  readonly stdout: NodeJS.WritableStream;
+  readonly stdoutIsTTY?: boolean | undefined;
+  exitCode: NodeJS.Process["exitCode"];
+}
+
+const cliRuntimeContext = new AsyncLocalStorage<WikiGraphCLIRuntimeContext>();
+
+export async function withWikiGraphCLIRuntimeContext<T>(
+  context: WikiGraphCLIRuntimeContext,
+  operation: () => Promise<T> | T,
+): Promise<T> {
+  return await cliRuntimeContext.run(context, operation);
+}
+
+export function getCLIArgv(): readonly string[] {
+  return cliRuntimeContext.getStore()?.argv ?? process.argv.slice(2);
+}
+
+export function getCLICwd(): string {
+  return cliRuntimeContext.getStore()?.cwd ?? process.cwd();
+}
+
+export function getCLIEnv(): NodeJS.ProcessEnv {
+  return cliRuntimeContext.getStore()?.env ?? process.env;
+}
+
+export function getCLIEnvValue(name: string): string | undefined {
+  return getCLIEnv()[name];
+}
+
+export function getCLIStdin(): NodeJS.ReadableStream & {
+  isTTY?: boolean | undefined;
+} {
+  return (
+    cliRuntimeContext.getStore()?.stdin ??
+    (process.stdin as NodeJS.ReadableStream & { isTTY?: boolean | undefined })
+  );
+}
+
+export function getCLIStdout(): NodeJS.WritableStream {
+  return cliRuntimeContext.getStore()?.stdout ?? process.stdout;
+}
+
+export function getCLIStderr(): NodeJS.WritableStream {
+  return cliRuntimeContext.getStore()?.stderr ?? process.stderr;
+}
+
+export function getCLIStdoutIsTTY(): boolean | undefined {
+  const context = cliRuntimeContext.getStore();
+
+  return (
+    context?.stdoutIsTTY ??
+    (getCLIStdout() as NodeJS.WritableStream & { isTTY?: boolean }).isTTY
+  );
+}
+
+export function getCLIExitCode(): NodeJS.Process["exitCode"] {
+  return cliRuntimeContext.getStore()?.exitCode ?? process.exitCode;
+}
+
+export function setCLIExitCode(exitCode: NodeJS.Process["exitCode"]): void {
+  const context = cliRuntimeContext.getStore();
+
+  if (context === undefined) {
+    process.exitCode = exitCode;
+    return;
+  }
+
+  context.exitCode = exitCode;
+}

--- a/packages/cli/src/runtime/context.ts
+++ b/packages/cli/src/runtime/context.ts
@@ -4,6 +4,7 @@ export interface WikiGraphCLIRuntimeContext {
   readonly argv: readonly string[];
   readonly cwd: string;
   readonly env: NodeJS.ProcessEnv;
+  readonly signal?: AbortSignal | undefined;
   readonly stderr: NodeJS.WritableStream;
   readonly stderrIsTTY?: boolean | undefined;
   readonly stdin: NodeJS.ReadableStream & { isTTY?: boolean | undefined };
@@ -36,6 +37,10 @@ export function getCLIEnv(): NodeJS.ProcessEnv {
 
 export function getCLIEnvValue(name: string): string | undefined {
   return getCLIEnv()[name];
+}
+
+export function getCLISignal(): AbortSignal | undefined {
+  return cliRuntimeContext.getStore()?.signal;
 }
 
 export function getCLIStdin(): NodeJS.ReadableStream & {

--- a/packages/cli/src/runtime/internal-child.ts
+++ b/packages/cli/src/runtime/internal-child.ts
@@ -2,6 +2,8 @@ import { spawn } from "child_process";
 import { existsSync } from "fs";
 import { join, resolve } from "path";
 
+import { getCLICwd, getCLIEnv, getCLIEnvValue } from "./context.js";
+
 export type InternalChildKind = "gc-worker" | "queue-worker";
 
 export interface InternalChildSpawnOptions {
@@ -24,7 +26,7 @@ export function spawnInternalChild(
   return spawn(command.command, command.args, {
     detached: options.detached === true,
     env: {
-      ...process.env,
+      ...getCLIEnv(),
       [INTERNAL_CHILD_ENV_KEY]: kind,
     },
     stdio: options.detached === true ? "ignore" : ["ignore", "pipe", "pipe"],
@@ -77,8 +79,10 @@ function createInternalChildCommand(
   kind: InternalChildKind,
   args: readonly string[],
 ): { readonly args: readonly string[]; readonly command: string } {
-  if (process.env.WIKIGRAPH_DEV !== undefined) {
-    const projectRoot = resolveDevProjectRoot(process.env.WIKIGRAPH_DEV);
+  const devStateDirPath = getCLIEnvValue("WIKIGRAPH_DEV");
+
+  if (devStateDirPath !== undefined) {
+    const projectRoot = resolveDevProjectRoot(devStateDirPath);
 
     return {
       args: [
@@ -124,7 +128,7 @@ function resolveProductionEntryPath(kind: InternalChildKind): string {
   const filename = `${kind}.js`;
   const distDirPath =
     globalThis.__WIKIGRAPH_CLI_DIST_DIR__ ??
-    resolve(process.cwd(), "packages", "cli", "dist");
+    resolve(getCLICwd(), "packages", "cli", "dist");
   const adjacent = join(distDirPath, filename);
 
   if (existsSync(adjacent)) {

--- a/packages/cli/src/runtime/internal-child.ts
+++ b/packages/cli/src/runtime/internal-child.ts
@@ -24,6 +24,7 @@ export function spawnInternalChild(
   const command = createInternalChildCommand(kind, options.args ?? []);
 
   return spawn(command.command, command.args, {
+    cwd: getCLICwd(),
     detached: options.detached === true,
     env: {
       ...getCLIEnv(),

--- a/packages/cli/src/runtime/progress-output.ts
+++ b/packages/cli/src/runtime/progress-output.ts
@@ -1,5 +1,6 @@
 import { writeTextToStdout } from "../support/index.js";
 import { formatCLIJSONLine } from "../support/index.js";
+import { getCLIStdoutIsTTY } from "./context.js";
 
 export interface ProgressCounter {
   readonly done: number;
@@ -47,7 +48,7 @@ export class ProgressOutputWriter {
   }) {
     this.#jsonl = input.jsonl;
     this.#throttleMs = input.throttleMs;
-    this.#tty = input.tty ?? process.stdout.isTTY === true;
+    this.#tty = input.tty ?? getCLIStdoutIsTTY() === true;
   }
 
   public async write(event: ProgressOutputEvent): Promise<void> {

--- a/packages/cli/src/support/io.ts
+++ b/packages/cli/src/support/io.ts
@@ -3,10 +3,18 @@ import { rm } from "fs/promises";
 import { join } from "path";
 
 import { createWikiGraphTempDirectory } from "wiki-graph-core";
+import {
+  getCLIStderr,
+  getCLIStdin,
+  getCLIStdout,
+  setCLIExitCode,
+} from "../runtime/context.js";
 
 export function readTextStreamFromStdin(): AsyncIterable<string> {
-  process.stdin.setEncoding("utf8");
-  return process.stdin;
+  const stdin = getCLIStdin();
+
+  stdin.setEncoding("utf8");
+  return stdin as AsyncIterable<string>;
 }
 
 export async function writeTextFileToStdout(path: string): Promise<void> {
@@ -21,7 +29,7 @@ export async function writeTextToStdout(text: string): Promise<void> {
 
 export async function writeTextToStderr(text: string): Promise<void> {
   await new Promise<void>((resolve, reject) => {
-    process.stderr.write(text, (error) => {
+    getCLIStderr().write(text, (error) => {
       if (error === undefined || error === null) {
         resolve();
         return;
@@ -38,13 +46,15 @@ export async function writeBinaryToStdout(data: Uint8Array): Promise<void> {
 
 async function writeChunkToStdout(chunk: string | Uint8Array): Promise<void> {
   await new Promise<void>((resolve, reject) => {
-    process.stdout.write(chunk, (error) => {
+    getCLIStdout().write(chunk, (error) => {
       if (error === undefined || error === null) {
         resolve();
         return;
       }
       if (isBrokenPipeError(error)) {
-        process.exit(0);
+        setCLIExitCode(0);
+        resolve();
+        return;
       }
 
       reject(error);

--- a/packages/cli/src/support/version.ts
+++ b/packages/cli/src/support/version.ts
@@ -1,6 +1,8 @@
 import { existsSync, readFileSync } from "fs";
 import { dirname, join, parse, resolve } from "path";
 
+import { getCLICwd } from "../runtime/context.js";
+
 function isCLIPackageJSON(path: string): boolean {
   const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
 
@@ -13,7 +15,7 @@ function isCLIPackageJSON(path: string): boolean {
 }
 
 function findPackageJSONPathFromWorkingDirectory(): string | undefined {
-  let currentDirectoryPath = process.cwd();
+  let currentDirectoryPath = getCLICwd();
   const rootDirectoryPath = parse(currentDirectoryPath).root;
 
   while (true) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -95,6 +95,7 @@ export type {
 export {
   resolveWikiGraphCoreDatabasePath,
   resolveWikiGraphHomeDirectoryPath,
+  withWikiGraphRuntimeEnvironment,
 } from "./runtime/common/wiki-graph/dir.js";
 export {
   createWikiGraphTempDirectory,

--- a/packages/core/src/runtime/common/wiki-graph/dir.ts
+++ b/packages/core/src/runtime/common/wiki-graph/dir.ts
@@ -5,6 +5,7 @@ import { join, resolve } from "path";
 const testingStateDirectoryPath = new AsyncLocalStorage<{
   readonly path: string | undefined;
 }>();
+const runtimeEnvironment = new AsyncLocalStorage<NodeJS.ProcessEnv>();
 
 export function resolveWikiGraphHomeDirectoryPath(): string {
   const testingStateDirPath = testingStateDirectoryPath.getStore()?.path;
@@ -13,13 +14,14 @@ export function resolveWikiGraphHomeDirectoryPath(): string {
     return resolve(testingStateDirPath);
   }
 
-  const devStateDirPath = process.env.WIKIGRAPH_DEV;
+  const environment = runtimeEnvironment.getStore() ?? process.env;
+  const devStateDirPath = environment.WIKIGRAPH_DEV;
 
   if (devStateDirPath !== undefined && devStateDirPath.trim() !== "") {
     return resolve(devStateDirPath);
   }
 
-  const legacyStateDirPath = process.env.WIKIGRAPH_STATE_DIR;
+  const legacyStateDirPath = environment.WIKIGRAPH_STATE_DIR;
 
   if (legacyStateDirPath !== undefined && legacyStateDirPath.trim() !== "") {
     return resolve(legacyStateDirPath);
@@ -46,6 +48,13 @@ export async function withWikiGraphStateDirectoryPathForTesting<T>(
   operation: () => Promise<T> | T,
 ): Promise<T> {
   return await testingStateDirectoryPath.run({ path }, operation);
+}
+
+export async function withWikiGraphRuntimeEnvironment<T>(
+  environment: NodeJS.ProcessEnv,
+  operation: () => Promise<T> | T,
+): Promise<T> {
+  return await runtimeEnvironment.run(environment, operation);
 }
 
 export function getWikiGraphStateDirectoryPathForTesting(): string | undefined {

--- a/test/cli/sdk-runner.test.ts
+++ b/test/cli/sdk-runner.test.ts
@@ -55,6 +55,20 @@ describe("cli/sdk-runner", () => {
     });
   });
 
+  it("honors an aborted runner signal", async () => {
+    const controller = new AbortController();
+    const reason = new Error("stop runner");
+
+    controller.abort(reason);
+
+    await expect(
+      runWikiGraphCLICaptured({
+        argv: ["--version"],
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow(reason);
+  });
+
   it("uses runner cwd, env, stdio, TTY flags, and exit code without changing process globals", async () => {
     const originalCwd = process.cwd();
     const outerCwd = await mkdtemp(join(tmpdir(), "wikigraph-runner-outer-"));

--- a/test/cli/sdk-runner.test.ts
+++ b/test/cli/sdk-runner.test.ts
@@ -1,9 +1,17 @@
+import { mkdtemp, realpath, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+
 import { describe, expect, it } from "vitest";
 
 import {
   createWikiGraphCLI,
   runWikiGraphCLICaptured,
 } from "../../packages/cli/src/index.js";
+import {
+  resolveWikiGraphHomeDirectoryPath,
+  withWikiGraphRuntimeEnvironment,
+} from "wiki-graph-core";
 
 describe("cli/sdk-runner", () => {
   it("captures stdout and stderr without spawning a process", async () => {
@@ -45,5 +53,95 @@ describe("cli/sdk-runner", () => {
         type: "error",
       },
     });
+  });
+
+  it("uses runner cwd, env, stdio, TTY flags, and exit code without changing process globals", async () => {
+    const originalCwd = process.cwd();
+    const outerCwd = await mkdtemp(join(tmpdir(), "wikigraph-runner-outer-"));
+    const stateDir = await mkdtemp(join(tmpdir(), "wikigraph-runner-state-"));
+
+    try {
+      process.chdir(outerCwd);
+      const result = await runWikiGraphCLICaptured({
+        argv: ["--version"],
+        cwd: originalCwd,
+        env: {
+          WIKIGRAPH_STATE_DIR: stateDir,
+        },
+        stdin: "ignored",
+        stdinIsTTY: false,
+        stdoutIsTTY: true,
+        stderrIsTTY: true,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/^\d+\.\d+\.\d+\n$/u);
+      expect(result.stderr).toBe("");
+      expect(await realpath(process.cwd())).toBe(await realpath(outerCwd));
+      expect(process.env.WIKIGRAPH_STATE_DIR).not.toBe(stateDir);
+    } finally {
+      process.chdir(originalCwd);
+      await rm(outerCwd, { force: true, recursive: true });
+      await rm(stateDir, { force: true, recursive: true });
+    }
+  });
+
+  it("lets the core SDK and CLI runner use the same state dir in one process", async () => {
+    const stateDir = await mkdtemp(join(tmpdir(), "wikigraph-shared-state-"));
+
+    try {
+      const coreStateDir = await withWikiGraphRuntimeEnvironment(
+        {
+          ...process.env,
+          WIKIGRAPH_STATE_DIR: stateDir,
+        },
+        () => resolveWikiGraphHomeDirectoryPath(),
+      );
+      const result = await runWikiGraphCLICaptured({
+        argv: ["wikg://local/config/concurrent", "put", "job", "4"],
+        env: {
+          WIKIGRAPH_STATE_DIR: stateDir,
+        },
+      });
+
+      expect(coreStateDir).toBe(stateDir);
+      expect(result.exitCode).toBe(0);
+      expect(JSON.parse(result.stdout)).toStrictEqual({ job: 4 });
+      expect(result.stderr).toBe("");
+    } finally {
+      await rm(stateDir, { force: true, recursive: true });
+    }
+  });
+
+  it("allows independent runner calls to run concurrently", async () => {
+    const leftStateDir = await mkdtemp(join(tmpdir(), "wikigraph-left-state-"));
+    const rightStateDir = await mkdtemp(
+      join(tmpdir(), "wikigraph-right-state-"),
+    );
+
+    try {
+      const [left, right] = await Promise.all([
+        runWikiGraphCLICaptured({
+          argv: ["wikg://local/config/concurrent", "put", "job", "2"],
+          env: {
+            WIKIGRAPH_STATE_DIR: leftStateDir,
+          },
+        }),
+        runWikiGraphCLICaptured({
+          argv: ["wikg://local/config/concurrent", "put", "request", "3"],
+          env: {
+            WIKIGRAPH_STATE_DIR: rightStateDir,
+          },
+        }),
+      ]);
+
+      expect(left.exitCode).toBe(0);
+      expect(JSON.parse(left.stdout)).toStrictEqual({ job: 2 });
+      expect(right.exitCode).toBe(0);
+      expect(JSON.parse(right.stdout)).toStrictEqual({ request: 3 });
+    } finally {
+      await rm(leftStateDir, { force: true, recursive: true });
+      await rm(rightStateDir, { force: true, recursive: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Harden the in-process CLI runner so `runWikiGraphCLI` no longer patches process argv/env/cwd/stdio/exitCode or uses the entry-level `activeRunner` lock.
- Add an AsyncLocalStorage-backed CLI runtime context for argv/cwd/env/stdio/TTY/exitCode and route CLI helpers plus state-dir resolution through that context.
- Add runner contract coverage for explicit inputs, shared core+runner state dir use, and independent concurrent runner calls.

Closes https://github.com/oomol-lab/wiki-graph/issues/203

## Issue #203 acceptance evidence
1. `wiki-graph-core` entry: verified via `withWikiGraphRuntimeEnvironment` with a temporary `WIKIGRAPH_STATE_DIR`; manual dist check confirmed core resolves that same state dir.
2. CLI runner SDK entry: `test/cli/sdk-runner.test.ts` calls `runWikiGraphCLICaptured` with explicit argv/cwd/env/stdin/stdout/stderr TTY inputs and verifies exit code/stdout/stderr plus no process-global cwd/env pollution.
3. `wg` bin entry: after build, ran `WIKIGRAPH_STATE_DIR=$tmp node packages/cli/dist/cli.js wikg://local/config/concurrent put job 5`; result exit=0, stdout JSON `{ "job": 5 }`, stderr empty.
4. Same-process core + runner: tested and manually verified core SDK and CLI runner use the same temporary state dir in one Node process.
5. Runner concurrency: `test/cli/sdk-runner.test.ts` runs two independent `runWikiGraphCLICaptured` calls concurrently with distinct state dirs and distinct captured streams; both succeed.
6. Output contract: runner API remains `{ exitCode }` for `runWikiGraphCLI` and `{ exitCode, stdout, stderr }` for captured runner; no JSON/JSONL parser, typed result, help API, Wanta helper, or business SDK helper was added.
7. Scope boundary: no package.json exports/bin/build/bundle/external dependency strategy changes.
8. Recommended commands and results are listed below.

## Verification
- `pnpm exec vitest run test/cli/sdk-runner.test.ts` — pass, 6 tests
- `pnpm run test:run` — pass, 130 files / 858 tests
- `pnpm run lint` — pass
- `pnpm run typecheck` — pass
- `pnpm run format:check` — pass
- `pnpm run build` — pass
- Manual `wg` bin check after build — pass, exit=0/stdout JSON/stderr empty
- Manual dist core+runner same-process check — pass, shared state dir and runner output `{ "request": 6 }`

## Review note
Blind reviewer was attempted (`deleg_d8cbb023`) but failed after 3 API retries with HTTP 503 (“所有供应商暂时不可用”). Per task rules I performed a non-blind fallback review against issue #203 acceptance criteria; verdict: pass. The change does not touch security, permissions, production data, irreversible migrations, or package publishing shape.