### PR TITLE
fix: use opaque chapter keys

### DIFF
--- a/packages/core/src/api/chapter/entries.ts
+++ b/packages/core/src/api/chapter/entries.ts
@@ -34,7 +34,8 @@ export async function normalizeChapterToc(
   };
 
   await normalizeItems(items);
-  changed ||= ensureChapterKeys(items);
+  const keysChanged = ensureChapterKeys(items);
+  changed ||= keysChanged;
 
   const toc: MutableTocFile = {
     items,
@@ -53,7 +54,7 @@ export async function readChapterToc(
 ): Promise<MutableTocFile> {
   const toc = await document.readToc();
   const items = toc?.items.map(cloneTocItem) ?? [];
-  ensureChapterKeys(items);
+  assertChapterKeys(items);
 
   return toc === undefined
     ? { items: [], version: TOC_FILE_VERSION }
@@ -80,7 +81,7 @@ function ensureChapterKeys(items: MutableTocItem[]): boolean {
   const visit = (nodes: MutableTocItem[]): void => {
     for (const item of nodes) {
       if (item.key === undefined) {
-        item.key = createChapterKey(normalizeTitle(item.title), existingKeys);
+        item.key = createChapterKey(existingKeys);
         existingKeys.add(item.key);
         changed = true;
       }
@@ -90,6 +91,26 @@ function ensureChapterKeys(items: MutableTocItem[]): boolean {
   collectExistingKeys(items);
   visit(items);
   return changed;
+}
+
+function assertChapterKeys(items: MutableTocItem[]): void {
+  const existingKeys = new Set<string>();
+  const visit = (nodes: MutableTocItem[]): void => {
+    for (const item of nodes) {
+      if (item.key === undefined) {
+        throw new Error(
+          "Missing chapter key in TOC. Run a writable chapter operation or `wg maintenance upgrade` before using read-only chapter paths.",
+        );
+      }
+      if (existingKeys.has(item.key)) {
+        throw new Error(`Duplicate chapter key: ${item.key}.`);
+      }
+      existingKeys.add(item.key);
+      visit(item.children);
+    }
+  };
+
+  visit(items);
 }
 
 export async function findChapterEntry(

--- a/packages/core/src/api/chapter/entries.ts
+++ b/packages/core/src/api/chapter/entries.ts
@@ -1,8 +1,6 @@
 import type { Document, ReadonlyDocument } from "../../document/index.js";
-import {
-  createChapterKey,
-  formatChapterUri,
-} from "../../document/chapter/path.js";
+import { formatChapterUri } from "../../document/chapter/path.js";
+import { ensureChapterKeys } from "../../document/chapter/toc.js";
 import { TOC_FILE_VERSION, type TocItem } from "../../text/source/index.js";
 
 import {
@@ -62,35 +60,6 @@ export async function readChapterToc(
         items,
         version: toc.version,
       };
-}
-
-function ensureChapterKeys(items: MutableTocItem[]): boolean {
-  const existingKeys = new Set<string>();
-  let changed = false;
-  const collectExistingKeys = (nodes: MutableTocItem[]): void => {
-    for (const item of nodes) {
-      if (item.key !== undefined) {
-        if (existingKeys.has(item.key)) {
-          throw new Error(`Duplicate chapter key: ${item.key}.`);
-        }
-        existingKeys.add(item.key);
-      }
-      collectExistingKeys(item.children);
-    }
-  };
-  const visit = (nodes: MutableTocItem[]): void => {
-    for (const item of nodes) {
-      if (item.key === undefined) {
-        item.key = createChapterKey(existingKeys);
-        existingKeys.add(item.key);
-        changed = true;
-      }
-      visit(item.children);
-    }
-  };
-  collectExistingKeys(items);
-  visit(items);
-  return changed;
 }
 
 function assertChapterKeys(items: MutableTocItem[]): void {

--- a/packages/core/src/api/chapter/manage.ts
+++ b/packages/core/src/api/chapter/manage.ts
@@ -44,7 +44,7 @@ export async function addChapter(
     const chapterId = await openedDocument.createSerial();
     const chapterItem = {
       children: [],
-      key: createChapterKey(normalizedTitle, existingKeys),
+      key: createChapterKey(existingKeys),
       serialId: chapterId,
       ...(normalizedTitle === undefined ? {} : { title: normalizedTitle }),
     } satisfies TocItem;

--- a/packages/core/src/api/digest.ts
+++ b/packages/core/src/api/digest.ts
@@ -11,6 +11,7 @@ import {
   type SourceAdapter,
 } from "../text/source/index.js";
 import { DirectoryDocument } from "../document/index.js";
+import { createChapterKey } from "../document/chapter/path.js";
 import type { Language } from "../runtime/common/language.js";
 import type { WikiGraphScope } from "../runtime/common/llm-scope.js";
 import {
@@ -93,6 +94,7 @@ export async function digestTextStreamSession<T>(
     await document.openSession(async (openedDocument) => {
       const serialId = await openedDocument.peekNextSerialId();
       const normalizedTitle = normalizeTitle(options.title);
+      const key = createChapterKey(new Set());
       const targetStage = options.targetStage ?? "summarized";
       await progressTracker.markDiscoveryUnavailable();
 
@@ -169,6 +171,7 @@ export async function digestTextStreamSession<T>(
           {
             serialId,
             children: [],
+            key,
             ...(normalizedTitle === undefined
               ? {}
               : { title: normalizedTitle }),

--- a/packages/core/src/api/import.ts
+++ b/packages/core/src/api/import.ts
@@ -1,4 +1,5 @@
 import type { Document } from "../document/index.js";
+import { createChapterKey } from "../document/chapter/path.js";
 import type { DigestProgressTracker } from "../runtime/progress/index.js";
 import { AsyncSemaphore } from "../utils/async-semaphore.js";
 import {
@@ -82,6 +83,7 @@ export async function importSourceDocument(
     version: TOC_FILE_VERSION,
     items: [
       ...planTocItems({
+        existingKeys: new Set<string>(),
         fallbackTitle: meta.title,
         plannedSections,
         sections,
@@ -258,6 +260,7 @@ async function generatePlannedSerials(
 }
 
 function planTocItems(input: {
+  readonly existingKeys: Set<string>;
   readonly fallbackTitle: string | null | undefined;
   readonly plannedSections: PlannedSection[];
   readonly sections: readonly SourceSection[];
@@ -267,6 +270,7 @@ function planTocItems(input: {
     planTocItem({
       fallbackTitle:
         input.sections.length === 1 ? input.fallbackTitle : undefined,
+      existingKeys: input.existingKeys,
       indexPath: [index],
       plannedSections: input.plannedSections,
       section,
@@ -276,6 +280,7 @@ function planTocItems(input: {
 }
 
 function planTocItem(input: {
+  readonly existingKeys: Set<string>;
   readonly fallbackTitle: string | null | undefined;
   readonly indexPath: readonly number[];
   readonly plannedSections: PlannedSection[];
@@ -287,6 +292,7 @@ function planTocItem(input: {
     : undefined;
   const children = input.section.children.map((child, index) =>
     planTocItem({
+      existingKeys: input.existingKeys,
       fallbackTitle: undefined,
       indexPath: [...input.indexPath, index],
       plannedSections: input.plannedSections,
@@ -304,8 +310,11 @@ function planTocItem(input: {
 
   const title =
     normalizeTitle(input.section.title) ?? normalizeTitle(input.fallbackTitle);
+  const key = createChapterKey(input.existingKeys);
+  input.existingKeys.add(key);
 
   return {
+    key,
     ...(title === undefined ? {} : { title }),
     ...(serialId === undefined ? {} : { serialId }),
     children,

--- a/packages/core/src/document/chapter/path.ts
+++ b/packages/core/src/document/chapter/path.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from "crypto";
+
 import type { TocItem } from "../../text/source/index.js";
 
 export const RESERVED_CHAPTER_KEYS = new Set([
@@ -14,6 +16,9 @@ export const RESERVED_CHAPTER_KEYS = new Set([
   "job",
   "help",
 ]);
+
+const CHAPTER_KEY_RANDOM_BYTES = 6;
+const CREATE_CHAPTER_KEY_MAX_ATTEMPTS = 100;
 
 export function formatChapterUri(path: string): string {
   return `wikg://chapter/${path}`;
@@ -72,22 +77,27 @@ export function validateChapterKey(key: string, label = "chapter key"): string {
   return key;
 }
 
-export function createChapterKey(
-  input: string | null | undefined,
-  existingKeys: ReadonlySet<string>,
-): string {
-  const base = slugify(input ?? "chapter") || "chapter";
-  let key = RESERVED_CHAPTER_KEYS.has(base) ? `${base}-chapter` : base;
-  key = ensureValidKeyBase(key);
-  if (!existingKeys.has(key)) {
-    return key;
-  }
-  for (let index = 2; ; index += 1) {
-    const candidate = `${key}-${index}`;
+export function createChapterKey(existingKeys: ReadonlySet<string>): string {
+  for (
+    let attempt = 0;
+    attempt < CREATE_CHAPTER_KEY_MAX_ATTEMPTS;
+    attempt += 1
+  ) {
+    const candidate = randomBytes(CHAPTER_KEY_RANDOM_BYTES).toString("hex");
+
+    try {
+      validateChapterKey(candidate);
+    } catch {
+      continue;
+    }
     if (!existingKeys.has(candidate)) {
       return candidate;
     }
   }
+
+  throw new Error(
+    `Unable to create a unique chapter key after ${CREATE_CHAPTER_KEY_MAX_ATTEMPTS} attempts.`,
+  );
 }
 
 export function resolveChapterIdByPath(
@@ -139,24 +149,4 @@ export function collectChapterPathById(
     }
   }
   return undefined;
-}
-
-function slugify(value: string): string {
-  return value
-    .normalize("NFKD")
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/gu, "-")
-    .replace(/^-+|-+$/gu, "")
-    .replace(/-{2,}/gu, "-");
-}
-
-function ensureValidKeyBase(value: string): string {
-  const normalized = value.replace(/^-+/u, "").replace(/-+$/u, "");
-  if (/^\d+$/u.test(normalized)) {
-    return `chapter-${normalized}`;
-  }
-  if (/^[a-z0-9][a-z0-9-]*$/u.test(normalized)) {
-    return normalized;
-  }
-  return "chapter";
 }

--- a/packages/core/src/document/chapter/toc.ts
+++ b/packages/core/src/document/chapter/toc.ts
@@ -10,7 +10,6 @@ export async function readChapterToc(
 ): Promise<MutableTocFile> {
   const toc = await document.readToc();
   const items = toc?.items.map(cloneTocItem) ?? [];
-  ensureChapterKeys(items);
 
   return toc === undefined
     ? { items: [], version: TOC_FILE_VERSION }
@@ -37,7 +36,7 @@ export function ensureChapterKeys(items: MutableTocFile["items"]): boolean {
   const visit = (nodes: MutableTocFile["items"]): void => {
     for (const item of nodes) {
       if (item.key === undefined) {
-        item.key = createChapterKey(normalizeTitle(item.title), existingKeys);
+        item.key = createChapterKey(existingKeys);
         existingKeys.add(item.key);
         changed = true;
       }

--- a/packages/core/src/storage/schema-upgrade/index.ts
+++ b/packages/core/src/storage/schema-upgrade/index.ts
@@ -1,8 +1,11 @@
 import { randomUUID } from "crypto";
-import { rename, rm, stat } from "fs/promises";
+import { mkdtemp, rename, rm, stat, writeFile } from "fs/promises";
+import { tmpdir } from "os";
 import { dirname, join, resolve } from "path";
 
 import { Database } from "../../document/database.js";
+import { ensureChapterKeys } from "../../document/chapter/toc.js";
+import type { MutableTocFile } from "../../document/chapter/tree.js";
 import { ensureWikiGraphHomeSchemaCurrent } from "../../document/home-schema-upgrade.js";
 import {
   resolveWikiGraphHomeDirectoryPath,
@@ -20,6 +23,7 @@ import {
 } from "../wikg/archive/zip.js";
 import { writeWikgArchiveWithOverlays } from "../wikg/archive/write.js";
 import { createArchiveKey } from "../wikg/wikg-coordinator/archive-key.js";
+import { tocFileSchema, type TocFile } from "../../text/source/toc.js";
 
 export {
   ensureWikiGraphHomeSchemaCurrent,
@@ -94,20 +98,95 @@ export async function upgradeWikiGraphArchiveSchema(
     dirname(resolvedArchivePath),
     `.${getArchiveBasename(resolvedArchivePath)}.${process.pid}.${randomUUID()}.upgrade.tmp`,
   );
+  const temporaryDirectories: string[] = [];
 
-  await writeWikgArchiveWithOverlays(
-    resolvedArchivePath,
-    temporaryPath,
-    [
-      {
-        entryPath: SEARCH_INDEX_DATABASE_PATH,
-        kind: "deleted",
-      },
-    ],
-    { preserveMutationToken: true },
-  );
-  await rename(temporaryPath, resolvedArchivePath);
-  await cleanupArchiveDerivedData(archiveKey);
+  try {
+    const tocOverlay = await createChapterTocUpgradeOverlay(
+      resolvedArchivePath,
+      temporaryDirectories,
+    );
+    await writeWikgArchiveWithOverlays(
+      resolvedArchivePath,
+      temporaryPath,
+      [
+        {
+          entryPath: SEARCH_INDEX_DATABASE_PATH,
+          kind: "deleted",
+        },
+        ...(tocOverlay === undefined ? [] : [tocOverlay]),
+      ],
+      { preserveMutationToken: true },
+    );
+    await rename(temporaryPath, resolvedArchivePath);
+    await cleanupArchiveDerivedData(archiveKey);
+  } finally {
+    await Promise.all(
+      temporaryDirectories.map(async (path) => {
+        await deletePathIfExists(path);
+      }),
+    );
+  }
+}
+
+async function createChapterTocUpgradeOverlay(
+  archivePath: string,
+  temporaryDirectories: string[],
+): Promise<
+  | {
+      readonly entryPath: "toc.json";
+      readonly kind: "file";
+      readonly workspacePath: string;
+    }
+  | undefined
+> {
+  const { entries, zipFile } = await openIndexedArchive(archivePath);
+
+  try {
+    const tocEntry = entries.find(
+      (entry) => normalizeArchivePath(entry.fileName) === "toc.json",
+    );
+
+    if (tocEntry === undefined) {
+      return undefined;
+    }
+
+    const tocText = await readArchiveEntryText(archivePath, tocEntry);
+    let toc: TocFile;
+
+    try {
+      const parsed = tocFileSchema.safeParse(JSON.parse(tocText));
+      if (!parsed.success) {
+        return undefined;
+      }
+      toc = parsed.data;
+    } catch {
+      return undefined;
+    }
+
+    const mutableToc = JSON.parse(JSON.stringify(toc)) as MutableTocFile;
+    if (!ensureChapterKeys(mutableToc.items)) {
+      return undefined;
+    }
+
+    const temporaryDirectory = await mkdtemp(
+      join(tmpdir(), "wikigraph-toc-upgrade-"),
+    );
+    temporaryDirectories.push(temporaryDirectory);
+    const workspacePath = join(temporaryDirectory, "toc.json");
+    await writeFile(
+      workspacePath,
+      `${JSON.stringify(mutableToc, null, 2)}\n`,
+      "utf8",
+    );
+
+    return {
+      entryPath: "toc.json",
+      kind: "file",
+      workspacePath,
+    };
+  } finally {
+    zipFile.close();
+  }
 }
 
 async function cleanupArchiveDerivedData(archiveKey: string): Promise<void> {

--- a/test/cli/archive/chapter.test.ts
+++ b/test/cli/archive/chapter.test.ts
@@ -112,9 +112,9 @@ vi.mock("../../../packages/core/src/api/index.js", () => ({
       ...chapterDetails,
       chapterId: 3,
       stage: "planned",
-      path: "new-chapter",
+      path: "a1b2c3d4e5f6",
       title: "New Chapter",
-      uri: "wikg://chapter/new-chapter",
+      uri: "wikg://chapter/a1b2c3d4e5f6",
     });
   }),
   assertNoActiveBuildJobs: vi.fn((input: unknown) => {
@@ -182,7 +182,7 @@ vi.mock("../../../packages/core/src/api/index.js", () => ({
     const chapterIds = new Map<string, number>([
       ["part-i", 1],
       ["part-i/chapter-1", 2],
-      ["new-chapter", 3],
+      ["a1b2c3d4e5f6", 3],
     ]);
 
     return Promise.resolve(chapterIds.get(chapterPath));
@@ -360,7 +360,7 @@ describe("cli/archive-chapter", () => {
       },
     ]);
     expect(chapterMockState.textWrites[0]).toContain(
-      "Chapter: wikg://chapter/new-chapter\n",
+      "Chapter: wikg://chapter/a1b2c3d4e5f6\n",
     );
   });
 
@@ -379,7 +379,7 @@ describe("cli/archive-chapter", () => {
       sourceUnits: 2,
       stage: "planned",
       title: "New Chapter",
-      uri: "wikg://chapter/new-chapter",
+      uri: "wikg://chapter/a1b2c3d4e5f6",
     });
   });
 

--- a/test/core/api/chapter.test.ts
+++ b/test/core/api/chapter.test.ts
@@ -51,6 +51,12 @@ describe("facade/chapter", () => {
           stage: "planned",
           title: "Chapter 1",
         });
+        expect(parent.key).toMatch(/^(?!\d+$)[0-9a-f]{12}$/u);
+        expect(parent.key).not.toBe("part-i");
+        expect(parent.path).toBe(parent.key);
+        expect(child.key).toMatch(/^(?!\d+$)[0-9a-f]{12}$/u);
+        expect(child.key).not.toBe("chapter-1");
+        expect(child.path).toBe(`${parent.key}/${child.key}`);
         expect(await listChapters(document)).toMatchObject([
           {
             chapterId: 1,
@@ -71,7 +77,7 @@ describe("facade/chapter", () => {
     });
   });
 
-  it("keeps serial-less grouping nodes read-only when listing chapters", async () => {
+  it("does not randomize missing chapter keys on read-only chapter paths", async () => {
     await withTempDir("wikigraph-chapter-", async (path) => {
       const document = await DirectoryDocument.open(path);
 
@@ -99,6 +105,7 @@ describe("facade/chapter", () => {
           {
             chapterId: 1,
             depth: 1,
+            path: "chapter-group/chapter-1",
             stage: "planned",
             title: "Chapter 1",
             tocPath: ["Part I", "Chapter 1"],
@@ -109,7 +116,7 @@ describe("facade/chapter", () => {
             {
               children: [],
               title: "Chapter 1",
-              uri: "wikg://chapter/part-i/chapter-1",
+              uri: "wikg://chapter/chapter-group/chapter-1",
             },
           ],
         });
@@ -181,7 +188,8 @@ describe("facade/chapter", () => {
             title: "Chapter 2",
           },
         ]);
-        expect(await document.readToc()).toMatchObject({
+        const toc = await document.readToc();
+        expect(toc).toMatchObject({
           items: [
             {
               serialId: 2,
@@ -193,6 +201,33 @@ describe("facade/chapter", () => {
             },
           ],
         });
+        expect(toc?.items[0]?.key).toMatch(/^(?!\d+$)[0-9a-f]{12}$/u);
+        expect(toc?.items[0]?.children[0]?.key).toMatch(
+          /^(?!\d+$)[0-9a-f]{12}$/u,
+        );
+        expect(toc?.items[1]?.key).toMatch(/^(?!\d+$)[0-9a-f]{12}$/u);
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("uses unique opaque keys for duplicate and non-latin chapter titles", async () => {
+    await withTempDir("wikigraph-chapter-", async (path) => {
+      const document = await DirectoryDocument.open(path);
+
+      try {
+        const first = await addChapter(document, { title: "Repeat" });
+        const second = await addChapter(document, { title: "Repeat" });
+        const nonLatin = await addChapter(document, { title: "中文标题" });
+
+        expect(new Set([first.key, second.key, nonLatin.key]).size).toBe(3);
+        for (const chapter of [first, second, nonLatin]) {
+          expect(chapter.key).toMatch(/^(?!\d+$)[0-9a-f]{12}$/u);
+        }
+        expect(second.key).not.toBe("repeat-2");
+        expect(nonLatin.key).not.toBe("chapter");
+        expect(nonLatin.key).not.toBe("chapter-2");
       } finally {
         await document.release();
       }
@@ -297,6 +332,8 @@ describe("facade/chapter", () => {
         const chapter = await addChapter(document, {
           title: "Original",
         });
+        const originalKey = chapter.key;
+        const originalUri = chapter.uri;
 
         await expect(
           setChapterTitle(document, chapter.chapterId, "  Renamed  "),
@@ -337,11 +374,17 @@ describe("facade/chapter", () => {
           items: [
             {
               children: [],
-              key: "original",
+              key: originalKey,
               serialId: chapter.chapterId,
             },
           ],
           version: 1,
+        });
+        await expect(
+          getChapterDetails(document, chapter.chapterId),
+        ).resolves.toMatchObject({
+          key: originalKey,
+          uri: originalUri,
         });
       } finally {
         await document.release();
@@ -449,6 +492,7 @@ describe("facade/chapter", () => {
         const second = await addChapter(document, {
           parentChapterId: part.chapterId,
         });
+        const secondRootUri = `wikg://chapter/${second.key}`;
 
         await expect(getChapterTree(document)).resolves.toStrictEqual({
           chapters: [
@@ -477,7 +521,7 @@ describe("facade/chapter", () => {
             chapters: [
               {
                 children: [],
-                uri: "wikg://chapter/chapter",
+                uri: secondRootUri,
                 title: "Second",
               },
               {
@@ -497,22 +541,20 @@ describe("facade/chapter", () => {
 
         expect(dryRun.changed).toBe(true);
         expect(dryRun.moved.map((move) => move.oldUri)).toContain(second.uri);
-        expect(
-          [...dryRun.renamed].sort((left, right) =>
-            left.uri.localeCompare(right.uri),
-          ),
-        ).toStrictEqual([
-          {
-            uri: "wikg://chapter/chapter",
-            newTitle: "Second",
-            oldTitle: null,
-          },
-          {
-            uri: first.uri,
-            newTitle: null,
-            oldTitle: "First",
-          },
-        ]);
+        expect(dryRun.renamed).toStrictEqual(
+          expect.arrayContaining([
+            {
+              uri: secondRootUri,
+              newTitle: "Second",
+              oldTitle: null,
+            },
+            {
+              uri: first.uri,
+              newTitle: null,
+              oldTitle: "First",
+            },
+          ]),
+        );
         await expect(listChapters(document)).resolves.toMatchObject([
           { chapterId: part.chapterId, title: "Part" },
           { chapterId: first.chapterId, title: "First" },
@@ -525,7 +567,7 @@ describe("facade/chapter", () => {
             chapters: [
               {
                 children: [],
-                uri: "wikg://chapter/chapter",
+                uri: secondRootUri,
                 title: "Second",
               },
               {
@@ -566,7 +608,7 @@ describe("facade/chapter", () => {
             chapters: [
               {
                 children: [],
-                uri: second.uri,
+                uri: secondRootUri,
                 summary: "not allowed",
               },
             ],

--- a/test/core/api/chapter.test.ts
+++ b/test/core/api/chapter.test.ts
@@ -541,6 +541,7 @@ describe("facade/chapter", () => {
 
         expect(dryRun.changed).toBe(true);
         expect(dryRun.moved.map((move) => move.oldUri)).toContain(second.uri);
+        expect(dryRun.renamed).toHaveLength(2);
         expect(dryRun.renamed).toStrictEqual(
           expect.arrayContaining([
             {

--- a/test/core/api/digest.test.ts
+++ b/test/core/api/digest.test.ts
@@ -157,7 +157,8 @@ describe("facade/digest", () => {
           sourceFormat: "txt",
           title: "Digest Title",
         });
-        expect(await digest.readToc()).toStrictEqual({
+        const toc = await digest.readToc();
+        expect(toc).toMatchObject({
           items: [
             {
               children: [],
@@ -167,6 +168,7 @@ describe("facade/digest", () => {
           ],
           version: 1,
         });
+        expect(toc?.items[0]?.key).toMatch(/^(?!\d+$)[0-9a-f]{12}$/u);
 
         return (await digest.readMeta())?.title;
       },
@@ -209,7 +211,8 @@ describe("facade/digest", () => {
             sourceFormat: "markdown",
             title: null,
           });
-          expect(await digest.readToc()).toStrictEqual({
+          const toc = await digest.readToc();
+          expect(toc).toMatchObject({
             items: [
               {
                 children: [],
@@ -218,6 +221,7 @@ describe("facade/digest", () => {
             ],
             version: 1,
           });
+          expect(toc?.items[0]?.key).toMatch(/^(?!\d+$)[0-9a-f]{12}$/u);
         },
       );
     });

--- a/test/core/api/import.test.ts
+++ b/test/core/api/import.test.ts
@@ -169,7 +169,7 @@ describe("facade/import", () => {
         expect(imported.serials.map((serial) => serial.id)).toStrictEqual([
           1, 2,
         ]);
-        expect(imported.toc.items).toStrictEqual([
+        expect(imported.toc.items).toMatchObject([
           {
             children: [
               {
@@ -183,6 +183,11 @@ describe("facade/import", () => {
             serialId: 2,
           },
         ]);
+        expect(imported.toc.items[0]?.key).toMatch(/^(?!\d+$)[0-9a-f]{12}$/u);
+        expect(imported.toc.items[0]?.children[0]?.key).toMatch(
+          /^(?!\d+$)[0-9a-f]{12}$/u,
+        );
+        expect(imported.toc.items[1]?.key).toMatch(/^(?!\d+$)[0-9a-f]{12}$/u);
 
         expect(await document.readBookMeta()).toStrictEqual(meta);
         expect(await document.readCover()).toMatchObject({
@@ -242,13 +247,14 @@ describe("facade/import", () => {
           },
         );
 
-        expect(imported.toc.items).toStrictEqual([
+        expect(imported.toc.items).toMatchObject([
           {
             children: [],
             serialId: 1,
             title: "Single Section Book",
           },
         ]);
+        expect(imported.toc.items[0]?.key).toMatch(/^(?!\d+$)[0-9a-f]{12}$/u);
       } finally {
         await document.release();
       }

--- a/test/core/retrieval/query/archive-view/collection.test.ts
+++ b/test/core/retrieval/query/archive-view/collection.test.ts
@@ -102,11 +102,13 @@ describe("archive/query/archive-view/collection", () => {
             items: [
               {
                 children: [],
+                key: "introduction",
                 serialId: 1,
                 title: "Introduction",
               },
               {
                 children: [],
+                key: "second",
                 serialId: 2,
                 title: "Second",
               },

--- a/test/core/retrieval/query/archive-view/helpers.ts
+++ b/test/core/retrieval/query/archive-view/helpers.ts
@@ -147,6 +147,7 @@ export async function seedSourcedDocument(
       items: [
         {
           children: [],
+          key: "introduction",
           serialId: 1,
           title: "Introduction",
         },

--- a/test/core/retrieval/query/archive-view/pages.test.ts
+++ b/test/core/retrieval/query/archive-view/pages.test.ts
@@ -514,11 +514,13 @@ describe("archive/query/archive-view/pages", () => {
             items: [
               {
                 children: [],
+                key: "second-in-id-first-in-document",
                 serialId: 2,
                 title: "Second in id, first in document",
               },
               {
                 children: [],
+                key: "first-in-id-second-in-document",
                 serialId: 1,
                 title: "First in id, second in document",
               },

--- a/test/core/retrieval/query/archive-view/text-search.test.ts
+++ b/test/core/retrieval/query/archive-view/text-search.test.ts
@@ -314,11 +314,13 @@ describe("archive/query/archive-view/text search", () => {
             items: [
               {
                 children: [],
+                key: "alpha-appears-in-a-weak-chapter",
                 serialId: 1,
                 title: "alpha appears in a weak chapter",
               },
               {
                 children: [],
+                key: "alpha-beta-alpha-beta-strongest-chapter",
                 serialId: 2,
                 title: "alpha beta alpha beta strongest chapter",
               },

--- a/test/core/storage/schema-upgrade/index.test.ts
+++ b/test/core/storage/schema-upgrade/index.test.ts
@@ -81,6 +81,57 @@ describe("schema-upgrade", () => {
     });
   });
 
+  it("persists missing chapter keys while upgrading a legacy archive", async () => {
+    await withTempDir("wikigraph-schema-upgrade-toc-", async (root) => {
+      setWikiGraphStateDirectoryPathForTesting(join(root, "home"));
+      const archivePath = join(root, "book.wikg");
+      await writeArchiveWithSchemaVersion(
+        archivePath,
+        1,
+        `${JSON.stringify({
+          version: 1,
+          items: [
+            {
+              children: [
+                {
+                  children: [],
+                  key: "existing-key",
+                  serialId: 2,
+                  title: "Existing",
+                },
+              ],
+              serialId: 1,
+              title: "Part I",
+            },
+          ],
+        })}\n`,
+      );
+
+      await upgradeWikiGraphArchiveSchema(archivePath);
+
+      const upgradedTocEntry = await readWikgArchiveEntry(
+        archivePath,
+        "toc.json",
+      );
+      expect(upgradedTocEntry).toBeInstanceOf(Uint8Array);
+      const upgradedToc = JSON.parse(
+        Buffer.from(upgradedTocEntry as Uint8Array).toString("utf8"),
+      ) as {
+        readonly items: readonly {
+          readonly children: readonly { readonly key?: string }[];
+          readonly key?: string;
+        }[];
+      };
+
+      expect(upgradedToc.items[0]?.key).toMatch(/^(?!\d+$)[0-9a-f]{12}$/u);
+      expect(upgradedToc.items[0]?.key).not.toBe("part-i");
+      expect(upgradedToc.items[0]?.children[0]?.key).toBe("existing-key");
+      await expect(
+        readWikgArchiveEntry(archivePath, SEARCH_INDEX_DATABASE_PATH),
+      ).resolves.toBeUndefined();
+    });
+  });
+
   it("rejects a future archive schema version", async () => {
     await withTempDir("wikigraph-schema-future-archive-", async (root) => {
       setWikiGraphStateDirectoryPathForTesting(join(root, "home"));
@@ -829,6 +880,7 @@ async function writeLegacyArchive(archivePath: string): Promise<void> {
 async function writeArchiveWithSchemaVersion(
   archivePath: string,
   schemaVersion: number,
+  tocContent = "legacy toc",
 ): Promise<void> {
   await mkdir(dirname(archivePath), { recursive: true });
 
@@ -853,7 +905,7 @@ async function writeArchiveWithSchemaVersion(
   zipFile.addBuffer(Buffer.from("legacy db", "utf8"), "database.db", {
     compress: false,
   });
-  zipFile.addBuffer(Buffer.from("legacy toc", "utf8"), "toc.json", {
+  zipFile.addBuffer(Buffer.from(tocContent, "utf8"), "toc.json", {
     compress: false,
   });
   zipFile.addBuffer(

--- a/test/core/storage/wikg/wiki-graph-archive-file.test.ts
+++ b/test/core/storage/wikg/wiki-graph-archive-file.test.ts
@@ -263,6 +263,7 @@ describe("wikg/wiki-graph-archive-file", () => {
             items: [
               {
                 children: [],
+                key: "fresh-cache-title",
                 serialId: 1,
                 title: "Fresh Cache Title",
               },


### PR DESCRIPTION
## Summary
- Replace title-derived chapter key generation with validated opaque 12-character lowercase hex keys, with retry on invalid/collision.
- Persist missing chapter keys in writable TOC normalization and schema v1→v2 archive upgrade while preserving existing keys.
- Update digest/import creation paths and tests so new TOC items receive opaque keys directly.

Closes #210

## Acceptance / Verification
- New `addChapter(document, { title: "Part I" })` tests verify generated key/path are not `part-i`, title is retained, and keys match the short opaque hex format.
- Duplicate-title and non-Latin-title tests verify keys stay globally unique and do not use slug suffixes like `-2` or fallback `chapter` / `chapter-2`.
- `setChapterTitle()` test verifies rename/clear keeps the original key and URI.
- Missing-key tests cover writable normalization persistence, read-only paths not generating random keys, and schema v1→v2 upgrade preserving existing keys while filling missing ones and deleting search index.
- Review confirms no new user-facing CLI/API for editing keys, no whole-archive rewrite of existing keys, and no old-URI mapping table.

## Commands Run
- `pnpm exec vitest run test/core/api/chapter.test.ts test/core/api/import.test.ts test/core/api/digest.test.ts test/core/storage/schema-upgrade/index.test.ts --passWithNoTests` — passed (57 tests)
- `pnpm run lint` — passed
- `pnpm run typecheck` — passed
- `pnpm run format:check` — passed
- `pnpm run test` — passed (131 files / 864 tests)
- `pnpm run build` — passed

## Review Note
Blind reviewer creation was attempted via Hermes delegation, but the reviewer run failed because all model providers returned HTTP 503 after 3 retries. I performed a non blind fallback review against issue #210’s acceptance rubric; verdict: pass. The change is limited to chapter key generation/normalization/upgrade and tests, with no security, permission, production-data, irreversible migration, or public compatibility high-risk boundary beyond the issue-scoped schema upgrade behavior.
