### PR TITLE
fix: centralize Wiki Graph URI syntax parsing

### DIFF
--- a/packages/cli/src/args/helper/uri.ts
+++ b/packages/cli/src/args/helper/uri.ts
@@ -5,7 +5,7 @@ import {
 } from "../../runtime/local-config.js";
 import {
   parseLocatedWikiGraphUri,
-  WIKI_GRAPH_JOB_URI_PREFIX,
+  parseWikiGraphUriSyntax,
   WIKI_GRAPH_URI_PREFIX,
 } from "wiki-graph-core";
 import type { CLIArchiveAction } from "../types.js";
@@ -276,22 +276,18 @@ export function isWikiGraphJobUri(value: string | undefined): boolean {
 }
 
 export function isWikiGraphLocalConfigUri(value: string | undefined): boolean {
-  return (
-    value === `${WIKI_GRAPH_URI_PREFIX}local/config` ||
-    value?.startsWith(`${WIKI_GRAPH_URI_PREFIX}local/config/`) === true
-  );
+  const path = parseWikiGraphPath(value);
+  return path?.[0] === "local" && path[1] === "config" && path.length >= 2;
 }
 
 export function parseLocalConfigUriSection(
   uri: string,
 ): LocalConfigSection | undefined {
-  const prefix = `${WIKI_GRAPH_URI_PREFIX}local/config/`;
-
-  if (!uri.startsWith(prefix)) {
+  const path = parseWikiGraphPath(uri);
+  if (path?.[0] !== "local" || path[1] !== "config") {
     return undefined;
   }
-
-  const [section] = uri.slice(prefix.length).split("/");
+  const section = path[2];
 
   return parseLocalConfigSection(section);
 }
@@ -353,25 +349,38 @@ export function getWikiGraphUriPrefix(uri: string): string | undefined {
 }
 
 export function isWikiGraphLocalJobUri(value: string | undefined): boolean {
-  return (
-    value === WIKI_GRAPH_JOB_URI_PREFIX ||
-    value?.startsWith(`${WIKI_GRAPH_JOB_URI_PREFIX}/`) === true
-  );
+  const path = parseWikiGraphPath(value);
+  return path?.[0] === "local" && path[1] === "job";
 }
 
 export function parseWikiGraphJobUriBody(uri: string): string | undefined {
-  if (uri === WIKI_GRAPH_JOB_URI_PREFIX) {
+  const path = parseWikiGraphPath(uri);
+  if (path?.[0] !== "local" || path[1] !== "job") {
+    return undefined;
+  }
+  if (path.length === 2) {
     return "";
   }
-  if (uri.startsWith(`${WIKI_GRAPH_JOB_URI_PREFIX}/`)) {
-    return uri.slice(WIKI_GRAPH_JOB_URI_PREFIX.length);
-  }
 
-  return undefined;
+  return `/${path.slice(2).join("/")}`;
 }
 
 export function stripLeadingSlash(value: string): string {
   return value.replace(/^\/+/u, "");
+}
+
+function parseWikiGraphPath(
+  value: string | undefined,
+): readonly string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  try {
+    const parsed = parseWikiGraphUriSyntax(value);
+    return parsed.protocol === "wikg" ? parsed.path : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 export function requireArchiveUriPath(uri: string, helpRoute: string): string {

--- a/packages/cli/src/args/root/local-config.ts
+++ b/packages/cli/src/args/root/local-config.ts
@@ -48,7 +48,7 @@ export function parseLocalConfigUriFirstArguments(
     if (
       values.help === true &&
       explicitAction === undefined &&
-      uri === "wikg://local/config"
+      parseLocalConfigUriSection(uri) === undefined
     ) {
       return {
         help: true,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -202,6 +202,7 @@ export {
   formatWikiGraphCommandUri,
   formatLocatedWikiGraphUri,
   parseLocatedWikiGraphUri,
+  parseWikiGraphUriSyntax,
   requireArchiveUri,
   requireLocatedObjectOrArchiveUri,
   requireLocatedObjectUri,
@@ -210,7 +211,10 @@ export {
   WIKI_GRAPH_URI_PREFIX,
   writeWikgArchive,
 } from "./storage/wikg/index.js";
-export type { LocatedWikiGraphUri } from "./storage/wikg/index.js";
+export type {
+  LocatedWikiGraphUri,
+  ParsedWikiGraphUri,
+} from "./storage/wikg/index.js";
 export {
   DirectoryDocument,
   openSharedStateDatabase,

--- a/packages/core/src/library/membership.test.ts
+++ b/packages/core/src/library/membership.test.ts
@@ -839,8 +839,11 @@ async function getDefaultMetadata(
 describe("library URI locators", () => {
   it("separates library archives from library scopes", () => {
     expect(isWikiGraphLibraryUri("wikg://lib")).toBe(true);
+    expect(isWikiGraphLibraryUri("wikg://lib/")).toBe(true);
     expect(isWikiGraphLibraryUri("wikg://lib/team")).toBe(true);
+    expect(isWikiGraphLibraryUri("wikg://lib/team/")).toBe(true);
     expect(isWikiGraphLibraryUri("wikg://lib/entity/Q23")).toBe(true);
+    expect(isWikiGraphLibraryUri("wikg://library")).toBe(false);
     expect(isWikiGraphLibraryUri("wikg://lib/arc/archive123/chapter")).toBe(
       false,
     );
@@ -858,6 +861,18 @@ describe("library URI locators", () => {
       isDefault: true,
       kind: "scope",
       objectUri: "wikg://entity/Q23",
+    });
+    expect(parseWikiGraphLibraryUri("wikg://lib/entity/Q23/")).toMatchObject({
+      isDefault: true,
+      kind: "scope",
+      objectUri: "wikg://entity/Q23",
+    });
+    expect(
+      parseWikiGraphLibraryUri("wikg://lib/chapter/part/source#1..5"),
+    ).toMatchObject({
+      isDefault: true,
+      kind: "scope",
+      objectUri: "wikg://chapter/part/source#1..5",
     });
     expect(parseWikiGraphLibraryUri("wikg://lib/index")).toMatchObject({
       isDefault: true,
@@ -878,6 +893,19 @@ describe("library URI locators", () => {
       objectUri: "wikg://entity",
       publicId: "team",
     });
+    expect(
+      parseWikiGraphLibraryUri(
+        "wikg://lib/team/arc/archive123/chapter/part/source#12",
+      ),
+    ).toMatchObject({
+      archivePublicId: "archive123",
+      kind: "archive",
+      objectUri: "wikg://chapter/part/source#12",
+      publicId: "team",
+    });
+    expect(() => parseWikiGraphLibraryUri("wikg://lib#1")).toThrow(
+      "does not support fragments",
+    );
   });
 
   it("resolves a library archive locator to the managed .wikg file", async () => {

--- a/packages/core/src/library/registry.ts
+++ b/packages/core/src/library/registry.ts
@@ -15,7 +15,10 @@ import {
   resolveWikiGraphHomeDirectoryPath,
   resolveWikiGraphStagingDirectoryPath,
 } from "../runtime/common/wiki-graph/dir.js";
-import { WIKI_GRAPH_ARCHIVE_EXTENSION } from "../runtime/common/wiki-graph/uri.js";
+import {
+  parseWikiGraphUriSyntax,
+  WIKI_GRAPH_ARCHIVE_EXTENSION,
+} from "../runtime/common/wiki-graph/uri.js";
 import { isNodeError } from "../utils/node-error.js";
 import { withWikiGraphLibraryLock } from "./lock.js";
 import { RESERVED_LIBRARY_URI_SEGMENTS } from "./segments.js";
@@ -96,13 +99,17 @@ export interface ParsedWikiGraphLibraryUri {
 }
 
 export function isWikiGraphLibraryUri(uri: string | undefined): uri is string {
-  if (uri?.startsWith("wikg://lib") !== true) {
+  if (uri === undefined) {
     return false;
   }
-  if (uri.split("/").some((segment) => segment.endsWith(".lib"))) {
-    return true;
-  }
   try {
+    const syntax = parseWikiGraphUriSyntax(uri);
+    if (syntax.protocol !== "wikg" || syntax.path[0] !== "lib") {
+      return false;
+    }
+    if (syntax.path.some((segment) => segment.endsWith(".lib"))) {
+      return true;
+    }
     const target = parseWikiGraphLibraryUri(uri);
     return (
       target !== undefined &&
@@ -116,25 +123,26 @@ export function isWikiGraphLibraryUri(uri: string | undefined): uri is string {
 export function parseWikiGraphLibraryUri(
   uri: string,
 ): ParsedWikiGraphLibraryUri | undefined {
-  if (uri === "wikg://lib") {
+  if (!uri.includes("://")) {
+    return undefined;
+  }
+  const parsed = parseWikiGraphUriSyntax(uri);
+  if (parsed.protocol !== "wikg" || parsed.path[0] !== "lib") {
+    return undefined;
+  }
+
+  const segments = parsed.path.slice(1);
+  const fragment = formatWikiGraphUriFragment(parsed.fragment);
+
+  if (segments.length === 0) {
+    rejectLibraryStructureFragment(uri, fragment);
     return { isDefault: true, kind: "scope" };
   }
-  if (!uri.startsWith("wikg://lib/")) {
+  if (segments.some((part) => part.endsWith(WIKI_GRAPH_ARCHIVE_EXTENSION))) {
     return undefined;
   }
 
-  const path = uri.slice("wikg://lib/".length).replace(/\/+$/u, "");
-  if (
-    path.split("/").some((part) => part.endsWith(WIKI_GRAPH_ARCHIVE_EXTENSION))
-  ) {
-    return undefined;
-  }
-
-  const segments = path.split("/");
-  if (
-    segments.includes("") ||
-    segments.some((segment) => segment.endsWith(".lib"))
-  ) {
+  if (segments.some((segment) => segment.endsWith(".lib"))) {
     throw new Error(
       `Invalid Wiki Graph library URI: ${uri}. Use wikg://lib/<lib-id> and wikg://lib/<lib-id>/arc/<arc-id>; .lib suffixes are no longer supported.`,
     );
@@ -142,31 +150,33 @@ export function parseWikiGraphLibraryUri(
 
   const [first, second, third, ...rest] = segments;
   if (first === "registry" && second === undefined) {
+    rejectLibraryStructureFragment(uri, fragment);
     return { isDefault: true, kind: "registry" };
   }
   if (first === "meta" && second === undefined) {
+    rejectLibraryStructureFragment(uri, fragment);
     return { isDefault: true, kind: "metadata" };
   }
   if (first === "path" && second === undefined) {
+    rejectLibraryStructureFragment(uri, fragment);
     return { isDefault: true, kind: "path" };
   }
 
   const defaultLibraryScopeMatch =
-    /^(index|chapter|chunk|entity|triple)(?:\/(.*))?$/u.exec(path);
+    /^(index|chapter|chunk|entity|triple)$/u.exec(first ?? "");
   if (defaultLibraryScopeMatch?.[1] !== undefined) {
     return {
       isDefault: true,
       kind: "scope",
       objectUri: formatWikiGraphLibraryObjectUri(
-        [defaultLibraryScopeMatch[1], defaultLibraryScopeMatch[2]]
-          .filter(Boolean)
-          .join("/"),
+        [first, second, third, ...rest].filter(Boolean).join("/"),
+        fragment,
       ),
     };
   }
 
   if (first === "arc") {
-    return parseLibraryArcUri(uri, undefined, segments.slice(1));
+    return parseLibraryArcUri(uri, undefined, segments.slice(1), fragment);
   }
 
   if (first === undefined || RESERVED_LIBRARY_URI_SEGMENTS.has(first)) {
@@ -175,12 +185,15 @@ export function parseWikiGraphLibraryUri(
     );
   }
   if (second === undefined) {
+    rejectLibraryStructureFragment(uri, fragment);
     return { isDefault: false, kind: "scope", publicId: first };
   }
   if (second === "meta" && third === undefined) {
+    rejectLibraryStructureFragment(uri, fragment);
     return { isDefault: false, kind: "metadata", publicId: first };
   }
   if (second === "path" && third === undefined) {
+    rejectLibraryStructureFragment(uri, fragment);
     return { isDefault: false, kind: "path", publicId: first };
   }
   if (/^(index|chapter|chunk|entity|triple)$/u.test(second)) {
@@ -189,12 +202,13 @@ export function parseWikiGraphLibraryUri(
       kind: "scope",
       objectUri: formatWikiGraphLibraryObjectUri(
         [second, third, ...rest].filter(Boolean).join("/"),
+        fragment,
       ),
       publicId: first,
     };
   }
   if (second === "arc") {
-    return parseLibraryArcUri(uri, first, segments.slice(2));
+    return parseLibraryArcUri(uri, first, segments.slice(2), fragment);
   }
 
   throw new Error(
@@ -206,11 +220,13 @@ function parseLibraryArcUri(
   uri: string,
   publicId: string | undefined,
   segments: readonly string[],
+  fragment: string | undefined,
 ): ParsedWikiGraphLibraryUri {
   const isDefault = publicId === undefined;
   const [first, second, ...rest] = segments;
   const base = { isDefault, ...(publicId === undefined ? {} : { publicId }) };
   if (first === undefined) {
+    rejectLibraryStructureFragment(uri, fragment);
     return { ...base, kind: "archive-collection" };
   }
   if (/^(chapter|chunk|entity|triple)$/u.test(first)) {
@@ -219,10 +235,12 @@ function parseLibraryArcUri(
       kind: "scope",
       objectUri: formatWikiGraphLibraryObjectUri(
         [first, second, ...rest].filter(Boolean).join("/"),
+        fragment,
       ),
     };
   }
   if (first === "tree" && second === undefined) {
+    rejectLibraryStructureFragment(uri, fragment);
     return { ...base, kind: "archive-tree" };
   }
   if (RESERVED_LIBRARY_URI_SEGMENTS.has(first)) {
@@ -231,20 +249,58 @@ function parseLibraryArcUri(
     );
   }
   if (second === undefined) {
+    rejectLibraryStructureFragment(uri, fragment);
     return { ...base, archivePublicId: first, kind: "archive" };
   }
   if (second === "path" && rest.length === 0) {
+    rejectLibraryStructureFragment(uri, fragment);
     return { ...base, archivePublicId: first, kind: "archive-path" };
   }
   return {
     ...base,
     archivePublicId: first,
     kind: "archive",
-    objectUri: formatWikiGraphLibraryObjectUri([second, ...rest].join("/")),
+    objectUri: formatWikiGraphLibraryObjectUri(
+      [second, ...rest].join("/"),
+      fragment,
+    ),
   };
 }
-function formatWikiGraphLibraryObjectUri(path: string): string {
-  return `wikg://${path.replace(/^\/+|\/+$/gu, "")}`;
+
+function rejectLibraryStructureFragment(
+  uri: string,
+  fragment: string | undefined,
+): void {
+  if (fragment !== undefined) {
+    throw new Error(
+      `Invalid Wiki Graph library URI: ${uri}. This library URI target does not support fragments.`,
+    );
+  }
+}
+
+function formatWikiGraphLibraryObjectUri(
+  path: string,
+  fragment?: string,
+): string {
+  return `wikg://${path.replace(/^\/+|\/+$/gu, "")}${
+    fragment === undefined ? "" : `#${fragment}`
+  }`;
+}
+
+function formatWikiGraphUriFragment(
+  fragment:
+    | number
+    | { readonly begin: number; readonly end: number }
+    | undefined,
+): string | undefined {
+  if (fragment === undefined) {
+    return undefined;
+  }
+  if (typeof fragment === "number") {
+    return String(fragment);
+  }
+
+  return `${fragment.begin}..${fragment.end}`;
 }
 
 export function formatWikiGraphLibraryUri(publicId?: string): string {

--- a/packages/core/src/retrieval/query/archive-view/pages.ts
+++ b/packages/core/src/retrieval/query/archive-view/pages.ts
@@ -1,4 +1,5 @@
 import type { ReadonlyDocument } from "../../../document/index.js";
+import { parseWikiGraphUriSyntax } from "../../../runtime/common/wiki-graph/uri.js";
 import {
   getChapterTree,
   listChapters,
@@ -221,8 +222,10 @@ async function resolveChapterPathObjectUri(
   document: ReadonlyDocument,
   uri: string,
 ): Promise<string> {
-  const [base = "", hash] = uri.split("#", 2);
   const prefix = "wikg://chapter/";
+  const parsed = parseWikiGraphUriSyntax(uri);
+  const base = `wikg://${parsed.path.join("/")}`;
+  const hash = formatParsedUriFragment(parsed.fragment);
 
   if (!base.startsWith(prefix) || base === "wikg://chapter/tree") {
     return uri;
@@ -241,6 +244,22 @@ async function resolveChapterPathObjectUri(
   const suffix = path.slice(chapter.path.length);
   const resolved = `${prefix}${chapter.chapterId}${suffix}`;
   return hash === undefined ? resolved : `${resolved}#${hash}`;
+}
+
+function formatParsedUriFragment(
+  fragment:
+    | number
+    | { readonly begin: number; readonly end: number }
+    | undefined,
+): string | undefined {
+  if (fragment === undefined) {
+    return undefined;
+  }
+  if (typeof fragment === "number") {
+    return String(fragment);
+  }
+
+  return `${fragment.begin}..${fragment.end}`;
 }
 
 async function readWikiGraphPage(

--- a/packages/core/src/retrieval/query/archive-view/references.ts
+++ b/packages/core/src/retrieval/query/archive-view/references.ts
@@ -1,5 +1,9 @@
 import type { ReadingEdgeRecord } from "../../../document/index.js";
-import { WIKI_GRAPH_URI_PREFIX } from "../../../runtime/common/wiki-graph/uri.js";
+import {
+  parseWikiGraphUriSyntax,
+  WIKI_GRAPH_URI_PREFIX,
+  type ParsedWikiGraphUri,
+} from "../../../runtime/common/wiki-graph/uri.js";
 
 import {
   isWikiGraphObjectUri,
@@ -127,10 +131,12 @@ export function parseWikiGraphReference(uri: string): WikiGraphReference {
     return { type: "meta" };
   }
 
-  const [rawPath = "", hash = ""] = uri
-    .slice(WIKI_GRAPH_URI_PREFIX.length)
-    .split("#", 2);
-  const pathParts = rawPath.split("/").filter((part) => part !== "");
+  const parsedUri = parseWikiGraphUriSyntax(uri);
+  if (parsedUri.protocol !== "wikg") {
+    throw new Error(`Invalid Wiki Graph URI: ${uri}`);
+  }
+  const pathParts = parsedUri.path;
+  const hash = formatParsedFragment(parsedUri.fragment);
 
   if (pathParts.length === 0) {
     return { type: "meta" };
@@ -317,6 +323,19 @@ function parseSentenceRange(hash: string): readonly [number, number] {
   }
 
   throw new Error(`Invalid source sentence range: ${hash}`);
+}
+
+function formatParsedFragment(
+  fragment: ParsedWikiGraphUri["fragment"],
+): string {
+  if (fragment === undefined) {
+    return "";
+  }
+  if (typeof fragment === "number") {
+    return String(fragment);
+  }
+
+  return `${fragment.begin}..${fragment.end}`;
 }
 
 export function parseArchiveReference(id: string):

--- a/packages/core/src/runtime/common/wiki-graph/uri.ts
+++ b/packages/core/src/runtime/common/wiki-graph/uri.ts
@@ -7,6 +7,12 @@ export const WIKI_GRAPH_URI_PREFIX = "wikg://";
 export const WIKI_GRAPH_JOB_URI_PREFIX = "wikg://local/job";
 export const WIKI_GRAPH_ARCHIVE_EXTENSION = ".wikg";
 
+export interface ParsedWikiGraphUri {
+  readonly protocol: string;
+  readonly path: readonly string[];
+  readonly fragment?: number | { readonly begin: number; readonly end: number };
+}
+
 export interface LocatedWikiGraphUri {
   readonly archivePath?: string;
   readonly objectUri?: string;
@@ -21,30 +27,36 @@ export function isWikiGraphJobUri(value: string | undefined): value is string {
 }
 
 export function parseLocatedWikiGraphUri(uri: string): LocatedWikiGraphUri {
-  const prefix = getWikiGraphUriPrefix(uri);
+  const parsed = parseWikiGraphUriSyntax(uri);
 
-  if (prefix === undefined) {
+  if (parsed.protocol !== "wikg") {
     throw new Error(formatWikiGraphUriExpectedError(uri));
   }
 
-  const body = uri.slice(prefix.length);
-  const libraryArchive = parseLibraryArchiveLocatorBody(body);
+  const libraryArchive = parseLibraryArchiveLocatorPath(
+    parsed.path,
+    parsed.fragment,
+  );
   if (libraryArchive !== undefined) {
     return libraryArchive;
   }
-  const split = body.split("#", 2);
-  const path = split[0] ?? "";
-  const hash = split[1] ?? "";
-  const parts = path.split("/");
+  const parts = parsed.path;
   const archiveIndex = parts.findIndex((part) =>
     part.endsWith(WIKI_GRAPH_ARCHIVE_EXTENSION),
   );
 
   if (archiveIndex < 0) {
-    return { objectUri: uri };
+    return {
+      objectUri: formatWikiGraphObjectUri(
+        parts.join("/"),
+        formatWikiGraphUriFragment(parsed.fragment),
+      ),
+    };
   }
 
-  const archivePath = parts.slice(0, archiveIndex + 1).join("/");
+  const archivePath = formatArchivePathFromUriSegments(
+    parts.slice(0, archiveIndex + 1),
+  );
   const objectPath = parts.slice(archiveIndex + 1).join("/");
 
   if (archivePath === "") {
@@ -58,21 +70,109 @@ export function parseLocatedWikiGraphUri(uri: string): LocatedWikiGraphUri {
       : {
           objectUri: formatWikiGraphObjectUri(
             objectPath,
-            hash === "" ? undefined : hash,
+            formatWikiGraphUriFragment(parsed.fragment),
           ),
         }),
   };
 }
 
-function parseLibraryArchiveLocatorBody(
-  body: string,
-): LocatedWikiGraphUri | undefined {
-  const match =
-    /^lib(?:\/(?<library>[^/.][^/]*))?\/arc\/(?<archive>[^/.][^/]*)(?:\/(?<object>.*))?$/u.exec(
-      body,
+export function parseWikiGraphUriSyntax(uri: string): ParsedWikiGraphUri {
+  const separatorIndex = uri.indexOf("://");
+  if (separatorIndex <= 0) {
+    throw new Error(formatWikiGraphUriExpectedError(uri));
+  }
+
+  const protocol = uri.slice(0, separatorIndex);
+  const body = uri.slice(separatorIndex + "://".length);
+  const hashIndex = body.indexOf("#");
+  const rawPath = hashIndex < 0 ? body : body.slice(0, hashIndex);
+  const rawFragment = hashIndex < 0 ? undefined : body.slice(hashIndex + 1);
+
+  if (rawFragment?.includes("#") === true) {
+    throw new Error(`Invalid Wiki Graph URI fragment: ${uri}`);
+  }
+
+  return {
+    protocol,
+    path: parseWikiGraphUriPath(rawPath, uri),
+    ...optionalWikiGraphUriFragment(rawFragment, uri),
+  };
+}
+
+function parseWikiGraphUriPath(path: string, uri: string): readonly string[] {
+  const trimmed = path.replace(/\/+$/u, "");
+  if (trimmed === "") {
+    return [];
+  }
+
+  if (trimmed.startsWith("/")) {
+    const absoluteTail = trimmed.slice(1);
+    if (absoluteTail === "") {
+      return ["/"];
+    }
+    const segments = absoluteTail.split("/");
+    rejectEmptyUriSegments(segments, uri);
+    return ["/", ...segments];
+  }
+
+  const segments = trimmed.split("/");
+  rejectEmptyUriSegments(segments, uri);
+  return segments;
+}
+
+function rejectEmptyUriSegments(
+  segments: readonly string[],
+  uri: string,
+): void {
+  if (segments.includes("")) {
+    throw new Error(
+      `Invalid Wiki Graph URI path: empty path segment in ${uri}`,
     );
-  const groups = match?.groups;
-  const archive = groups?.archive;
+  }
+}
+
+function optionalWikiGraphUriFragment(
+  fragment: string | undefined,
+  uri: string,
+): {
+  readonly fragment?: number | { readonly begin: number; readonly end: number };
+} {
+  if (fragment === undefined) {
+    return {};
+  }
+  if (fragment === "") {
+    throw new Error(`Invalid Wiki Graph URI fragment: ${uri}`);
+  }
+
+  const range = /^(?<begin>[0-9]+)\.\.(?<end>[0-9]+)$/u.exec(fragment);
+  if (range?.groups !== undefined) {
+    const begin = Number(range.groups.begin);
+    const end = Number(range.groups.end);
+    return { fragment: { begin, end } };
+  }
+
+  if (/^[0-9]+$/u.test(fragment)) {
+    return { fragment: Number(fragment) };
+  }
+
+  throw new Error(`Invalid Wiki Graph URI fragment: ${uri}`);
+}
+
+function parseLibraryArchiveLocatorPath(
+  path: readonly string[],
+  fragment: ParsedWikiGraphUri["fragment"],
+): LocatedWikiGraphUri | undefined {
+  if (path[0] !== "lib") {
+    return undefined;
+  }
+
+  const arcIndex = path[1] === "arc" ? 1 : path[2] === "arc" ? 2 : -1;
+  if (arcIndex < 0) {
+    return undefined;
+  }
+
+  const library = arcIndex === 2 ? path[1] : undefined;
+  const archive = path[arcIndex + 1];
   if (
     archive === undefined ||
     archive.endsWith(WIKI_GRAPH_ARCHIVE_EXTENSION) ||
@@ -80,18 +180,43 @@ function parseLibraryArchiveLocatorBody(
   ) {
     return undefined;
   }
-  const library = groups?.library;
   const archivePath = `${WIKI_GRAPH_URI_PREFIX}lib/${
     library === undefined ? "" : `${library}/`
   }arc/${archive}`;
-  const objectPath = groups?.object;
+  const objectPath = path.slice(arcIndex + 2).join("/");
 
   return {
     archivePath,
-    ...(objectPath === undefined || objectPath === ""
+    ...(objectPath === ""
       ? {}
-      : { objectUri: formatWikiGraphObjectUri(objectPath) }),
+      : {
+          objectUri: formatWikiGraphObjectUri(
+            objectPath,
+            formatWikiGraphUriFragment(fragment),
+          ),
+        }),
   };
+}
+
+function formatArchivePathFromUriSegments(segments: readonly string[]): string {
+  if (segments[0] === "/") {
+    return `/${segments.slice(1).join("/")}`;
+  }
+
+  return segments.join("/");
+}
+
+function formatWikiGraphUriFragment(
+  fragment: ParsedWikiGraphUri["fragment"],
+): string | undefined {
+  if (fragment === undefined) {
+    return undefined;
+  }
+  if (typeof fragment === "number") {
+    return String(fragment);
+  }
+
+  return `${fragment.begin}..${fragment.end}`;
 }
 
 function isLibraryScopeSegment(segment: string): boolean {

--- a/packages/core/src/storage/wikg/archive-uri.ts
+++ b/packages/core/src/storage/wikg/archive-uri.ts
@@ -9,6 +9,7 @@ export {
   isWikiGraphJobUri,
   isWikiGraphUri,
   parseLocatedWikiGraphUri,
+  parseWikiGraphUriSyntax,
   requireArchiveUri,
   requireLocatedObjectOrArchiveUri,
   requireLocatedObjectUri,
@@ -16,4 +17,5 @@ export {
   WIKI_GRAPH_JOB_URI_PREFIX,
   WIKI_GRAPH_URI_PREFIX,
   type LocatedWikiGraphUri,
+  type ParsedWikiGraphUri,
 } from "../../runtime/common/wiki-graph/uri.js";

--- a/packages/core/src/storage/wikg/index.ts
+++ b/packages/core/src/storage/wikg/index.ts
@@ -23,6 +23,7 @@ export {
   isWikiGraphJobUri,
   isWikiGraphUri,
   parseLocatedWikiGraphUri,
+  parseWikiGraphUriSyntax,
   requireArchiveUri,
   requireLocatedObjectOrArchiveUri,
   requireLocatedObjectUri,
@@ -30,6 +31,6 @@ export {
   WIKI_GRAPH_JOB_URI_PREFIX,
   WIKI_GRAPH_URI_PREFIX,
 } from "./archive-uri.js";
-export type { LocatedWikiGraphUri } from "./archive-uri.js";
+export type { LocatedWikiGraphUri, ParsedWikiGraphUri } from "./archive-uri.js";
 export { WikiGraphArchiveFile } from "./wiki-graph-archive-file.js";
 export { runWikgCoordinatorGc, WikgCoordinator } from "./coordinator.js";

--- a/test/core/retrieval/query/archive-view/pages.test.ts
+++ b/test/core/retrieval/query/archive-view/pages.test.ts
@@ -385,7 +385,7 @@ describe("archive/query/archive-view/pages", () => {
 
         await expect(
           readArchivePage(document, "wikg://chapter/1/source#1..2..3"),
-        ).rejects.toThrow("Invalid source sentence range: 1..2..3");
+        ).rejects.toThrow("Invalid Wiki Graph URI fragment");
         await expect(
           readArchivePage(document, "wikg://chapter/1/source#0"),
         ).rejects.toThrow("Invalid source sentence range: 0");

--- a/test/core/runtime/common/wiki-graph-uri.test.ts
+++ b/test/core/runtime/common/wiki-graph-uri.test.ts
@@ -7,6 +7,7 @@ import {
   formatWikiGraphCommandUri,
   formatWikiGraphObjectUri,
   parseLocatedWikiGraphUri,
+  parseWikiGraphUriSyntax,
 } from "../../../../packages/core/src/runtime/common/wiki-graph/uri.js";
 
 describe("wiki graph URI helpers", () => {
@@ -61,6 +62,57 @@ describe("wiki graph URI helpers", () => {
     });
     expect(parseLocatedWikiGraphUri("wikg://~user/book.wikg")).toStrictEqual({
       archivePath: resolve("~user/book.wikg"),
+    });
+  });
+
+  it("parses Wiki Graph URI syntax before business classification", () => {
+    expect(parseWikiGraphUriSyntax("wikg://lib")).toStrictEqual({
+      protocol: "wikg",
+      path: ["lib"],
+    });
+    expect(parseWikiGraphUriSyntax("wikg://lib/")).toStrictEqual({
+      protocol: "wikg",
+      path: ["lib"],
+    });
+    expect(
+      parseWikiGraphUriSyntax("wikg://lib/arc/a/entity/Q1#1..5"),
+    ).toStrictEqual({
+      fragment: { begin: 1, end: 5 },
+      protocol: "wikg",
+      path: ["lib", "arc", "a", "entity", "Q1"],
+    });
+    expect(
+      parseWikiGraphUriSyntax("wikg:///file/path/to.wikg/entity/Q1#12"),
+    ).toStrictEqual({
+      fragment: 12,
+      protocol: "wikg",
+      path: ["/", "file", "path", "to.wikg", "entity", "Q1"],
+    });
+    expect(() => parseWikiGraphUriSyntax("wikg://lib//arc")).toThrow(
+      "empty path segment",
+    );
+  });
+
+  it("normalizes located URI object paths through the syntax parser", () => {
+    expect(
+      parseLocatedWikiGraphUri("wikg://book.wikg/entity/Q1/"),
+    ).toStrictEqual({
+      archivePath: resolve("book.wikg"),
+      objectUri: "wikg://entity/Q1",
+    });
+    expect(
+      parseLocatedWikiGraphUri("wikg:///file/path/to.wikg/entity/Q1#12"),
+    ).toStrictEqual({
+      archivePath: "/file/path/to.wikg",
+      objectUri: "wikg://entity/Q1#12",
+    });
+    expect(
+      parseLocatedWikiGraphUri(
+        "wikg://lib/arc/archive123/chapter/part/source#1..5",
+      ),
+    ).toStrictEqual({
+      archivePath: "wikg://lib/arc/archive123",
+      objectUri: "wikg://chapter/part/source#1..5",
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds a shared `parseWikiGraphUriSyntax` contract for Wiki Graph URI protocol/path/fragment parsing.
- Routes located archive, library URI, local config/job, and archive-view reference parsing through the shared syntax layer so trailing slash, absolute archive locator, and fragment behavior stays consistent.
- Adds parser/unit coverage plus library/archive routing regression coverage for trailing slash and fragment handling.

Closes https://github.com/oomol-lab/wiki-graph/issues/208

## Issue #208 acceptance evidence

### Automated tests
- `pnpm verify` — passed (`lint`, `typecheck`, `format:check`).
- `pnpm test:run` — passed: 131 test files, 864 tests.
- `pnpm build` — passed.
- `pnpm smoke:pack-install` — passed.

Parser coverage added in `test/core/runtime/common/wiki-graph-uri.test.ts`:
- `wikg://lib` -> `protocol: "wikg"`, `path: ["lib"]`
- `wikg://lib/` -> `protocol: "wikg"`, `path: ["lib"]`
- `wikg://lib/arc/a/entity/Q1#1..5` -> path `['lib','arc','a','entity','Q1']`, range fragment
- `wikg:///file/path/to.wikg/entity/Q1#12` -> path `['/','file','path','to.wikg','entity','Q1']`, numeric fragment
- `wikg://lib//arc` -> explicit empty path segment error

Additional routing coverage:
- `packages/core/src/library/membership.test.ts` covers `wikg://lib/`, `wikg://lib/team/`, `wikg://library` false-positive prevention, library-wide object fragments, and library archive shortcuts.
- `test/core/retrieval/query/archive-view/pages.test.ts` updated for syntax-layer fragment validation.

### Manual no-side-effect URI matrix
Built and ran the current branch via `pnpm --filter wiki-graph dev` against a temporary `.wikg` archive and repository-local dev state, then cleaned `.wikigraph` afterward.

Report: `/tmp/t_afcb8f3e-review/manual-uri-validation.txt`

Result: 167 pass / 0 fail.

Covered families include:
- library root/named scopes, registry/meta/path/index/arc/tree, archive shortcut, library-wide chapter/chunk/entity/triple targets, and readonly predicates/help;
- ordinary and absolute `.wikg` archive URI targets;
- archive meta/index/cover, chapter/chapter tree/source/summary/title/state, chunk/entity/triple scope/object targets and readonly predicates/help;
- local job/config readonly/help targets;
- continuation cursor routing through `wg next`;
- fragment targets with `#12` and `#1..5`; for trailing slash plus fragment, validated the legal slash-before-fragment form such as `/source/#12` rather than treating `#12/` as a valid fragment.

### Structure review
- Syntax parser is business-neutral: it only parses `protocol`, `path`, and numeric/range fragments.
- Business terms such as `lib`, `arc`, `.wikg`, `chapter`, `entity`, `triple`, `local`, `job`, and `config` remain in business classifiers.
- Business parsers now consume the shared path/fragment contract for the touched routing paths instead of reimplementing protocol/fragment/trailing-slash/absolute-path splitting.
- No public URI field additions beyond the parser contract requested by the issue.
- No database schema, state schema, or `.wikg` format migration.
- No Web URL authority/host semantics; `wikg://` content remains Wiki Graph path data.

## Review note
A blind reviewer was actually attempted through Hermes delegation (`deleg_4a26b600`), but the reviewer run failed before producing a report because all model providers returned HTTP 503 after 3 retries. Per task rules, I performed a non-blind fallback review against the issue acceptance rubric. Fallback verdict: pass; no blocking risks found.
