### PR TITLE
fix: prune stale library archive members on scan

### DIFF
--- a/packages/cli/src/commands/library.test.ts
+++ b/packages/cli/src/commands/library.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   addWikiGraphLibraryArchive,
+  createWikiGraphLibrary,
   parseWikiGraphLibraryUri,
 } from "../../../core/src/index.js";
 import { withWikiGraphStateDirectoryPathForTesting } from "../../../core/src/runtime/common/wiki-graph/dir.js";
@@ -12,6 +13,62 @@ import { runLibraryCommand } from "./library.js";
 import { createEmptyArchive } from "./test-helpers.js";
 
 describe("library command", () => {
+  it("scan prunes deleted members while registry listing remains library-only", async () => {
+    await withLibraryCommandTestState(async (tempDir) => {
+      const libraryFolder = join(tempDir, "library");
+      const library = await createWikiGraphLibrary({
+        folderPath: libraryFolder,
+      });
+      const target = parseWikiGraphLibraryUri(`${library.uri}/arc`);
+      expect(target).toBeDefined();
+      await createEmptyArchive({
+        path: join(libraryFolder, "book.wikg"),
+        tempDir,
+      });
+
+      const firstScanOutput = await captureStdout(async () => {
+        await runLibraryCommand({
+          action: "scan",
+          json: true,
+          target: target!,
+        });
+      });
+      const firstScan = JSON.parse(firstScanOutput) as {
+        readonly items: Array<{
+          readonly id: string;
+          readonly relativePath: string;
+        }>;
+      };
+      expect(firstScan.items).toHaveLength(1);
+      const archiveId = firstScan.items[0]?.id;
+
+      await rm(join(libraryFolder, "book.wikg"));
+      const secondScanOutput = await captureStdout(async () => {
+        await runLibraryCommand({
+          action: "scan",
+          json: true,
+          target: target!,
+        });
+      });
+      expect(JSON.parse(secondScanOutput)).toStrictEqual({ items: [] });
+
+      const libraryListOutput = await captureStdout(async () => {
+        await runLibraryCommand({
+          action: "list",
+          json: true,
+          target: { isDefault: true, kind: "registry" },
+        });
+      });
+      const libraryList = JSON.parse(libraryListOutput) as {
+        readonly items: Array<{ readonly id: string; readonly uri: string }>;
+      };
+      expect(libraryList.items).toContainEqual(
+        expect.objectContaining({ id: library.publicId, uri: library.uri }),
+      );
+      expect(libraryListOutput).not.toContain(archiveId);
+    });
+  });
+
   it("filters archive tree by file parent without changing the display root", async () => {
     await withLibraryCommandTestState(async (tempDir) => {
       const target = parseWikiGraphLibraryUri("wikg://lib");

--- a/packages/core/src/library/membership.test.ts
+++ b/packages/core/src/library/membership.test.ts
@@ -21,6 +21,7 @@ import {
   findWikiGraphLibraryArchiveMembers,
   getWikiGraphLibraryMetadata,
   isWikiGraphLibraryUri,
+  listWikiGraphLibraryArchives,
   moveWikiGraphLibraryArchive,
   parseLocatedWikiGraphUri,
   parseWikiGraphLibraryUri,
@@ -52,7 +53,7 @@ import { acquireWikiGraphLibraryLock } from "./lock.js";
 import { listWikiGraphLibrarySearchIndex } from "./search-index.js";
 
 describe("library archive membership", () => {
-  it("scans nested .wikg files and reports missing registered files", async () => {
+  it("scans nested .wikg files and prunes deleted registered files", async () => {
     await withLibraryTestState(async () => {
       const library = await ensureDefaultWikiGraphLibrary();
       await mkdir(join(library.folderPath, "nested"), { recursive: true });
@@ -73,7 +74,10 @@ describe("library archive membership", () => {
           relativePath: archive.relativePath,
           status: archive.status,
         })),
-      ).toContainEqual({ relativePath: "a.wikg", status: "missing" });
+      ).toStrictEqual([{ relativePath: "nested/b.wikg", status: "present" }]);
+      await expect(listWikiGraphLibraryArchives(target!)).resolves.toHaveLength(
+        1,
+      );
     });
   });
 
@@ -199,11 +203,11 @@ describe("library archive membership", () => {
       );
 
       expect(fresh?.publicId).not.toBe(first.archives[0]?.publicId);
-      expect(second.archives).toContainEqual(
-        expect.objectContaining({
-          relativePath: "old.wikg",
-          status: "missing",
-        }),
+      expect(second.archives.map((archive) => archive.relativePath)).toEqual([
+        "new.wikg",
+      ]);
+      expect(second.archives).not.toContainEqual(
+        expect.objectContaining({ relativePath: "old.wikg" }),
       );
     });
   });
@@ -731,9 +735,30 @@ describe("library archive membership", () => {
       expect(fresh?.lastSeenMutationToken).not.toBe(
         oldArchive?.lastSeenMutationToken,
       );
-      expect(rebound.archives).toContainEqual(
+      expect(rebound.archives).not.toContainEqual(
+        expect.objectContaining({ publicId: oldArchive?.publicId }),
+      );
+      expect(rebound.archives).toHaveLength(1);
+    });
+  });
+
+  it("does not prune members when the library folder root is missing", async () => {
+    await withLibraryTestState(async () => {
+      const library = await ensureDefaultWikiGraphLibrary();
+      const target = parseWikiGraphLibraryUri("wikg://lib");
+      expect(target).toBeDefined();
+      await writeFile(join(library.folderPath, "book.wikg"), "book");
+      const first = await scanWikiGraphLibrary(target!);
+
+      await rm(library.folderPath, { recursive: true });
+      await expect(scanWikiGraphLibrary(target!)).rejects.toThrow(
+        "Wiki Graph library folder is missing",
+      );
+      await expect(
+        listWikiGraphLibraryArchives(target!),
+      ).resolves.toContainEqual(
         expect.objectContaining({
-          publicId: oldArchive?.publicId,
+          publicId: first.archives[0]?.publicId,
           relativePath: "book.wikg",
           status: "missing",
         }),

--- a/packages/core/src/library/membership.ts
+++ b/packages/core/src/library/membership.ts
@@ -30,6 +30,7 @@ import { isNodeError } from "../utils/node-error.js";
 import {
   parseWikiGraphLibraryUri,
   resolveWikiGraphLibrary,
+  resolveWikiGraphLibraryForScan,
   updateWikiGraphLibraryFolderPathForRebind,
   type ParsedWikiGraphLibraryUri,
   type WikiGraphLibraryRecord,
@@ -103,7 +104,7 @@ interface DiscoveredLibraryArchiveFile {
 export async function scanWikiGraphLibrary(
   target: ParsedWikiGraphLibraryUri,
 ): Promise<WikiGraphLibraryScanResult> {
-  const library = await resolveWikiGraphLibrary(target);
+  const library = await resolveWikiGraphLibraryForScan(target);
   return await withWikiGraphLibraryLock(library.id, "write", async () => {
     const result = await scanWikiGraphLibraryUnlocked(target, library, {
       pathIdentity: "trusted",
@@ -207,7 +208,6 @@ async function scanWikiGraphLibraryUnlocked(
         });
       }
 
-      const now = new Date().toISOString();
       for (const archive of existing) {
         if (
           seenArchiveIds.has(archive.id) ||
@@ -218,11 +218,10 @@ async function scanWikiGraphLibraryUnlocked(
         }
         await database.run(
           `
-            UPDATE library_archives
-            SET status = 'missing', updated_at = ?, last_scanned_at = ?
+            DELETE FROM library_archives
             WHERE id = ?
           `,
-          [now, now, archive.id],
+          [archive.id],
         );
       }
     });
@@ -772,6 +771,7 @@ function archivePathMatchRank(archive: WikiGraphLibraryArchiveRecord): number {
 async function listWikgFiles(
   root: string,
 ): Promise<DiscoveredLibraryArchiveFile[]> {
+  await assertLibraryFolderExists(root);
   const relativePaths: string[] = [];
   await walkLibraryDirectory(root, root, relativePaths);
   const files: DiscoveredLibraryArchiveFile[] = [];
@@ -784,6 +784,20 @@ async function listWikgFiles(
     );
   }
   return files;
+}
+
+async function assertLibraryFolderExists(root: string): Promise<void> {
+  try {
+    const rootStat = await stat(root);
+    if (!rootStat.isDirectory()) {
+      throw new Error(`Wiki Graph library folder is not a directory: ${root}`);
+    }
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      throw new Error(`Wiki Graph library folder is missing: ${root}`);
+    }
+    throw error;
+  }
 }
 
 async function ensureLibraryArchiveFileHasNoSearchIndexAndInspect(

--- a/packages/core/src/library/registry.ts
+++ b/packages/core/src/library/registry.ts
@@ -406,6 +406,19 @@ export async function resolveWikiGraphLibrary(
   );
 }
 
+export async function resolveWikiGraphLibraryForScan(
+  target: ParsedWikiGraphLibraryUri,
+): Promise<WikiGraphLibraryRecord> {
+  if (!target.isDefault) {
+    return await resolveWikiGraphLibrary(target);
+  }
+
+  const existing = await withLibraryRegistryDatabase(
+    async (database) => await readDefaultLibraryRecord(database),
+  );
+  return existing ?? (await ensureDefaultWikiGraphLibrary());
+}
+
 export async function resolveWikiGraphLibraryById(
   id: number,
 ): Promise<WikiGraphLibraryRecord> {


### PR DESCRIPTION
## Summary

- Prune stale library archive membership rows during `arc scan` instead of persisting scan-stable `missing` members.
- Preserve mutation-token based rename/move adoption, while deleting old rows when token identity is absent or not adoptable.
- Add scan-specific default-library resolution so a missing default library root fails instead of being recreated and treated as an empty folder.
- Cover core scan semantics and CLI list/registry behavior.

Closes https://github.com/oomol-lab/wiki-graph/issues/222

## Acceptance coverage

- New `.wikg` files are scanned as `present` members.
- Deleted registered files are removed from membership; subsequent scan/list output no longer returns them.
- Rename/move with a unique mutation token keeps the archive id and updates `relativePath`.
- Missing mutation token does not guess identity: old member is deleted and the new path is inserted as a new member.
- Copied same-token files remain inspectable as current-file conflicts without producing a stable `missing` member.
- Missing library folder root fails scan and does not prune existing membership rows.
- Registry listing remains library-registry-only and does not perform/replace archive member cleanup.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run packages/core/src/library/membership.test.ts packages/cli/src/commands/library.test.ts` — 32 tests passed
- `pnpm exec prettier --check packages/core/src/library/membership.ts packages/core/src/library/membership.test.ts packages/cli/src/commands/library.test.ts`
- `pnpm lint && pnpm typecheck`
- Manual source CLI verification on a temporary non-default library: registry add, create real `.wikg`, scan, delete, scan/list no longer returned the deleted member, registry remained library-only, rename/move preserved archive id
- `pnpm lint && pnpm typecheck && pnpm test && pnpm run format:check && pnpm run build` — lint/typecheck passed, 131 test files / 875 tests passed, format check passed, build passed

## Review note

Blind reviewer attempt failed before producing a report because the delegated reviewer hit provider unavailability after retries: `HTTP 503: 所有供应商暂时不可用，请稍后重试`. Per task rules this entered non-blind fallback review.

Non-blind fallback review verdict: pass. I reviewed the issue acceptance list against the final diff and verification evidence. The implementation changes core membership persistence rather than CLI-only filtering; keeps `missing` only as dynamic read/remove-result state; protects missing root directories from destructive prune; and includes automated plus manual coverage for deletion, rename/move, token-missing, copied-token conflict, root-missing, and registry/list behavior. No high-risk boundary such as security, credentials, production data, irreversible migration, or public API incompatibility was introduced beyond the intended scan semantics change.