### PR TITLE
fix: repair current archive TOC keys during upgrade

### DIFF
--- a/packages/core/src/maintenance/upgrade.ts
+++ b/packages/core/src/maintenance/upgrade.ts
@@ -126,7 +126,7 @@ export async function upgradeWikiGraphMaintenanceTarget(
   const archivePath = resolveArchiveUpgradeTarget(target);
   const schemaVersionBefore =
     await readWikiGraphArchiveSchemaVersion(archivePath);
-  await upgradeWikiGraphArchiveSchema(archivePath);
+  const upgradeResult = await upgradeWikiGraphArchiveSchema(archivePath);
   const schemaVersionAfter =
     await readWikiGraphArchiveSchemaVersion(archivePath);
   return {
@@ -134,10 +134,7 @@ export async function upgradeWikiGraphMaintenanceTarget(
     path: archivePath,
     schemaVersionBefore,
     schemaVersionAfter,
-    status:
-      schemaVersionBefore === schemaVersionAfter
-        ? "already-current"
-        : "upgraded",
+    status: upgradeResult.changed ? "upgraded" : "already-current",
   };
 }
 
@@ -185,18 +182,24 @@ export async function upgradeWikiGraphLibrarySchema(
       const schemaVersionBefore = await readWikiGraphArchiveSchemaVersion(
         archive.path,
       );
-      if (schemaVersionBefore === CURRENT_ARCHIVE_SCHEMA_VERSION) {
-        skipped.push({
+      try {
+        const upgradeResult = await upgradeWikiGraphArchiveSchema(archive.path);
+        const schemaVersionAfter = await readWikiGraphArchiveSchemaVersion(
+          archive.path,
+        );
+        const item = {
           path: archive.path,
           publicId: archive.publicId,
-          schemaVersionAfter: schemaVersionBefore,
+          schemaVersionAfter,
           schemaVersionBefore,
           uri: archive.uri,
-        });
-        continue;
-      }
-      try {
-        await upgradeWikiGraphArchiveSchema(archive.path);
+        };
+
+        if (upgradeResult.changed) {
+          upgraded.push(item);
+        } else {
+          skipped.push(item);
+        }
       } catch (error) {
         return {
           failed: {
@@ -212,15 +215,6 @@ export async function upgradeWikiGraphLibrarySchema(
           upgraded,
         };
       }
-      upgraded.push({
-        path: archive.path,
-        publicId: archive.publicId,
-        schemaVersionAfter: await readWikiGraphArchiveSchemaVersion(
-          archive.path,
-        ),
-        schemaVersionBefore,
-        uri: archive.uri,
-      });
     }
 
     return {

--- a/packages/core/src/storage/schema-upgrade/index.ts
+++ b/packages/core/src/storage/schema-upgrade/index.ts
@@ -33,6 +33,12 @@ export {
 export const CURRENT_ARCHIVE_SCHEMA_VERSION = 2;
 const LOCK_STALE_TIMEOUT_MS = 5 * 60 * 1000;
 
+export interface WikiGraphArchiveSchemaUpgradeResult {
+  readonly changed: boolean;
+  readonly repairedToc: boolean;
+  readonly schemaChanged: boolean;
+}
+
 export async function ensureWikiGraphArchiveSchemaCurrent(
   archivePath: string,
 ): Promise<void> {
@@ -74,14 +80,10 @@ export async function readWikiGraphArchiveSchemaVersion(
 
 export async function upgradeWikiGraphArchiveSchema(
   archivePath: string,
-): Promise<void> {
+): Promise<WikiGraphArchiveSchemaUpgradeResult> {
   const resolvedArchivePath = resolve(archivePath);
   const schemaVersion =
     await readWikiGraphArchiveSchemaVersion(resolvedArchivePath);
-
-  if (schemaVersion === CURRENT_ARCHIVE_SCHEMA_VERSION) {
-    return;
-  }
 
   if (schemaVersion > CURRENT_ARCHIVE_SCHEMA_VERSION) {
     throw new Error(
@@ -89,15 +91,6 @@ export async function upgradeWikiGraphArchiveSchema(
     );
   }
 
-  await ensureWikiGraphHomeSchemaCurrent();
-
-  const archiveKey = createArchiveKey(resolvedArchivePath);
-  await assertArchiveUpgradeSafe(archiveKey);
-
-  const temporaryPath = join(
-    dirname(resolvedArchivePath),
-    `.${getArchiveBasename(resolvedArchivePath)}.${process.pid}.${randomUUID()}.upgrade.tmp`,
-  );
   const temporaryDirectories: string[] = [];
 
   try {
@@ -105,20 +98,50 @@ export async function upgradeWikiGraphArchiveSchema(
       resolvedArchivePath,
       temporaryDirectories,
     );
+    const schemaChanged = schemaVersion < CURRENT_ARCHIVE_SCHEMA_VERSION;
+
+    if (!schemaChanged && tocOverlay === undefined) {
+      return {
+        changed: false,
+        repairedToc: false,
+        schemaChanged: false,
+      };
+    }
+
+    await ensureWikiGraphHomeSchemaCurrent();
+
+    const archiveKey = createArchiveKey(resolvedArchivePath);
+    await assertArchiveUpgradeSafe(archiveKey);
+
+    const temporaryPath = join(
+      dirname(resolvedArchivePath),
+      `.${getArchiveBasename(resolvedArchivePath)}.${process.pid}.${randomUUID()}.upgrade.tmp`,
+    );
+
     await writeWikgArchiveWithOverlays(
       resolvedArchivePath,
       temporaryPath,
       [
-        {
-          entryPath: SEARCH_INDEX_DATABASE_PATH,
-          kind: "deleted",
-        },
+        ...(schemaChanged
+          ? [
+              {
+                entryPath: SEARCH_INDEX_DATABASE_PATH,
+                kind: "deleted" as const,
+              },
+            ]
+          : []),
         ...(tocOverlay === undefined ? [] : [tocOverlay]),
       ],
       { preserveMutationToken: true },
     );
     await rename(temporaryPath, resolvedArchivePath);
     await cleanupArchiveDerivedData(archiveKey);
+
+    return {
+      changed: true,
+      repairedToc: tocOverlay !== undefined,
+      schemaChanged,
+    };
   } finally {
     await Promise.all(
       temporaryDirectories.map(async (path) => {

--- a/test/core/storage/schema-upgrade/index.test.ts
+++ b/test/core/storage/schema-upgrade/index.test.ts
@@ -132,6 +132,73 @@ describe("schema-upgrade", () => {
     });
   });
 
+  it("repairs missing chapter keys in a current archive", async () => {
+    await withTempDir("wikigraph-schema-upgrade-current-toc-", async (root) => {
+      setWikiGraphStateDirectoryPathForTesting(join(root, "home"));
+      const archivePath = join(root, "book.wikg");
+      await writeArchiveWithSchemaVersion(
+        archivePath,
+        2,
+        `${JSON.stringify({
+          version: 1,
+          items: [
+            {
+              children: [
+                {
+                  children: [],
+                  serialId: 2,
+                  title: "Chapter 1",
+                },
+              ],
+              serialId: 1,
+              title: "Part I",
+            },
+          ],
+        })}\n`,
+      );
+
+      await expect(
+        upgradeWikiGraphArchiveSchema(archivePath),
+      ).resolves.toStrictEqual({
+        changed: true,
+        repairedToc: true,
+        schemaChanged: false,
+      });
+      await expect(
+        readWikiGraphArchiveSchemaVersion(archivePath),
+      ).resolves.toBe(2);
+
+      const upgradedTocEntry = await readWikgArchiveEntry(
+        archivePath,
+        "toc.json",
+      );
+      expect(upgradedTocEntry).toBeInstanceOf(Uint8Array);
+      const upgradedToc = JSON.parse(
+        Buffer.from(upgradedTocEntry as Uint8Array).toString("utf8"),
+      ) as {
+        readonly items: readonly {
+          readonly children: readonly { readonly key?: string }[];
+          readonly key?: string;
+        }[];
+      };
+
+      expect(upgradedToc.items[0]?.key).toMatch(/^(?!\d+$)[0-9a-f]{12}$/u);
+      expect(upgradedToc.items[0]?.children[0]?.key).toMatch(
+        /^(?!\d+$)[0-9a-f]{12}$/u,
+      );
+      await expect(
+        readWikgArchiveEntry(archivePath, SEARCH_INDEX_DATABASE_PATH),
+      ).resolves.toBeInstanceOf(Uint8Array);
+      await expect(
+        upgradeWikiGraphArchiveSchema(archivePath),
+      ).resolves.toStrictEqual({
+        changed: false,
+        repairedToc: false,
+        schemaChanged: false,
+      });
+    });
+  });
+
   it("rejects a future archive schema version", async () => {
     await withTempDir("wikigraph-schema-future-archive-", async (root) => {
       setWikiGraphStateDirectoryPathForTesting(join(root, "home"));


### PR DESCRIPTION
## Summary
- repair missing TOC chapter keys even when an archive is already at the current schema version
- report standalone/library maintenance upgrade items as upgraded when data repair rewrites the archive
- add regression coverage for current-schema archives missing chapter keys

## Verification
- pnpm verify
- pnpm vitest run test/core/storage/schema-upgrade/index.test.ts --passWithNoTests
- pnpm --filter wiki-graph dev maintenance upgrade '/Users/taozeyu/Library/Mobile Documents/com~apple~CloudDocs/Documents/WIKG/三国演义.wikg' --json
- pnpm --filter wiki-graph dev 'wikg:///Users/taozeyu/Library/Mobile Documents/com~apple~CloudDocs/Documents/WIKG/三国演义.wikg/chapter' --json
- pnpm --filter wiki-graph dev 'wikg:///Users/taozeyu/Library/Mobile Documents/com~apple~CloudDocs/Documents/WIKG/三国演义.wikg' inspect --json