### PR TITLE
fix: restore library root scope semantics

### DIFF
--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -760,7 +760,8 @@ describe("cli/args/help", () => {
     expect(scopeHelpText).toContain(
       "Use `wg wikg://lib/registry` to list all library registries.",
     );
-    expect(scopeHelpText).toContain("lists archive members");
+    expect(scopeHelpText).toContain("reads the library-wide scope collection");
+    expect(scopeHelpText).not.toContain("lists archive members");
     expect(scopeHelpText).not.toContain("List archive memberships");
     expect(scopeTrailingSlashHelp).not.toContain("wikg://lib//");
     expect(scopeTrailingSlashHelp).not.toContain("List archive memberships");
@@ -775,9 +776,12 @@ describe("cli/args/help", () => {
     expect(() =>
       parseCLIArguments(["wikg://lib/team", "list", "--help"]),
     ).toThrow("does not support `list`");
-    expect(scopeHelpText).toContain("searches archive members");
-    expect(scopeHelpText).not.toContain("broad library index search");
+    expect(scopeHelpText).toContain("wg wikg://lib [--json]");
     expect(scopeHelpText).toContain("wg wikg://lib --query <query>");
+    expect(scopeHelpText).toContain("searches library-wide objects");
+    expect(scopeHelpText).not.toContain("searches archive members");
+    expect(scopeHelpText).not.toContain("broad library index search");
+
     expect(
       parseCLIArguments(["wikg://lib", "--query", "attention", "--help"]),
     ).toStrictEqual({

--- a/packages/cli/src/args/uri/library.ts
+++ b/packages/cli/src/args/uri/library.ts
@@ -176,6 +176,9 @@ export function parseLibraryUriFirstArguments(
   if (
     target.kind === "scope" &&
     (target.objectUri !== undefined ||
+      action === "related" ||
+      action === "evidence" ||
+      action === "pack" ||
       action === "search" ||
       (action === "list" && explicitAction === undefined))
   ) {
@@ -473,7 +476,12 @@ function parseLibraryQueryArguments(
     action !== "search" &&
     action !== "list"
   ) {
-    throw new Error("Internal error: missing library query object URI.");
+    throw new Error(
+      withHelpRoute(
+        formatMissingLibraryQueryObjectUriMessage(action),
+        formatWikiGraphHelpCommand(uri, action),
+      ),
+    );
   }
 
   const parsed = parseArchiveArguments(
@@ -513,6 +521,10 @@ function parseLibraryQueryArguments(
       ...optionalObjectId(replaceTemporaryUri(parsed.args.objectId)),
     },
   };
+}
+
+function formatMissingLibraryQueryObjectUriMessage(action: string): string {
+  return `The library \`${action}\` predicate requires a concrete library object URI.`;
 }
 
 function optionalDefaultKinds(

--- a/packages/cli/src/commands/archive-command/index.ts
+++ b/packages/cli/src/commands/archive-command/index.ts
@@ -2,9 +2,8 @@ import {
   listArchiveCollection,
   listArchiveEvidence,
   listRelatedArchiveObjects,
-  findWikiGraphLibraryArchiveMembers,
   findWikiGraphLibraryObjects,
-  listWikiGraphLibraryArchiveMembers,
+  formatWikiGraphLibraryUri,
   listRelatedWikiGraphLibraryObjects,
   listWikiGraphLibraryEvidence,
   listWikiGraphLibraryObjects,
@@ -331,24 +330,27 @@ async function runLibraryIndexArchiveCommand(
   target: NonNullable<ReturnType<typeof parseWikiGraphLibraryUri>>,
 ): Promise<void> {
   const library = await resolveWikiGraphLibrary(target);
-  const objectUri =
-    target.objectUri === undefined && args.objectId === undefined
-      ? "wikg://"
-      : getObjectUri(args.objectId ?? args.archivePath);
+  const isLibraryRootCollection =
+    target.objectUri === undefined && args.objectId === undefined;
+  const objectUri = isLibraryRootCollection
+    ? undefined
+    : getObjectUri(args.objectId ?? args.archivePath);
   const context = {
     ...createArchiveOutputContext(args),
-    archiveKey: args.archivePath,
+    archiveKey: isLibraryRootCollection
+      ? `${formatWikiGraphLibraryUri(target.publicId)}#scope`
+      : args.archivePath,
     archivePath: args.archivePath,
     indexScope: { kind: "library-index" as const, libraryId: library.id },
   };
 
   switch (args.action) {
     case "search":
-      if (objectUri === "wikg://") {
+      if (objectUri === undefined) {
         if (args.all === true) {
           await writeAllFindHits(
             async (cursor) =>
-              await findWikiGraphLibraryArchiveMembers(target, args.query!, {
+              await findWikiGraphLibraryObjects(target, args.query!, {
                 ...createFindOptions(args),
                 ...(cursor === undefined ? {} : { cursor }),
               }),
@@ -358,7 +360,7 @@ async function runLibraryIndexArchiveCommand(
           return;
         }
         await writeFindHits(
-          await findWikiGraphLibraryArchiveMembers(
+          await findWikiGraphLibraryObjects(
             target,
             args.query!,
             createFindOptions(args),
@@ -396,16 +398,30 @@ async function runLibraryIndexArchiveCommand(
         ...context,
         continuationKind: "collection" as const,
       };
-      if (objectUri === "wikg://") {
+      if (objectUri === undefined) {
         if (args.all === true) {
-          await writeAllFindHits(
-            async (cursor) =>
-              createCollectionFindResult(
-                await listWikiGraphLibraryArchiveMembers(target, {
-                  ...createCollectionOptions(args),
-                  ...(cursor === undefined ? {} : { cursor }),
-                }),
-              ),
+          if (args.limit !== undefined) {
+            await writeAllFindHits(
+              async (cursor) =>
+                createCollectionFindResult(
+                  await listWikiGraphLibraryObjects(target, {
+                    ...createCollectionOptions(args),
+                    ...(cursor === undefined ? {} : { cursor }),
+                  }),
+                ),
+              listContext,
+              args.format ?? "text",
+            );
+            return;
+          }
+
+          await writeFindHitsWithoutContinuation(
+            createCollectionFindResult(
+              await listWikiGraphLibraryObjects(target, {
+                ...createCollectionOptions(args),
+                limit: ALL_COLLECTION_OUTPUT_LIMIT,
+              }),
+            ),
             listContext,
             args.format ?? "text",
           );
@@ -413,7 +429,7 @@ async function runLibraryIndexArchiveCommand(
         }
         await writeFindHits(
           createCollectionFindResult(
-            await listWikiGraphLibraryArchiveMembers(
+            await listWikiGraphLibraryObjects(
               target,
               createCollectionOptions(args),
             ),
@@ -465,6 +481,24 @@ async function runLibraryIndexArchiveCommand(
       return;
     }
     case "get": {
+      if (objectUri === undefined) {
+        const getContext = {
+          ...context,
+          continuationKind: "collection" as const,
+        };
+        await writeFindHits(
+          createCollectionFindResult(
+            await listWikiGraphLibraryObjects(
+              target,
+              createCollectionOptions(args),
+            ),
+          ),
+          getContext,
+          args.format ?? "text",
+        );
+        return;
+      }
+
       const evidenceLimit = getSingleObjectEvidenceLimit(args, objectUri);
       await writePage(
         await readWikiGraphLibraryPage(target, objectUri, {
@@ -481,6 +515,9 @@ async function runLibraryIndexArchiveCommand(
       return;
     }
     case "related": {
+      if (objectUri === undefined) {
+        throw new Error("Internal error: missing library object URI.");
+      }
       const relatedContext = {
         ...context,
         continuationKind: "related" as const,
@@ -517,6 +554,9 @@ async function runLibraryIndexArchiveCommand(
       return;
     }
     case "evidence": {
+      if (objectUri === undefined) {
+        throw new Error("Internal error: missing library object URI.");
+      }
       const evidenceContext = {
         ...context,
         continuationKind: "evidence" as const,
@@ -553,6 +593,9 @@ async function runLibraryIndexArchiveCommand(
       return;
     }
     case "pack":
+      if (objectUri === undefined) {
+        throw new Error("Internal error: missing library object URI.");
+      }
       await writePack(
         await packWikiGraphLibraryContext(
           target,

--- a/packages/cli/src/commands/archive-command/index.ts
+++ b/packages/cli/src/commands/archive-command/index.ts
@@ -60,6 +60,9 @@ export async function runArchiveCommand(
     libraryTarget?.kind === "scope" &&
     libraryTarget.objectUri !== "wikg://index" &&
     (libraryTarget.objectUri !== undefined ||
+      args.action === "related" ||
+      args.action === "evidence" ||
+      args.action === "pack" ||
       args.action === "search" ||
       args.action === "list")
   ) {
@@ -515,18 +518,16 @@ async function runLibraryIndexArchiveCommand(
       return;
     }
     case "related": {
-      if (objectUri === undefined) {
-        throw new Error("Internal error: missing library object URI.");
-      }
+      const concreteObjectUri = requireLibraryObjectUri("related", objectUri);
       const relatedContext = {
         ...context,
         continuationKind: "related" as const,
-        targetUri: objectUri,
+        targetUri: concreteObjectUri,
       };
       const readPage = async (
         cursor: string | undefined,
       ): Promise<ArchiveRelatedResult> =>
-        await listRelatedWikiGraphLibraryObjects(target, objectUri, {
+        await listRelatedWikiGraphLibraryObjects(target, concreteObjectUri, {
           ...(cursor === undefined ? {} : { cursor }),
           ...createOptionalEvidenceLimit(args),
           ...(args.limit === undefined ? {} : { limit: args.limit }),
@@ -554,19 +555,17 @@ async function runLibraryIndexArchiveCommand(
       return;
     }
     case "evidence": {
-      if (objectUri === undefined) {
-        throw new Error("Internal error: missing library object URI.");
-      }
+      const concreteObjectUri = requireLibraryObjectUri("evidence", objectUri);
       const evidenceContext = {
         ...context,
         continuationKind: "evidence" as const,
-        targetUri: objectUri,
+        targetUri: concreteObjectUri,
       };
 
       if (args.all === true) {
         await writeAllEvidence(
           async (cursor) =>
-            await listWikiGraphLibraryEvidence(target, objectUri, {
+            await listWikiGraphLibraryEvidence(target, concreteObjectUri, {
               ...(cursor === undefined ? {} : { cursor }),
               ...(args.limit === undefined ? {} : { limit: args.limit }),
               ...(args.reverse === true ? { order: "doc-desc" } : {}),
@@ -580,7 +579,7 @@ async function runLibraryIndexArchiveCommand(
       }
 
       await writeEvidence(
-        await listWikiGraphLibraryEvidence(target, objectUri, {
+        await listWikiGraphLibraryEvidence(target, concreteObjectUri, {
           ...(args.cursor === undefined ? {} : { cursor: args.cursor }),
           ...(args.limit === undefined ? {} : { limit: args.limit }),
           ...(args.reverse === true ? { order: "doc-desc" } : {}),
@@ -592,20 +591,19 @@ async function runLibraryIndexArchiveCommand(
       );
       return;
     }
-    case "pack":
-      if (objectUri === undefined) {
-        throw new Error("Internal error: missing library object URI.");
-      }
+    case "pack": {
+      const concreteObjectUri = requireLibraryObjectUri("pack", objectUri);
       await writePack(
         await packWikiGraphLibraryContext(
           target,
-          objectUri,
+          concreteObjectUri,
           args.budget ?? 5000,
         ),
         context,
         args.format ?? "text",
       );
       return;
+    }
     case "create":
     case "export":
     case "inspect":
@@ -614,4 +612,17 @@ async function runLibraryIndexArchiveCommand(
         `The library index scope does not support \`${args.action}\`.`,
       );
   }
+}
+
+function requireLibraryObjectUri(
+  action: "related" | "evidence" | "pack",
+  objectUri: string | undefined,
+): string {
+  if (objectUri === undefined) {
+    throw new Error(
+      `The library \`${action}\` predicate requires a concrete library object URI.`,
+    );
+  }
+
+  return objectUri;
 }

--- a/packages/cli/src/commands/archive-command/run/next.test.ts
+++ b/packages/cli/src/commands/archive-command/run/next.test.ts
@@ -133,47 +133,59 @@ describe("runNextArchivePage library cursors", () => {
     );
   });
 
-  it("continues library archive member collection cursors", async () => {
-    vi.mocked(parseWikiGraphLibraryUri).mockReturnValue({
-      isDefault: true,
-      kind: "scope",
-    });
-    vi.mocked(listWikiGraphLibraryArchiveMembers).mockResolvedValue({
-      chapters: null,
-      ids: null,
-      items: [
-        {
-          archiveId: 8,
-          field: "metadata",
-          id: "wikg://lib/arc/book",
-          libraryArchiveUri: "wikg://lib/arc/book",
-          snippet: "books/book.wikg  present  exists",
-          title: "books/book.wikg",
-          type: "meta",
-        },
-      ],
-      limit: 20,
-      nextCursor: null,
-      order: "doc-asc",
-      types: null,
-    });
-
-    await runNextArchivePage({ action: "next", archivePath: "c_next" });
-
-    expect(listWikiGraphLibraryArchiveMembers).toHaveBeenCalledWith(
-      libraryTarget,
-      expect.objectContaining({ cursor: "raw-collection-cursor" }),
-    );
-    expect(listWikiGraphLibraryObjects).not.toHaveBeenCalled();
-  });
-
-  it("continues library archive member search cursors", async () => {
+  it("continues library root scope collection cursors as library-wide objects", async () => {
     vi.mocked(parseWikiGraphLibraryUri).mockReturnValue({
       isDefault: true,
       kind: "scope",
     });
     vi.mocked(readContinuationCursor).mockResolvedValue({
-      archiveKey: "wikg://lib",
+      archiveKey: "wikg://lib#scope",
+      archivePath: "wikg://lib",
+      chapters: null,
+      cursor: "raw-collection-cursor",
+      format: "json",
+      ids: null,
+      indexScope: { kind: "library-index", libraryId: 42 },
+      kind: "collection",
+      order: "doc-asc",
+      types: ["entity"],
+    });
+    vi.mocked(listWikiGraphLibraryObjects).mockResolvedValue({
+      chapters: null,
+      ids: null,
+      items: [
+        {
+          archiveId: 7,
+          field: "metadata",
+          id: "wikg://entity/Q7",
+          libraryArchiveUri: "wikg://lib/archive-7",
+          snippet: "Entity 7",
+          title: "Entity 7",
+          type: "entity",
+        },
+      ],
+      limit: 20,
+      nextCursor: null,
+      order: "doc-asc",
+      types: ["entity"],
+    });
+
+    await runNextArchivePage({ action: "next", archivePath: "c_next" });
+
+    expect(listWikiGraphLibraryObjects).toHaveBeenCalledWith(
+      libraryTarget,
+      expect.objectContaining({ cursor: "raw-collection-cursor" }),
+    );
+    expect(listWikiGraphLibraryArchiveMembers).not.toHaveBeenCalled();
+  });
+
+  it("continues library root search cursors as library-wide object searches", async () => {
+    vi.mocked(parseWikiGraphLibraryUri).mockReturnValue({
+      isDefault: true,
+      kind: "scope",
+    });
+    vi.mocked(readContinuationCursor).mockResolvedValue({
+      archiveKey: "wikg://lib#scope",
       archivePath: "wikg://lib",
       cursor: "raw-search-cursor",
       format: "json",
@@ -182,7 +194,7 @@ describe("runNextArchivePage library cursors", () => {
       query: "book",
       types: null,
     });
-    vi.mocked(findWikiGraphLibraryArchiveMembers).mockResolvedValue({
+    vi.mocked(findWikiGraphLibraryObjects).mockResolvedValue({
       chapters: null,
       items: [],
       lens: "typed",
@@ -198,11 +210,11 @@ describe("runNextArchivePage library cursors", () => {
 
     await runNextArchivePage({ action: "next", archivePath: "c_next" });
 
-    expect(findWikiGraphLibraryArchiveMembers).toHaveBeenCalledWith(
+    expect(findWikiGraphLibraryObjects).toHaveBeenCalledWith(
       libraryTarget,
       "book",
       expect.objectContaining({ cursor: "raw-search-cursor" }),
     );
-    expect(findWikiGraphLibraryObjects).not.toHaveBeenCalled();
+    expect(findWikiGraphLibraryArchiveMembers).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/archive-command/run/next.ts
+++ b/packages/cli/src/commands/archive-command/run/next.ts
@@ -414,7 +414,11 @@ function isLibraryArchiveMemberCursor(
   cursor: Awaited<ReturnType<typeof readContinuationCursor>>,
 ): boolean {
   const target = parseWikiGraphLibraryUri(cursor.archivePath);
-  return target?.kind === "scope" && target.objectUri === undefined;
+  return (
+    target?.kind === "scope" &&
+    target.objectUri === undefined &&
+    cursor.archiveKey === cursor.archivePath
+  );
 }
 
 function createCursorOutputContext(

--- a/packages/cli/src/commands/library.ts
+++ b/packages/cli/src/commands/library.ts
@@ -8,10 +8,12 @@ import {
   deleteWikiGraphLibraryMetadataKey,
   getWikiGraphLibraryMetadata,
   getWikiGraphLibraryArchive,
+  listWikiGraphLibraryObjects,
   listWikiGraphLibraries,
   listWikiGraphLibraryArchives,
   moveWikiGraphLibraryArchive,
   disableWikiGraphLibraryIndex,
+  formatWikiGraphLibraryUri,
   putWikiGraphLibraryMetadata,
   readWikiGraphLibraryIndexState,
   rebuildWikiGraphLibraryIndex,
@@ -30,6 +32,8 @@ import {
   readTextStreamFromStdin,
   writeTextToStdout,
 } from "../support/index.js";
+import { createCollectionFindResult } from "./archive-command/run/index.js";
+import { writeFindHits } from "./archive-output/index.js";
 import {
   ProgressOutputWriter,
   type ProgressCounter,
@@ -81,13 +85,13 @@ export async function runLibraryCommand(
         return;
       }
       if (args.target.kind === "archive-collection") {
-        await writeEmptyLibraryScope(args.json ?? false);
+        await writeLibraryArchives(
+          await listWikiGraphLibraryArchives(args.target),
+          args.json ?? false,
+        );
         return;
       }
-      await writeLibraryArchives(
-        await listWikiGraphLibraryArchives(args.target),
-        args.json ?? false,
-      );
+      await writeLibraryScopeCollection(args.target, args.json ?? false);
       return;
     }
     case "scan": {
@@ -230,10 +234,14 @@ export async function runLibraryCommand(
         );
         return;
       }
-      await writeLibraryArchives(
-        await listWikiGraphLibraryArchives(args.target),
-        args.json ?? false,
-      );
+      if (args.target.kind === "archive-collection") {
+        await writeLibraryArchives(
+          await listWikiGraphLibraryArchives(args.target),
+          args.json ?? false,
+        );
+        return;
+      }
+      await writeLibraryScopeCollection(args.target, args.json ?? false);
       return;
     }
     case "set": {
@@ -435,8 +443,27 @@ async function writeLibraryArchives(
   );
 }
 
-async function writeEmptyLibraryScope(json: boolean): Promise<void> {
-  await writeTextToStdout(json ? formatCLIJSON({ items: [] }) : "");
+async function writeLibraryScopeCollection(
+  target: Parameters<typeof listWikiGraphLibraryObjects>[0],
+  json: boolean,
+): Promise<void> {
+  const library = await resolveWikiGraphLibrary(target);
+  const baseUri = formatWikiGraphLibraryUri(target.publicId);
+  const context = {
+    archiveKey: `${baseUri}#scope`,
+    archivePath: baseUri,
+    continuationKind: "collection" as const,
+    format: json ? ("json" as const) : ("text" as const),
+    indexScope: { kind: "library-index" as const, libraryId: library.id },
+    limit: 20,
+    types: null,
+  };
+
+  await writeFindHits(
+    createCollectionFindResult(await listWikiGraphLibraryObjects(target)),
+    context,
+    json ? "json" : "text",
+  );
 }
 
 async function writeLibraryArchive(

--- a/packages/core/data/help/commands/library.jinja
+++ b/packages/core/data/help/commands/library.jinja
@@ -166,9 +166,9 @@ Related help:
 Library scope
 
 Default behavior:
-  - `{{ commandName }} {{ uri }}` lists archive members in this library.
+  - `{{ commandName }} {{ uri }}` reads the library-wide scope collection.
   - Use `{{ commandName }} wikg://lib/registry` to list all library registries.
-  - `{{ commandName }} {{ uri }} --query <query>` searches archive members by URI, relative path, and status.
+  - `{{ commandName }} {{ uri }} --query <query>` searches library-wide objects through the library index.
   - `{{ commandName }} {{ uri }}/arc scan` reconciles membership with `.wikg` files currently under the library folder.
   - Library-wide object scopes such as `/entity` and `/triple` query one object type through the library index after it is enabled.
   - Archive object search must use an explicit lens such as `/entity`, `/triple`, `/chapter`, or `/chunk`.
@@ -183,14 +183,14 @@ Use when:
 {% endif %}
 
 URI forms:
-  - `{{ commandName }} wikg://lib` addresses the default library.
-  - `{{ commandName }} wikg://lib/<lib-id>` addresses a non-default library.
+  - `{{ commandName }} wikg://lib` addresses the default library root scope.
+  - `{{ commandName }} wikg://lib/<lib-id>` addresses a non-default library root scope.
   - `{{ commandName }} wikg://lib/arc/<archive-id>/` addresses one archive membership in the default library.
   - `{{ commandName }} wikg://lib/<lib-id>/arc/<archive-id>/` addresses one archive membership in a non-default library.
 
 Usage:
 {% if target.isDefault %}
-  {{ commandName }} wikg://lib [--limit <n>] [--cursor <cursor>] [--json]
+  {{ commandName }} wikg://lib [--json]
   {{ commandName }} wikg://lib --query <query> [--limit <n>] [--cursor <cursor>] [--json]
   {{ commandName }} wikg://lib/chapter --query <query>
   {{ commandName }} wikg://lib/chunk --query <query>
@@ -204,7 +204,7 @@ Usage:
   {{ commandName }} wikg://lib/triple --query <query>
   {{ commandName }} wikg://lib/meta [--json]
 {% else %}
-  {{ commandName }} {{ uri }} [--limit <n>] [--cursor <cursor>] [--json]
+  {{ commandName }} {{ uri }} [--json]
   {{ commandName }} {{ uri }} --query <query> [--limit <n>] [--cursor <cursor>] [--json]
   {{ commandName }} {{ uri }}/chapter --query <query>
   {{ commandName }} {{ uri }}/chunk --query <query>

--- a/packages/core/data/help/topics/library.jinja
+++ b/packages/core/data/help/topics/library.jinja
@@ -12,8 +12,8 @@ Core model:
   - The default library is addressed as `wikg://lib`.
   - A non-default library is addressed as `wikg://lib/<lib-id>`.
   - The `arc` reserved segment keeps library ids distinct from archive member ids.
-  - `{{ commandName }} wikg://lib` reads the default library's archive member collection.
-  - `{{ commandName }} wikg://lib --query <query>` searches archive members by URI, relative path, and status.
+  - `{{ commandName }} wikg://lib` reads the default library root scope.
+  - `{{ commandName }} wikg://lib --query <query>` searches library-wide objects through the library index.
 
 Registry discovery:
   - `{{ commandName }} wikg://lib/registry add --path <folder>` prints the new non-default library URI.
@@ -31,7 +31,7 @@ Library folders:
 Archive memberships:
   - `{{ commandName }} wikg://lib/arc scan` recursively discovers `.wikg` files under the default library folder and reconciles registry state.
   - `{{ commandName }} wikg://lib/arc add --input <path> [--to <relative-wikg-path>]` copies one `.wikg` file into the default library folder and registers it.
-  - `{{ commandName }} wikg://lib` and `{{ commandName }} wikg://lib/arc` list archive members; use `{{ commandName }} wikg://lib/arc/tree` when you want a file tree visualization.
+  - `{{ commandName }} wikg://lib` and `{{ commandName }} wikg://lib/arc` separate the library root scope from archive membership management; use `{{ commandName }} wikg://lib/arc/tree` when you want a file tree visualization.
   - For a non-default library, replace `wikg://lib` with `wikg://lib/<lib-id>` in those `arc` commands.
   - `{{ commandName }} <library-archive-uri>/path set <relative-wikg-path>` moves or renames one managed archive inside the same folder.
   - `{{ commandName }} <library-archive-uri> remove --confirm` deletes one managed archive file and unregisters it.
@@ -50,7 +50,7 @@ Library archive shortcuts:
   - `{{ commandName }} <library-archive-uri>/entity --help` explains the archive object scope reached through that library shortcut.
 
 Library-wide query:
-  - `{{ commandName }} wikg://lib --query <archive-term>` searches archive members themselves, not objects inside archives.
+  - `{{ commandName }} wikg://lib --query <archive-term>` searches library-wide objects through the library index.
   - `{{ commandName }} wikg://lib/entity --query <query>` searches across present archive members through the library index.
   - `{{ commandName }} wikg://lib/triple --query <query>` searches library-wide Knowledge Graph triples.
   - `{{ commandName }} wikg://lib/chunk --query <query>` searches library-wide Reading Graph chunks.

--- a/packages/core/data/help/topics/uri.jinja
+++ b/packages/core/data/help/topics/uri.jinja
@@ -23,7 +23,7 @@ Archive locator:
 Library locators:
   - `wikg://lib` addresses the default library.
   - `wikg://lib/<lib-id>` addresses a non-default library.
-  - Naked library scopes list archive members; `--query` on a naked library scope searches archive members themselves.
+  - Naked library scopes enumerate library-wide objects; `--query` on a naked library scope searches library-wide objects through the library index.
   - Use explicit object lenses such as `/entity`, `/triple`, `/chapter`, or `/chunk` for archive object search.
   - `wikg://lib/arc/<archive-id>/` addresses one archive membership in the default library.
   - `wikg://lib/<lib-id>/arc/<archive-id>/` addresses one archive membership in a non-default library.

--- a/test/cli/library.test.ts
+++ b/test/cli/library.test.ts
@@ -6,6 +6,7 @@ import type * as WikiGraphCore from "wiki-graph-core";
 const libraryMockState = vi.hoisted(() => ({
   archives: [] as unknown[],
   metadata: {} as Record<string, unknown>,
+  objects: [] as unknown[],
   putCalls: [] as unknown[],
   textWrites: [] as string[],
 }));
@@ -21,6 +22,24 @@ vi.mock("wiki-graph-core", async (importOriginal) => {
     ),
     listWikiGraphLibraryArchives: vi.fn(() =>
       Promise.resolve(libraryMockState.archives),
+    ),
+    listWikiGraphLibraryObjects: vi.fn(() =>
+      Promise.resolve({
+        chapters: null,
+        ids: null,
+        items: libraryMockState.objects,
+        limit: 20,
+        nextCursor: null,
+        order: "doc-asc",
+        types: null,
+      }),
+    ),
+    resolveWikiGraphLibrary: vi.fn((target: { kind: string }) =>
+      Promise.resolve({
+        id: target.kind === "scope" ? 42 : 7,
+        isDefault: true,
+        publicId: target.kind === "scope" ? undefined : "book",
+      }),
     ),
     scanWikiGraphLibrary: vi.fn(() =>
       Promise.resolve({ archives: libraryMockState.archives }),
@@ -54,6 +73,7 @@ describe("cli/library args", () => {
   beforeEach(() => {
     libraryMockState.archives = [];
     libraryMockState.metadata = {};
+    libraryMockState.objects = [];
     libraryMockState.putCalls.length = 0;
     libraryMockState.textWrites.length = 0;
   });
@@ -440,7 +460,45 @@ describe("cli/library args", () => {
     });
   });
 
-  it("lists archive members from the library scope root", async () => {
+  it("lists library-wide objects from the library scope root", async () => {
+    libraryMockState.objects = [
+      {
+        archiveId: 7,
+        field: "metadata",
+        id: "wikg://entity/Q7",
+        libraryArchiveUri: "wikg://lib/arc/book",
+        snippet: "Entity 7",
+        title: "Entity 7",
+        type: "meta",
+      },
+    ];
+
+    await runLibraryCommand({
+      action: "get",
+      json: true,
+      target: { isDefault: true, kind: "scope" },
+    });
+
+    const output = JSON.parse(libraryMockState.textWrites[0] ?? "{}") as {
+      objects: Array<Record<string, unknown>>;
+    };
+    expect(output).toMatchObject({
+      objects: [
+        {
+          archiveId: 7,
+          libraryArchiveUri: "wikg://lib/arc/book",
+          text: "Entity 7",
+          title: "Entity 7",
+          type: "meta",
+          uri: "wikg://entity/Q7",
+        },
+      ],
+    });
+    expect(output.objects[0]).not.toHaveProperty("relativePath");
+    expect(output.objects[0]).not.toHaveProperty("status");
+  });
+
+  it("lists archive members from the library archive collection root", async () => {
     libraryMockState.archives = [
       {
         uri: "wikg://lib/arc/book",
@@ -456,14 +514,13 @@ describe("cli/library args", () => {
     await runLibraryCommand({
       action: "get",
       json: true,
-      target: { isDefault: true, kind: "scope" },
+      target: { isDefault: true, kind: "archive-collection" },
     });
 
     expect(JSON.parse(libraryMockState.textWrites[0] ?? "{}")).toMatchObject({
       items: [
         {
           uri: "wikg://lib/arc/book",
-          id: "book",
           relativePath: "books/book.wikg",
           status: "present",
         },

--- a/test/cli/library.test.ts
+++ b/test/cli/library.test.ts
@@ -67,7 +67,10 @@ vi.mock("../../packages/cli/src/support/index.js", async (importOriginal) => {
 });
 
 import { parseCLIArguments } from "../../packages/cli/src/args/index.js";
-import { runLibraryCommand } from "../../packages/cli/src/commands/index.js";
+import {
+  runArchiveCommand,
+  runLibraryCommand,
+} from "../../packages/cli/src/commands/index.js";
 
 describe("cli/library args", () => {
   beforeEach(() => {
@@ -372,6 +375,15 @@ describe("cli/library args", () => {
   });
 
   it("rejects reverse query combinations for library query predicates", () => {
+    expect(() => parseCLIArguments(["wikg://lib", "related"])).toThrow(
+      "The library `related` predicate requires a concrete library object URI.",
+    );
+    expect(() => parseCLIArguments(["wikg://lib/team", "evidence"])).toThrow(
+      "The library `evidence` predicate requires a concrete library object URI.",
+    );
+    expect(() => parseCLIArguments(["wikg://lib", "pack"])).toThrow(
+      "The library `pack` predicate requires a concrete library object URI.",
+    );
     expect(() =>
       parseCLIArguments([
         "wikg://lib/entity/Q1",
@@ -526,6 +538,24 @@ describe("cli/library args", () => {
         },
       ],
     });
+  });
+
+  it("rejects library object predicates without a concrete object URI", async () => {
+    await expect(
+      runArchiveCommand({ action: "related", archivePath: "wikg://lib" }),
+    ).rejects.toThrow(
+      "The library `related` predicate requires a concrete library object URI.",
+    );
+    await expect(
+      runArchiveCommand({ action: "evidence", archivePath: "wikg://lib/team" }),
+    ).rejects.toThrow(
+      "The library `evidence` predicate requires a concrete library object URI.",
+    );
+    await expect(
+      runArchiveCommand({ action: "pack", archivePath: "wikg://lib" }),
+    ).rejects.toThrow(
+      "The library `pack` predicate requires a concrete library object URI.",
+    );
   });
 
   it("renders archive member pages with business entry links and diagnostic metadata", async () => {


### PR DESCRIPTION
## Summary\n- Restore library root scope to library-wide object queries\n- Keep archive member listings under /arc and preserve /arc continuation behavior\n- Update CLI/help/tests for registry vs root scope vs archive collection separation\n\n## Verification\n- pnpm run verify\n- pnpm run build\n- pnpm run test:run\n- Manual CLI check in temporary non-default library confirmed:\n  - wikg://lib/registry --json returns registry items without member-only fields\n  - wikg://lib/<lib-id>/arc --json returns archive member items\n  - wikg://lib/<lib-id>/ --json returns objects, not items\n  - wikg://lib/<lib-id>/entity --query empty --json returns object results\n  - wikg://lib/<lib-id>/triple --query empty --json returns object results\n\nCloses #223