### PR TITLE
fix: close library archive scope gaps

### DIFF
--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -888,7 +888,10 @@ describe("cli/args/help", () => {
       throw new Error("Expected library archive help output.");
     }
     expect(archiveMemberHelp.helpText).toContain(
-      "reads the registry entry for this library archive member",
+      "reads the archive member page for this managed archive",
+    );
+    expect(archiveMemberHelp.helpText).toContain(
+      "Registry fields such as physical path, size, mtime, and mutation token are diagnostic metadata.",
     );
     expect(archiveMemberHelp.helpText).toContain("inspect [--json]");
     expect(archiveMemberHelp.helpText).toContain("not the library registry");

--- a/packages/cli/src/args/uri/library.ts
+++ b/packages/cli/src/args/uri/library.ts
@@ -74,7 +74,9 @@ export function parseLibraryUriFirstArguments(
     explicitAction ??
     (target.kind === "scope" &&
     ((target.objectUri !== undefined && target.objectUri !== "wikg://index") ||
-      values.query !== undefined)
+      values.query !== undefined ||
+      values.limit !== undefined ||
+      values.cursor !== undefined)
       ? resolveImplicitLibraryQueryAction(target.objectUri, values.query)
       : target.kind === "scope" ||
           target.kind === "archive-collection" ||
@@ -173,7 +175,9 @@ export function parseLibraryUriFirstArguments(
 
   if (
     target.kind === "scope" &&
-    (target.objectUri !== undefined || action === "search")
+    (target.objectUri !== undefined ||
+      action === "search" ||
+      (action === "list" && explicitAction === undefined))
   ) {
     return parseLibraryQueryArguments(
       uri,

--- a/packages/cli/src/commands/archive-command/run/next.test.ts
+++ b/packages/cli/src/commands/archive-command/run/next.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  findWikiGraphLibraryArchiveMembers,
+  findWikiGraphLibraryObjects,
+  listWikiGraphLibraryArchiveMembers,
   listWikiGraphLibraryObjects,
+  parseWikiGraphLibraryUri,
   readContinuationCursor,
   resolveWikiGraphLibraryQueryTargetById,
 } from "wiki-graph-core";
@@ -10,13 +14,18 @@ import { runNextArchivePage } from "./next.js";
 
 vi.mock("wiki-graph-core", () => ({
   findArchiveObjects: vi.fn(),
+  findWikiGraphLibraryArchiveMembers: vi.fn(),
   findWikiGraphLibraryObjects: vi.fn(),
   listArchiveCollection: vi.fn(),
   listArchiveEvidence: vi.fn(),
+  listWikiGraphLibraryArchiveMembers: vi.fn(),
   listRelatedArchiveObjects: vi.fn(),
   listRelatedWikiGraphLibraryObjects: vi.fn(),
   listWikiGraphLibraryEvidence: vi.fn(),
   listWikiGraphLibraryObjects: vi.fn(),
+  parseWikiGraphLibraryUri: vi.fn((uri: string) =>
+    uri === "wikg://lib" ? { isDefault: true, kind: "scope" } : undefined,
+  ),
   readContinuationCursor: vi.fn(),
   resolveWikiGraphLibraryQueryTargetById: vi.fn(),
 }));
@@ -54,6 +63,11 @@ beforeEach(() => {
 
 describe("runNextArchivePage library cursors", () => {
   it("re-enters the library index path for collection cursors", async () => {
+    vi.mocked(parseWikiGraphLibraryUri).mockReturnValue({
+      isDefault: true,
+      kind: "scope",
+      objectUri: "wikg://entity",
+    });
     vi.mocked(listWikiGraphLibraryObjects).mockResolvedValue({
       chapters: null,
       ids: null,
@@ -101,6 +115,11 @@ describe("runNextArchivePage library cursors", () => {
   });
 
   it("surfaces dirty library index failures from next", async () => {
+    vi.mocked(parseWikiGraphLibraryUri).mockReturnValue({
+      isDefault: true,
+      kind: "scope",
+      objectUri: "wikg://entity",
+    });
     vi.mocked(listWikiGraphLibraryObjects).mockRejectedValue(
       new Error("Wiki Graph library index is dirty."),
     );
@@ -112,5 +131,78 @@ describe("runNextArchivePage library cursors", () => {
       libraryTarget,
       expect.objectContaining({ cursor: "raw-collection-cursor" }),
     );
+  });
+
+  it("continues library archive member collection cursors", async () => {
+    vi.mocked(parseWikiGraphLibraryUri).mockReturnValue({
+      isDefault: true,
+      kind: "scope",
+    });
+    vi.mocked(listWikiGraphLibraryArchiveMembers).mockResolvedValue({
+      chapters: null,
+      ids: null,
+      items: [
+        {
+          archiveId: 8,
+          field: "metadata",
+          id: "wikg://lib/arc/book",
+          libraryArchiveUri: "wikg://lib/arc/book",
+          snippet: "books/book.wikg  present  exists",
+          title: "books/book.wikg",
+          type: "meta",
+        },
+      ],
+      limit: 20,
+      nextCursor: null,
+      order: "doc-asc",
+      types: null,
+    });
+
+    await runNextArchivePage({ action: "next", archivePath: "c_next" });
+
+    expect(listWikiGraphLibraryArchiveMembers).toHaveBeenCalledWith(
+      libraryTarget,
+      expect.objectContaining({ cursor: "raw-collection-cursor" }),
+    );
+    expect(listWikiGraphLibraryObjects).not.toHaveBeenCalled();
+  });
+
+  it("continues library archive member search cursors", async () => {
+    vi.mocked(parseWikiGraphLibraryUri).mockReturnValue({
+      isDefault: true,
+      kind: "scope",
+    });
+    vi.mocked(readContinuationCursor).mockResolvedValue({
+      archiveKey: "wikg://lib",
+      archivePath: "wikg://lib",
+      cursor: "raw-search-cursor",
+      format: "json",
+      indexScope: { kind: "library-index", libraryId: 42 },
+      kind: "search",
+      query: "book",
+      types: null,
+    });
+    vi.mocked(findWikiGraphLibraryArchiveMembers).mockResolvedValue({
+      chapters: null,
+      items: [],
+      lens: "typed",
+      lensHint: null,
+      limit: 20,
+      match: "any",
+      nextCursor: null,
+      order: "doc-asc",
+      query: "book",
+      terms: ["book"],
+      types: null,
+    });
+
+    await runNextArchivePage({ action: "next", archivePath: "c_next" });
+
+    expect(findWikiGraphLibraryArchiveMembers).toHaveBeenCalledWith(
+      libraryTarget,
+      "book",
+      expect.objectContaining({ cursor: "raw-search-cursor" }),
+    );
+    expect(findWikiGraphLibraryObjects).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/archive-command/run/next.ts
+++ b/packages/cli/src/commands/archive-command/run/next.ts
@@ -1,12 +1,15 @@
 import {
   findArchiveObjects,
+  findWikiGraphLibraryArchiveMembers,
   findWikiGraphLibraryObjects,
   listArchiveCollection,
   listArchiveEvidence,
+  listWikiGraphLibraryArchiveMembers,
   listRelatedWikiGraphLibraryObjects,
   listWikiGraphLibraryEvidence,
   listWikiGraphLibraryObjects,
   listRelatedArchiveObjects,
+  parseWikiGraphLibraryUri,
   readContinuationCursor,
   resolveWikiGraphLibraryQueryTargetById,
   type ArchiveCollectionOptions,
@@ -278,6 +281,20 @@ async function runNextLibraryIndexPage(
         });
       }
 
+      if (isLibraryArchiveMemberCursor(cursor)) {
+        await writeFindHits(
+          createCollectionFindResult(
+            await listWikiGraphLibraryArchiveMembers(target, collectionOptions),
+          ),
+          {
+            ...createCursorOutputContext(cursor, format, limit),
+            continuationKind: "collection",
+          },
+          format,
+        );
+        return;
+      }
+
       await writeFindHits(
         createCollectionFindResult(
           await listWikiGraphLibraryObjects(target, collectionOptions),
@@ -314,6 +331,19 @@ async function runNextLibraryIndexPage(
         Object.assign(findOptions, {
           types: cursor.types as ArchiveFindOptions["types"],
         });
+      }
+
+      if (isLibraryArchiveMemberCursor(cursor)) {
+        await writeFindHits(
+          await findWikiGraphLibraryArchiveMembers(
+            target,
+            cursor.query ?? "",
+            findOptions,
+          ),
+          createCursorOutputContext(cursor, format, limit),
+          format,
+        );
+        return;
       }
 
       await writeFindHits(
@@ -378,6 +408,13 @@ async function runNextLibraryIndexPage(
       );
       return;
   }
+}
+
+function isLibraryArchiveMemberCursor(
+  cursor: Awaited<ReturnType<typeof readContinuationCursor>>,
+): boolean {
+  const target = parseWikiGraphLibraryUri(cursor.archivePath);
+  return target?.kind === "scope" && target.objectUri === undefined;
 }
 
 function createCursorOutputContext(

--- a/packages/cli/src/commands/archive-output/object/objects.ts
+++ b/packages/cli/src/commands/archive-output/object/objects.ts
@@ -112,7 +112,9 @@ export async function createFindObject(
   if (hit.type === "meta") {
     return {
       ...librarySource,
+      text: hit.snippet,
       title: hit.title,
+      type: "meta",
       uri,
     };
   }

--- a/packages/cli/src/commands/library.ts
+++ b/packages/cli/src/commands/library.ts
@@ -224,10 +224,9 @@ export async function runLibraryCommand(
         return;
       }
       if (args.target.kind === "archive") {
-        await writeLibraryArchive(
+        await writeLibraryArchivePage(
           await getWikiGraphLibraryArchive(args.target),
           args.json ?? false,
-          "Library archive",
         );
         return;
       }
@@ -454,6 +453,32 @@ async function writeLibraryArchive(
   );
 }
 
+async function writeLibraryArchivePage(
+  archive: Awaited<ReturnType<typeof getWikiGraphLibraryArchive>>,
+  json: boolean,
+): Promise<void> {
+  if (json) {
+    await writeTextToStdout(
+      formatCLIJSON(formatLibraryArchivePageJSON(archive)),
+    );
+    return;
+  }
+
+  await writeTextToStdout(
+    [
+      `Library archive: ${archive.uri}`,
+      `Label: ${archive.relativePath}`,
+      `Status: ${archive.status}${archive.exists ? "" : " (missing file)"}`,
+      `Chapter: ${archive.uri}/chapter`,
+      `Entity: ${archive.uri}/entity`,
+      `Triple: ${archive.uri}/triple`,
+      `Inspect: ${archive.uri} inspect`,
+      `Metadata path: ${archive.path}`,
+      "",
+    ].join("\n"),
+  );
+}
+
 function formatLibraryArchiveJSON(
   archive: Awaited<ReturnType<typeof addWikiGraphLibraryArchive>>,
 ): object {
@@ -471,6 +496,35 @@ function formatLibraryArchiveJSON(
     lastScannedAt: archive.lastScannedAt,
     createdAt: archive.createdAt,
     updatedAt: archive.updatedAt,
+  };
+}
+
+function formatLibraryArchivePageJSON(
+  archive: Awaited<ReturnType<typeof getWikiGraphLibraryArchive>>,
+): object {
+  return {
+    uri: archive.uri,
+    id: archive.publicId,
+    libraryUri: archive.libraryUri,
+    label: archive.relativePath,
+    relativePath: archive.relativePath,
+    status: archive.status,
+    entries: {
+      chapter: `${archive.uri}/chapter`,
+      entity: `${archive.uri}/entity`,
+      triple: `${archive.uri}/triple`,
+      inspect: `${archive.uri} inspect`,
+    },
+    metadata: {
+      path: archive.path,
+      exists: archive.exists,
+      lastSeenMutationToken: archive.lastSeenMutationToken,
+      lastSeenSize: archive.lastSeenSize,
+      lastSeenMtimeMs: archive.lastSeenMtimeMs,
+      lastScannedAt: archive.lastScannedAt,
+      createdAt: archive.createdAt,
+      updatedAt: archive.updatedAt,
+    },
   };
 }
 

--- a/packages/core/data/help/commands/library.jinja
+++ b/packages/core/data/help/commands/library.jinja
@@ -121,8 +121,9 @@ Predicate commands:
 Library archive membership
 
 Default behavior:
-  - `{{ commandName }} {{ uri }}` reads the registry entry for this library archive member.
-  - The membership entry identifies the archive id, relative path, status, and containing library.
+  - `{{ commandName }} {{ uri }}` reads the archive member page for this managed archive.
+  - The member page shows the member URI, readable label or relative path, status, and business entry URIs for `/chapter`, `/entity`, `/triple`, and `inspect`.
+  - Registry fields such as physical path, size, mtime, and mutation token are diagnostic metadata.
   - `{{ commandName }} {{ uri }} inspect` checks readiness for this managed archive's contents, not the library registry.
   - Add archive object suffixes such as `/chapter`, `/entity`, or `/triple` when you want to query the archive contents.
 
@@ -189,8 +190,8 @@ URI forms:
 
 Usage:
 {% if target.isDefault %}
-  {{ commandName }} wikg://lib
-  {{ commandName }} wikg://lib --query <query>
+  {{ commandName }} wikg://lib [--limit <n>] [--cursor <cursor>] [--json]
+  {{ commandName }} wikg://lib --query <query> [--limit <n>] [--cursor <cursor>] [--json]
   {{ commandName }} wikg://lib/chapter --query <query>
   {{ commandName }} wikg://lib/chunk --query <query>
   {{ commandName }} wikg://lib/registry add --path <folder> [--json]
@@ -203,8 +204,8 @@ Usage:
   {{ commandName }} wikg://lib/triple --query <query>
   {{ commandName }} wikg://lib/meta [--json]
 {% else %}
-  {{ commandName }} {{ uri }}
-  {{ commandName }} {{ uri }} --query <query>
+  {{ commandName }} {{ uri }} [--limit <n>] [--cursor <cursor>] [--json]
+  {{ commandName }} {{ uri }} --query <query> [--limit <n>] [--cursor <cursor>] [--json]
   {{ commandName }} {{ uri }}/chapter --query <query>
   {{ commandName }} {{ uri }}/chunk --query <query>
   {{ commandName }} {{ uri }}/arc scan [--json|--jsonl]

--- a/packages/core/data/help/topics/library.jinja
+++ b/packages/core/data/help/topics/library.jinja
@@ -38,8 +38,9 @@ Archive memberships:
   - Missing registered files remain visible as missing or stale until `arc scan`, archive `path set`, archive `remove`, or library `path set` resolves them.
 
 Library archive shortcuts:
-  - `wikg://lib/arc/<archive-id>/` addresses one archive membership in the default library.
-  - `wikg://lib/<lib-id>/arc/<archive-id>/` addresses one archive membership in a non-default library.
+  - `wikg://lib/arc/<archive-id>/` addresses one archive member page in the default library.
+  - `wikg://lib/<lib-id>/arc/<archive-id>/` addresses one archive member page in a non-default library.
+  - The archive member page exposes the managed archive's business entry URIs (`/chapter`, `/entity`, `/triple`, and `inspect`) and keeps registry fields as diagnostic metadata.
   - Add normal archive object suffixes after the trailing slash to query that archive's contents:
     {{ commandName }} wikg://lib/arc/<archive-id>/chapter
     {{ commandName }} wikg://lib/arc/<archive-id>/entity --query "term"

--- a/packages/core/src/library/membership.test.ts
+++ b/packages/core/src/library/membership.test.ts
@@ -18,6 +18,7 @@ import {
   disableWikiGraphLibraryIndex,
   ensureDefaultWikiGraphLibrary,
   finalizeWikiGraphLibraryArchiveWrite,
+  findWikiGraphLibraryArchiveMembers,
   getWikiGraphLibraryMetadata,
   isWikiGraphLibraryUri,
   moveWikiGraphLibraryArchive,
@@ -29,6 +30,7 @@ import {
   rebuildArchiveSearchIndex,
   rebindWikiGraphLibrary,
   setFtsIndexEmbedded,
+  listWikiGraphLibraryArchiveMembers,
   rebuildWikiGraphLibraryIndex,
   removeWikiGraphLibrary,
   removeWikiGraphLibraryArchive,
@@ -72,6 +74,51 @@ describe("library archive membership", () => {
           status: archive.status,
         })),
       ).toContainEqual({ relativePath: "a.wikg", status: "missing" });
+    });
+  });
+
+  it("searches and paginates archive member collection results", async () => {
+    await withLibraryTestState(async () => {
+      const library = await ensureDefaultWikiGraphLibrary();
+      await mkdir(join(library.folderPath, "books"), { recursive: true });
+      await writeFile(join(library.folderPath, "books", "alpha.wikg"), "alpha");
+      await writeFile(join(library.folderPath, "books", "beta.wikg"), "beta");
+
+      const target = parseWikiGraphLibraryUri("wikg://lib");
+      expect(target).toBeDefined();
+      await scanWikiGraphLibrary(target!);
+
+      const matched = await findWikiGraphLibraryArchiveMembers(
+        target!,
+        "alpha",
+        { limit: 5 },
+      );
+      expect(matched.items).toHaveLength(1);
+      expect(matched.items[0]).toMatchObject({
+        title: "books/alpha.wikg",
+        type: "meta",
+      });
+
+      const missing = await findWikiGraphLibraryArchiveMembers(
+        target!,
+        "missing-term",
+        { limit: 5 },
+      );
+      expect(missing.items).toStrictEqual([]);
+
+      const firstPage = await listWikiGraphLibraryArchiveMembers(target!, {
+        limit: 1,
+      });
+      expect(firstPage.items).toHaveLength(1);
+      expect(firstPage.nextCursor).not.toBeNull();
+      const nextCursor = firstPage.nextCursor;
+      expect(nextCursor).toBeDefined();
+      const secondPage = await listWikiGraphLibraryArchiveMembers(target!, {
+        cursor: nextCursor!,
+        limit: 1,
+      });
+      expect(secondPage.items).toHaveLength(1);
+      expect(secondPage.items[0]?.id).not.toBe(firstPage.items[0]?.id);
     });
   });
 

--- a/packages/core/src/retrieval/query/archive-view/helper/sort.ts
+++ b/packages/core/src/retrieval/query/archive-view/helper/sort.ts
@@ -123,6 +123,6 @@ export function getSearchBucket(type: ArchiveFindObjectType): number {
     case "chapter-tree":
     case "meta":
     case "fragment":
-      throw new Error(`Unsupported search result bucket type: ${type}`);
+      return 4;
   }
 }

--- a/test/cli/library.test.ts
+++ b/test/cli/library.test.ts
@@ -16,6 +16,9 @@ vi.mock("wiki-graph-core", async (importOriginal) => {
   return {
     ...actual,
     assertWikiGraphLibrarySchemaCurrent: vi.fn(() => Promise.resolve()),
+    getWikiGraphLibraryArchive: vi.fn(() =>
+      Promise.resolve(libraryMockState.archives[0]),
+    ),
     listWikiGraphLibraryArchives: vi.fn(() =>
       Promise.resolve(libraryMockState.archives),
     ),
@@ -408,6 +411,33 @@ describe("cli/library args", () => {
       },
       kind: "archive",
     });
+    expect(
+      parseCLIArguments(["wikg://lib", "--limit", "1", "--json"]),
+    ).toMatchObject({
+      args: {
+        action: "list",
+        archivePath: "wikg://lib",
+        format: "json",
+        limit: 1,
+      },
+      kind: "archive",
+    });
+    expect(
+      parseCLIArguments([
+        "wikg://lib/abc123abc123",
+        "--cursor",
+        "c_next",
+        "--json",
+      ]),
+    ).toMatchObject({
+      args: {
+        action: "list",
+        archivePath: "wikg://lib/abc123abc123",
+        cursor: "c_next",
+        format: "json",
+      },
+      kind: "archive",
+    });
   });
 
   it("lists archive members from the library scope root", async () => {
@@ -438,6 +468,49 @@ describe("cli/library args", () => {
           status: "present",
         },
       ],
+    });
+  });
+
+  it("renders archive member pages with business entry links and diagnostic metadata", async () => {
+    libraryMockState.archives = [
+      {
+        uri: "wikg://lib/arc/book",
+        publicId: "book",
+        libraryUri: "wikg://lib",
+        relativePath: "books/book.wikg",
+        path: "/tmp/library/books/book.wikg",
+        exists: true,
+        status: "present",
+        lastSeenMutationToken: "mtime:1:size:2",
+        lastSeenSize: 2,
+        lastSeenMtimeMs: 1,
+        lastScannedAt: "2026-01-01T00:00:00.000Z",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ];
+
+    await runLibraryCommand({
+      action: "get",
+      json: true,
+      target: { archivePublicId: "book", isDefault: true, kind: "archive" },
+    });
+
+    expect(JSON.parse(libraryMockState.textWrites[0] ?? "{}")).toMatchObject({
+      uri: "wikg://lib/arc/book",
+      label: "books/book.wikg",
+      relativePath: "books/book.wikg",
+      status: "present",
+      entries: {
+        chapter: "wikg://lib/arc/book/chapter",
+        entity: "wikg://lib/arc/book/entity",
+        triple: "wikg://lib/arc/book/triple",
+        inspect: "wikg://lib/arc/book inspect",
+      },
+      metadata: {
+        path: "/tmp/library/books/book.wikg",
+        exists: true,
+      },
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/oomol-lab/wiki-graph/issues/220

## Summary
- Route `wikg://lib` / `wikg://lib/<lib-id>` with `--limit` or `--cursor` through the archive-member collection path so collection pagination and `wg next` work.
- Keep archive-member search/list results sortable and visible by supporting `meta` hits in search sorting and exposing their snippet/type in JSON output.
- Upgrade `wikg://lib/arc/<archive-id>` and `wikg://lib/<lib-id>/arc/<archive-id>` default output to an archive member page with business entry links and diagnostic metadata.
- Update library help text and regression coverage for search, pagination, continuation, member pages, and `wg next` routing.

## Acceptance evidence
Automated:
- `pnpm vitest run packages/core/src/library/membership.test.ts test/cli/library.test.ts packages/cli/src/commands/archive-command/run/next.test.ts packages/cli/src/args/help.test.ts --passWithNoTests` — 51 tests passed.
- `pnpm run typecheck` — passed.
- `pnpm run lint` — passed.
- `pnpm run format:check` — passed.
- `pnpm run test` — 131 files / 873 tests passed.
- `pnpm run build` — passed.

Manual CLI fixture:
- Library id: default library plus non-default `4e046471d75c`.
- Default archive id used for page/suffix checks: `bb73d97d48aa`.
- Non-default archive id used for page checks: `b1b61a563faa`.
- Matching query: `alpha`; missing query: `missing-term`.
- `wg wikg://lib --json` returned 2 archive members.
- `wg wikg://lib --limit 1 --json` returned 1 object and `nextCursor`; `wg next <cursor> --json` returned the second archive member.
- `wg wikg://lib --query alpha --json` returned 1 archive-member object; `wg wikg://lib --query missing-term --json` returned 0 objects.
- `wg wikg://lib/4e046471d75c --limit 1 --json` returned 1 object and `nextCursor`; `wg wikg://lib/4e046471d75c --query alpha --json` returned 1 object.
- `wg wikg://lib/arc/bb73d97d48aa --json` exposed `entries.chapter`, `entries.entity`, `entries.triple`, `entries.inspect` and diagnostic `metadata` keys (`path`, `exists`, `lastSeenMutationToken`, `lastSeenSize`, `lastSeenMtimeMs`, `lastScannedAt`, `createdAt`, `updatedAt`).
- `wg wikg://lib/4e046471d75c/arc/b1b61a563faa --json` exposed the same business entry shape for the non-default library.
- `wg wikg://lib/arc/bb73d97d48aa/chapter --json` executed through the archive shortcut suffix retrieval path and returned an empty collection for the empty test archive.

## Review note
Attempted blind reviewer via Hermes delegation once, but the subagent failed before review with provider outage: `HTTP 503: 所有供应商暂时不可用，请稍后重试`. Per task fallback rules, I completed a non-blind fallback review.

Fallback review conclusion: pass. The issue acceptance items above are covered by automated tests plus manual CLI evidence; the change does not touch security, permissions, production data, irreversible migrations, or public compatibility beyond the intended CLI output shape for archive member pages.
