### PR TITLE
fix: split CLI SDK core packaging

### DIFF
--- a/docs/en/sdk.md
+++ b/docs/en/sdk.md
@@ -22,7 +22,11 @@ $ npm install -g wiki-graph
 $ pnpm add --global wiki-graph
 ```
 
-The CLI package depends on `wiki-graph-core`. Application code should depend on `wiki-graph-core` directly.
+The installed CLI command is self-contained for normal `wg` usage. Application
+code should depend on `wiki-graph-core` directly when it needs the core SDK. If
+an application uses the `wiki-graph` package's programmatic CLI runner entry, it
+should install both `wiki-graph` and `wiki-graph-core` so the runner can share
+the same core package as the application.
 
 ## Main SDK
 

--- a/docs/local-cli-development.md
+++ b/docs/local-cli-development.md
@@ -21,15 +21,22 @@ release:
 pnpm cli:install-local
 ```
 
-The script builds and packs the workspace, then installs the generated
-`wiki-graph` package through pnpm as a global package. After it finishes, `wg`
-and `wikigraph` resolve through the machine-level pnpm installation.
+The script builds the workspace, packs the `packages/cli` package, then installs
+the generated `wiki-graph` tarball through `npm install --global --force`. After
+it finishes, `wg` and `wikigraph` resolve through the machine-level global
+installation.
 
 This workflow is useful for:
 
 - previewing an unreleased version outside the repository;
 - checking package contents, `dist` output, shebangs, and `bin` entries;
 - testing how a normal user will experience the CLI after installation.
+
+This workflow previews the CLI package only. It does not create or install a
+`wiki-graph-core` tarball, and it is not the SDK integration workflow. The
+packaged `wg` command is self-contained for normal CLI use, but the
+`wiki-graph` package's programmatic runner entry still expects applications that
+use it as an SDK surface to install `wiki-graph-core` as well.
 
 It is not the default regression workflow for agents or parallel worktrees. A
 global install is shared by all shells and worktrees on the same machine, so one
@@ -130,6 +137,23 @@ text, archive operations, state handling, or bug fixes in the current checkout.
 Use the install workflow only when the question is about the packaged command
 itself: global `wg` resolution, package layout, `dist` artifacts, executable
 metadata, or previewing an unreleased branch outside this repository.
+
+When validating package installation boundaries, use the pack smoke workflow:
+
+```bash
+pnpm smoke:pack-install
+```
+
+That workflow separately packs and installs `wiki-graph-core` and `wiki-graph`
+in temporary projects so it can validate CLI-only, core-only, and combined SDK
+installation scenarios. For manual tarball inspection, build first and pack the
+two packages explicitly:
+
+```bash
+pnpm build
+pnpm --filter wiki-graph-core pack --pack-destination /tmp/wiki-graph-packs
+pnpm --filter wiki-graph pack --pack-destination /tmp/wiki-graph-packs
+```
 
 ## Related Maintainer Docs
 

