### PR TITLE
fix: harden runtime env entry policies

### DIFF
--- a/docs/en/sdk.md
+++ b/docs/en/sdk.md
@@ -60,7 +60,7 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { WikiGraph } from "wiki-graph-core";
 
 const openai = createOpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
+  apiKey: "<your-openai-api-key>",
 });
 
 const wikiGraph = new WikiGraph({
@@ -72,6 +72,10 @@ const wikiGraph = new WikiGraph({
   },
 });
 ```
+
+Wiki Graph does not automatically read `OPENAI_API_KEY` or any CLI provider
+configuration. Your application owns credential loading and must pass a fully
+configured AI SDK `LanguageModel` into `WikiGraph`.
 
 ## Queue Control
 

--- a/docs/en/sdk.md
+++ b/docs/en/sdk.md
@@ -74,8 +74,8 @@ const wikiGraph = new WikiGraph({
 ```
 
 Wiki Graph does not automatically read `OPENAI_API_KEY` or any CLI provider
-configuration. Your application owns credential loading and must pass a fully
-configured AI SDK `LanguageModel` into `WikiGraph`.
+configuration. Your application owns credential loading and must pass its fully
+configured AI SDK `LanguageModel` through the `WikiGraph` `llm` option.
 
 ## Queue Control
 

--- a/docs/local-cli-development.md
+++ b/docs/local-cli-development.md
@@ -69,10 +69,11 @@ The extra `--` is passed to the CLI and changes the parsed command.
 ## Development State Directory
 
 The installed CLI stores local runtime state under `~/.wikigraph`. The
-development CLI entry point sets an internal `WIKIGRAPH_DEV` value that points
-at the repository-level `.wikigraph/state` directory instead. Do not set this
-variable manually; use the pnpm dev script so child processes such as build
-workers and GC use the same checkout-local state.
+development CLI entry point runs with a development entry policy and passes the
+repository-level `.wikigraph/state` directory through the explicit runtime
+context instead. Do not set Wiki Graph runtime environment variables manually;
+use the pnpm dev script so child processes such as build workers and GC use the
+same checkout-local state.
 
 Use repository-root `.wikigraph/` for local development data:
 

--- a/docs/zh-CN/sdk.md
+++ b/docs/zh-CN/sdk.md
@@ -74,7 +74,8 @@ const wikiGraph = new WikiGraph({
 ```
 
 Wiki Graph 不会自动读取 `OPENAI_API_KEY` 或任何 CLI provider 配置。应用负责加载
-凭据，并且必须把已配置好的 AI SDK `LanguageModel` 传给 `WikiGraph`。
+凭据，并且必须通过 `WikiGraph` 的 `llm` option 传入已配置好的 AI SDK
+`LanguageModel`。
 
 ## 队列控制
 

--- a/docs/zh-CN/sdk.md
+++ b/docs/zh-CN/sdk.md
@@ -60,7 +60,7 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { WikiGraph } from "wiki-graph-core";
 
 const openai = createOpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
+  apiKey: "<your-openai-api-key>",
 });
 
 const wikiGraph = new WikiGraph({
@@ -72,6 +72,9 @@ const wikiGraph = new WikiGraph({
   },
 });
 ```
+
+Wiki Graph 不会自动读取 `OPENAI_API_KEY` 或任何 CLI provider 配置。应用负责加载
+凭据，并且必须把已配置好的 AI SDK `LanguageModel` 传给 `WikiGraph`。
 
 ## 队列控制
 

--- a/packages/cli/src/app/main.ts
+++ b/packages/cli/src/app/main.ts
@@ -1,6 +1,13 @@
-import { runWikiGraphCLI } from "./runner.js";
+import {
+  runWikiGraphCLIWithEntryPolicy,
+  type RunWikiGraphCLIInput,
+} from "./runner.js";
+import type { WikiGraphEntryEnvPolicy } from "../runtime/entry-context.js";
 
-export async function main(): Promise<void> {
-  const result = await runWikiGraphCLI();
+export async function main(
+  input: RunWikiGraphCLIInput = {},
+  envPolicy: WikiGraphEntryEnvPolicy = "production",
+): Promise<void> {
+  const result = await runWikiGraphCLIWithEntryPolicy(input, envPolicy);
   process.exitCode = result.exitCode;
 }

--- a/packages/cli/src/app/runner.ts
+++ b/packages/cli/src/app/runner.ts
@@ -1,12 +1,16 @@
 import { Readable, Writable } from "stream";
 
-import { withWikiGraphRuntimeEnvironment } from "wiki-graph-core";
+import { withWikiGraphRuntimeStateDirectoryPath } from "wiki-graph-core";
 import { dispatchWikiGraphCLI } from "./dispatch.js";
 import {
   getCLIExitCode,
   withWikiGraphCLIRuntimeContext,
   type WikiGraphCLIRuntimeContext,
 } from "../runtime/context.js";
+import {
+  createEntryRuntimeContext,
+  type WikiGraphEntryEnvPolicy,
+} from "../runtime/entry-context.js";
 
 export interface RunWikiGraphCLIInput {
   /**
@@ -17,6 +21,7 @@ export interface RunWikiGraphCLIInput {
   readonly cwd?: string | undefined;
   readonly env?: NodeJS.ProcessEnv | undefined;
   readonly signal?: AbortSignal | undefined;
+  readonly stateDir?: string | undefined;
   readonly stderr?: NodeJS.WritableStream | undefined;
   readonly stderrIsTTY?: boolean | undefined;
   readonly stdin?: NodeJS.ReadableStream | Uint8Array | string | undefined;
@@ -48,25 +53,44 @@ export interface WikiGraphCLI {
 export async function runWikiGraphCLI(
   input: RunWikiGraphCLIInput = {},
 ): Promise<RunWikiGraphCLIResult> {
+  return await runWikiGraphCLIWithEntryPolicy(input, "production");
+}
+
+export async function runWikiGraphCLIWithEntryPolicy(
+  input: RunWikiGraphCLIInput = {},
+  envPolicy: WikiGraphEntryEnvPolicy,
+): Promise<RunWikiGraphCLIResult> {
   throwIfAborted(input.signal);
 
   const stdin = createInputStream(input.stdin ?? process.stdin);
   const stdout = input.stdout ?? process.stdout;
   const stderr = input.stderr ?? process.stderr;
   const argv = input.argv ?? process.argv.slice(2);
-  const environment =
-    input.env === undefined
-      ? process.env
-      : {
-          ...process.env,
-          ...input.env,
-        };
+  let entryContext: ReturnType<typeof createEntryRuntimeContext>;
+
+  try {
+    entryContext = createEntryRuntimeContext({
+      argv,
+      cwd: input.cwd ?? process.cwd(),
+      env: input.env,
+      envPolicy,
+      stateDir: input.stateDir,
+    });
+  } catch (error) {
+    stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return { exitCode: 1 };
+  }
+
   const context: WikiGraphCLIRuntimeContext = {
     argv,
     cwd: input.cwd ?? process.cwd(),
-    env: environment,
+    devProjectRoot: entryContext.devProjectRoot,
+    env: entryContext.env,
+    envPolicy: entryContext.envPolicy,
     exitCode: 0,
+    queueAutostart: true,
     signal: input.signal,
+    stateDir: entryContext.stateDir,
     stderr,
     stderrIsTTY: input.stderrIsTTY,
     stdin,
@@ -75,19 +99,21 @@ export async function runWikiGraphCLI(
     stdoutIsTTY: input.stdoutIsTTY,
   };
 
-  return await withWikiGraphRuntimeEnvironment(environment, async () =>
-    withWikiGraphCLIRuntimeContext(context, async () => {
-      const result = await dispatchWikiGraphCLI({
-        argv,
-        stderr,
-        stdinIsTTY: context.stdinIsTTY ?? stdin.isTTY,
-        stdout,
-      });
-      throwIfAborted(input.signal);
-      const exitCode = normalizeExitCode(getCLIExitCode(), result.exitCode);
+  return await withWikiGraphRuntimeStateDirectoryPath(
+    entryContext.stateDir,
+    async () =>
+      withWikiGraphCLIRuntimeContext(context, async () => {
+        const result = await dispatchWikiGraphCLI({
+          argv,
+          stderr,
+          stdinIsTTY: context.stdinIsTTY ?? stdin.isTTY,
+          stdout,
+        });
+        throwIfAborted(input.signal);
+        const exitCode = normalizeExitCode(getCLIExitCode(), result.exitCode);
 
-      return { exitCode };
-    }),
+        return { exitCode };
+      }),
   );
 }
 

--- a/packages/cli/src/app/runner.ts
+++ b/packages/cli/src/app/runner.ts
@@ -19,6 +19,7 @@ export interface RunWikiGraphCLIInput {
    */
   readonly argv?: readonly string[] | undefined;
   readonly cwd?: string | undefined;
+  readonly devProjectRoot?: string | undefined;
   readonly env?: NodeJS.ProcessEnv | undefined;
   readonly signal?: AbortSignal | undefined;
   readonly stateDir?: string | undefined;
@@ -72,6 +73,7 @@ export async function runWikiGraphCLIWithEntryPolicy(
     entryContext = createEntryRuntimeContext({
       argv,
       cwd: input.cwd ?? process.cwd(),
+      devProjectRoot: input.devProjectRoot,
       env: input.env,
       envPolicy,
       stateDir: input.stateDir,

--- a/packages/cli/src/bin/dev-cli.ts
+++ b/packages/cli/src/bin/dev-cli.ts
@@ -1,8 +1,12 @@
 import { main } from "../app/index.js";
-import { resolveDevStateDirectoryPath } from "../runtime/dev-state.js";
+import {
+  resolveDevProjectRootPath,
+  resolveDevStateDirectoryPath,
+} from "../runtime/dev-state.js";
 
 void main(
   {
+    devProjectRoot: resolveDevProjectRootPath(),
     stateDir: resolveDevStateDirectoryPath(),
   },
   "development",

--- a/packages/cli/src/bin/dev-cli.ts
+++ b/packages/cli/src/bin/dev-cli.ts
@@ -1,6 +1,9 @@
-import { enableDevStateDirectory } from "../runtime/dev-state.js";
+import { main } from "../app/index.js";
+import { resolveDevStateDirectoryPath } from "../runtime/dev-state.js";
 
-enableDevStateDirectory();
-const { main } = await import("../app/index.js");
-
-void main();
+void main(
+  {
+    stateDir: resolveDevStateDirectoryPath(),
+  },
+  "development",
+);

--- a/packages/cli/src/bin/dev-gc-worker.ts
+++ b/packages/cli/src/bin/dev-gc-worker.ts
@@ -1,7 +1,0 @@
-#!/usr/bin/env node
-
-import { enableDevStateDirectory } from "../runtime/dev-state.js";
-
-enableDevStateDirectory();
-
-await import("./gc-worker.js");

--- a/packages/cli/src/bin/dev-queue-worker.ts
+++ b/packages/cli/src/bin/dev-queue-worker.ts
@@ -1,7 +1,0 @@
-#!/usr/bin/env node
-
-import { enableDevStateDirectory } from "../runtime/dev-state.js";
-
-enableDevStateDirectory();
-
-await import("./queue-worker.js");

--- a/packages/cli/src/bin/gc-worker.ts
+++ b/packages/cli/src/bin/gc-worker.ts
@@ -2,24 +2,21 @@
 
 import { tryRunWikiGraphGc } from "wiki-graph-core/gc";
 
+import { withWorkerEntryRuntime } from "../runtime/worker-entry.js";
 import { formatCLIJSON } from "../support/index.js";
 
 async function main(): Promise<void> {
-  if (process.env.WIKIGRAPH_INTERNAL_CHILD !== "gc-worker") {
-    process.stderr.write("This Wiki Graph worker entry is internal.\n");
-    process.exitCode = 1;
-    return;
-  }
-
-  const args = parseGcWorkerArguments(process.argv.slice(2));
-  process.stdout.write(
-    formatCLIJSON(
-      await tryRunWikiGraphGc({
-        dryRun: args.dryRun,
-        force: args.force,
-      }),
-    ),
-  );
+  await withWorkerEntryRuntime("gc-worker", async ({ argv }) => {
+    const args = parseGcWorkerArguments(argv);
+    process.stdout.write(
+      formatCLIJSON(
+        await tryRunWikiGraphGc({
+          dryRun: args.dryRun,
+          force: args.force,
+        }),
+      ),
+    );
+  });
 }
 
 function parseGcWorkerArguments(argv: readonly string[]): {

--- a/packages/cli/src/bin/queue-worker.ts
+++ b/packages/cli/src/bin/queue-worker.ts
@@ -1,15 +1,13 @@
 #!/usr/bin/env node
 
 import { runQueueWorker } from "../commands/index.js";
+import { withWorkerEntryRuntime } from "../runtime/worker-entry.js";
 
 async function main(): Promise<void> {
-  if (process.env.WIKIGRAPH_INTERNAL_CHILD !== "queue-worker") {
-    process.stderr.write("This Wiki Graph worker entry is internal.\n");
-    process.exitCode = 1;
-    return;
-  }
-
-  await runQueueWorker();
+  await withWorkerEntryRuntime(
+    "queue-worker",
+    async () => await runQueueWorker(),
+  );
 }
 
 void main().catch((error: unknown) => {

--- a/packages/cli/src/commands/queue/add.ts
+++ b/packages/cli/src/commands/queue/add.ts
@@ -8,7 +8,7 @@ import { WikiGraphArchiveFile } from "wiki-graph-core";
 
 import type { CLIQueueArguments } from "../../args/index.js";
 import type { CLIConfig } from "../../runtime/config.js";
-import { getCLIEnvValue } from "../../runtime/context.js";
+import { isCLIQueueAutostartEnabled } from "../../runtime/context.js";
 import { spawnInternalChild } from "../../runtime/internal-child.js";
 import { createQueueAddEstimate } from "./estimate.js";
 import { writeArchiveAddSummary } from "./output.js";
@@ -150,7 +150,7 @@ export function assertBuildCostAccepted(args: CLIQueueArguments): void {
 }
 
 export function tryStartQueueWorker(): void {
-  if (getCLIEnvValue("WIKIGRAPH_QUEUE_DISABLE_AUTOSTART") === "1") {
+  if (!isCLIQueueAutostartEnabled()) {
     return;
   }
 

--- a/packages/cli/src/runtime/context.ts
+++ b/packages/cli/src/runtime/context.ts
@@ -3,8 +3,12 @@ import { AsyncLocalStorage } from "async_hooks";
 export interface WikiGraphCLIRuntimeContext {
   readonly argv: readonly string[];
   readonly cwd: string;
+  readonly devProjectRoot?: string | undefined;
   readonly env: NodeJS.ProcessEnv;
+  readonly envPolicy: "development" | "production";
+  readonly queueAutostart: boolean;
   readonly signal?: AbortSignal | undefined;
+  readonly stateDir?: string | undefined;
   readonly stderr: NodeJS.WritableStream;
   readonly stderrIsTTY?: boolean | undefined;
   readonly stdin: NodeJS.ReadableStream & { isTTY?: boolean | undefined };
@@ -15,6 +19,7 @@ export interface WikiGraphCLIRuntimeContext {
 }
 
 const cliRuntimeContext = new AsyncLocalStorage<WikiGraphCLIRuntimeContext>();
+let queueAutostartForTesting: boolean | undefined;
 
 export async function withWikiGraphCLIRuntimeContext<T>(
   context: WikiGraphCLIRuntimeContext,
@@ -37,6 +42,28 @@ export function getCLIEnv(): NodeJS.ProcessEnv {
 
 export function getCLIEnvValue(name: string): string | undefined {
   return getCLIEnv()[name];
+}
+
+export function getCLIDevProjectRoot(): string | undefined {
+  return cliRuntimeContext.getStore()?.devProjectRoot;
+}
+
+export function getCLIStateDir(): string | undefined {
+  return cliRuntimeContext.getStore()?.stateDir;
+}
+
+export function isCLIQueueAutostartEnabled(): boolean {
+  return (
+    queueAutostartForTesting ??
+    cliRuntimeContext.getStore()?.queueAutostart ??
+    true
+  );
+}
+
+export function setCLIQueueAutostartForTesting(
+  enabled: boolean | undefined,
+): void {
+  queueAutostartForTesting = enabled;
 }
 
 export function getCLISignal(): AbortSignal | undefined {

--- a/packages/cli/src/runtime/dev-state.ts
+++ b/packages/cli/src/runtime/dev-state.ts
@@ -1,9 +1,9 @@
 import { resolve } from "path";
 
-export function resolveDevStateDirectoryPath(): string {
-  return resolve(import.meta.dirname, "../../../../.wikigraph/state");
+export function resolveDevProjectRoot(stateDirPath: string): string {
+  return resolve(stateDirPath, "..", "..");
 }
 
-export function enableDevStateDirectory(): void {
-  process.env.WIKIGRAPH_DEV = resolveDevStateDirectoryPath();
+export function resolveDevStateDirectoryPath(): string {
+  return resolve(import.meta.dirname, "../../../../.wikigraph/state");
 }

--- a/packages/cli/src/runtime/dev-state.ts
+++ b/packages/cli/src/runtime/dev-state.ts
@@ -1,9 +1,9 @@
 import { resolve } from "path";
 
-export function resolveDevProjectRoot(stateDirPath: string): string {
-  return resolve(stateDirPath, "..", "..");
+export function resolveDevProjectRootPath(): string {
+  return resolve(import.meta.dirname, "../../../..");
 }
 
 export function resolveDevStateDirectoryPath(): string {
-  return resolve(import.meta.dirname, "../../../../.wikigraph/state");
+  return resolve(resolveDevProjectRootPath(), ".wikigraph/state");
 }

--- a/packages/cli/src/runtime/entry-context.ts
+++ b/packages/cli/src/runtime/entry-context.ts
@@ -1,10 +1,9 @@
-import { resolve } from "path";
-
 export type WikiGraphEntryEnvPolicy = "development" | "production";
 
 export interface WikiGraphEntryRuntimeOptions {
   readonly argv?: readonly string[] | undefined;
   readonly cwd?: string | undefined;
+  readonly devProjectRoot?: string | undefined;
   readonly env?: NodeJS.ProcessEnv | undefined;
   readonly envPolicy: WikiGraphEntryEnvPolicy;
   readonly stateDir?: string | undefined;
@@ -49,7 +48,7 @@ export function createEntryRuntimeContext(
 
   const envStateDir =
     environment.WIKIGRAPH_DEV ?? environment.WIKIGRAPH_STATE_DIR;
-  const stateDir = options.stateDir ?? envStateDir;
+  const stateDir = normalizeOptionalPath(options.stateDir ?? envStateDir);
 
   if (stateDir === undefined) {
     throw new Error(
@@ -57,8 +56,16 @@ export function createEntryRuntimeContext(
     );
   }
 
+  const devProjectRoot = normalizeOptionalPath(options.devProjectRoot);
+
+  if (devProjectRoot === undefined) {
+    throw new Error(
+      "Wiki Graph development entries require an explicit project root.",
+    );
+  }
+
   return {
-    devProjectRoot: resolveDevProjectRoot(stateDir),
+    devProjectRoot,
     env: environment,
     envPolicy: options.envPolicy,
     stateDir,
@@ -78,6 +85,10 @@ function createMergedEnvironment(
   };
 }
 
-function resolveDevProjectRoot(stateDirPath: string): string {
-  return resolve(stateDirPath, "..", "..");
+function normalizeOptionalPath(path: string | undefined): string | undefined {
+  if (path === undefined || path.trim() === "") {
+    return undefined;
+  }
+
+  return path;
 }

--- a/packages/cli/src/runtime/entry-context.ts
+++ b/packages/cli/src/runtime/entry-context.ts
@@ -1,0 +1,83 @@
+import { resolve } from "path";
+
+export type WikiGraphEntryEnvPolicy = "development" | "production";
+
+export interface WikiGraphEntryRuntimeOptions {
+  readonly argv?: readonly string[] | undefined;
+  readonly cwd?: string | undefined;
+  readonly env?: NodeJS.ProcessEnv | undefined;
+  readonly envPolicy: WikiGraphEntryEnvPolicy;
+  readonly stateDir?: string | undefined;
+}
+
+export interface WikiGraphEntryRuntimeContext {
+  readonly devProjectRoot?: string | undefined;
+  readonly env: NodeJS.ProcessEnv;
+  readonly envPolicy: WikiGraphEntryEnvPolicy;
+  readonly stateDir?: string | undefined;
+}
+
+const DANGEROUS_RUNTIME_ENV_NAMES = [
+  "WIKIGRAPH_DEV",
+  "WIKIGRAPH_ENV_POLICY",
+  "WIKIGRAPH_QUEUE_DISABLE_AUTOSTART",
+  "WIKIGRAPH_STATE_DIR",
+] as const;
+
+export function createEntryRuntimeContext(
+  options: WikiGraphEntryRuntimeOptions,
+): WikiGraphEntryRuntimeContext {
+  const environment = createMergedEnvironment(options.env);
+
+  if (options.envPolicy === "production") {
+    const blocked = DANGEROUS_RUNTIME_ENV_NAMES.filter(
+      (name) => environment[name] !== undefined,
+    );
+
+    if (blocked.length > 0) {
+      throw new Error(
+        `Wiki Graph production entries do not support runtime env overrides: ${blocked.join(", ")}. Use the development entry or explicit SDK options instead.`,
+      );
+    }
+
+    return {
+      env: environment,
+      envPolicy: options.envPolicy,
+      stateDir: options.stateDir,
+    };
+  }
+
+  const envStateDir =
+    environment.WIKIGRAPH_DEV ?? environment.WIKIGRAPH_STATE_DIR;
+  const stateDir = options.stateDir ?? envStateDir;
+
+  if (stateDir === undefined) {
+    throw new Error(
+      "Wiki Graph development entries require an explicit runtime state directory.",
+    );
+  }
+
+  return {
+    devProjectRoot: resolveDevProjectRoot(stateDir),
+    env: environment,
+    envPolicy: options.envPolicy,
+    stateDir,
+  };
+}
+
+function createMergedEnvironment(
+  environment: NodeJS.ProcessEnv | undefined,
+): NodeJS.ProcessEnv {
+  if (environment === undefined) {
+    return { ...process.env };
+  }
+
+  return {
+    ...process.env,
+    ...environment,
+  };
+}
+
+function resolveDevProjectRoot(stateDirPath: string): string {
+  return resolve(stateDirPath, "..", "..");
+}

--- a/packages/cli/src/runtime/internal-child.test.ts
+++ b/packages/cli/src/runtime/internal-child.test.ts
@@ -1,53 +1,75 @@
 import { join } from "path";
 import { describe, expect, it } from "vitest";
 
+import {
+  withWikiGraphCLIRuntimeContext,
+  type WikiGraphCLIRuntimeContext,
+} from "./context.js";
 import { createInternalChildCommandForTesting } from "./internal-child.js";
 
 describe("runtime/internal-child", () => {
-  it("uses dev worker entries when WIKIGRAPH_DEV is set", () => {
-    const previous = process.env.WIKIGRAPH_DEV;
-
-    try {
-      process.env.WIKIGRAPH_DEV = join("/repo", ".wikigraph", "state");
-
-      expect(
-        createInternalChildCommandForTesting("queue-worker", ["--flag"]),
-      ).toStrictEqual({
-        args: [
-          join("/repo", "node_modules", "tsx", "dist", "cli.mjs"),
-          join("/repo", "packages", "cli", "src", "bin", "dev-queue-worker.ts"),
-          "--flag",
-        ],
-        command: process.execPath,
-      });
-      expect(createInternalChildCommandForTesting("gc-worker").args[1]).toBe(
-        join("/repo", "packages", "cli", "src", "bin", "dev-gc-worker.ts"),
-      );
-    } finally {
-      if (previous === undefined) {
-        delete process.env.WIKIGRAPH_DEV;
-      } else {
-        process.env.WIKIGRAPH_DEV = previous;
-      }
-    }
+  it("uses source worker entries from the development runtime context", async () => {
+    await withRuntimeContext(
+      {
+        devProjectRoot: "/repo",
+        stateDir: join("/repo", ".wikigraph", "state"),
+      },
+      () => {
+        expect(
+          createInternalChildCommandForTesting("queue-worker", ["--flag"]),
+        ).toStrictEqual({
+          args: [
+            join("/repo", "node_modules", "tsx", "dist", "cli.mjs"),
+            join("/repo", "packages", "cli", "src", "bin", "queue-worker.ts"),
+            "--wikigraph-internal-child",
+            "queue-worker",
+            "--wikigraph-state-dir",
+            join("/repo", ".wikigraph", "state"),
+            "--flag",
+          ],
+          command: process.execPath,
+        });
+        expect(createInternalChildCommandForTesting("gc-worker").args[1]).toBe(
+          join("/repo", "packages", "cli", "src", "bin", "gc-worker.ts"),
+        );
+      },
+    );
   });
 
-  it("uses production worker entries when WIKIGRAPH_DEV is unset", () => {
-    const previous = process.env.WIKIGRAPH_DEV;
-
-    try {
-      delete process.env.WIKIGRAPH_DEV;
-
-      expect(createInternalChildCommandForTesting("queue-worker").args[0]).toBe(
+  it("uses production worker entries when no development project root is set", async () => {
+    await withRuntimeContext({}, () => {
+      const queueCommand = createInternalChildCommandForTesting("queue-worker");
+      expect(queueCommand.args[0]).toBe(
         join(process.cwd(), "packages", "cli", "dist", "queue-worker.js"),
       );
+      expect(queueCommand.args.slice(1)).toStrictEqual([
+        "--wikigraph-internal-child",
+        "queue-worker",
+      ]);
       expect(createInternalChildCommandForTesting("gc-worker").args[0]).toBe(
         join(process.cwd(), "packages", "cli", "dist", "gc-worker.js"),
       );
-    } finally {
-      if (previous !== undefined) {
-        process.env.WIKIGRAPH_DEV = previous;
-      }
-    }
+    });
   });
 });
+
+async function withRuntimeContext(
+  overrides: Partial<WikiGraphCLIRuntimeContext>,
+  operation: () => void,
+): Promise<void> {
+  await withWikiGraphCLIRuntimeContext(
+    {
+      argv: [],
+      cwd: process.cwd(),
+      env: process.env,
+      envPolicy: "production",
+      exitCode: 0,
+      queueAutostart: true,
+      stderr: process.stderr,
+      stdin: process.stdin,
+      stdout: process.stdout,
+      ...overrides,
+    },
+    operation,
+  );
+}

--- a/packages/cli/src/runtime/internal-child.ts
+++ b/packages/cli/src/runtime/internal-child.ts
@@ -2,7 +2,12 @@ import { spawn } from "child_process";
 import { existsSync } from "fs";
 import { join, resolve } from "path";
 
-import { getCLICwd, getCLIEnv, getCLIEnvValue } from "./context.js";
+import {
+  getCLICwd,
+  getCLIDevProjectRoot,
+  getCLIEnv,
+  getCLIStateDir,
+} from "./context.js";
 
 export type InternalChildKind = "gc-worker" | "queue-worker";
 
@@ -10,8 +15,6 @@ export interface InternalChildSpawnOptions {
   readonly args?: readonly string[];
   readonly detached?: boolean;
 }
-
-const INTERNAL_CHILD_ENV_KEY = "WIKIGRAPH_INTERNAL_CHILD";
 
 declare global {
   var __WIKIGRAPH_CLI_DIST_DIR__: string | undefined;
@@ -26,10 +29,7 @@ export function spawnInternalChild(
   return spawn(command.command, command.args, {
     cwd: getCLICwd(),
     detached: options.detached === true,
-    env: {
-      ...getCLIEnv(),
-      [INTERNAL_CHILD_ENV_KEY]: kind,
-    },
+    env: getCLIEnv(),
     stdio: options.detached === true ? "ignore" : ["ignore", "pipe", "pipe"],
   });
 }
@@ -80,22 +80,18 @@ function createInternalChildCommand(
   kind: InternalChildKind,
   args: readonly string[],
 ): { readonly args: readonly string[]; readonly command: string } {
-  const devStateDirPath = getCLIEnvValue("WIKIGRAPH_DEV");
+  const devProjectRoot = getCLIDevProjectRoot();
+  const stateDir = getCLIStateDir();
 
-  if (devStateDirPath !== undefined) {
-    const projectRoot = resolveDevProjectRoot(devStateDirPath);
-
+  if (devProjectRoot !== undefined && stateDir !== undefined) {
     return {
       args: [
-        join(projectRoot, "node_modules", "tsx", "dist", "cli.mjs"),
-        join(
-          projectRoot,
-          "packages",
-          "cli",
-          "src",
-          "bin",
-          createDevEntryName(kind),
-        ),
+        join(devProjectRoot, "node_modules", "tsx", "dist", "cli.mjs"),
+        join(devProjectRoot, "packages", "cli", "src", "bin", `${kind}.ts`),
+        "--wikigraph-internal-child",
+        kind,
+        "--wikigraph-state-dir",
+        stateDir,
         ...args,
       ],
       command: process.execPath,
@@ -103,26 +99,15 @@ function createInternalChildCommand(
   }
 
   return {
-    args: [resolveProductionEntryPath(kind), ...args],
+    args: [
+      resolveProductionEntryPath(kind),
+      "--wikigraph-internal-child",
+      kind,
+      ...(stateDir === undefined ? [] : ["--wikigraph-state-dir", stateDir]),
+      ...args,
+    ],
     command: process.execPath,
   };
-}
-
-function createDevEntryName(kind: InternalChildKind): string {
-  switch (kind) {
-    case "gc-worker":
-      return "dev-gc-worker.ts";
-    case "queue-worker":
-      return "dev-queue-worker.ts";
-  }
-}
-
-function resolveDevProjectRoot(devStateDirPath: string | undefined): string {
-  if (devStateDirPath === undefined || devStateDirPath.trim() === "") {
-    throw new Error("WIKIGRAPH_DEV must contain the development state path.");
-  }
-
-  return resolve(devStateDirPath, "..", "..");
 }
 
 function resolveProductionEntryPath(kind: InternalChildKind): string {

--- a/packages/cli/src/runtime/worker-entry.test.ts
+++ b/packages/cli/src/runtime/worker-entry.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { withWorkerEntryRuntime } from "./worker-entry.js";
+
+describe("runtime/worker-entry", () => {
+  it("rejects direct worker entry execution without the internal flag", async () => {
+    await withProcessArgv(["node", "queue-worker.js"], async () => {
+      await expect(
+        withWorkerEntryRuntime("queue-worker", () => undefined),
+      ).rejects.toThrow("This Wiki Graph worker entry is internal.");
+    });
+  });
+
+  it("strips internal worker arguments before running the worker", async () => {
+    await withProcessArgv(
+      [
+        "node",
+        "queue-worker.js",
+        "--wikigraph-internal-child",
+        "queue-worker",
+        "--wikigraph-state-dir",
+        "/tmp/wiki-graph-state",
+        "--flag",
+      ],
+      async () => {
+        await expect(
+          withWorkerEntryRuntime("queue-worker", (args) => {
+            expect(args.argv).toStrictEqual(["--flag"]);
+            expect(args.stateDir).toBe("/tmp/wiki-graph-state");
+          }),
+        ).resolves.toBeUndefined();
+      },
+    );
+  });
+});
+
+async function withProcessArgv(
+  argv: string[],
+  operation: () => Promise<void>,
+): Promise<void> {
+  const originalArgv = process.argv;
+
+  try {
+    process.argv = argv;
+    await operation();
+  } finally {
+    process.argv = originalArgv;
+  }
+}

--- a/packages/cli/src/runtime/worker-entry.ts
+++ b/packages/cli/src/runtime/worker-entry.ts
@@ -1,0 +1,74 @@
+import { withWikiGraphRuntimeStateDirectoryPath } from "wiki-graph-core";
+
+import { createEntryRuntimeContext } from "./entry-context.js";
+
+export interface WorkerEntryArguments {
+  readonly argv: readonly string[];
+  readonly internalChild: string;
+  readonly stateDir?: string | undefined;
+}
+
+const INTERNAL_CHILD_FLAG = "--wikigraph-internal-child";
+const STATE_DIR_FLAG = "--wikigraph-state-dir";
+
+export async function withWorkerEntryRuntime<T>(
+  expectedInternalChild: string,
+  operation: (args: WorkerEntryArguments) => Promise<T> | T,
+): Promise<T> {
+  const args = parseWorkerEntryArguments(process.argv.slice(2));
+
+  if (args.internalChild !== expectedInternalChild) {
+    throw new Error("This Wiki Graph worker entry is internal.");
+  }
+
+  const entryContext = createEntryRuntimeContext({
+    argv: args.argv,
+    envPolicy: "production",
+    stateDir: args.stateDir,
+  });
+
+  return await withWikiGraphRuntimeStateDirectoryPath(
+    entryContext.stateDir,
+    () => operation(args),
+  );
+}
+
+function parseWorkerEntryArguments(
+  argv: readonly string[],
+): WorkerEntryArguments {
+  const stripped: string[] = [];
+  let internalChild: string | undefined;
+  let stateDir: string | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]!;
+
+    if (arg === INTERNAL_CHILD_FLAG) {
+      if (index + 1 >= argv.length) {
+        throw new Error(`${INTERNAL_CHILD_FLAG} requires a value.`);
+      }
+
+      internalChild = argv[index + 1]!;
+      index += 1;
+      continue;
+    }
+
+    if (arg !== STATE_DIR_FLAG) {
+      stripped.push(arg);
+      continue;
+    }
+
+    if (index + 1 >= argv.length) {
+      throw new Error(`${STATE_DIR_FLAG} requires a value.`);
+    }
+
+    stateDir = argv[index + 1]!;
+    index += 1;
+  }
+
+  return {
+    argv: stripped,
+    internalChild: internalChild ?? "",
+    stateDir,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -96,6 +96,7 @@ export {
   resolveWikiGraphCoreDatabasePath,
   resolveWikiGraphHomeDirectoryPath,
   withWikiGraphRuntimeEnvironment,
+  withWikiGraphRuntimeStateDirectoryPath,
 } from "./runtime/common/wiki-graph/dir.js";
 export {
   createWikiGraphTempDirectory,

--- a/packages/core/src/runtime/common/wiki-graph/dir.ts
+++ b/packages/core/src/runtime/common/wiki-graph/dir.ts
@@ -5,7 +5,9 @@ import { join, resolve } from "path";
 const testingStateDirectoryPath = new AsyncLocalStorage<{
   readonly path: string | undefined;
 }>();
-const runtimeEnvironment = new AsyncLocalStorage<NodeJS.ProcessEnv>();
+const runtimeStateDirectoryPath = new AsyncLocalStorage<{
+  readonly path: string | undefined;
+}>();
 
 export function resolveWikiGraphHomeDirectoryPath(): string {
   const testingStateDirPath = testingStateDirectoryPath.getStore()?.path;
@@ -14,17 +16,10 @@ export function resolveWikiGraphHomeDirectoryPath(): string {
     return resolve(testingStateDirPath);
   }
 
-  const environment = runtimeEnvironment.getStore() ?? process.env;
-  const devStateDirPath = environment.WIKIGRAPH_DEV;
+  const runtimeStateDirPath = runtimeStateDirectoryPath.getStore()?.path;
 
-  if (devStateDirPath !== undefined && devStateDirPath.trim() !== "") {
-    return resolve(devStateDirPath);
-  }
-
-  const legacyStateDirPath = environment.WIKIGRAPH_STATE_DIR;
-
-  if (legacyStateDirPath !== undefined && legacyStateDirPath.trim() !== "") {
-    return resolve(legacyStateDirPath);
+  if (runtimeStateDirPath !== undefined && runtimeStateDirPath.trim() !== "") {
+    return resolve(runtimeStateDirPath);
   }
 
   return join(homedir(), ".wikigraph");
@@ -34,13 +29,6 @@ export function setWikiGraphStateDirectoryPathForTesting(
   path: string | undefined,
 ): void {
   testingStateDirectoryPath.enterWith({ path });
-
-  if (path === undefined) {
-    delete process.env.WIKIGRAPH_DEV;
-    return;
-  }
-
-  process.env.WIKIGRAPH_DEV = path;
 }
 
 export async function withWikiGraphStateDirectoryPathForTesting<T>(
@@ -50,15 +38,26 @@ export async function withWikiGraphStateDirectoryPathForTesting<T>(
   return await testingStateDirectoryPath.run({ path }, operation);
 }
 
-export async function withWikiGraphRuntimeEnvironment<T>(
-  environment: NodeJS.ProcessEnv,
+export async function withWikiGraphRuntimeStateDirectoryPath<T>(
+  path: string | undefined,
   operation: () => Promise<T> | T,
 ): Promise<T> {
-  return await runtimeEnvironment.run(environment, operation);
+  return await runtimeStateDirectoryPath.run({ path }, operation);
+}
+
+/**
+ * @deprecated Runtime state overrides are no longer read from process-style
+ * environment objects. Use `withWikiGraphRuntimeStateDirectoryPath` instead.
+ */
+export async function withWikiGraphRuntimeEnvironment<T>(
+  _environment: NodeJS.ProcessEnv,
+  operation: () => Promise<T> | T,
+): Promise<T> {
+  return await operation();
 }
 
 export function getWikiGraphStateDirectoryPathForTesting(): string | undefined {
-  return process.env.WIKIGRAPH_DEV;
+  return testingStateDirectoryPath.getStore()?.path;
 }
 
 export function resolveWikiGraphCoreDatabasePath(): string {

--- a/test/cli/queue.test.ts
+++ b/test/cli/queue.test.ts
@@ -325,11 +325,9 @@ import {
   runQueueCommand,
   runQueueWorker,
 } from "../../packages/cli/src/commands/index.js";
+import { setCLIQueueAutostartForTesting } from "../../packages/cli/src/runtime/context.js";
 
 describe("cli/queue", () => {
-  const originalDisableAutostart =
-    process.env.WIKIGRAPH_QUEUE_DISABLE_AUTOSTART;
-
   beforeEach(() => {
     queueMockState.activeError = undefined;
     queueMockState.activeJobChecks.length = 0;
@@ -384,16 +382,11 @@ describe("cli/queue", () => {
         words: 800,
       },
     ];
-    process.env.WIKIGRAPH_QUEUE_DISABLE_AUTOSTART = "1";
+    setCLIQueueAutostartForTesting(false);
   });
 
   afterEach(() => {
-    if (originalDisableAutostart === undefined) {
-      delete process.env.WIKIGRAPH_QUEUE_DISABLE_AUTOSTART;
-      return;
-    }
-
-    process.env.WIKIGRAPH_QUEUE_DISABLE_AUTOSTART = originalDisableAutostart;
+    setCLIQueueAutostartForTesting(undefined);
   });
 
   it("checks archive source before the cost gate", async () => {

--- a/test/cli/sdk-runner.test.ts
+++ b/test/cli/sdk-runner.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../../packages/cli/src/index.js";
 import {
   resolveWikiGraphHomeDirectoryPath,
-  withWikiGraphRuntimeEnvironment,
+  withWikiGraphRuntimeStateDirectoryPath,
 } from "wiki-graph-core";
 
 describe("cli/sdk-runner", () => {
@@ -69,6 +69,23 @@ describe("cli/sdk-runner", () => {
     ).rejects.toThrow(reason);
   });
 
+  it("rejects dangerous runtime env overrides in production policy", async () => {
+    const result = await runWikiGraphCLICaptured({
+      argv: ["--version"],
+      env: {
+        WIKIGRAPH_DEV: "/tmp/dev-state",
+        WIKIGRAPH_ENV_POLICY: "development",
+        WIKIGRAPH_QUEUE_DISABLE_AUTOSTART: "1",
+        WIKIGRAPH_STATE_DIR: "/tmp/state",
+      },
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("production entries do not support");
+    expect(result.stderr).toContain("WIKIGRAPH_ENV_POLICY");
+  });
+
   it("uses runner cwd, env, stdio, TTY flags, and exit code without changing process globals", async () => {
     const originalCwd = process.cwd();
     const outerCwd = await mkdtemp(join(tmpdir(), "wikigraph-runner-outer-"));
@@ -79,9 +96,7 @@ describe("cli/sdk-runner", () => {
       const result = await runWikiGraphCLICaptured({
         argv: ["--version"],
         cwd: originalCwd,
-        env: {
-          WIKIGRAPH_STATE_DIR: stateDir,
-        },
+        stateDir,
         stdin: "ignored",
         stdinIsTTY: false,
         stdoutIsTTY: true,
@@ -92,7 +107,6 @@ describe("cli/sdk-runner", () => {
       expect(result.stdout).toMatch(/^\d+\.\d+\.\d+\n$/u);
       expect(result.stderr).toBe("");
       expect(await realpath(process.cwd())).toBe(await realpath(outerCwd));
-      expect(process.env.WIKIGRAPH_STATE_DIR).not.toBe(stateDir);
     } finally {
       process.chdir(originalCwd);
       await rm(outerCwd, { force: true, recursive: true });
@@ -104,18 +118,13 @@ describe("cli/sdk-runner", () => {
     const stateDir = await mkdtemp(join(tmpdir(), "wikigraph-shared-state-"));
 
     try {
-      const coreStateDir = await withWikiGraphRuntimeEnvironment(
-        {
-          ...process.env,
-          WIKIGRAPH_STATE_DIR: stateDir,
-        },
+      const coreStateDir = await withWikiGraphRuntimeStateDirectoryPath(
+        stateDir,
         () => resolveWikiGraphHomeDirectoryPath(),
       );
       const result = await runWikiGraphCLICaptured({
         argv: ["wikg://local/config/concurrent", "put", "job", "4"],
-        env: {
-          WIKIGRAPH_STATE_DIR: stateDir,
-        },
+        stateDir,
       });
 
       expect(coreStateDir).toBe(stateDir);
@@ -137,15 +146,11 @@ describe("cli/sdk-runner", () => {
       const [left, right] = await Promise.all([
         runWikiGraphCLICaptured({
           argv: ["wikg://local/config/concurrent", "put", "job", "2"],
-          env: {
-            WIKIGRAPH_STATE_DIR: leftStateDir,
-          },
+          stateDir: leftStateDir,
         }),
         runWikiGraphCLICaptured({
           argv: ["wikg://local/config/concurrent", "put", "request", "3"],
-          env: {
-            WIKIGRAPH_STATE_DIR: rightStateDir,
-          },
+          stateDir: rightStateDir,
         }),
       ]);
 

--- a/test/core/storage/schema-upgrade/index.test.ts
+++ b/test/core/storage/schema-upgrade/index.test.ts
@@ -39,6 +39,7 @@ import { withStateDatabase } from "../../../../packages/core/src/storage/wikg/wi
 import {
   resolveWikiGraphHomeDirectoryPath,
   setWikiGraphStateDirectoryPathForTesting,
+  withWikiGraphRuntimeStateDirectoryPath,
 } from "../../../../packages/core/src/runtime/common/wiki-graph/dir.js";
 import { withTempDir } from "../../../helpers/temp.js";
 
@@ -49,7 +50,6 @@ describe("schema-upgrade", () => {
 
   afterEach(() => {
     setWikiGraphStateDirectoryPathForTesting(undefined);
-    delete process.env.WIKIGRAPH_STATE_DIR;
   });
 
   it("upgrades a legacy archive in place", async () => {
@@ -529,12 +529,13 @@ describe("schema-upgrade", () => {
     });
   });
 
-  it("resolves the legacy home env fallback", async () => {
+  it("resolves an explicit runtime home override", async () => {
     await withTempDir("wikigraph-schema-home-env-", async (home) => {
-      process.env.WIKIGRAPH_STATE_DIR = home;
-      setWikiGraphStateDirectoryPathForTesting(undefined);
-      expect(resolveWikiGraphHomeDirectoryPath()).toBe(home);
-      await Promise.resolve();
+      await withWikiGraphRuntimeStateDirectoryPath(home, async () => {
+        setWikiGraphStateDirectoryPathForTesting(undefined);
+        expect(resolveWikiGraphHomeDirectoryPath()).toBe(home);
+        await Promise.resolve();
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes https://github.com/oomol-lab/wiki-graph/issues/205.

- Add a fixed entry runtime policy layer for CLI/worker entries: production rejects dangerous `WIKIGRAPH_*` env overrides, while development passes an explicit checkout-local state dir.
- Move runtime state overrides to explicit context (`stateDir`, `withWikiGraphRuntimeStateDirectoryPath`) and remove scattered `process.env.WIKIGRAPH_*` reads from command/core/worker logic.
- Replace `WIKIGRAPH_INTERNAL_CHILD` with a non-env internal worker argv gate and explicit worker state-dir propagation.
- Update tests to use explicit helpers/context for state-dir and queue-autostart isolation.
- Update SDK docs so LLM examples no longer use `process.env.OPENAI_API_KEY`, and explicitly state the SDK does not auto-read CLI config/env credentials.

## Acceptance matrix

| Scenario | Command / test | Result |
| --- | --- | --- |
| Production `wg` + dangerous env | `WIKIGRAPH_STATE_DIR=/tmp/wg-state node packages/cli/dist/cli.js --version`; repeated for `WIKIGRAPH_DEV`, `WIKIGRAPH_QUEUE_DISABLE_AUTOSTART`, `WIKIGRAPH_ENV_POLICY=development` | Each exited 1 with `Wiki Graph production entries do not support runtime env overrides: ...`; env policy could not be overridden from shell. |
| Source dev CLI | `pnpm --filter wiki-graph dev --version`; `pnpm --filter wiki-graph dev wikg://local/config/concurrent put job 2 --json` | Dev entry exited 0, output `0.4.0`, and used checkout-local `.wikigraph/state` for config writes. Temporary `.wikigraph` was cleaned after validation. |
| Source dev worker | `packages/cli/src/runtime/internal-child.test.ts` | Source worker resolver uses parent CLI runtime context `devProjectRoot/stateDir` and passes explicit hidden args to worker entries. |
| CLI runner production policy | `test/cli/sdk-runner.test.ts` | Runner `env` input with dangerous `WIKIGRAPH_*` is rejected; state-dir tests use explicit `stateDir`. |
| Test state-dir isolation | `packages/core/src/runtime/common/wiki-graph/dir.test.ts`; `test/core/storage/schema-upgrade/index.test.ts`; `test/cli/sdk-runner.test.ts` | Tests use AsyncLocal/runtime helpers or explicit runner `stateDir`, not global env mutation. |
| Queue autostart isolation | `test/cli/queue.test.ts`; `packages/cli/src/commands/queue/add.ts` | Tests use `setCLIQueueAutostartForTesting(false)`; production context defaults to autostart enabled. |
| Worker internal marker | Direct: `node packages/cli/dist/queue-worker.js`; env+internal: `WIKIGRAPH_STATE_DIR=/tmp/wg-state node packages/cli/dist/queue-worker.js --wikigraph-internal-child queue-worker`; tests: `packages/cli/src/runtime/worker-entry.test.ts` | Direct worker entry exits 1 with `This Wiki Graph worker entry is internal.`; internal+dangerous env exits 1 with production policy env error; no `WIKIGRAPH_INTERNAL_CHILD` env injection/check remains. |
| Code surface area | `rg 'process\.env\.WIKIGRAPH_|WIKIGRAPH_INTERNAL_CHILD|WIKIGRAPH_QUEUE_DISABLE_AUTOSTART|WIKIGRAPH_STATE_DIR|WIKIGRAPH_DEV|WIKIGRAPH_ENV_POLICY' packages test docs` | `packages` hits are limited to entry context; `test` hits are limited to production-policy env rejection test; docs no longer demonstrate env credentials. |
| SDK docs | `docs/en/sdk.md`, `docs/zh-CN/sdk.md` | No `process.env.OPENAI_API_KEY` sample remains; docs state apps must pass their own configured `LanguageModel`. |

## Verification

- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- `pnpm run format:check` ✅
- `pnpm run build` ✅
- `pnpm run test:run` ✅ — 131 files / 862 tests passed
- `pnpm run smoke:pack-install` ✅
- Production CLI env matrix ✅
- Production worker direct/internal env matrix ✅
- Source dev CLI state-dir smoke ✅

## Review

Blind review attempt through Hermes delegation failed due provider HTTP 503/all suppliers unavailable. I then ran an independent Codex CLI read-only review against the final uncommitted diff and issue acceptance matrix; the first Codex review found a worker direct-entry gate regression, which was fixed by adding the non-env `--wikigraph-internal-child` gate and tests. The second Codex review returned `verdict: pass` with no blocking risks.

Non-blocking note from review: `withWikiGraphRuntimeEnvironment()` is kept as a deprecated compatibility export but no longer applies process-style env overrides. Callers that need explicit SDK state isolation should migrate to `withWikiGraphRuntimeStateDirectoryPath()` or CLI runner `stateDir`.
