### PR TITLE
fix: parse nested library scope patterns

### DIFF
--- a/packages/cli/src/args/archive.test.ts
+++ b/packages/cli/src/args/archive.test.ts
@@ -293,6 +293,137 @@ describe("cli/args/archive", () => {
       kind: "archive",
     });
 
+    expect(
+      parseCLIArguments([
+        "wikg://lib/triple/Q1",
+        "--query",
+        "memory",
+        "--json",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "search",
+        archivePath: "wikg://lib/triple/Q1",
+        format: "json",
+        kinds: ["triple"],
+        query: "memory",
+        triplePattern: { subjectQid: "Q1" },
+      },
+      help: false,
+      kind: "archive",
+    });
+
+    expect(
+      parseCLIArguments([
+        "wikg://lib/triple/Q1/P31",
+        "--query",
+        "memory",
+        "--json",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "search",
+        archivePath: "wikg://lib/triple/Q1/P31",
+        format: "json",
+        kinds: ["triple"],
+        query: "memory",
+        triplePattern: { predicate: "P31", subjectQid: "Q1" },
+      },
+      help: false,
+      kind: "archive",
+    });
+
+    expect(
+      parseCLIArguments(["wikg://lib/triple/Q1/P31/Q2", "--json"]),
+    ).toStrictEqual({
+      args: {
+        action: "get",
+        archivePath: "wikg://lib/triple/Q1/P31/Q2",
+        format: "json",
+        objectId: "wikg://lib/triple/Q1/P31/Q2",
+      },
+      help: false,
+      kind: "archive",
+    });
+
+    expect(
+      parseCLIArguments([
+        "wikg://lib/team/triple/Q1/P31",
+        "--query",
+        "memory",
+        "--json",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "search",
+        archivePath: "wikg://lib/team/triple/Q1/P31",
+        format: "json",
+        kinds: ["triple"],
+        query: "memory",
+        triplePattern: { predicate: "P31", subjectQid: "Q1" },
+      },
+      help: false,
+      kind: "archive",
+    });
+
+    expect(
+      parseCLIArguments([
+        "wikg://lib/chapter/part/entity",
+        "--query",
+        "memory",
+        "--json",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "search",
+        archivePath: "wikg://lib/chapter/part/entity",
+        format: "json",
+        kinds: ["entity"],
+        query: "memory",
+      },
+      help: false,
+      kind: "archive",
+    });
+
+    expect(
+      parseCLIArguments([
+        "wikg://lib/chapter/part/triple",
+        "--query",
+        "memory",
+        "--json",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "search",
+        archivePath: "wikg://lib/chapter/part/triple",
+        format: "json",
+        kinds: ["triple"],
+        query: "memory",
+      },
+      help: false,
+      kind: "archive",
+    });
+
+    expect(
+      parseCLIArguments([
+        "wikg://lib/chapter/part/triple/Q1/P31",
+        "--query",
+        "memory",
+        "--json",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "search",
+        archivePath: "wikg://lib/chapter/part/triple/Q1/P31",
+        format: "json",
+        kinds: ["triple"],
+        query: "memory",
+        triplePattern: { predicate: "P31", subjectQid: "Q1" },
+      },
+      help: false,
+      kind: "archive",
+    });
+
     expect(parseCLIArguments(["wikg://lib/team/entity"])).toStrictEqual({
       args: {
         action: "list",

--- a/packages/cli/src/args/uri/library.ts
+++ b/packages/cli/src/args/uri/library.ts
@@ -1,5 +1,6 @@
 import {
   parseWikiGraphLibraryUri,
+  type ArchiveTriplePattern,
   type ParsedWikiGraphLibraryUri,
 } from "wiki-graph-core";
 
@@ -496,6 +497,7 @@ function parseLibraryQueryArguments(
     formatWikiGraphHelpCommand(uri, action),
     {
       ...optionalDefaultKinds(getLibraryQueryDefaultKinds(target.objectUri)),
+      ...optionalTriplePattern(getLibraryQueryTriplePattern(target.objectUri)),
     },
   );
 
@@ -533,6 +535,12 @@ function optionalDefaultKinds(
   return defaultKinds === undefined ? {} : { defaultKinds };
 }
 
+function optionalTriplePattern(
+  triplePattern: ArchiveTriplePattern | undefined,
+): { readonly triplePattern?: ArchiveTriplePattern } {
+  return triplePattern === undefined ? {} : { triplePattern };
+}
+
 function optionalObjectId(objectId: string | undefined): {
   readonly objectId?: string;
 } {
@@ -549,6 +557,27 @@ function getLibraryQueryDefaultKinds(
 ): readonly CLIObjectKind[] | undefined {
   if (objectUri === undefined) {
     return undefined;
+  }
+  const chapterTarget = parseChapterTarget(objectUri);
+  if (chapterTarget !== undefined) {
+    switch (chapterTarget.kind) {
+      case "collection":
+      case "chapter":
+        return ["chapter"];
+      case "lens":
+      case "chapter-lens":
+        return [chapterTarget.lens];
+      case "triple-pattern-lens":
+      case "chapter-triple-pattern-lens":
+        return ["triple"];
+      case "chapter-resource":
+        return chapterTarget.resource === "title"
+          ? undefined
+          : [chapterTarget.resource];
+      case "chapter-state":
+      case "tree":
+        return undefined;
+    }
   }
   const path = stripObjectUriPrefix(objectUri);
   const [head] = path.split("/");
@@ -571,6 +600,26 @@ function getLibraryQueryDefaultKinds(
   }
 }
 
+function getLibraryQueryTriplePattern(
+  objectUri: string | undefined,
+): ArchiveTriplePattern | undefined {
+  if (objectUri === undefined) {
+    return undefined;
+  }
+  const chapterTarget = parseChapterTarget(objectUri);
+  if (chapterTarget === undefined) {
+    return undefined;
+  }
+
+  switch (chapterTarget.kind) {
+    case "triple-pattern-lens":
+    case "chapter-triple-pattern-lens":
+      return chapterTarget.pattern;
+    default:
+      return undefined;
+  }
+}
+
 function resolveImplicitLibraryQueryAction(
   objectUri: string | undefined,
   query: string | undefined,
@@ -578,12 +627,35 @@ function resolveImplicitLibraryQueryAction(
   if (objectUri === undefined) {
     return query === undefined ? "list" : "search";
   }
-  const path = stripObjectUriPrefix(objectUri);
-  if (/^(?:chapter|chunk|entity|source|summary|triple)$/u.test(path)) {
+  if (isLibraryScopeObjectUri(objectUri)) {
     return query === undefined ? "list" : "search";
   }
 
   return "get";
+}
+
+function isLibraryScopeObjectUri(objectUri: string): boolean {
+  const chapterTarget = parseChapterTarget(objectUri);
+  if (chapterTarget !== undefined) {
+    switch (chapterTarget.kind) {
+      case "collection":
+      case "chapter":
+      case "lens":
+      case "triple-pattern-lens":
+      case "chapter-lens":
+      case "chapter-triple-pattern-lens":
+        return true;
+      case "chapter-resource":
+      case "chapter-state":
+      case "tree":
+        return false;
+    }
+  }
+
+  const path = stripObjectUriPrefix(objectUri);
+  return /^(?:chunk|entity|source|summary|triple)$/u.test(path)
+    ? true
+    : isTripleScopePath(path);
 }
 
 function parseLibraryRegistryArguments(

--- a/packages/cli/src/commands/archive-command/index.test.ts
+++ b/packages/cli/src/commands/archive-command/index.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  findWikiGraphLibraryObjects,
+  listWikiGraphLibraryObjects,
+} from "wiki-graph-core";
+import type * as WikiGraphCore from "wiki-graph-core";
+import { parseCLIArguments } from "../../args/index.js";
+import { writeFindHits } from "../archive-output/index.js";
+import { runArchiveCommand } from "./index.js";
+import type * as ArchiveRun from "./run/index.js";
+
+vi.mock("wiki-graph-core", async (importOriginal) => {
+  const actual = await importOriginal<typeof WikiGraphCore>();
+  return {
+    ...actual,
+    findArchiveObjects: vi.fn(),
+    findWikiGraphLibraryObjects: vi.fn(),
+    formatWikiGraphLibraryUri: vi.fn((publicId?: string) =>
+      publicId === undefined ? "wikg://lib" : `wikg://lib/${publicId}`,
+    ),
+    listArchiveCollection: vi.fn(),
+    listArchiveEvidence: vi.fn(),
+    listRelatedArchiveObjects: vi.fn(),
+    listRelatedWikiGraphLibraryObjects: vi.fn(),
+    listWikiGraphLibraryEvidence: vi.fn(),
+    listWikiGraphLibraryObjects: vi.fn(),
+    packArchiveContext: vi.fn(),
+    packWikiGraphLibraryContext: vi.fn(),
+    parseLocatedWikiGraphUri: vi.fn((uri: string) => ({
+      archivePath: uri,
+      ...parseMockObjectUri(uri),
+    })),
+    parseWikiGraphLibraryUri: vi.fn((uri: string) => parseMockLibraryUri(uri)),
+    readArchivePage: vi.fn(),
+    readWikiGraphLibraryPage: vi.fn(),
+    resolveWikiGraphLibrary: vi.fn().mockResolvedValue({ id: 42 }),
+  };
+});
+
+vi.mock("../archive-output/index.js", () => ({
+  writeAllEvidence: vi.fn(),
+  writeAllFindHits: vi.fn(),
+  writeAllRelatedItems: vi.fn(),
+  writeEvidence: vi.fn(),
+  writeFindHits: vi.fn(),
+  writeFindHitsWithoutContinuation: vi.fn(),
+  writeList: vi.fn(),
+  writePack: vi.fn(),
+  writePage: vi.fn(),
+}));
+
+vi.mock("../convert.js", () => ({ runConvertCommand: vi.fn() }));
+vi.mock("./create.js", () => ({ createArchive: vi.fn() }));
+vi.mock("./inspect.js", () => ({ writeArchiveInspectReport: vi.fn() }));
+vi.mock("./run/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof ArchiveRun>();
+  return {
+    ...actual,
+    readArchiveDocument: vi.fn(),
+    resolveArchiveCommandRuntimeArguments: vi.fn((args) =>
+      Promise.resolve(args),
+    ),
+    runNextArchivePage: vi.fn(),
+  };
+});
+vi.mock("./run/scope.js", () => ({ resolveArchiveChapterScope: vi.fn() }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(findWikiGraphLibraryObjects).mockResolvedValue({
+    chapters: null,
+    items: [],
+    lens: "typed",
+    lensHint: null,
+    limit: 20,
+    match: "any",
+    nextCursor: null,
+    order: "doc-asc",
+    query: "memory",
+    terms: ["memory"],
+    types: ["triple"],
+  });
+  vi.mocked(listWikiGraphLibraryObjects).mockResolvedValue({
+    chapters: null,
+    ids: null,
+    items: [],
+    limit: 20,
+    nextCursor: null,
+    order: "doc-asc",
+    types: ["triple"],
+  });
+});
+
+describe("runArchiveCommand library nested scopes", () => {
+  it("searches library-wide triple pattern scopes through the library index", async () => {
+    const parsed = parseCLIArguments([
+      "wikg://lib/triple/Q1/P31",
+      "--query",
+      "memory",
+      "--json",
+    ]);
+    if (parsed.kind !== "archive") {
+      throw new Error(`Expected archive arguments, got ${parsed.kind}.`);
+    }
+
+    await runArchiveCommand(parsed.args);
+
+    expect(findWikiGraphLibraryObjects).toHaveBeenCalledWith(
+      {
+        isDefault: true,
+        kind: "scope",
+        objectUri: "wikg://triple/Q1/P31",
+      },
+      "memory",
+      expect.objectContaining({
+        archiveKey: "wikg://lib/triple/Q1/P31",
+        triplePattern: { predicate: "P31", subjectQid: "Q1" },
+        types: ["triple"],
+      }),
+    );
+    expect(writeFindHits).toHaveBeenCalled();
+  });
+
+  it("lists chapter-qualified triple pattern scopes through the library index", async () => {
+    const parsed = parseCLIArguments([
+      "wikg://lib/chapter/part/triple/Q1/P31",
+      "--json",
+    ]);
+    if (parsed.kind !== "archive") {
+      throw new Error(`Expected archive arguments, got ${parsed.kind}.`);
+    }
+
+    await runArchiveCommand(parsed.args);
+
+    expect(listWikiGraphLibraryObjects).toHaveBeenCalledWith(
+      {
+        isDefault: true,
+        kind: "scope",
+        objectUri: "wikg://chapter/part/triple/Q1/P31",
+      },
+      expect.objectContaining({
+        triplePattern: { predicate: "P31", subjectQid: "Q1" },
+        types: ["triple"],
+      }),
+    );
+    expect(writeFindHits).toHaveBeenCalled();
+  });
+});
+
+function parseMockLibraryUri(uri: string):
+  | {
+      readonly isDefault: boolean;
+      readonly kind: "scope";
+      readonly objectUri?: string;
+      readonly publicId?: string;
+    }
+  | undefined {
+  if (!uri.startsWith("wikg://lib")) {
+    return undefined;
+  }
+  const rest = uri.slice("wikg://lib".length).replace(/^\/+|\/+$/gu, "");
+  if (rest === "") {
+    return { isDefault: true, kind: "scope" };
+  }
+  const parts = rest.split("/");
+  if (
+    [
+      "chapter",
+      "chunk",
+      "entity",
+      "index",
+      "source",
+      "summary",
+      "triple",
+    ].includes(parts[0]!)
+  ) {
+    return {
+      isDefault: true,
+      kind: "scope",
+      objectUri: `wikg://${parts.join("/")}`,
+    };
+  }
+  const publicId = parts[0];
+  if (publicId === undefined) {
+    throw new Error(`Invalid mock library URI: ${uri}`);
+  }
+  return {
+    isDefault: false,
+    kind: "scope",
+    ...(parts.length === 1
+      ? {}
+      : { objectUri: `wikg://${parts.slice(1).join("/")}` }),
+    publicId,
+  };
+}
+
+function parseMockObjectUri(uri: string): { readonly objectUri?: string } {
+  const libraryTarget = parseMockLibraryUri(uri);
+  if (libraryTarget?.objectUri !== undefined) {
+    return { objectUri: libraryTarget.objectUri };
+  }
+  return {};
+}


### PR DESCRIPTION
Fixes https://github.com/oomol-lab/wiki-graph/issues/226

## Summary
- Treat nested library scope object URIs as search/list scopes when they match archive/chapter triple-pattern and chapter-lens rules.
- Pass through the same default lens kinds and triplePattern options used by archive URI parsing, including chapter-qualified triple pattern lenses.
- Keep concrete triple objects such as `wikg://lib/triple/Q1/P31/Q2` on the get path.

## Acceptance coverage
- CLI parsing now covers:
  - `wikg://lib/triple/Q1 --query ...` and `wikg://lib/triple/Q1/P31 --query ...` as search scopes with triplePattern.
  - `wikg://lib/triple/Q1/P31/Q2 --json` as concrete get.
  - non-default library `wikg://lib/<lib-id>/triple/Q1/P31 --query ...` with the same parsing path.
  - `wikg://lib/chapter/<chapter>/entity`, `wikg://lib/chapter/<chapter>/triple`, and chapter-qualified triple patterns as scope search/list.
- Command runner tests verify library index routing into `findWikiGraphLibraryObjects` / `listWikiGraphLibraryObjects` with the expected types/triplePattern.
- Existing full test suite covers root library scope, `/arc`, and `/registry` regressions.

## Verification
- `pnpm vitest run packages/cli/src/args/archive.test.ts packages/cli/src/commands/archive-command/index.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm test:run`
- `pnpm run build`
- Manual source CLI checks after enabling an empty default library index:
  - `wikg://lib/triple/Q1 --query x --json` -> empty search/list result, not `get does not support --query`.
  - `wikg://lib/triple/Q1/P31 --query x --json` -> empty search/list result.
  - `wikg://lib/chapter/part/entity --query x --json` -> empty search/list result.
  - `wikg://lib/chapter/part/triple/Q1 --query x --json` -> empty search/list result.
  - `wikg://lib/triple/Q1/P31/Q2 --json` -> concrete object not-found error for `wikg://triple/Q1/P31/Q2`, confirming get/read path remains concrete.
- Manual source CLI checks on a newly created empty non-default library showed the same empty search/list result shape for triple and chapter-qualified scope URIs.

## Review note
Blind reviewer attempt failed because the model/provider API returned HTTP 503 after 3 retries (`所有供应商暂时不可用，请稍后重试`). Per task rules, I completed a non-blind fallback review. Fallback verdict: pass. This change is limited to CLI parsing/routing and tests, with no security, permissions, production data, irreversible migration, or public compatibility boundary that requires human confirmation before continuing.
