### PR TITLE
fix: remove stale library list semantics

### DIFF
--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -733,6 +733,10 @@ describe("cli/args/help", () => {
       isDefault: true,
       kind: "scope",
     });
+    const scopeTrailingSlashHelp = renderLibraryUriHelpText("wikg://lib/", {
+      isDefault: true,
+      kind: "scope",
+    });
     const metadataHelpText = renderLibraryUriHelpText("wikg://lib/meta", {
       isDefault: true,
       kind: "metadata",
@@ -757,6 +761,20 @@ describe("cli/args/help", () => {
       "Use `wg wikg://lib/registry` to list all library registries.",
     );
     expect(scopeHelpText).not.toContain("lists archive memberships");
+    expect(scopeHelpText).not.toContain("List archive memberships");
+    expect(scopeTrailingSlashHelp).not.toContain("wikg://lib//");
+    expect(scopeTrailingSlashHelp).not.toContain("List archive memberships");
+    expect(parseCLIArguments(["wikg://lib/", "--help"])).toStrictEqual({
+      help: true,
+      helpText: scopeTrailingSlashHelp,
+      kind: "help",
+    });
+    expect(() => parseCLIArguments(["wikg://lib", "list", "--help"])).toThrow(
+      "does not support `list`",
+    );
+    expect(() =>
+      parseCLIArguments(["wikg://lib/team", "list", "--help"]),
+    ).toThrow("does not support `list`");
     expect(scopeHelpText).toContain("broad library index search");
     expect(scopeHelpText).toContain("wg wikg://lib --query <query>");
     expect(
@@ -894,6 +912,10 @@ describe("cli/args/help", () => {
       isDefault: true,
       kind: "archive-collection",
     });
+    const arcTrailingSlashHelp = renderLibraryUriHelpText("wikg://lib/arc/", {
+      isDefault: true,
+      kind: "archive-collection",
+    });
     const arcTreeHelpText = renderLibraryUriHelpText("wikg://lib/arc/tree", {
       isDefault: true,
       kind: "archive-tree",
@@ -907,6 +929,19 @@ describe("cli/args/help", () => {
     expect(arcHelpText).toContain("wikg://lib/arc/tree --help");
     expect(arcHelpText).not.toContain("lists archive members");
     expect(arcHelpText).toContain("use `/tree` for member file visualization");
+    expect(arcTrailingSlashHelp).not.toContain("wikg://lib/arc//");
+    expect(arcTrailingSlashHelp).toContain("wikg://lib/arc/tree --help");
+    expect(parseCLIArguments(["wikg://lib/arc/", "--help"])).toStrictEqual({
+      help: true,
+      helpText: arcTrailingSlashHelp,
+      kind: "help",
+    });
+    expect(() =>
+      parseCLIArguments(["wikg://lib/arc", "list", "--help"]),
+    ).toThrow("does not support `list`");
+    expect(() =>
+      parseCLIArguments(["wikg://lib/team/arc", "list", "--help"]),
+    ).toThrow("does not support `list`");
     expect(arcTreeHelpText).toContain("This object is read-only");
     for (const text of [
       scopeHelpText,

--- a/packages/cli/src/args/help.ts
+++ b/packages/cli/src/args/help.ts
@@ -1,4 +1,5 @@
 import {
+  formatWikiGraphLibraryUri,
   parseLocatedWikiGraphUri,
   parseWikiGraphLibraryUri,
   resolveDataDirPath,
@@ -314,7 +315,10 @@ export function renderLibraryUriHelpText(
   uri: string,
   target: ParsedWikiGraphLibraryUri,
 ): string {
-  return renderHelpTemplate("help/commands/library", { target, uri });
+  return renderHelpTemplate("help/commands/library", {
+    target,
+    uri: formatLibraryHelpUri(uri, target),
+  });
 }
 
 export function renderLibraryPredicateHelpText(
@@ -325,8 +329,62 @@ export function renderLibraryPredicateHelpText(
   return renderHelpTemplate("help/commands/library-predicate", {
     predicate,
     target,
-    uri,
+    uri: formatLibraryHelpUri(uri, target),
   });
+}
+
+function formatLibraryHelpUri(
+  fallbackUri: string,
+  target: ParsedWikiGraphLibraryUri,
+): string {
+  const scopeUri = formatWikiGraphLibraryUri(target.publicId);
+  switch (target.kind) {
+    case "archive":
+      if (target.archivePublicId === undefined) {
+        return fallbackUri.replace(/\/+$/u, "");
+      }
+      return appendLibraryHelpPath(
+        appendLibraryHelpPath(`${scopeUri}/arc`, target.archivePublicId),
+        stripHelpObjectUriPrefix(target.objectUri),
+      );
+    case "archive-collection":
+      return `${scopeUri}/arc`;
+    case "archive-path":
+      return target.archivePublicId === undefined
+        ? `${scopeUri}/arc/path`
+        : `${scopeUri}/arc/${target.archivePublicId}/path`;
+    case "archive-tree":
+      return `${scopeUri}/arc/tree`;
+    case "metadata":
+      return `${scopeUri}/meta`;
+    case "path":
+      return `${scopeUri}/path`;
+    case "registry":
+      return "wikg://lib/registry";
+    case "scope":
+      return appendLibraryHelpPath(
+        scopeUri,
+        stripHelpObjectUriPrefix(target.objectUri),
+      );
+    default:
+      throw new Error("Internal error: unknown library help target.");
+  }
+}
+
+function appendLibraryHelpPath(
+  baseUri: string,
+  path: string | undefined,
+): string {
+  if (path === undefined || path === "") {
+    return baseUri;
+  }
+  return `${baseUri.replace(/\/+$/u, "")}/${path.replace(/^\/+|\/+$/gu, "")}`;
+}
+
+function stripHelpObjectUriPrefix(
+  objectUri: string | undefined,
+): string | undefined {
+  return objectUri?.replace(/^wikg:\/\//u, "");
 }
 
 export function isUriHelpPredicate(

--- a/packages/cli/src/args/uri/library.ts
+++ b/packages/cli/src/args/uri/library.ts
@@ -31,7 +31,7 @@ import { parseChapterTarget } from "./chapter/target.js";
 import { isTripleScopePath } from "./triple-pattern.js";
 
 const LIBRARY_ARCHIVE_ACTIONS = new Set(["get", "remove"]);
-const LIBRARY_ARCHIVE_COLLECTION_ACTIONS = new Set(["add", "list", "scan"]);
+const LIBRARY_ARCHIVE_COLLECTION_ACTIONS = new Set(["add", "get", "scan"]);
 const LIBRARY_ARCHIVE_PATH_ACTIONS = new Set(["get", "set"]);
 const LIBRARY_ARCHIVE_TREE_ACTIONS = new Set(["archive-tree"]);
 const LIBRARY_METADATA_ACTIONS = new Set([
@@ -43,7 +43,7 @@ const LIBRARY_METADATA_ACTIONS = new Set([
 ]);
 const LIBRARY_PATH_ACTIONS = new Set(["get", "set"]);
 const LIBRARY_REGISTRY_ACTIONS = new Set(["add", "list"]);
-const LIBRARY_SCOPE_ACTIONS = new Set(["get", "list", "remove"]);
+const LIBRARY_SCOPE_ACTIONS = new Set(["get", "remove"]);
 const LIBRARY_INDEX_ACTIONS = new Set(["disable", "enable", "get"]);
 const LIBRARY_QUERY_ACTIONS = new Set([
   "evidence",
@@ -76,7 +76,9 @@ export function parseLibraryUriFirstArguments(
     ((target.objectUri !== undefined && target.objectUri !== "wikg://index") ||
       values.query !== undefined)
       ? resolveImplicitLibraryQueryAction(target.objectUri, values.query)
-      : target.kind === "metadata" ||
+      : target.kind === "scope" ||
+          target.kind === "archive-collection" ||
+          target.kind === "metadata" ||
           target.kind === "path" ||
           target.kind === "archive" ||
           target.kind === "archive-path" ||
@@ -171,7 +173,7 @@ export function parseLibraryUriFirstArguments(
 
   if (
     target.kind === "scope" &&
-    (target.objectUri !== undefined || action === "search" || action === "list")
+    (target.objectUri !== undefined || action === "search")
   ) {
     return parseLibraryQueryArguments(
       uri,
@@ -715,12 +717,9 @@ function parseLibraryArchiveCollectionArguments(
   }
   rejectArchiveFlag(action, "--input", values.input, helpRoute);
   rejectArchiveFlag(action, "--to", values.to, helpRoute);
-  if (action === "list") {
-    rejectArchiveBooleanFlag(action, "--jsonl", values.jsonl, helpRoute);
-  }
   return {
     args: {
-      action: action as "list" | "scan",
+      action: action === "get" ? "get" : "scan",
       json: values.json,
       jsonl: values.jsonl,
       target,

--- a/packages/core/data/help/commands/library-predicate.jinja
+++ b/packages/core/data/help/commands/library-predicate.jinja
@@ -177,15 +177,15 @@ Notes:
   - This is not a list of all library registries; use known `wikg://lib/<lib-id>` URIs for non-default libraries.
 {% elif target.kind == "scope" and predicate == "list" %}
 Purpose:
-  List archive memberships in this library scope.
+  This library scope does not expose an archive membership flat list.
 
 Usage:
-  {{ commandName }} {{ uri }} list [--json]
+  {{ commandName }} {{ uri }} [--json]
 
 Notes:
-  - The output includes registered archive ids, relative paths, and membership status.
-  - Use `{{ commandName }} <lib-scope>/arc scan` when the folder contents changed outside Wiki Graph.
-  - This lists archive memberships in this library, not all library registries.
+  - Use `{{ commandName }} {{ uri }}/arc/tree` to inspect the managed archive file tree.
+  - Use `{{ commandName }} {{ uri }}/arc scan` when the folder contents changed outside Wiki Graph.
+  - Use `{{ commandName }} wikg://lib/registry` to list all library registries.
 {% elif target.kind == "scope" and predicate == "remove" %}
 Purpose:
   Remove this non-default library registry.

--- a/test/cli/library.test.ts
+++ b/test/cli/library.test.ts
@@ -77,19 +77,19 @@ describe("cli/library args", () => {
 
     expect(parseCLIArguments(["wikg://lib"])).toMatchObject({
       args: {
-        action: "list",
-        archivePath: "wikg://lib",
+        action: "get",
+        target: { isDefault: true, kind: "scope" },
       },
       help: false,
-      kind: "archive",
+      kind: "library",
     });
     expect(parseCLIArguments(["wikg://lib/abc123abc123"])).toMatchObject({
       args: {
-        action: "list",
-        archivePath: "wikg://lib/abc123abc123",
+        action: "get",
+        target: { isDefault: false, kind: "scope", publicId: "abc123abc123" },
       },
       help: false,
-      kind: "archive",
+      kind: "library",
     });
 
     expect(() =>
@@ -292,12 +292,12 @@ describe("cli/library args", () => {
       kind: "library",
     });
     expect(parseCLIArguments(["wikg://lib/arc"])).toMatchObject({
-      args: { action: "list", target: { kind: "archive-collection" } },
+      args: { action: "get", target: { kind: "archive-collection" } },
       kind: "library",
     });
     expect(parseCLIArguments(["wikg://lib/team/arc"])).toMatchObject({
       args: {
-        action: "list",
+        action: "get",
         target: { kind: "archive-collection", publicId: "team" },
       },
       kind: "library",
@@ -305,7 +305,16 @@ describe("cli/library args", () => {
 
     expect(() =>
       parseCLIArguments(["wikg://lib/arc", "list", "--jsonl"]),
-    ).toThrow("does not support --jsonl");
+    ).toThrow("does not support `list`");
+    expect(() => parseCLIArguments(["wikg://lib", "list"])).toThrow(
+      "does not support `list`",
+    );
+    expect(() => parseCLIArguments(["wikg://lib/team", "list"])).toThrow(
+      "does not support `list`",
+    );
+    expect(() => parseCLIArguments(["wikg://lib/team/arc", "list"])).toThrow(
+      "does not support `list`",
+    );
     expect(() =>
       parseCLIArguments(["wikg://lib/registry", "remove", "--help"]),
     ).toThrow("does not support `remove`");


### PR DESCRIPTION
## Summary
- Close #214.
- Route bare library scopes and archive collection scopes through explicit scope reads instead of stale `list` semantics.
- Reject `wikg://lib list`, `wikg://lib/<lib-id> list`, `wikg://lib/arc list`, and `wikg://lib/<lib-id>/arc list` as unsupported predicates.
- Normalize library help URIs before template rendering so trailing-slash inputs do not produce `//` examples.

## Acceptance / Verification
- `pnpm vitest run packages/cli/src/args/help.test.ts packages/cli/src/commands/library.test.ts test/cli/library.test.ts` — passed, 3 files / 17 tests.
- `pnpm typecheck` — passed.
- `pnpm lint` — passed.
- `pnpm format:check` — passed.
- `pnpm build` — passed.

Manual CLI/help checks:
- `pnpm --filter wiki-graph dev wikg://lib --help` — exit 0; no `wikg://lib//`; no archive-membership flat-list wording; registry and `arc/tree` remain discoverable.
- `pnpm --filter wiki-graph dev wikg://lib/ --help` — exit 0; normalized command `wg wikg://lib`; no double slash.
- `pnpm --filter wiki-graph dev wikg://lib list --help` — exit 1; `list` unsupported and routes to `wg wikg://lib --help`.
- `pnpm --filter wiki-graph dev wikg://lib/arc --help` — exit 0; points to `wikg://lib/arc/tree --help`; no flat-list wording.
- `pnpm --filter wiki-graph dev wikg://lib/arc/ --help` — exit 0; normalized command `wg wikg://lib/arc`; no double slash.
- `pnpm --filter wiki-graph dev wikg://lib/arc list --help` — exit 1; `list` unsupported and routes to `wg wikg://lib/arc --help`.
- `pnpm --filter wiki-graph dev wikg://lib/registry --help` — exit 0; registry list entry remains discoverable.
- `pnpm --filter wiki-graph dev wikg://lib/arc/tree --help` — exit 0; `--parent` / `--depth` help remains present.
- `pnpm --filter wiki-graph dev wikg://lib/team list --help` — exit 1; non-default library scope `list` unsupported.
- `pnpm --filter wiki-graph dev wikg://lib/team/arc list --help` — exit 1; non-default archive collection `list` unsupported.
- `pnpm --filter wiki-graph dev wikg://lib/team/ --help` and `pnpm --filter wiki-graph dev wikg://lib/team/arc/ --help` — exit 0; normalized trailing-slash examples.
- `pnpm --filter wiki-graph dev wikg://lib --json` — exit 0; outputs `{ "items": [] }`, not an archive membership flat list.

## Review note
Blind reviewer attempt was made via isolated subagent, but failed with `HTTP 503: 所有供应商暂时不可用` after retries. Per task rules, I performed a non-blind fallback review against Issue #214 acceptance criteria. Fallback verdict: pass. The diff does not touch schema upgrade/migration/state format code and does not touch opaque chapter key behavior.