--- a/docs/zh-CN/sdk.md
+++ b/docs/zh-CN/sdk.md
@@ -22,7 +22,10 @@ $ npm install -g wiki-graph
 $ pnpm add --global wiki-graph
 ```
 
-CLI 包依赖 `wiki-graph-core`。应用代码应直接依赖 `wiki-graph-core`。
+正常使用 `wg` 时，安装后的 CLI 命令是自包含的。应用代码需要 core SDK 时，应直接依赖
+`wiki-graph-core`。如果应用使用 `wiki-graph` 包提供的 programmatic CLI runner
+入口，应同时安装 `wiki-graph` 和 `wiki-graph-core`，让 runner 与应用共享同一份
+core 包。
 
 ## Main SDK
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -67,5 +67,16 @@
     "yauzl": "^3.3.0",
     "yazl": "^3.3.1",
     "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "wiki-graph-core": "workspace:*"
+  },
+  "peerDependencies": {
+    "wiki-graph-core": "^0.4.0"
+  },
+  "peerDependenciesMeta": {
+    "wiki-graph-core": {
+      "optional": true
+    }
   }
 }

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -14,7 +14,6 @@ const ESM_DATA_DIR_BANNER = [
   'globalThis.__WIKIGRAPH_DATA_DIR__ ??= __WIKIGRAPH_RESOLVE__(__WIKIGRAPH_FILE_URL_TO_PATH__(new URL("./data", import.meta.url)));',
 ].join("\n");
 const SHARED_OPTIONS = {
-  bundle: true,
   clean: false,
   outDir: "dist",
   platform: "node",
@@ -23,6 +22,28 @@ const SHARED_OPTIONS = {
   splitting: false,
   target: "node22",
 } as const;
+const INDEX_EXTERNAL = [
+  "wiki-graph-core",
+  "wiki-graph-core/gc",
+  "wiki-graph-core/worker",
+];
+const WIKI_GRAPH_CORE_EXTERNAL_PLUGIN = {
+  name: "wiki-graph-core-external",
+  setup(build: {
+    onResolve(
+      options: { readonly filter: RegExp },
+      callback: (args: { readonly path: string }) => {
+        readonly external: boolean;
+        readonly path: string;
+      },
+    ): void;
+  }) {
+    build.onResolve({ filter: /^wiki-graph-core(?:\/.*)?$/ }, (args) => ({
+      external: true,
+      path: args.path,
+    }));
+  },
+};
 
 export default defineConfig([
   {
@@ -30,11 +51,14 @@ export default defineConfig([
     banner: {
       js: CJS_DATA_DIR_BANNER,
     },
+    bundle: true,
     clean: true,
     dts: true,
     entry: {
       index: "src/index.ts",
     },
+    esbuildPlugins: [WIKI_GRAPH_CORE_EXTERNAL_PLUGIN],
+    external: INDEX_EXTERNAL,
     format: ["cjs"],
     outExtension() {
       return {
@@ -47,13 +71,28 @@ export default defineConfig([
     banner: {
       js: ESM_DATA_DIR_BANNER,
     },
+    bundle: true,
     dts: true,
     entry: {
       cli: "src/bin/cli.ts",
       "gc-worker": "src/bin/gc-worker.ts",
-      index: "src/index.ts",
       "queue-worker": "src/bin/queue-worker.ts",
     },
+    format: ["esm"],
+    minify: true,
+  },
+  {
+    ...SHARED_OPTIONS,
+    banner: {
+      js: ESM_DATA_DIR_BANNER,
+    },
+    bundle: true,
+    dts: true,
+    entry: {
+      index: "src/index.ts",
+    },
+    esbuildPlugins: [WIKI_GRAPH_CORE_EXTERNAL_PLUGIN],
+    external: INDEX_EXTERNAL,
     format: ["esm"],
   },
 ]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,10 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+    devDependencies:
+      wiki-graph-core:
+        specifier: workspace:*
+        version: link:../core
 
   packages/core:
     dependencies:

--- a/scripts/smoke-pack-install.mjs
+++ b/scripts/smoke-pack-install.mjs
@@ -9,6 +9,7 @@ const cliRoot = join(packageRoot, "packages", "cli");
 const tempRoot = mkdtempSync(join(tmpdir(), "wiki-graph-pack-"));
 const cliInstallRoot = join(tempRoot, "cli-install");
 const coreInstallRoot = join(tempRoot, "core-install");
+const sdkInstallRoot = join(tempRoot, "sdk-install");
 const packedTarballs = [];
 
 function readTarballName(packOutput) {
@@ -131,8 +132,6 @@ try {
   installTarballs(cliInstallRoot, [cliTarballPath]);
 
   assertModuleMissing(cliInstallRoot, "wiki-graph-core");
-  assertCommonJsExport(cliInstallRoot, "wiki-graph", "Language");
-  assertEsmExport(cliInstallRoot, "wiki-graph", "Language");
 
   for (const command of ["wg", "wikigraph"]) {
     execFileSync(
@@ -174,6 +173,14 @@ try {
     "wiki-graph-core/worker",
     "runBuildJobWorker",
   );
+
+  writeInstallPackageJson(sdkInstallRoot, "wiki-graph-sdk-pack-smoke");
+  installTarballs(sdkInstallRoot, [coreTarballPath, cliTarballPath]);
+
+  assertCommonJsExport(sdkInstallRoot, "wiki-graph", "runWikiGraphCLICaptured");
+  assertEsmExport(sdkInstallRoot, "wiki-graph", "runWikiGraphCLICaptured");
+  assertCommonJsExport(sdkInstallRoot, "wiki-graph", "Language");
+  assertEsmExport(sdkInstallRoot, "wiki-graph", "Language");
 } finally {
   for (const tarballPath of packedTarballs) {
     rmSync(tarballPath, { force: true });


### PR DESCRIPTION
## Summary
- externalize wiki-graph-core from the wiki-graph SDK runner entry while keeping the wg bin and worker entries bundled
- keep wiki-graph-core as an optional peer plus workspace dev dependency for package development
- update pack smoke coverage for CLI-only, core-only, and combined SDK installs
- clarify local CLI packaging and SDK package boundaries in docs

## Verification
- pnpm --filter wiki-graph build
- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm smoke:pack-install
- CI=true pnpm install --frozen-lockfile
- git diff --check