### PR TITLE
fix: tighten opaque chapter key tests

### DIFF
--- a/packages/cli/src/commands/archive-command/run/uri.test.ts
+++ b/packages/cli/src/commands/archive-command/run/uri.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import { mkdtemp, rm, writeFile } from "fs/promises";
+import { mkdtemp, rm } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -17,7 +17,7 @@ import {
   TOC_FILE_VERSION,
   WikiGraphArchiveFile,
   writeWikgArchive,
-} from "wiki-graph-core";
+} from "../../../../../core/src/index.js";
 import {
   getWikiGraphStateDirectoryPathForTesting,
   setWikiGraphStateDirectoryPathForTesting,
@@ -45,13 +45,12 @@ afterEach(async () => {
 
 describe("archive-command URI runtime resolution", () => {
   it("resolves library archive object URIs before running archive commands", async () => {
-    const target = parseWikiGraphLibraryUri("wikg://lib");
-    expect(target).toBeDefined();
+    const target = await createTestLibraryTarget();
     const source = join(tempDir, "book.wikg");
-    await writeFile(source, "content");
+    await createEmptyArchive(source);
     const archive = await addWikiGraphLibraryArchive({
       inputPath: source,
-      target: target!,
+      target,
       to: "books/book.wikg",
     });
 
@@ -93,25 +92,24 @@ describe("archive-command URI runtime resolution", () => {
     });
   });
 
-  it("marks the default library index dirty after successful archive writes through a library locator", async () => {
-    const target = parseWikiGraphLibraryUri("wikg://lib");
-    expect(target).toBeDefined();
-    const archive = await addTestArchiveToLibrary(target!);
+  it("marks a library index dirty after successful archive writes through a library locator", async () => {
+    const target = await createTestLibraryTarget();
+    const archive = await addTestArchiveToLibrary(target);
 
-    await rebuildWikiGraphLibraryIndex(target!);
-    await expect(
-      readWikiGraphLibraryIndexState(target!),
-    ).resolves.toMatchObject({
-      status: "current",
-    });
+    await rebuildWikiGraphLibraryIndex(target);
+    await expect(readWikiGraphLibraryIndexState(target)).resolves.toMatchObject(
+      {
+        status: "current",
+      },
+    );
 
     await runArchiveChapterCommand({ action: "add", path: archive.uri });
 
-    await expect(
-      readWikiGraphLibraryIndexState(target!),
-    ).resolves.toMatchObject({
-      status: "dirty",
-    });
+    await expect(readWikiGraphLibraryIndexState(target)).resolves.toMatchObject(
+      {
+        status: "dirty",
+      },
+    );
   });
 
   it("marks the explicit library index dirty after successful archive writes through a library locator", async () => {
@@ -139,35 +137,33 @@ describe("archive-command URI runtime resolution", () => {
   });
 
   it("does not dirty a library index for filesystem archive URI writes", async () => {
-    const target = parseWikiGraphLibraryUri("wikg://lib");
-    expect(target).toBeDefined();
-    const archive = await addTestArchiveToLibrary(target!);
+    const target = await createTestLibraryTarget();
+    const archive = await addTestArchiveToLibrary(target);
 
-    await rebuildWikiGraphLibraryIndex(target!);
-    await expect(
-      readWikiGraphLibraryIndexState(target!),
-    ).resolves.toMatchObject({
-      status: "current",
-    });
+    await rebuildWikiGraphLibraryIndex(target);
+    await expect(readWikiGraphLibraryIndexState(target)).resolves.toMatchObject(
+      {
+        status: "current",
+      },
+    );
 
     await runArchiveChapterCommand({
       action: "add",
       path: `wikg://${archive.path}`,
     });
 
-    await expect(
-      readWikiGraphLibraryIndexState(target!),
-    ).resolves.toMatchObject({
-      status: "current",
-    });
+    await expect(readWikiGraphLibraryIndexState(target)).resolves.toMatchObject(
+      {
+        status: "current",
+      },
+    );
   });
 
   it("does not dirty a library index when an archive write fails", async () => {
-    const target = parseWikiGraphLibraryUri("wikg://lib");
-    expect(target).toBeDefined();
-    const archive = await addTestArchiveToLibrary(target!);
+    const target = await createTestLibraryTarget();
+    const archive = await addTestArchiveToLibrary(target);
 
-    await rebuildWikiGraphLibraryIndex(target!);
+    await rebuildWikiGraphLibraryIndex(target);
     await expect(
       runArchiveChapterCommand({
         action: "set-title",
@@ -177,11 +173,11 @@ describe("archive-command URI runtime resolution", () => {
       }),
     ).rejects.toThrow();
 
-    await expect(
-      readWikiGraphLibraryIndexState(target!),
-    ).resolves.toMatchObject({
-      status: "current",
-    });
+    await expect(readWikiGraphLibraryIndexState(target)).resolves.toMatchObject(
+      {
+        status: "current",
+      },
+    );
   });
 
   it("removes embedded FTS from library archive URI writes without changing the policy", async () => {
@@ -230,6 +226,21 @@ async function addTestArchiveToLibrary(
     target,
     to: `${randomUUID()}.wikg`,
   });
+}
+
+async function createTestLibraryTarget(): Promise<
+  NonNullable<ReturnType<typeof parseWikiGraphLibraryUri>>
+> {
+  const library = await createWikiGraphLibrary({
+    folderPath: join(tempDir, `library-${randomUUID()}`),
+  });
+  const target = parseWikiGraphLibraryUri(library.uri);
+
+  if (target === undefined) {
+    throw new Error(`Invalid test library URI: ${library.uri}`);
+  }
+
+  return target;
 }
 
 async function createEmptyArchive(path: string): Promise<void> {

--- a/packages/cli/src/commands/archive-command/run/uri.test.ts
+++ b/packages/cli/src/commands/archive-command/run/uri.test.ts
@@ -7,16 +7,13 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   addWikiGraphLibraryArchive,
   createWikiGraphLibrary,
-  DirectoryDocument,
   parseWikiGraphLibraryUri,
   readArchiveIndexSettings,
   readWikiGraphLibraryIndexState,
   rebuildArchiveSearchIndex,
   rebuildWikiGraphLibraryIndex,
   setFtsIndexEmbedded,
-  TOC_FILE_VERSION,
   WikiGraphArchiveFile,
-  writeWikgArchive,
 } from "../../../../../core/src/index.js";
 import {
   getWikiGraphStateDirectoryPathForTesting,
@@ -28,6 +25,7 @@ import {
   resolveArchiveCommandRuntimeArguments,
   resolveArchiveRuntimeLocation,
 } from "./uri.js";
+import { createEmptyArchive } from "../../test-helpers.js";
 
 let previousStateDir: string | undefined;
 let tempDir: string;
@@ -47,7 +45,7 @@ describe("archive-command URI runtime resolution", () => {
   it("resolves library archive object URIs before running archive commands", async () => {
     const target = await createTestLibraryTarget();
     const source = join(tempDir, "book.wikg");
-    await createEmptyArchive(source);
+    await createEmptyArchive({ path: source, tempDir });
     const archive = await addWikiGraphLibraryArchive({
       inputPath: source,
       target,
@@ -219,7 +217,7 @@ async function addTestArchiveToLibrary(
   target: NonNullable<ReturnType<typeof parseWikiGraphLibraryUri>>,
 ): ReturnType<typeof addWikiGraphLibraryArchive> {
   const source = join(tempDir, `${randomUUID()}.wikg`);
-  await createEmptyArchive(source);
+  await createEmptyArchive({ path: source, tempDir });
 
   return await addWikiGraphLibraryArchive({
     inputPath: source,
@@ -241,22 +239,4 @@ async function createTestLibraryTarget(): Promise<
   }
 
   return target;
-}
-
-async function createEmptyArchive(path: string): Promise<void> {
-  const sourceDir = await mkdtemp(join(tempDir, "wikg-source-"));
-  const document = await DirectoryDocument.open(sourceDir);
-
-  try {
-    try {
-      await document.openSession(async (openedDocument) => {
-        await openedDocument.writeToc({ items: [], version: TOC_FILE_VERSION });
-      });
-    } finally {
-      await document.release();
-    }
-    await writeWikgArchive(sourceDir, path);
-  } finally {
-    await rm(sourceDir, { force: true, recursive: true });
-  }
 }

--- a/packages/cli/src/commands/library.test.ts
+++ b/packages/cli/src/commands/library.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   addWikiGraphLibraryArchive,
@@ -9,84 +9,89 @@ import {
   parseWikiGraphLibraryUri,
   TOC_FILE_VERSION,
   writeWikgArchive,
-} from "wiki-graph-core";
-import {
-  getWikiGraphStateDirectoryPathForTesting,
-  setWikiGraphStateDirectoryPathForTesting,
-} from "../../../core/src/runtime/common/wiki-graph/dir.js";
+} from "../../../core/src/index.js";
+import { withWikiGraphStateDirectoryPathForTesting } from "../../../core/src/runtime/common/wiki-graph/dir.js";
 import { runLibraryCommand } from "./library.js";
-
-let previousStateDir: string | undefined;
-let tempDir: string;
-
-beforeEach(async () => {
-  previousStateDir = getWikiGraphStateDirectoryPathForTesting();
-  tempDir = await mkdtemp(join(tmpdir(), "wikigraph-cli-library-test-"));
-  setWikiGraphStateDirectoryPathForTesting(join(tempDir, "state"));
-});
-
-afterEach(async () => {
-  setWikiGraphStateDirectoryPathForTesting(previousStateDir);
-  await rm(tempDir, { force: true, recursive: true });
-});
 
 describe("library command", () => {
   it("filters archive tree by file parent without changing the display root", async () => {
-    const target = parseWikiGraphLibraryUri("wikg://lib");
-    expect(target).toBeDefined();
-    const source = join(tempDir, "source.wikg");
-    await createEmptyArchive(source);
-    const archive = await addWikiGraphLibraryArchive({
-      inputPath: source,
-      target: target!,
-      to: "nested/book.wikg",
-    });
-
-    await addWikiGraphLibraryArchive({
-      inputPath: source,
-      target: target!,
-      to: "other.wikg",
-    });
-
-    const output = await captureStdout(async () => {
-      await runLibraryCommand({
-        action: "archive-tree",
-        json: true,
-        parent: "nested/book.wikg",
-        target: { isDefault: true, kind: "archive-tree" },
+    await withLibraryCommandTestState(async (tempDir) => {
+      const target = parseWikiGraphLibraryUri("wikg://lib");
+      expect(target).toBeDefined();
+      const source = join(tempDir, "source.wikg");
+      await createEmptyArchive(tempDir, source);
+      const archive = await addWikiGraphLibraryArchive({
+        inputPath: source,
+        target: target!,
+        to: "nested/book.wikg",
       });
-    });
 
-    expect(JSON.parse(output)).toStrictEqual({
-      items: [
-        {
-          children: [
-            {
-              children: [],
-              name: "book.wikg",
-              path: "nested/book.wikg",
-              uri: archive.uri,
-            },
-          ],
-          name: "nested",
-          path: "nested",
-        },
-      ],
-    });
-
-    const textOutput = await captureStdout(async () => {
-      await runLibraryCommand({
-        action: "archive-tree",
-        parent: "nested/book.wikg",
-        target: { isDefault: true, kind: "archive-tree" },
+      await addWikiGraphLibraryArchive({
+        inputPath: source,
+        target: target!,
+        to: "other.wikg",
       });
-    });
 
-    expect(textOutput).toBe(`└─ nested\n   └─ book.wikg (${archive.uri})\n`);
+      const output = await captureStdout(async () => {
+        await runLibraryCommand({
+          action: "archive-tree",
+          json: true,
+          parent: "nested/book.wikg",
+          target: { isDefault: true, kind: "archive-tree" },
+        });
+      });
+
+      expect(JSON.parse(output)).toStrictEqual({
+        items: [
+          {
+            children: [
+              {
+                children: [],
+                name: "book.wikg",
+                path: "nested/book.wikg",
+                uri: archive.uri,
+              },
+            ],
+            name: "nested",
+            path: "nested",
+          },
+        ],
+      });
+
+      const textOutput = await captureStdout(async () => {
+        await runLibraryCommand({
+          action: "archive-tree",
+          parent: "nested/book.wikg",
+          target: { isDefault: true, kind: "archive-tree" },
+        });
+      });
+
+      expect(textOutput).toBe(`└─ nested\n   └─ book.wikg (${archive.uri})\n`);
+    });
   });
 });
 
-async function createEmptyArchive(path: string): Promise<void> {
+async function withLibraryCommandTestState(
+  operation: (tempDir: string) => Promise<void>,
+): Promise<void> {
+  const tempDir = await mkdtemp(join(tmpdir(), "wikigraph-cli-library-test-"));
+
+  try {
+    await withWikiGraphStateDirectoryPathForTesting(
+      join(tempDir, "state"),
+      async () => {
+        await operation(tempDir);
+      },
+    );
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+}
+
+async function createEmptyArchive(
+  tempDir: string,
+  path: string,
+): Promise<void> {
   const sourceDir = await mkdtemp(join(tempDir, "wikg-source-"));
   const document = await DirectoryDocument.open(sourceDir);
   try {

--- a/packages/cli/src/commands/library.test.ts
+++ b/packages/cli/src/commands/library.test.ts
@@ -5,13 +5,11 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   addWikiGraphLibraryArchive,
-  DirectoryDocument,
   parseWikiGraphLibraryUri,
-  TOC_FILE_VERSION,
-  writeWikgArchive,
 } from "../../../core/src/index.js";
 import { withWikiGraphStateDirectoryPathForTesting } from "../../../core/src/runtime/common/wiki-graph/dir.js";
 import { runLibraryCommand } from "./library.js";
+import { createEmptyArchive } from "./test-helpers.js";
 
 describe("library command", () => {
   it("filters archive tree by file parent without changing the display root", async () => {
@@ -19,7 +17,7 @@ describe("library command", () => {
       const target = parseWikiGraphLibraryUri("wikg://lib");
       expect(target).toBeDefined();
       const source = join(tempDir, "source.wikg");
-      await createEmptyArchive(tempDir, source);
+      await createEmptyArchive({ path: source, tempDir });
       const archive = await addWikiGraphLibraryArchive({
         inputPath: source,
         target: target!,
@@ -85,26 +83,6 @@ async function withLibraryCommandTestState(
     );
   } finally {
     await rm(tempDir, { force: true, recursive: true });
-  }
-}
-
-async function createEmptyArchive(
-  tempDir: string,
-  path: string,
-): Promise<void> {
-  const sourceDir = await mkdtemp(join(tempDir, "wikg-source-"));
-  const document = await DirectoryDocument.open(sourceDir);
-  try {
-    try {
-      await document.openSession(async (openedDocument) => {
-        await openedDocument.writeToc({ items: [], version: TOC_FILE_VERSION });
-      });
-    } finally {
-      await document.release();
-    }
-    await writeWikgArchive(sourceDir, path);
-  } finally {
-    await rm(sourceDir, { force: true, recursive: true });
   }
 }
 

--- a/packages/cli/src/commands/test-helpers.ts
+++ b/packages/cli/src/commands/test-helpers.ts
@@ -1,0 +1,29 @@
+import { mkdtemp, rm } from "fs/promises";
+import { join } from "path";
+
+import {
+  DirectoryDocument,
+  TOC_FILE_VERSION,
+  writeWikgArchive,
+} from "../../../core/src/index.js";
+
+export async function createEmptyArchive(input: {
+  readonly tempDir: string;
+  readonly path: string;
+}): Promise<void> {
+  const sourceDir = await mkdtemp(join(input.tempDir, "wikg-source-"));
+  const document = await DirectoryDocument.open(sourceDir);
+
+  try {
+    try {
+      await document.openSession(async (openedDocument) => {
+        await openedDocument.writeToc({ items: [], version: TOC_FILE_VERSION });
+      });
+    } finally {
+      await document.release();
+    }
+    await writeWikgArchive(sourceDir, input.path);
+  } finally {
+    await rm(sourceDir, { force: true, recursive: true });
+  }
+}

--- a/packages/core/src/document/chapter/toc.ts
+++ b/packages/core/src/document/chapter/toc.ts
@@ -10,6 +10,7 @@ export async function readChapterToc(
 ): Promise<MutableTocFile> {
   const toc = await document.readToc();
   const items = toc?.items.map(cloneTocItem) ?? [];
+  assertChapterKeys(items);
 
   return toc === undefined
     ? { items: [], version: TOC_FILE_VERSION }
@@ -17,6 +18,26 @@ export async function readChapterToc(
         items,
         version: toc.version,
       };
+}
+
+function assertChapterKeys(items: MutableTocFile["items"]): void {
+  const existingKeys = new Set<string>();
+  const visit = (nodes: MutableTocFile["items"]): void => {
+    for (const item of nodes) {
+      if (item.key === undefined) {
+        throw new Error(
+          "Missing chapter key in TOC. Run a writable chapter operation or `wg maintenance upgrade` before using read-only chapter paths.",
+        );
+      }
+      if (existingKeys.has(item.key)) {
+        throw new Error(`Duplicate chapter key: ${item.key}.`);
+      }
+      existingKeys.add(item.key);
+      visit(item.children);
+    }
+  };
+
+  visit(items);
 }
 
 export function ensureChapterKeys(items: MutableTocFile["items"]): boolean {

--- a/packages/core/src/document/directory/core.ts
+++ b/packages/core/src/document/directory/core.ts
@@ -5,6 +5,8 @@ import { z } from "zod";
 import { bookMetaSchema, type BookMeta } from "../../text/source/meta.js";
 import { tocFileSchema, type TocFile } from "../../text/source/toc.js";
 import type { SourceAsset } from "../../text/source/types.js";
+import { ensureChapterKeys } from "../chapter/toc.js";
+import type { MutableTocFile, MutableTocItem } from "../chapter/tree.js";
 import { Database } from "../database.js";
 import { TextStreams, type SerialTextStream } from "../text-streams/index.js";
 import { initializeDocumentSchema, SCHEMA_SQL } from "../schema.js";
@@ -360,25 +362,29 @@ export class DirectoryDocument implements Document {
   }
 
   public async writeToc(toc: TocFile): Promise<void> {
+    const writableToc = createWritableToc(toc);
+
     await writeJsonFile({
       context: this.#contextScope.getStore(),
       fileStore: this.#fileStore,
       path: getTocPath(this.path),
-      value: toc,
+      value: writableToc,
     });
-    await this.#replaceDocumentOrder(toc);
+    await this.#replaceDocumentOrder(writableToc);
     await this.serials.bumpChaptersRevision();
   }
 
   public async replaceToc(toc: TocFile): Promise<void> {
+    const writableToc = createWritableToc(toc);
+
     await writeJsonFile({
       context: this.#contextScope.getStore(),
       fileStore: this.#fileStore,
       options: { overwrite: true },
       path: getTocPath(this.path),
-      value: toc,
+      value: writableToc,
     });
-    await this.#replaceDocumentOrder(toc);
+    await this.#replaceDocumentOrder(writableToc);
     await this.serials.bumpChaptersRevision();
   }
 
@@ -440,4 +446,23 @@ export class DirectoryDocument implements Document {
       textStreams: this.#textStreams,
     });
   }
+}
+
+function createWritableToc(toc: TocFile): TocFile {
+  const writableToc: MutableTocFile = {
+    items: toc.items.map(cloneWritableTocItem),
+    version: toc.version,
+  };
+  ensureChapterKeys(writableToc.items);
+
+  return writableToc;
+}
+
+function cloneWritableTocItem(item: TocFile["items"][number]): MutableTocItem {
+  return {
+    children: item.children.map(cloneWritableTocItem),
+    ...(item.key === undefined ? {} : { key: item.key }),
+    ...(item.serialId === undefined ? {} : { serialId: item.serialId }),
+    ...(item.title === undefined ? {} : { title: item.title }),
+  };
 }

--- a/packages/core/src/storage/migration/legacy-sdpub/upgrade/index.ts
+++ b/packages/core/src/storage/migration/legacy-sdpub/upgrade/index.ts
@@ -2,6 +2,7 @@ import { rm } from "fs/promises";
 import { join, resolve } from "path";
 
 import { createWikiGraphTempDirectory } from "../../../../runtime/common/wiki-graph/temp.js";
+import { DirectoryDocument } from "../../../../document/index.js";
 import { writeWikgArchive } from "../../../wikg/index.js";
 import { extractLegacySdpubArchive } from "./extract.js";
 import { migrateLegacyDatabase } from "./schema.js";
@@ -28,11 +29,26 @@ export async function migrateLegacySdpubToWikg(
     await extractLegacySdpubArchive(inputPath, workspacePath);
     await migrateLegacyDatabase(join(workspacePath, "database.db"));
     await migrateLegacyTextStorage(workspacePath);
+    await normalizeLegacyToc(workspacePath);
     await writeWikgArchive(workspacePath, outputPath);
 
     return { inputPath, outputPath };
   } finally {
     await rm(workspacePath, { force: true, recursive: true });
+  }
+}
+
+async function normalizeLegacyToc(workspacePath: string): Promise<void> {
+  const document = await DirectoryDocument.open(workspacePath);
+
+  try {
+    const toc = await document.readToc();
+
+    if (toc !== undefined) {
+      await document.replaceToc(toc);
+    }
+  } finally {
+    await document.release();
   }
 }
 

--- a/test/cli/archive/chapter.test.ts
+++ b/test/cli/archive/chapter.test.ts
@@ -17,11 +17,11 @@ const chapterMockState = vi.hoisted(() => ({
           {
             children: [],
             title: "Chapter 1",
-            uri: "wikg://chapter/part-i/chapter-1",
+            uri: "wikg://chapter/a1b2c3d4e5f6/b2c3d4e5f6a1",
           },
         ],
         title: "Part I",
-        uri: "wikg://chapter/part-i",
+        uri: "wikg://chapter/a1b2c3d4e5f6",
       },
     ],
   },
@@ -31,23 +31,23 @@ const chapterMockState = vi.hoisted(() => ({
       childCount: 1,
       depth: 0,
       fragmentCount: 0,
-      key: "part-i",
-      path: "part-i",
+      key: "a1b2c3d4e5f6",
+      path: "a1b2c3d4e5f6",
       stage: "planned",
       title: "Part I",
       tocPath: ["Part I"],
-      uri: "wikg://chapter/part-i",
+      uri: "wikg://chapter/a1b2c3d4e5f6",
     },
     {
       childCount: 0,
       depth: 1,
       fragmentCount: 2,
-      key: "chapter-1",
-      path: "part-i/chapter-1",
+      key: "b2c3d4e5f6a1",
+      path: "a1b2c3d4e5f6/b2c3d4e5f6a1",
       stage: "sourced",
       title: "Chapter 1",
       tocPath: ["Part I", "Chapter 1"],
-      uri: "wikg://chapter/part-i/chapter-1",
+      uri: "wikg://chapter/a1b2c3d4e5f6/b2c3d4e5f6a1",
     },
   ],
   removeCalls: [] as unknown[],
@@ -70,12 +70,12 @@ const chapterDetails = {
   fragmentCount: 2,
   graphReady: false,
   hasSummary: false,
-  key: "chapter-1",
-  path: "part-i/chapter-1",
+  key: "b2c3d4e5f6a1",
+  path: "a1b2c3d4e5f6/b2c3d4e5f6a1",
   stage: "sourced",
   title: "Chapter 1",
   tocPath: ["Part I", "Chapter 1"],
-  uri: "wikg://chapter/part-i/chapter-1",
+  uri: "wikg://chapter/a1b2c3d4e5f6/b2c3d4e5f6a1",
 };
 
 vi.mock(
@@ -112,9 +112,9 @@ vi.mock("../../../packages/core/src/api/index.js", () => ({
       ...chapterDetails,
       chapterId: 3,
       stage: "planned",
-      path: "a1b2c3d4e5f6",
+      path: "c3d4e5f6a1b2",
       title: "New Chapter",
-      uri: "wikg://chapter/a1b2c3d4e5f6",
+      uri: "wikg://chapter/c3d4e5f6a1b2",
     });
   }),
   assertNoActiveBuildJobs: vi.fn((input: unknown) => {
@@ -150,17 +150,17 @@ vi.mock("../../../packages/core/src/api/index.js", () => ({
           {
             newIndex: 0,
             newParentUri: null,
-            newPath: ["chapter-1"],
-            newUri: "wikg://chapter/chapter-1",
+            newPath: ["b2c3d4e5f6a1"],
+            newUri: "wikg://chapter/b2c3d4e5f6a1",
             oldIndex: 0,
-            oldParentUri: "wikg://chapter/part-i",
-            oldPath: ["part-i", "chapter-1"],
-            oldUri: "wikg://chapter/part-i/chapter-1",
+            oldParentUri: "wikg://chapter/a1b2c3d4e5f6",
+            oldPath: ["a1b2c3d4e5f6", "b2c3d4e5f6a1"],
+            oldUri: "wikg://chapter/a1b2c3d4e5f6/b2c3d4e5f6a1",
           },
         ],
         renamed: [
           {
-            uri: "wikg://chapter/part-i/chapter-1",
+            uri: "wikg://chapter/a1b2c3d4e5f6/b2c3d4e5f6a1",
             newTitle: null,
             oldTitle: "Chapter 1",
           },
@@ -180,9 +180,9 @@ vi.mock("../../../packages/core/src/api/index.js", () => ({
   ),
   resolveChapterPath: vi.fn((_document: unknown, chapterPath: string) => {
     const chapterIds = new Map<string, number>([
-      ["part-i", 1],
-      ["part-i/chapter-1", 2],
-      ["a1b2c3d4e5f6", 3],
+      ["a1b2c3d4e5f6", 1],
+      ["a1b2c3d4e5f6/b2c3d4e5f6a1", 2],
+      ["c3d4e5f6a1b2", 3],
     ]);
 
     return Promise.resolve(chapterIds.get(chapterPath));
@@ -318,7 +318,7 @@ describe("cli/archive-chapter", () => {
     expect(chapterMockState.readCalls).toStrictEqual(["/tmp/book.wikg"]);
     expect(chapterMockState.writeCalls).toStrictEqual([]);
     expect(chapterMockState.textWrites).toStrictEqual([
-      "[planned] Part I (wikg://chapter/part-i)\n  [source] Chapter 1 (wikg://chapter/part-i/chapter-1)\n",
+      "[planned] Part I (wikg://chapter/a1b2c3d4e5f6)\n  [source] Chapter 1 (wikg://chapter/a1b2c3d4e5f6/b2c3d4e5f6a1)\n",
     ]);
   });
 
@@ -334,12 +334,12 @@ describe("cli/archive-chapter", () => {
         {
           stage: "planned",
           title: "Part I",
-          uri: "wikg://chapter/part-i",
+          uri: "wikg://chapter/a1b2c3d4e5f6",
         },
         {
           stage: "source",
           title: "Chapter 1",
-          uri: "wikg://chapter/part-i/chapter-1",
+          uri: "wikg://chapter/a1b2c3d4e5f6/b2c3d4e5f6a1",
         },
       ],
     });
@@ -348,7 +348,7 @@ describe("cli/archive-chapter", () => {
   it("adds a chapter and prints the new chapter id", async () => {
     await runArchiveChapterCommand({
       action: "add",
-      parentChapterPath: "part-i",
+      parentChapterPath: "a1b2c3d4e5f6",
       path: "/tmp/book.wikg",
       title: "New Chapter",
     });
@@ -360,7 +360,7 @@ describe("cli/archive-chapter", () => {
       },
     ]);
     expect(chapterMockState.textWrites[0]).toContain(
-      "Chapter: wikg://chapter/a1b2c3d4e5f6\n",
+      "Chapter: wikg://chapter/c3d4e5f6a1b2\n",
     );
   });
 
@@ -379,7 +379,7 @@ describe("cli/archive-chapter", () => {
       sourceUnits: 2,
       stage: "planned",
       title: "New Chapter",
-      uri: "wikg://chapter/a1b2c3d4e5f6",
+      uri: "wikg://chapter/c3d4e5f6a1b2",
     });
   });
 
@@ -425,7 +425,7 @@ describe("cli/archive-chapter", () => {
   it("reads source content from --input", async () => {
     await runArchiveChapterCommand({
       action: "set-source",
-      chapterPath: "part-i/chapter-1",
+      chapterPath: "a1b2c3d4e5f6/b2c3d4e5f6a1",
       inputPath: "/tmp/chapter.md",
       path: "/tmp/book.wikg",
     });
@@ -441,7 +441,7 @@ describe("cli/archive-chapter", () => {
   it("reads source content from stdin when --input is dash", async () => {
     await runArchiveChapterCommand({
       action: "set-source",
-      chapterPath: "part-i/chapter-1",
+      chapterPath: "a1b2c3d4e5f6/b2c3d4e5f6a1",
       inputPath: "-",
       path: "/tmp/book.wikg",
     });
@@ -457,7 +457,7 @@ describe("cli/archive-chapter", () => {
   it("reads source content from a positional value", async () => {
     await runArchiveChapterCommand({
       action: "set-source",
-      chapterPath: "part-i/chapter-1",
+      chapterPath: "a1b2c3d4e5f6/b2c3d4e5f6a1",
       inputValue: "inline source",
       path: "/tmp/book.wikg",
     });
@@ -474,7 +474,7 @@ describe("cli/archive-chapter", () => {
     await expect(
       runArchiveChapterCommand({
         action: "set-source",
-        chapterPath: "part-i/chapter-1",
+        chapterPath: "a1b2c3d4e5f6/b2c3d4e5f6a1",
         path: "/tmp/book.wikg",
       }),
     ).rejects.toThrow(
@@ -487,7 +487,7 @@ describe("cli/archive-chapter", () => {
   it("reads summary content from --input", async () => {
     await runArchiveChapterCommand({
       action: "set-summary",
-      chapterPath: "part-i/chapter-1",
+      chapterPath: "a1b2c3d4e5f6/b2c3d4e5f6a1",
       inputPath: "/tmp/summary.txt",
       path: "/tmp/book.wikg",
     });
@@ -503,7 +503,7 @@ describe("cli/archive-chapter", () => {
   it("reads summary content from stdin when --input is dash", async () => {
     await runArchiveChapterCommand({
       action: "set-summary",
-      chapterPath: "part-i/chapter-1",
+      chapterPath: "a1b2c3d4e5f6/b2c3d4e5f6a1",
       inputPath: "-",
       path: "/tmp/book.wikg",
     });
@@ -519,7 +519,7 @@ describe("cli/archive-chapter", () => {
   it("reads summary content from a positional value", async () => {
     await runArchiveChapterCommand({
       action: "set-summary",
-      chapterPath: "part-i/chapter-1",
+      chapterPath: "a1b2c3d4e5f6/b2c3d4e5f6a1",
       inputValue: "inline summary",
       path: "/tmp/book.wikg",
     });
@@ -536,7 +536,7 @@ describe("cli/archive-chapter", () => {
     await expect(
       runArchiveChapterCommand({
         action: "set-summary",
-        chapterPath: "part-i/chapter-1",
+        chapterPath: "a1b2c3d4e5f6/b2c3d4e5f6a1",
         path: "/tmp/book.wikg",
       }),
     ).rejects.toThrow(
@@ -549,7 +549,7 @@ describe("cli/archive-chapter", () => {
   it("prints summary set result as JSON when requested", async () => {
     await runArchiveChapterCommand({
       action: "set-summary",
-      chapterPath: "part-i/chapter-1",
+      chapterPath: "a1b2c3d4e5f6/b2c3d4e5f6a1",
       inputValue: "inline summary",
       json: true,
       path: "/tmp/book.wikg",
@@ -562,14 +562,14 @@ describe("cli/archive-chapter", () => {
       sourceUnits: 2,
       stage: "reading-summary",
       title: "Chapter 1",
-      uri: "wikg://chapter/part-i/chapter-1",
+      uri: "wikg://chapter/a1b2c3d4e5f6/b2c3d4e5f6a1",
     });
   });
 
   it("sets a chapter title", async () => {
     await runArchiveChapterCommand({
       action: "set-title",
-      chapterPath: "part-i/chapter-1",
+      chapterPath: "a1b2c3d4e5f6/b2c3d4e5f6a1",
       path: "/tmp/book.wikg",
       title: "Renamed Chapter",
     });
@@ -586,7 +586,7 @@ describe("cli/archive-chapter", () => {
   it("clears a chapter title", async () => {
     await runArchiveChapterCommand({
       action: "set-title",
-      chapterPath: "part-i/chapter-1",
+      chapterPath: "a1b2c3d4e5f6/b2c3d4e5f6a1",
       clearTitle: true,
       path: "/tmp/book.wikg",
     });
@@ -609,9 +609,9 @@ describe("cli/archive-chapter", () => {
   it("moves a chapter", async () => {
     await runArchiveChapterCommand({
       action: "move",
-      chapterPath: "part-i/chapter-1",
+      chapterPath: "a1b2c3d4e5f6/b2c3d4e5f6a1",
       first: true,
-      parentChapterPath: "part-i",
+      parentChapterPath: "a1b2c3d4e5f6",
       path: "/tmp/book.wikg",
     });
 
@@ -632,7 +632,7 @@ describe("cli/archive-chapter", () => {
       },
     ]);
     expect(chapterMockState.textWrites[0]).toContain(
-      "Chapter: wikg://chapter/part-i/chapter-1\n",
+      "Chapter: wikg://chapter/a1b2c3d4e5f6/b2c3d4e5f6a1\n",
     );
   });
 
@@ -644,7 +644,9 @@ describe("cli/archive-chapter", () => {
     });
 
     expect(chapterMockState.textWrites[0]).toBe(
-      ["└─ Part I (part-i)", "   └─ Chapter 1 (chapter-1)", ""].join("\n"),
+      ["└─ Part I (a1b2c3d4e5f6)", "   └─ Chapter 1 (b2c3d4e5f6a1)", ""].join(
+        "\n",
+      ),
     );
 
     await runArchiveChapterCommand({
@@ -660,12 +662,12 @@ describe("cli/archive-chapter", () => {
       chapters: [
         {
           children: [],
-          uri: "wikg://chapter/part-i/chapter-1",
+          uri: "wikg://chapter/a1b2c3d4e5f6/b2c3d4e5f6a1",
           title: null,
         },
         {
           children: [],
-          uri: "wikg://chapter/part-i",
+          uri: "wikg://chapter/a1b2c3d4e5f6",
         },
       ],
     });
@@ -686,12 +688,12 @@ describe("cli/archive-chapter", () => {
           chapters: [
             {
               children: [],
-              uri: "wikg://chapter/part-i/chapter-1",
+              uri: "wikg://chapter/a1b2c3d4e5f6/b2c3d4e5f6a1",
               title: null,
             },
             {
               children: [],
-              uri: "wikg://chapter/part-i",
+              uri: "wikg://chapter/a1b2c3d4e5f6",
             },
           ],
         },
@@ -710,7 +712,7 @@ describe("cli/archive-chapter", () => {
           {
             children: [],
             title: "Chapter 1",
-            uri: "wikg://chapter/part-i/chapter-1",
+            uri: "wikg://chapter/a1b2c3d4e5f6/b2c3d4e5f6a1",
           },
         ],
       }),
@@ -732,7 +734,7 @@ describe("cli/archive-chapter", () => {
           chapters: [
             {
               children: [],
-              uri: "wikg://chapter/part-i/chapter-1",
+              uri: "wikg://chapter/a1b2c3d4e5f6/b2c3d4e5f6a1",
               title: "Chapter 1",
             },
           ],
@@ -758,7 +760,7 @@ describe("cli/archive-chapter", () => {
   it("removes chapters recursively when requested", async () => {
     await runArchiveChapterCommand({
       action: "remove",
-      chapterPath: "part-i",
+      chapterPath: "a1b2c3d4e5f6",
       path: "/tmp/book.wikg",
       recursive: true,
     });
@@ -779,7 +781,7 @@ describe("cli/archive-chapter", () => {
       },
     ]);
     expect(chapterMockState.textWrites).toStrictEqual([
-      "Removed chapter wikg://chapter/part-i.\n",
+      "Removed chapter wikg://chapter/a1b2c3d4e5f6.\n",
     ]);
   });
 });

--- a/test/core/api/chapter.test.ts
+++ b/test/core/api/chapter.test.ts
@@ -1,4 +1,4 @@
-import { rm } from "fs/promises";
+import { rm, writeFile } from "fs/promises";
 
 import { describe, expect, it } from "vitest";
 
@@ -84,7 +84,10 @@ describe("facade/chapter", () => {
       try {
         await document.openSession(async (openedDocument) => {
           await openedDocument.createSerial();
-          await openedDocument.writeToc({
+        });
+        await writeFile(
+          `${path}/toc.json`,
+          `${JSON.stringify({
             items: [
               {
                 children: [
@@ -98,8 +101,9 @@ describe("facade/chapter", () => {
               },
             ],
             version: 1,
-          });
-        });
+          })}\n`,
+          "utf8",
+        );
 
         await expect(listChapters(document)).rejects.toThrow(
           "Missing chapter key in TOC.",
@@ -136,7 +140,10 @@ describe("facade/chapter", () => {
         await document.openSession(async (openedDocument) => {
           await openedDocument.createSerial();
           await openedDocument.createSerial();
-          await openedDocument.writeToc({
+        });
+        await writeFile(
+          `${path}/toc.json`,
+          `${JSON.stringify({
             items: [
               {
                 children: [],
@@ -152,8 +159,9 @@ describe("facade/chapter", () => {
               },
             ],
             version: 1,
-          });
-        });
+          })}\n`,
+          "utf8",
+        );
 
         await expect(listChapters(document)).rejects.toThrow(
           "Duplicate chapter key: a1b2c3d4e5f6.",

--- a/test/core/api/chapter.test.ts
+++ b/test/core/api/chapter.test.ts
@@ -77,7 +77,7 @@ describe("facade/chapter", () => {
     });
   });
 
-  it("does not randomize missing chapter keys on read-only chapter paths", async () => {
+  it("rejects missing chapter keys on read-only chapter paths", async () => {
     await withTempDir("wikigraph-chapter-", async (path) => {
       const document = await DirectoryDocument.open(path);
 
@@ -101,25 +101,12 @@ describe("facade/chapter", () => {
           });
         });
 
-        expect(await listChapters(document)).toMatchObject([
-          {
-            chapterId: 1,
-            depth: 1,
-            path: "chapter-group/chapter-1",
-            stage: "planned",
-            title: "Chapter 1",
-            tocPath: ["Part I", "Chapter 1"],
-          },
-        ]);
-        expect(await getChapterTree(document)).toStrictEqual({
-          chapters: [
-            {
-              children: [],
-              title: "Chapter 1",
-              uri: "wikg://chapter/chapter-group/chapter-1",
-            },
-          ],
-        });
+        await expect(listChapters(document)).rejects.toThrow(
+          "Missing chapter key in TOC.",
+        );
+        await expect(getChapterTree(document)).rejects.toThrow(
+          "Missing chapter key in TOC.",
+        );
         expect(await document.readToc()).toStrictEqual({
           items: [
             {
@@ -135,6 +122,45 @@ describe("facade/chapter", () => {
           ],
           version: 1,
         });
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
+  it("rejects duplicate chapter keys on read-only chapter paths", async () => {
+    await withTempDir("wikigraph-chapter-", async (path) => {
+      const document = await DirectoryDocument.open(path);
+
+      try {
+        await document.openSession(async (openedDocument) => {
+          await openedDocument.createSerial();
+          await openedDocument.createSerial();
+          await openedDocument.writeToc({
+            items: [
+              {
+                children: [],
+                key: "a1b2c3d4e5f6",
+                serialId: 1,
+                title: "First",
+              },
+              {
+                children: [],
+                key: "a1b2c3d4e5f6",
+                serialId: 2,
+                title: "Second",
+              },
+            ],
+            version: 1,
+          });
+        });
+
+        await expect(listChapters(document)).rejects.toThrow(
+          "Duplicate chapter key: a1b2c3d4e5f6.",
+        );
+        await expect(getChapterTree(document)).rejects.toThrow(
+          "Duplicate chapter key: a1b2c3d4e5f6.",
+        );
       } finally {
         await document.release();
       }

--- a/test/core/library/registry.test.ts
+++ b/test/core/library/registry.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm, stat } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import {
   clearWikiGraphLibraryMetadata,
@@ -17,64 +17,59 @@ import {
   removeWikiGraphLibrary,
   replaceWikiGraphLibraryMetadata,
 } from "../../../packages/core/src/index.js";
-import {
-  getWikiGraphStateDirectoryPathForTesting,
-  setWikiGraphStateDirectoryPathForTesting,
-} from "../../../packages/core/src/runtime/common/wiki-graph/dir.js";
+import { withWikiGraphStateDirectoryPathForTesting } from "../../../packages/core/src/runtime/common/wiki-graph/dir.js";
 
 describe("wiki graph library registry", () => {
-  const originalStateDir = getWikiGraphStateDirectoryPathForTesting();
-  let stateDir: string;
-
-  beforeEach(async () => {
-    stateDir = await mkdtemp(join(tmpdir(), "wikg-library-"));
-    setWikiGraphStateDirectoryPathForTesting(stateDir);
-  });
-
-  afterEach(async () => {
-    setWikiGraphStateDirectoryPathForTesting(originalStateDir);
-    await rm(stateDir, { force: true, recursive: true });
-  });
-
   it("auto-creates the default library with empty metadata", async () => {
-    const library = await ensureDefaultWikiGraphLibrary();
+    await withRegistryTestState(async (stateDir) => {
+      const library = await ensureDefaultWikiGraphLibrary();
 
-    expect(library.id).toEqual(expect.any(Number));
-    expect(library.isDefault).toBe(true);
-    expect(library.uri).toBe("wikg://lib");
-    expect(library.folderPath).toBe(join(stateDir, "default-library"));
-    expect((await stat(library.folderPath)).isDirectory()).toBe(true);
-    expect(
-      await getWikiGraphLibraryMetadata({ isDefault: true, kind: "metadata" }),
-    ).toStrictEqual({});
+      expect(library.id).toEqual(expect.any(Number));
+      expect(library.isDefault).toBe(true);
+      expect(library.uri).toBe("wikg://lib");
+      expect(library.folderPath).toBe(join(stateDir, "default-library"));
+      expect((await stat(library.folderPath)).isDirectory()).toBe(true);
+      expect(
+        await getWikiGraphLibraryMetadata({
+          isDefault: true,
+          kind: "metadata",
+        }),
+      ).toStrictEqual({});
+    });
   });
 
   it("reuses one default library across concurrent first-run callers", async () => {
-    const libraries = await Promise.all(
-      Array.from(
-        { length: 8 },
-        async () => await ensureDefaultWikiGraphLibrary(),
-      ),
-    );
+    await withRegistryTestState(async () => {
+      const libraries = await Promise.all(
+        Array.from(
+          { length: 8 },
+          async () => await ensureDefaultWikiGraphLibrary(),
+        ),
+      );
 
-    expect(new Set(libraries.map((library) => library.id)).size).toBe(1);
-    expect(new Set(libraries.map((library) => library.publicId)).size).toBe(1);
-    expect((await stat(libraries[0]!.folderPath)).isDirectory()).toBe(true);
+      expect(new Set(libraries.map((library) => library.id)).size).toBe(1);
+      expect(new Set(libraries.map((library) => library.publicId)).size).toBe(
+        1,
+      );
+      expect((await stat(libraries[0]!.folderPath)).isDirectory()).toBe(true);
+    });
   });
 
   it("creates non-default libraries with public library URIs and refuses existing folders", async () => {
-    const folderPath = join(stateDir, "research");
-    const library = await createWikiGraphLibrary({ folderPath });
+    await withRegistryTestState(async (stateDir) => {
+      const folderPath = join(stateDir, "research");
+      const library = await createWikiGraphLibrary({ folderPath });
 
-    expect(library.id).toEqual(expect.any(Number));
-    expect(Number.isInteger(library.id)).toBe(true);
-    expect(library.publicId).toMatch(/^[0-9a-f]{12}$/u);
-    expect(library.uri).toBe(`wikg://lib/${library.publicId}`);
-    expect(formatWikiGraphLibraryUri(library.publicId)).toBe(library.uri);
-    expect((await stat(folderPath)).isDirectory()).toBe(true);
-    await expect(createWikiGraphLibrary({ folderPath })).rejects.toThrow(
-      "Library folder already exists",
-    );
+      expect(library.id).toEqual(expect.any(Number));
+      expect(Number.isInteger(library.id)).toBe(true);
+      expect(library.publicId).toMatch(/^[0-9a-f]{12}$/u);
+      expect(library.uri).toBe(`wikg://lib/${library.publicId}`);
+      expect(formatWikiGraphLibraryUri(library.publicId)).toBe(library.uri);
+      expect((await stat(folderPath)).isDirectory()).toBe(true);
+      await expect(createWikiGraphLibrary({ folderPath })).rejects.toThrow(
+        "Library folder already exists",
+      );
+    });
   });
 
   it("parses library URIs without stealing .wikg archive URIs", () => {
@@ -110,45 +105,63 @@ describe("wiki graph library registry", () => {
   });
 
   it("supports metadata put, set, delete, and clear while rejecting system fields", async () => {
-    const library = await createWikiGraphLibrary({
-      folderPath: join(stateDir, "metadata-library"),
-    });
-    const target = parseWikiGraphLibraryUri(`${library.uri}/meta`)!;
+    await withRegistryTestState(async (stateDir) => {
+      const library = await createWikiGraphLibrary({
+        folderPath: join(stateDir, "metadata-library"),
+      });
+      const target = parseWikiGraphLibraryUri(`${library.uri}/meta`)!;
 
-    expect(
-      await putWikiGraphLibraryMetadata(target, "title", "Research"),
-    ).toStrictEqual({
-      title: "Research",
+      expect(
+        await putWikiGraphLibraryMetadata(target, "title", "Research"),
+      ).toStrictEqual({
+        title: "Research",
+      });
+      expect(
+        await putWikiGraphLibraryMetadata(target, "description", "Notes"),
+      ).toStrictEqual({ description: "Notes", title: "Research" });
+      expect(
+        await replaceWikiGraphLibraryMetadata(target, { title: "Only title" }),
+      ).toStrictEqual({ title: "Only title" });
+      await expect(
+        putWikiGraphLibraryMetadata(target, "folder_path", "/tmp"),
+      ).rejects.toThrow("system field");
+      expect(
+        await deleteWikiGraphLibraryMetadataKey(target, "title"),
+      ).toStrictEqual({});
+      expect(await clearWikiGraphLibraryMetadata(target)).toStrictEqual({});
     });
-    expect(
-      await putWikiGraphLibraryMetadata(target, "description", "Notes"),
-    ).toStrictEqual({ description: "Notes", title: "Research" });
-    expect(
-      await replaceWikiGraphLibraryMetadata(target, { title: "Only title" }),
-    ).toStrictEqual({ title: "Only title" });
-    await expect(
-      putWikiGraphLibraryMetadata(target, "folder_path", "/tmp"),
-    ).rejects.toThrow("system field");
-    expect(
-      await deleteWikiGraphLibraryMetadataKey(target, "title"),
-    ).toStrictEqual({});
-    expect(await clearWikiGraphLibraryMetadata(target)).toStrictEqual({});
   });
 
   it("removes only registry records and keeps folders; default removal is rejected", async () => {
-    const library = await createWikiGraphLibrary({
-      folderPath: join(stateDir, "kept"),
-    });
-    const target = parseWikiGraphLibraryUri(library.uri)!;
+    await withRegistryTestState(async (stateDir) => {
+      const library = await createWikiGraphLibrary({
+        folderPath: join(stateDir, "kept"),
+      });
+      const target = parseWikiGraphLibraryUri(library.uri)!;
 
-    expect(await listWikiGraphLibraryScope(target)).toStrictEqual([]);
-    expect((await removeWikiGraphLibrary(target)).uri).toBe(library.uri);
-    await expect(stat(library.folderPath)).resolves.toBeTruthy();
-    await expect(
-      removeWikiGraphLibrary({ isDefault: true, kind: "scope" }),
-    ).rejects.toThrow("default library");
-    await expect(listWikiGraphLibraryScope(target)).rejects.toThrow(
-      "Unknown Wiki Graph library",
-    );
+      expect(await listWikiGraphLibraryScope(target)).toStrictEqual([]);
+      expect((await removeWikiGraphLibrary(target)).uri).toBe(library.uri);
+      await expect(stat(library.folderPath)).resolves.toBeTruthy();
+      await expect(
+        removeWikiGraphLibrary({ isDefault: true, kind: "scope" }),
+      ).rejects.toThrow("default library");
+      await expect(listWikiGraphLibraryScope(target)).rejects.toThrow(
+        "Unknown Wiki Graph library",
+      );
+    });
   });
 });
+
+async function withRegistryTestState(
+  operation: (stateDir: string) => Promise<void>,
+): Promise<void> {
+  const stateDir = await mkdtemp(join(tmpdir(), "wikg-library-"));
+
+  try {
+    await withWikiGraphStateDirectoryPathForTesting(stateDir, async () => {
+      await operation(stateDir);
+    });
+  } finally {
+    await rm(stateDir, { force: true, recursive: true });
+  }
+}

--- a/test/core/retrieval/query/archive-view/text-search.test.ts
+++ b/test/core/retrieval/query/archive-view/text-search.test.ts
@@ -76,14 +76,16 @@ describe("archive/query/archive-view/text search", () => {
             version: 1,
           });
         });
+        const toc = await document.readToc();
+        const chapterUri = `wikg://chapter/${toc?.items[0]?.key}`;
 
         const fullPage = await readArchivePage(
           document,
-          "wikg://chapter/chapter-1/source",
+          `${chapterUri}/source`,
         );
         const rangePage = await readArchivePage(
           document,
-          "wikg://chapter/chapter-1/source#1..2",
+          `${chapterUri}/source#1..2`,
         );
 
         expect(fullPage.type).toBe("fragment");

--- a/test/core/runtime/gc/gc.test.ts
+++ b/test/core/runtime/gc/gc.test.ts
@@ -509,7 +509,14 @@ async function createArchiveWithExternalSearchIndex(path: string): Promise<{
       draft.addSentence("Indexed source sentence.", 3);
       await draft.commit();
       await openedDocument.writeToc({
-        items: [{ children: [], serialId: 1, title: "Indexed" }],
+        items: [
+          {
+            children: [],
+            key: "a1b2c3d4e5f6",
+            serialId: 1,
+            title: "Indexed",
+          },
+        ],
         version: 1,
       });
     });

--- a/test/core/storage/wikg/wiki-graph-archive-file.test.ts
+++ b/test/core/storage/wikg/wiki-graph-archive-file.test.ts
@@ -560,6 +560,7 @@ async function seedDocument(document: DirectoryDocument): Promise<void> {
       items: [
         {
           children: [],
+          key: "a1b2c3d4e5f6",
           serialId: 1,
           title: "Recovered Chapter",
         },


### PR DESCRIPTION
## Summary
- Restore read-only chapter TOC key validation so missing or duplicate keys fail instead of silently falling back.
- Replace stale CLI chapter test fixtures that still used title-derived slug keys with fixed opaque key values.
- Add read-only duplicate-key coverage alongside the missing-key rejection test.

## Verification
- `pnpm exec vitest run test/core/api/chapter.test.ts test/cli/archive/chapter.test.ts --passWithNoTests`
- `pnpm typecheck`
- `pnpm lint`

Follow-up to #212 / #210.
