### PR TITLE
chore: bump packages to 0.4.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-graph",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "CLI for building and querying .wikg knowledge-base archives from long-form text and ebooks.",
   "keywords": [
     "wiki-graph",
@@ -72,7 +72,7 @@
     "wiki-graph-core": "workspace:*"
   },
   "peerDependencies": {
-    "wiki-graph-core": "^0.4.0"
+    "wiki-graph-core": "^0.4.1"
   },
   "peerDependenciesMeta": {
     "wiki-graph-core": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-graph-core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Core SDK for building and querying .wikg knowledge-base archives.",
   "keywords": [
     "wiki-graph",


### PR DESCRIPTION
## Summary
- Bump wiki-graph and wiki-graph-core to 0.4.1.
- Update the wiki-graph peer dependency range for wiki-graph-core to ^0.4.1.

## Verification
- pnpm verify
- pnpm test:run
- pnpm build
- pnpm smoke:pack-install