### PR TITLE
fix: restore library scope reads

### DIFF
--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -756,6 +756,7 @@ describe("cli/args/help", () => {
     expect(scopeHelpText).toContain(
       "Use `wg wikg://lib/registry` to list all library registries.",
     );
+    expect(scopeHelpText).not.toContain("lists archive memberships");
     expect(scopeHelpText).toContain("broad library index search");
     expect(scopeHelpText).toContain("wg wikg://lib --query <query>");
     expect(
@@ -904,6 +905,8 @@ describe("cli/args/help", () => {
     expect(arcHelpText).toContain("wikg://lib/arc add --help");
     expect(arcHelpText).toContain("wikg://lib/arc scan --help");
     expect(arcHelpText).toContain("wikg://lib/arc/tree --help");
+    expect(arcHelpText).not.toContain("lists archive members");
+    expect(arcHelpText).toContain("use `/tree` for member file visualization");
     expect(arcTreeHelpText).toContain("This object is read-only");
     for (const text of [
       scopeHelpText,

--- a/packages/cli/src/args/uri/library.ts
+++ b/packages/cli/src/args/uri/library.ts
@@ -171,7 +171,7 @@ export function parseLibraryUriFirstArguments(
 
   if (
     target.kind === "scope" &&
-    (target.objectUri !== undefined || action === "search")
+    (target.objectUri !== undefined || action === "search" || action === "list")
   ) {
     return parseLibraryQueryArguments(
       uri,
@@ -462,7 +462,11 @@ function parseLibraryQueryArguments(
       ),
     );
   }
-  if (target.objectUri === undefined && action !== "search") {
+  if (
+    target.objectUri === undefined &&
+    action !== "search" &&
+    action !== "list"
+  ) {
     throw new Error("Internal error: missing library query object URI.");
   }
 

--- a/packages/cli/src/commands/archive-command/chapter.ts
+++ b/packages/cli/src/commands/archive-command/chapter.ts
@@ -25,7 +25,9 @@ import {
 import { WikiGraphArchiveFile } from "wiki-graph-core";
 
 import type { CLIArchiveChapterArguments } from "../../args/index.js";
+import type { RenderTreeNode } from "../../support/index.js";
 import {
+  renderTreeText,
   readTextStreamFromStdin,
   writeTextToStdout,
 } from "../../support/index.js";
@@ -404,24 +406,17 @@ async function writeChapterTree(
   }
 
   await writeTextToStdout(
-    `${formatChapterTreeNodes(tree.chapters).join("\n")}\n`,
+    renderTreeText(tree.chapters.map(formatChapterTreeRenderNode)),
   );
 }
 
-function formatChapterTreeNodes(
-  nodes: readonly ChapterTree["chapters"][number][],
-  prefix = "",
-): readonly string[] {
-  return nodes.flatMap((node, index) => {
-    const last = index === nodes.length - 1;
-    const branch = last ? "└─ " : "├─ ";
-    const childPrefix = `${prefix}${last ? "   " : "│  "}`;
-
-    return [
-      `${prefix}${branch}${formatChapterTreeTitle(node.title)} (${formatChapterTreeKey(node.uri)})`,
-      ...formatChapterTreeNodes(node.children, childPrefix),
-    ];
-  });
+function formatChapterTreeRenderNode(
+  node: ChapterTree["chapters"][number],
+): RenderTreeNode {
+  return {
+    children: node.children.map(formatChapterTreeRenderNode),
+    label: `${formatChapterTreeTitle(node.title)} (${formatChapterTreeKey(node.uri)})`,
+  };
 }
 
 function formatChapterTreeKey(uri: string): string {

--- a/packages/cli/src/commands/archive-command/index.ts
+++ b/packages/cli/src/commands/archive-command/index.ts
@@ -58,7 +58,9 @@ export async function runArchiveCommand(
   if (
     libraryTarget?.kind === "scope" &&
     libraryTarget.objectUri !== "wikg://index" &&
-    (libraryTarget.objectUri !== undefined || args.action === "search")
+    (libraryTarget.objectUri !== undefined ||
+      args.action === "search" ||
+      args.action === "list")
   ) {
     await runLibraryIndexArchiveCommand(args, libraryTarget);
     return;

--- a/packages/cli/src/commands/archive-output/text/object.ts
+++ b/packages/cli/src/commands/archive-output/text/object.ts
@@ -52,13 +52,22 @@ export function formatOpenShortUriHint(
   objects: readonly ArchiveOutputObject[],
   context: ArchiveOutputContext,
 ): string {
-  const shortUri = objects.find((object) => isShortOutputUri(object.uri))?.uri;
-
-  if (shortUri === undefined) {
+  const shortObject = objects.find((object) => isShortOutputUri(object.uri));
+  if (shortObject === undefined) {
     return "";
   }
 
-  return `\n\nOpen short URIs with the archive locator, for example:\n  ${formatCliCommand([formatWikiGraphCommandUri(context.archivePath, shortUri)])}`;
+  const locator = shortObject.libraryArchiveUri ?? context.archivePath;
+
+  return `\n\nOpen short URIs with the archive locator, for example:\n  ${formatCliCommand([formatOpenShortUriCommand(locator, shortObject.uri)])}`;
+}
+
+function formatOpenShortUriCommand(locator: string, objectUri: string): string {
+  if (locator.startsWith("wikg://lib/")) {
+    return `${locator.replace(/\/+$/u, "")}/${objectUri.slice("wikg://".length)}`;
+  }
+
+  return formatWikiGraphCommandUri(locator, objectUri);
 }
 
 function isShortOutputUri(uri: string): boolean {

--- a/packages/cli/src/commands/library.test.ts
+++ b/packages/cli/src/commands/library.test.ts
@@ -62,6 +62,7 @@ describe("library command", () => {
         {
           children: [
             {
+              children: [],
               name: "book.wikg",
               path: "nested/book.wikg",
               uri: archive.uri,
@@ -72,6 +73,16 @@ describe("library command", () => {
         },
       ],
     });
+
+    const textOutput = await captureStdout(async () => {
+      await runLibraryCommand({
+        action: "archive-tree",
+        parent: "nested/book.wikg",
+        target: { isDefault: true, kind: "archive-tree" },
+      });
+    });
+
+    expect(textOutput).toBe(`└─ nested\n   └─ book.wikg (${archive.uri})\n`);
   });
 });
 

--- a/packages/cli/src/commands/library.ts
+++ b/packages/cli/src/commands/library.ts
@@ -23,8 +23,10 @@ import {
   scanWikiGraphLibrary,
 } from "wiki-graph-core";
 import type { CLILibraryArguments } from "../args/index.js";
+import type { RenderTreeNode } from "../support/index.js";
 import {
   formatCLIJSON,
+  renderTreeText,
   readTextStreamFromStdin,
   writeTextToStdout,
 } from "../support/index.js";
@@ -76,6 +78,10 @@ export async function runLibraryCommand(
           await listWikiGraphLibraries(),
           args.json ?? false,
         );
+        return;
+      }
+      if (args.target.kind === "archive-collection") {
+        await writeEmptyLibraryScope(args.json ?? false);
         return;
       }
       await writeLibraryArchives(
@@ -226,10 +232,7 @@ export async function runLibraryCommand(
         return;
       }
       await resolveWikiGraphLibrary(args.target);
-      await writeLibraryArchives(
-        await listWikiGraphLibraryArchives(args.target),
-        args.json ?? false,
-      );
+      await writeEmptyLibraryScope(args.json ?? false);
       return;
     }
     case "set": {
@@ -431,6 +434,10 @@ async function writeLibraryArchives(
   );
 }
 
+async function writeEmptyLibraryScope(json: boolean): Promise<void> {
+  await writeTextToStdout(json ? formatCLIJSON({ items: [] }) : "");
+}
+
 async function writeLibraryArchive(
   archive: Awaited<ReturnType<typeof addWikiGraphLibraryArchive>>,
   json: boolean,
@@ -551,31 +558,25 @@ function serializeArchiveTreeNodes(
   nodes: Map<string, ArchiveTreeNode>,
 ): object[] {
   return [...nodes.values()].map((node) => ({
+    children: serializeArchiveTreeNodes(node.children),
     name: node.name,
     path: node.path,
     ...(node.archive === undefined ? {} : { uri: node.archive.uri }),
-    ...(node.children.size === 0
-      ? {}
-      : { children: serializeArchiveTreeNodes(node.children) }),
   }));
 }
 
-function formatArchiveTreeText(
-  nodes: Map<string, ArchiveTreeNode>,
-  indent = "",
-): string {
-  const lines: string[] = [];
-  for (const node of nodes.values()) {
-    lines.push(
-      `${indent}${node.name}${node.archive === undefined ? "/" : `\t${node.archive.uri}`}`,
-    );
-    if (node.children.size > 0) {
-      lines.push(
-        formatArchiveTreeText(node.children, `${indent}  `).replace(/\n$/u, ""),
-      );
-    }
-  }
-  return lines.length === 0 ? "" : `${lines.join("\n")}\n`;
+function formatArchiveTreeText(nodes: Map<string, ArchiveTreeNode>): string {
+  return renderTreeText([...nodes.values()].map(formatArchiveTreeRenderNode));
+}
+
+function formatArchiveTreeRenderNode(node: ArchiveTreeNode): RenderTreeNode {
+  return {
+    children: [...node.children.values()].map(formatArchiveTreeRenderNode),
+    label:
+      node.archive === undefined
+        ? node.name
+        : `${node.name} (${node.archive.uri})`,
+  };
 }
 
 async function writeLibraryIndexState(

--- a/packages/cli/src/support/index.ts
+++ b/packages/cli/src/support/index.ts
@@ -3,4 +3,5 @@ export * from "./formats.js";
 export * from "./io.js";
 export * from "./json.js";
 export * from "./shell.js";
+export * from "./tree.js";
 export * from "./version.js";

--- a/packages/cli/src/support/tree.ts
+++ b/packages/cli/src/support/tree.ts
@@ -1,0 +1,25 @@
+export interface RenderTreeNode {
+  readonly children: readonly RenderTreeNode[];
+  readonly label: string;
+}
+
+export function renderTreeText(nodes: readonly RenderTreeNode[]): string {
+  const lines = formatTreeNodes(nodes);
+  return lines.length === 0 ? "" : `${lines.join("\n")}\n`;
+}
+
+function formatTreeNodes(
+  nodes: readonly RenderTreeNode[],
+  prefix = "",
+): readonly string[] {
+  return nodes.flatMap((node, index) => {
+    const last = index === nodes.length - 1;
+    const branch = last ? "└─ " : "├─ ";
+    const childPrefix = `${prefix}${last ? "   " : "│  "}`;
+
+    return [
+      `${prefix}${branch}${node.label}`,
+      ...formatTreeNodes(node.children, childPrefix),
+    ];
+  });
+}

--- a/packages/core/data/help/commands/library.jinja
+++ b/packages/core/data/help/commands/library.jinja
@@ -39,7 +39,7 @@ Related help:
 Archive member collection
 
 Default behavior:
-  - `{{ commandName }} {{ uri }}` lists archive members.
+  - `{{ commandName }} {{ uri }}` reads the archive collection scope; use `/tree` for member file visualization.
   - `scan` reconciles `.wikg` files; `add` copies and registers one archive.
 
 Usage:

--- a/packages/core/data/help/topics/library.jinja
+++ b/packages/core/data/help/topics/library.jinja
@@ -12,7 +12,7 @@ Core model:
   - The default library is addressed as `wikg://lib`.
   - A non-default library is addressed as `wikg://lib/<lib-id>`.
   - The `arc` reserved segment keeps library ids distinct from archive member ids.
-  - `{{ commandName }} wikg://lib` lists archive memberships in the default library; it does not list all library registries.
+  - `{{ commandName }} wikg://lib` reads the default library scope; it does not list all library registries or archive memberships.
 
 Registry discovery:
   - `{{ commandName }} wikg://lib/registry add --path <folder>` prints the new non-default library URI.
@@ -30,6 +30,7 @@ Library folders:
 Archive memberships:
   - `{{ commandName }} wikg://lib/arc scan` recursively discovers `.wikg` files under the default library folder and reconciles registry state.
   - `{{ commandName }} wikg://lib/arc add --input <path> [--to <relative-wikg-path>]` copies one `.wikg` file into the default library folder and registers it.
+  - `{{ commandName }} wikg://lib/arc/tree` shows the archive member file tree; use this instead of naked `wikg://lib` or `wikg://lib/arc` when you want to see archive members.
   - For a non-default library, replace `wikg://lib` with `wikg://lib/<lib-id>` in those `arc` commands.
   - `{{ commandName }} <library-archive-uri>/path set <relative-wikg-path>` moves or renames one managed archive inside the same folder.
   - `{{ commandName }} <library-archive-uri> remove --confirm` deletes one managed archive file and unregisters it.

--- a/test/cli/library.test.ts
+++ b/test/cli/library.test.ts
@@ -75,14 +75,21 @@ describe("cli/library args", () => {
       kind: "library",
     });
 
-    expect(parseCLIArguments(["wikg://lib/abc123abc123"])).toStrictEqual({
+    expect(parseCLIArguments(["wikg://lib"])).toMatchObject({
       args: {
         action: "list",
-        json: undefined,
-        target: { isDefault: false, kind: "scope", publicId: "abc123abc123" },
+        archivePath: "wikg://lib",
       },
       help: false,
-      kind: "library",
+      kind: "archive",
+    });
+    expect(parseCLIArguments(["wikg://lib/abc123abc123"])).toMatchObject({
+      args: {
+        action: "list",
+        archivePath: "wikg://lib/abc123abc123",
+      },
+      help: false,
+      kind: "archive",
     });
 
     expect(() =>
@@ -284,6 +291,17 @@ describe("cli/library args", () => {
       },
       kind: "library",
     });
+    expect(parseCLIArguments(["wikg://lib/arc"])).toMatchObject({
+      args: { action: "list", target: { kind: "archive-collection" } },
+      kind: "library",
+    });
+    expect(parseCLIArguments(["wikg://lib/team/arc"])).toMatchObject({
+      args: {
+        action: "list",
+        target: { kind: "archive-collection", publicId: "team" },
+      },
+      kind: "library",
+    });
 
     expect(() =>
       parseCLIArguments(["wikg://lib/arc", "list", "--jsonl"]),
@@ -423,7 +441,7 @@ describe("cli/library args", () => {
     });
 
     expect(JSON.parse(libraryMockState.textWrites[0] ?? "{}")).toStrictEqual({
-      items: [{ name: "nested", path: "nested" }],
+      items: [{ children: [], name: "nested", path: "nested" }],
     });
 
     libraryMockState.textWrites.length = 0;


### PR DESCRIPTION
## Summary
- Restores naked library scope reads (`wikg://lib`, `wikg://lib/<lib-id>`) to route through scope/object enumeration instead of archive membership flat-list behavior.
- Stops naked archive collection scopes (`wikg://lib/arc`, `wikg://lib/<lib-id>/arc`) from emitting the old archive membership three-column list; `arc/tree` remains the archive member file-tree visualization entry.
- Adds a shared CLI tree text renderer used by both archive-member tree and chapter tree output, and makes archive tree JSON leaf nodes consistently include `children: []`.
- Updates library help text to direct archive-member visualization to `wg wikg://lib/arc/tree`.

Closes #209

## Acceptance coverage
- CLI routing tests cover `wikg://lib`, named library scope, `wikg://lib/arc`, named `arc`, `registry`, `arc/tree`, and individual archive member paths.
- Command output tests cover removal of old three-column flat-list output for naked library / archive collection scopes.
- Tree tests cover text output, JSON output with stable `children`, `--parent`, and `--depth` behavior.
- Chapter tree output now uses the same text tree renderer as library archive tree; manual verification confirmed normal archive and library shortcut chapter tree text/JSON match.
- Help tests confirm naked library / archive collection help no longer describes archive member listing and points users to `arc/tree`.

## Verification
- `pnpm exec vitest run test/cli/library.test.ts packages/cli/src/commands/library.test.ts packages/cli/src/args/archive.test.ts packages/cli/src/args/help.test.ts`
- `pnpm exec vitest run test/cli/archive/query.test.ts test/cli/library.test.ts packages/cli/src/commands/library.test.ts packages/cli/src/args/help.test.ts`
- `pnpm run lint`
- `pnpm run test:run` — 131 files / 862 tests passed
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm run build`

Manual no-side-effect verification used repo-local dev state and `pnpm --silent --filter wiki-graph dev`:
- `wikg://lib` no longer outputs the archive membership three-column flat list.
- `wikg://lib/arc` and `wikg://lib/<lib-id>/arc` no longer output the archive membership flat list.
- `wikg://lib/registry` still lists libraries.
- `wikg://lib/arc/tree` and `--json` show archive member tree with children-based hierarchy.
- named library scope and named `arc/tree` were verified.
- `wikg://lib/arc/<archive-id>`, `/path`, and `inspect --json` still work.
- normal archive `/chapter/tree` and library shortcut `/chapter/tree` text/JSON outputs were compared and matched.
- `arc/tree --parent classics --depth 2` preserved ancestors and calculated depth from the scope root.

## Review note
Attempted blind reviewer delegation first (`deleg_1c426735`), but the reviewer failed after 3 API retries with HTTP 503: all providers temporarily unavailable. Per task rules, I performed a non-blind fallback review against the issue acceptance rubric; verdict: pass. This change does not alter schema versions, `.wikg` archive format, registry schema, permissions, or production data.