### PR TITLE
fix: address dense index review findings

### DIFF
--- a/docs/en/wikg-standard.md
+++ b/docs/en/wikg-standard.md
@@ -36,7 +36,7 @@ Only the following archive entries are part of the standard layout:
 | `cover/data.bin`               | No       | Binary          | Cover binary payload. Required when `cover/info.json` is present. |
 | `texts/source/<serialId>.txt`  | No       | UTF-8 text      | Source text stream for one chapter serial.                        |
 | `texts/summary/<serialId>.txt` | No       | UTF-8 text      | Summary text stream for one chapter serial.                       |
-| `index.db`                     | No       | SQLite database | Embedded full-text search index.                                  |
+| `index.db`                     | No       | SQLite database | Embedded search index with FTS records, Dense segments, or both.  |
 
 No other entry is currently standard. Examples of non-standard entries include
 SQLite journal files, arbitrary JSON sidecars, and text files outside
@@ -186,7 +186,8 @@ grounding layer.
 
 ### `index.db`
 
-`index.db` is an optional SQLite full-text search index.
+`index.db` is an optional SQLite search index. It may contain FTS records, Dense
+embedding segments, or both.
 
 Writers include `index.db` only when the archive index policy marks the search
 index as embedded. Otherwise, the search index may exist as a local cache and

--- a/docs/schema-upgrade.md
+++ b/docs/schema-upgrade.md
@@ -37,14 +37,15 @@ write the target schema marker.
 ## Archive Gate
 
 Archive schema belongs to each `.wikg` file. The archive gate runs at archive
-open/upgrade boundaries and covers archive entries such as `database.db` and an
-embedded `index.db`. It must not be reimplemented across query/list/search/evidence
-business paths.
+open/upgrade boundaries and covers archive entries such as `database.db`, an
+embedded `index.db`, and legacy embedded `fts.db`. It must not be reimplemented
+across query/list/search/evidence business paths.
 
-The v1 -> v2 archive upgrader removes the embedded archive `index.db` as derived
-search index data and preserves important archive content and the mutation token.
-It must refuse active coordinator state for the target archive and non-`index.db`
-overlays, because those can represent uncommitted important data.
+The v1 -> v2 archive upgrader removes embedded archive `index.db` and legacy
+`fts.db` as derived search index data and preserves important archive content
+and the mutation token. It must refuse active coordinator state for the target
+archive and non-search-index overlays, because those can represent uncommitted
+important data.
 
 ## Home Gate
 
@@ -79,7 +80,8 @@ code and tests when adding new home SQLite files:
 
 For v1 -> v2, derived home data is deleted or invalidated: query/search caches,
 external cache, GC state, build queue SQLite/cache when safe, library aggregate
-indexes, external archive search index overlays/workspaces for `index.db`, and
+indexes, external archive search index overlays/workspaces for `index.db` or
+legacy `fts.db`, and
 orphaned SQLite materialization cache overlays whose archive file no longer
 exists. The upgrader must block when active GC, build job, worker lease,
 coordinator owner/lock/sqlite lease/commit lock, or remaining non-derived

--- a/docs/zh-CN/wikg-standard.md
+++ b/docs/zh-CN/wikg-standard.md
@@ -18,17 +18,17 @@
 
 只有以下归档 entry 属于标准布局：
 
-| Entry                          | Required | Type            | Meaning                                         |
-| ------------------------------ | -------- | --------------- | ----------------------------------------------- |
-| `.wikg-mutation-token`         | Yes      | UTF-8 text      | 归档 mutation token。必须是第一个 ZIP entry。   |
-| `manifest.json`                | Yes      | JSON            | 归档格式 manifest。                             |
-| `database.db`                  | Yes      | SQLite database | 主文档、图谱、元数据和 readiness 数据库。       |
-| `toc.json`                     | No       | JSON            | 章节树。                                        |
-| `cover/info.json`              | No       | JSON            | 封面元数据。                                    |
-| `cover/data.bin`               | No       | Binary          | 封面二进制内容。存在 `cover/info.json` 时必需。 |
-| `texts/source/<serialId>.txt`  | No       | UTF-8 text      | 某个 chapter serial 的 source text stream。     |
-| `texts/summary/<serialId>.txt` | No       | UTF-8 text      | 某个 chapter serial 的 summary text stream。    |
-| `index.db`                     | No       | SQLite database | 内嵌全文搜索索引。                              |
+| Entry                          | Required | Type            | Meaning                                                 |
+| ------------------------------ | -------- | --------------- | ------------------------------------------------------- |
+| `.wikg-mutation-token`         | Yes      | UTF-8 text      | 归档 mutation token。必须是第一个 ZIP entry。           |
+| `manifest.json`                | Yes      | JSON            | 归档格式 manifest。                                     |
+| `database.db`                  | Yes      | SQLite database | 主文档、图谱、元数据和 readiness 数据库。               |
+| `toc.json`                     | No       | JSON            | 章节树。                                                |
+| `cover/info.json`              | No       | JSON            | 封面元数据。                                            |
+| `cover/data.bin`               | No       | Binary          | 封面二进制内容。存在 `cover/info.json` 时必需。         |
+| `texts/source/<serialId>.txt`  | No       | UTF-8 text      | 某个 chapter serial 的 source text stream。             |
+| `texts/summary/<serialId>.txt` | No       | UTF-8 text      | 某个 chapter serial 的 summary text stream。            |
+| `index.db`                     | No       | SQLite database | 内嵌搜索索引，包含 FTS records、Dense segments 或两者。 |
 
 当前没有其他标准 entry。非标准 entry 的例子包括 SQLite journal 文件、任意 JSON sidecar，以及 `texts/source/` 或 `texts/summary/` 之外的文本文件。
 
@@ -152,9 +152,9 @@ Summaries 是生成投影。它们不会替代 source text 作为 grounding laye
 
 ### `index.db`
 
-`index.db` 是可选的 SQLite 全文搜索索引。
+`index.db` 是可选的 SQLite 搜索索引。它可以包含 FTS records、Dense embedding segments，或同时包含两者。
 
-只有当归档 index policy 标记搜索索引为 embedded 时，writer 才会包含 `index.db`。否则，搜索索引可以作为本地 cache 存在，并且不得被视为必需归档内容。
+只有当归档 index policy 标记搜索索引为 embedded 时，writer 才会包含 `index.db`。否则，搜索索引可以作为本地 cache 存在，并且不得被视为必需的归档内容。
 
 Reader 必须能打开不包含 `index.db` 的归档。缺失或过期的搜索索引状态应作为 readiness 信息处理，而不是归档损坏。
 

--- a/packages/cli/src/commands/archive-command/search-index.ts
+++ b/packages/cli/src/commands/archive-command/search-index.ts
@@ -153,6 +153,11 @@ async function isRequestedSearchIndexAlreadyCurrent(
     return (
       capabilities.indexes === "dense" &&
       capabilities.dense.current &&
+      capabilities.dense.model === options.embeddingProvider.model &&
+      isDenseIdentityCurrent(
+        capabilities,
+        options.embeddingProvider.identity,
+      ) &&
       (options.embeddingProvider.dimensions === undefined ||
         capabilities.dense.dimensions === options.embeddingProvider.dimensions)
     );
@@ -162,9 +167,17 @@ async function isRequestedSearchIndexAlreadyCurrent(
     capabilities.indexes === "fts,dense" &&
     capabilities.dense.current &&
     capabilities.dense.model === options.embeddingProvider.model &&
+    isDenseIdentityCurrent(capabilities, options.embeddingProvider.identity) &&
     (options.embeddingProvider.dimensions === undefined ||
       capabilities.dense.dimensions === options.embeddingProvider.dimensions)
   );
+}
+
+function isDenseIdentityCurrent(
+  capabilities: Awaited<ReturnType<typeof readSearchIndexCapabilityStatus>>,
+  identity: string | undefined,
+): boolean {
+  return identity === undefined || capabilities.dense.identity === identity;
 }
 
 async function createSearchIndexBuildOptions(

--- a/packages/cli/src/runtime/config.test.ts
+++ b/packages/cli/src/runtime/config.test.ts
@@ -39,4 +39,23 @@ describe("runtime/config", () => {
       await rm(tempDir, { force: true, recursive: true });
     }
   });
+
+  it("ignores incomplete embedding config in general CLI config", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "wikigraph-config-test-"));
+
+    try {
+      await withWikiGraphStateDirectoryPathForTesting(tempDir, async () => {
+        await putLocalConfigValue(
+          "embeddings",
+          "provider",
+          "openai-compatible",
+        );
+        await putLocalConfigValue("embeddings", "dimensions", 1536);
+
+        await expect(loadCLIConfig()).resolves.not.toHaveProperty("embedding");
+      });
+    } finally {
+      await rm(tempDir, { force: true, recursive: true });
+    }
+  });
 });

--- a/packages/cli/src/runtime/config.ts
+++ b/packages/cli/src/runtime/config.ts
@@ -127,12 +127,10 @@ function createEmbeddingConfig(
   const name = readString(value.name);
 
   if (
-    apiKey === undefined &&
-    baseURL === undefined &&
-    dimensions === undefined &&
-    model === undefined &&
-    name === undefined &&
-    provider === undefined
+    provider === undefined ||
+    model === undefined ||
+    (provider === "openai-compatible" && baseURL === undefined) ||
+    (provider === "openai" && baseURL !== undefined)
   ) {
     return undefined;
   }

--- a/packages/cli/src/runtime/embedding.ts
+++ b/packages/cli/src/runtime/embedding.ts
@@ -62,7 +62,6 @@ export async function embedQueryText(
   const embeddingModel = createEmbeddingModel(provider, model, config);
   const providerOptions = createEmbeddingProviderOptions(provider, config);
   const result = await embed({
-    maxRetries: 0,
     model: embeddingModel,
     ...(providerOptions === undefined ? {} : { providerOptions }),
     value: normalized,
@@ -91,6 +90,7 @@ export function buildSearchIndexEmbeddingProvider(
     ...(config.dimensions === undefined
       ? {}
       : { dimensions: config.dimensions }),
+    identity: createEmbeddingIdentity(provider, model, config),
     model,
     embedTexts: async (texts) => {
       const embeddings: number[][] = [];
@@ -98,7 +98,6 @@ export function buildSearchIndexEmbeddingProvider(
 
       for (const batch of chunkTexts(texts, EMBEDDING_BATCH_SIZE)) {
         const result = await embedMany({
-          maxRetries: 0,
           model: embeddingModel,
           ...(providerOptions === undefined ? {} : { providerOptions }),
           values: [...batch],
@@ -113,6 +112,21 @@ export function buildSearchIndexEmbeddingProvider(
       };
     },
   };
+}
+
+function createEmbeddingIdentity(
+  provider: CLIEmbeddingProvider,
+  model: string,
+  config: CLIEmbeddingConfig,
+): string {
+  return JSON.stringify({
+    ...(config.baseURL === undefined ? {} : { baseURL: config.baseURL }),
+    ...(config.dimensions === undefined
+      ? {}
+      : { dimensions: config.dimensions }),
+    model,
+    provider,
+  });
 }
 
 function* chunkTexts(

--- a/packages/cli/src/runtime/local-config.ts
+++ b/packages/cli/src/runtime/local-config.ts
@@ -116,17 +116,7 @@ export function normalizeLocalConfigKey(
     throw new Error("Config key cannot be empty.");
   }
 
-  if (section === "llm") {
-    switch (normalized) {
-      case "api-key":
-        return "apiKey";
-      case "base-url":
-        return "baseURL";
-      default:
-        return normalized;
-    }
-  }
-  if (section === "embeddings") {
+  if (section === "llm" || section === "embeddings") {
     switch (normalized) {
       case "api-key":
         return "apiKey";

--- a/packages/core/data/help/commands/predicate.jinja
+++ b/packages/core/data/help/commands/predicate.jinja
@@ -448,7 +448,8 @@ Notes:
   - This switches the index storage policy to the `.wikg` archive and ensures the embedded index is current.
   - After embedding, CLI archive writes keep the embedded index synchronized automatically.
   - This makes the archive more portable, but increases archive size.
-  - Use it when distributing a `.wikg` with query support ready for another machine.
+  - Use it when distributing a `.wikg` with index materialization ready for another machine.
+  - If the index includes Dense, configure `wikg://local/config/embeddings` on the destination before Dense queries. Hybrid queries can fall back to FTS.
 {% endif %}
 {% elif predicate == "external" %}
 {% if target.name == "index-object" and libraryContext.isLibraryWide %}

--- a/packages/core/data/help/topics/readiness.jinja
+++ b/packages/core/data/help/topics/readiness.jinja
@@ -138,8 +138,8 @@ WikiSpine readiness:
 How to choose:
   - Need searchable retrieval on this machine: enable the archive index.
   - Need searchable retrieval across a managed folder: enable the library index.
-  - Need local-only indexing with no provider calls: use `--indexes fts`.
-  - Need semantic retrieval: configure embeddings, then use `--indexes auto`, `dense`, or `fts,dense`.
+  - Need local-only indexing with no provider calls: use `{{ commandName }} <archive-uri>/index enable --indexes fts`.
+  - Need semantic retrieval: configure embeddings, then use `{{ commandName }} <archive-uri>/index enable --indexes auto|dense|fts,dense`.
   - Need to send a more self-contained `.wikg`: consider embedding the index.
   - Need to intentionally drop query support or index materialization: disable index.
   - Need generated Reading Graph or summaries: configure LLM and use local jobs.

--- a/packages/core/src/retrieval/query/archive-view/index-state.test.ts
+++ b/packages/core/src/retrieval/query/archive-view/index-state.test.ts
@@ -21,6 +21,7 @@ describe("archive search index state", () => {
       await rebuildArchiveSearchIndex(document, undefined, {
         embeddingProvider: {
           dimensions: 3,
+          identity: "provider=openai-compatible;model=test-embedding;baseURL=a",
           model: "test-embedding",
           embedTexts: async (texts) => {
             await Promise.resolve();
@@ -60,6 +61,7 @@ describe("archive search index state", () => {
         dense: {
           current: true,
           dimensions: 3,
+          identity: "provider=openai-compatible;model=test-embedding;baseURL=a",
           model: "test-embedding",
         },
         indexes: "fts,dense",
@@ -92,6 +94,21 @@ describe("archive search index state", () => {
             ),
         ),
       ).resolves.toBe(0);
+    });
+  });
+
+  it("reports a state-less index database as missing", async () => {
+    await withTempDocument(async (document) => {
+      await document.writeSearchIndexDatabase(async () => {
+        await Promise.resolve();
+      });
+
+      await expect(
+        readSearchIndexCapabilityStatus(document),
+      ).resolves.toStrictEqual({
+        dense: { current: false },
+        indexes: "missing",
+      });
     });
   });
 
@@ -231,6 +248,36 @@ describe("archive search index state", () => {
     });
   });
 
+  it("stores inferred embedding dimensions when the provider omits dimensions", async () => {
+    await withTempDocument(async (document) => {
+      await writeSourceChapter(document);
+
+      await rebuildArchiveSearchIndex(document, undefined, {
+        embeddingProvider: {
+          model: "test-embedding",
+          embedTexts: async (texts) => {
+            await Promise.resolve();
+            return {
+              embeddings: texts.map((text, index) => [text.length, index, 1]),
+            };
+          },
+        },
+        indexes: "dense",
+      });
+
+      await expect(
+        readSearchIndexCapabilityStatus(document),
+      ).resolves.toStrictEqual({
+        dense: {
+          current: true,
+          dimensions: 3,
+          model: "test-embedding",
+        },
+        indexes: "dense",
+      });
+    });
+  });
+
   it("falls back to fts when hybrid query embedding fails", async () => {
     await withTempDocument(async (document) => {
       await writeSourceChapter(document);
@@ -336,7 +383,7 @@ describe("archive search index state", () => {
         querySearchIndex(document, "semantic vectors", {
           embeddingProvider: {
             dimensions: 2,
-            model: "wrong-size",
+            model: "test-embedding",
             embedTexts: async () => {
               await Promise.resolve();
               return { embeddings: [[1, 2]] };
@@ -347,6 +394,111 @@ describe("archive search index state", () => {
       ).rejects.toThrow(
         "Dense query embedding has 2 dimensions; index expects 3.",
       );
+    });
+  });
+
+  it("rejects dense-only query embedding model mismatch", async () => {
+    await withTempDocument(async (document) => {
+      await writeSourceChapter(document);
+      await rebuildArchiveSearchIndex(document, undefined, {
+        embeddingProvider: createFakeEmbeddingProvider(),
+        indexes: "dense",
+      });
+
+      await expect(
+        querySearchIndex(document, "semantic vectors", {
+          embeddingProvider: {
+            dimensions: 3,
+            model: "other-embedding",
+            embedTexts: async () => {
+              await Promise.resolve();
+              return { embeddings: [[1, 2, 3]] };
+            },
+          },
+          types: ["source"],
+        }),
+      ).rejects.toThrow(
+        "Dense query embedding model is other-embedding; index expects test-embedding.",
+      );
+    });
+  });
+
+  it("rejects dense-only query embedding identity mismatch", async () => {
+    await withTempDocument(async (document) => {
+      await writeSourceChapter(document);
+      await rebuildArchiveSearchIndex(document, undefined, {
+        embeddingProvider: {
+          ...createFakeEmbeddingProvider(),
+          identity: "provider=openai-compatible;model=test-embedding;baseURL=a",
+        },
+        indexes: "dense",
+      });
+
+      await expect(
+        querySearchIndex(document, "semantic vectors", {
+          embeddingProvider: {
+            ...createFakeEmbeddingProvider(),
+            identity:
+              "provider=openai-compatible;model=test-embedding;baseURL=b",
+          },
+          types: ["source"],
+        }),
+      ).rejects.toThrow(
+        "Dense query embedding identity does not match the index.",
+      );
+    });
+  });
+
+  it("rejects ragged dense build embeddings", async () => {
+    await withTempDocument(async (document) => {
+      await writeLongSourceChapter(document);
+
+      await expect(
+        rebuildArchiveSearchIndex(document, undefined, {
+          embeddingProvider: {
+            model: "ragged-embedding",
+            embedTexts: async (texts) => {
+              await Promise.resolve();
+              return {
+                embeddings: texts.map((_, index) =>
+                  index === 1 ? [1, 2] : [1, 2, 3],
+                ),
+              };
+            },
+          },
+          indexes: "dense",
+        }),
+      ).rejects.toThrow(
+        "Embedding provider returned 2 dimensions; expected 3.",
+      );
+    });
+  });
+
+  it("rejects inferred dense dimensions that change across flushes", async () => {
+    await withTempDocument(async (document) => {
+      await writeManySourceChapters(document, 3, 1000);
+      let calls = 0;
+
+      await expect(
+        rebuildArchiveSearchIndex(document, undefined, {
+          embeddingProvider: {
+            model: "changing-embedding",
+            embedTexts: async (texts) => {
+              await Promise.resolve();
+              calls += 1;
+              return {
+                embeddings: texts.map((_, index) =>
+                  calls === 2 ? [index, 1] : [index, 1, 1],
+                ),
+              };
+            },
+          },
+          indexes: "dense",
+        }),
+      ).rejects.toThrow(
+        "Embedding provider returned 2 dimensions; expected 3.",
+      );
+      expect(calls).toBeGreaterThan(1);
     });
   });
 });
@@ -376,6 +528,55 @@ async function writeSourceChapter(document: DirectoryDocument): Promise<void> {
       items: [{ children: [], serialId: 1, title: "Dense" }],
       version: 1,
     });
+  });
+}
+
+async function writeLongSourceChapter(
+  document: DirectoryDocument,
+): Promise<void> {
+  await document.openSession(async (openedDocument) => {
+    await openedDocument.createSerial();
+    const draft = await openedDocument.getSerialFragments(1).createDraft();
+
+    for (let index = 0; index < 80; index += 1) {
+      draft.addSentence(`Dense indexing long sentence ${index}.`, 10);
+    }
+    await draft.commit();
+    await openedDocument.writeToc({
+      items: [{ children: [], serialId: 1, title: "Dense" }],
+      version: 1,
+    });
+  });
+}
+
+async function writeManySourceChapters(
+  document: DirectoryDocument,
+  chapters: number,
+  sentencesPerChapter: number,
+): Promise<void> {
+  await document.openSession(async (openedDocument) => {
+    const items: Array<{ children: []; serialId: number; title: string }> = [];
+
+    for (let chapter = 0; chapter < chapters; chapter += 1) {
+      const serialId = await openedDocument.createSerial();
+      const draft = await openedDocument
+        .getSerialFragments(serialId)
+        .createDraft();
+
+      for (let index = 0; index < sentencesPerChapter; index += 1) {
+        draft.addSentence(
+          `Dense indexing chapter ${chapter} sentence ${index}.`,
+          10,
+        );
+      }
+      await draft.commit();
+      items.push({
+        children: [],
+        serialId,
+        title: `Dense ${chapter}`,
+      });
+    }
+    await openedDocument.writeToc({ items, version: 1 });
   });
 }
 

--- a/packages/core/src/retrieval/search-index/search/build.ts
+++ b/packages/core/src/retrieval/search-index/search/build.ts
@@ -6,7 +6,6 @@ import {
   insertFtsRecord,
   insertTextEmbeddingSegment,
   insertSearchObjectPropertyRecord,
-  insertTextSentenceRecord,
 } from "./write.js";
 import type {
   SearchIndexBuildOptions,
@@ -28,10 +27,13 @@ export type ArchiveIndexProjection = SearchIndexInput;
 export type SearchIndexWriteBatch = SearchIndexInput;
 export interface SearchIndexWriteCounters {
   readonly denseDone: number;
-  readonly denseRecords: readonly TextSentenceRecordInput[];
+  readonly denseDimensions?: number;
+  readonly denseRecords: TextSentenceRecordInput[];
   readonly objectDone: number;
   readonly textDone: number;
 }
+
+const DENSE_RECORD_FLUSH_THRESHOLD = 2000;
 
 export async function writeArchiveIndexProjection(
   document: Document,
@@ -57,103 +59,16 @@ export async function ensureSearchIndex(
   progress?: SearchIndexProgressReporter,
   options: SearchIndexBuildOptions = {},
 ): Promise<void> {
-  const chaptersRevision = await document.serials.getChaptersRevision();
-  const resolved = resolveSearchIndexBuildOptions(options);
-
-  await document.writeSearchIndexDatabase(async (database) => {
-    const fingerprint = createSearchIndexFingerprint(input);
-
-    await database.transaction(async () => {
-      await progress?.({ phase: "clearing" });
-      await database.run("DELETE FROM text_sentence_fts");
-      await database.run("DELETE FROM text_embedding_segments");
-      await database.run("DELETE FROM search_object_properties_fts");
-      await database.run("DELETE FROM text_sentence_records");
-      await database.run("DELETE FROM search_object_properties_records");
-      await database.run("DELETE FROM index_dirty_chapters");
-      await database.run("DELETE FROM search_index_state");
-
-      let textDone = 0;
-      const textSentenceRows: TextSentenceEmbeddingInput[] = [];
-      for (const record of input.textSentences) {
-        const rowId = await insertTextSentenceRecord(database, record);
-
-        if (resolved.indexes !== "dense") {
-          await insertFtsRecord(
-            database,
-            "text_sentence_fts",
-            rowId,
-            createSearchTokenPlan(record.text),
-          );
-        }
-        textSentenceRows.push(record);
-        textDone += 1;
-        await progress?.({
-          done: textDone,
-          phase: "indexing-text",
-          total: input.textSentences.length,
-          unit: "sentence",
-        });
-      }
-
-      if (resolved.indexes !== "fts") {
-        await writeTextEmbeddingSegments(database, textSentenceRows, {
-          doneOffset: 0,
-          embeddingProvider: resolved.embeddingProvider,
-          ...(progress === undefined ? {} : { progress }),
-        });
-      }
-
-      let objectDone = 0;
-      if (resolved.indexes !== "dense") {
-        for (const record of input.objectProperties) {
-          const plan = createSearchTokenPlan(record.text);
-          const rowId = await insertSearchObjectPropertyRecord(
-            database,
-            record,
-          );
-
-          await insertFtsRecord(
-            database,
-            "search_object_properties_fts",
-            rowId,
-            plan,
-          );
-          objectDone += 1;
-          await progress?.({
-            done: objectDone,
-            phase: "indexing-objects",
-            total: input.objectProperties.length,
-            unit: "object",
-          });
-        }
-      }
-
-      await progress?.({ phase: "finalizing" });
-      await database.run(
-        `
-          INSERT INTO search_index_state(key, value)
-          VALUES ('version', ?)
-        `,
-        [SEARCH_INDEX_VERSION],
-      );
-      await database.run(
-        `
-          INSERT INTO search_index_state(key, value)
-          VALUES ('fingerprint', ?)
-        `,
-        [fingerprint],
-      );
-      await database.run(
-        `
-          INSERT INTO search_index_state(key, value)
-          VALUES ('chaptersRevision', ?)
-        `,
-        [String(chaptersRevision)],
-      );
-      await writeSearchIndexBuildState(database, resolved.indexes, resolved);
-    });
-  });
+  await replaceSearchIndex(
+    document,
+    (async function* (): AsyncIterable<SearchIndexWriteBatch> {
+      await Promise.resolve();
+      yield input;
+    })(),
+    createSearchIndexFingerprint(input),
+    progress,
+    options,
+  );
 }
 
 export async function replaceSearchIndex(
@@ -233,8 +148,8 @@ export async function writeSearchIndexBatch(
   options: SearchIndexBuildOptions = {},
 ): Promise<SearchIndexWriteCounters> {
   const resolved = resolveSearchIndexBuildOptions(options);
-  const denseRecords = [...counters.denseRecords];
-  const { denseDone } = counters;
+  const denseRecords = counters.denseRecords;
+  const { denseDimensions, denseDone } = counters;
   let { objectDone, textDone } = counters;
 
   await database.transaction(async () => {
@@ -281,7 +196,22 @@ export async function writeSearchIndexBatch(
     }
   });
 
-  return { denseDone, denseRecords, objectDone, textDone };
+  const nextDenseDone = await writePendingDenseRecords(database, denseRecords, {
+    ...(denseDimensions === undefined ? {} : { denseDimensions }),
+    doneOffset: denseDone,
+    ...(resolved.indexes === "fts"
+      ? {}
+      : { embeddingProvider: resolved.embeddingProvider }),
+    force: false,
+    ...(progress === undefined ? {} : { progress }),
+  });
+
+  return {
+    ...nextDenseDone,
+    denseRecords,
+    objectDone,
+    textDone,
+  };
 }
 
 export async function writeSearchIndexDenseSegments(
@@ -296,17 +226,104 @@ export async function writeSearchIndexDenseSegments(
     return counters;
   }
 
-  const denseDone = await writeTextEmbeddingSegments(
+  const denseDone = await writePendingDenseRecords(
     database,
     counters.denseRecords,
     {
+      ...(counters.denseDimensions === undefined
+        ? {}
+        : { denseDimensions: counters.denseDimensions }),
       doneOffset: counters.denseDone,
       embeddingProvider: resolved.embeddingProvider,
+      force: true,
       ...(progress === undefined ? {} : { progress }),
     },
   );
 
-  return { ...counters, denseDone, denseRecords: [] };
+  return { ...counters, ...denseDone };
+}
+
+async function writePendingDenseRecords(
+  database: Database,
+  denseRecords: TextSentenceEmbeddingInput[],
+  input: {
+    readonly denseDimensions?: number;
+    readonly doneOffset: number;
+    readonly embeddingProvider?: SearchIndexEmbeddingProvider;
+    readonly force: boolean;
+    readonly progress?: SearchIndexProgressReporter;
+  },
+): Promise<{
+  readonly denseDimensions?: number;
+  readonly denseDone: number;
+}> {
+  const doneOffset = input.doneOffset;
+
+  if (
+    input.embeddingProvider === undefined ||
+    denseRecords.length === 0 ||
+    (!input.force && denseRecords.length < DENSE_RECORD_FLUSH_THRESHOLD)
+  ) {
+    return {
+      ...(input.denseDimensions === undefined
+        ? {}
+        : { denseDimensions: input.denseDimensions }),
+      denseDone: doneOffset,
+    };
+  }
+  const writeCount = input.force
+    ? denseRecords.length
+    : findCompletedDenseRecordFlushCount(denseRecords);
+
+  if (writeCount === 0) {
+    return {
+      ...(input.denseDimensions === undefined
+        ? {}
+        : { denseDimensions: input.denseDimensions }),
+      denseDone: doneOffset,
+    };
+  }
+
+  const result = await writeTextEmbeddingSegments(
+    database,
+    denseRecords.slice(0, writeCount),
+    {
+      doneOffset,
+      embeddingProvider: input.embeddingProvider,
+      ...(input.denseDimensions === undefined
+        ? {}
+        : { expectedDimensions: input.denseDimensions }),
+      ...(input.progress === undefined ? {} : { progress: input.progress }),
+    },
+  );
+
+  denseRecords.splice(0, writeCount);
+  return {
+    ...(result.dimensions === undefined
+      ? {}
+      : { denseDimensions: result.dimensions }),
+    denseDone: result.done,
+  };
+}
+
+function findCompletedDenseRecordFlushCount(
+  records: readonly TextSentenceEmbeddingInput[],
+): number {
+  const last = records.at(-1);
+
+  if (last === undefined) {
+    return 0;
+  }
+
+  const lastGroupKey = createTextEmbeddingGroupKey(last);
+
+  for (let index = records.length - 2; index >= 0; index -= 1) {
+    if (createTextEmbeddingGroupKey(records[index]!) !== lastGroupKey) {
+      return index + 1;
+    }
+  }
+
+  return 0;
 }
 
 async function insertReplacementTextSentenceRecord(
@@ -388,7 +405,7 @@ function resolveSearchIndexBuildOptions(
     case "dense": {
       if (options.embeddingProvider === undefined) {
         throw new Error(
-          "Embeddings configuration is required for --indexes dense.",
+          "Embeddings configuration is required to build a Dense search index.",
         );
       }
       return {
@@ -401,7 +418,7 @@ function resolveSearchIndexBuildOptions(
     case "fts,dense": {
       if (options.embeddingProvider === undefined) {
         throw new Error(
-          "Embeddings configuration is required for --indexes fts,dense.",
+          "Embeddings configuration is required to build an FTS + Dense search index.",
         );
       }
       return {
@@ -437,13 +454,19 @@ async function writeTextEmbeddingSegments(
   input: {
     readonly doneOffset: number;
     readonly embeddingProvider: SearchIndexEmbeddingProvider;
+    readonly expectedDimensions?: number;
     readonly progress?: SearchIndexProgressReporter;
   },
-): Promise<number> {
+): Promise<{ readonly dimensions?: number; readonly done: number }> {
   const segments = createTextEmbeddingSegments(records);
 
   if (segments.length === 0) {
-    return input.doneOffset;
+    return {
+      ...(input.expectedDimensions === undefined
+        ? {}
+        : { dimensions: input.expectedDimensions }),
+      done: input.doneOffset,
+    };
   }
 
   const result = await input.embeddingProvider.embedTexts(
@@ -456,22 +479,29 @@ async function writeTextEmbeddingSegments(
     );
   }
 
+  const expectedDimensions =
+    input.expectedDimensions ??
+    input.embeddingProvider.dimensions ??
+    result.embeddings[0]?.length;
+
+  if (expectedDimensions === undefined || expectedDimensions <= 0) {
+    throw new Error("Embedding provider returned no usable vector dimensions.");
+  }
+
   let done = input.doneOffset;
   for (const [index, segment] of segments.entries()) {
     const vector = result.embeddings[index]!;
-    const dimensions =
-      input.embeddingProvider.dimensions ?? result.embeddings[index]!.length;
 
-    if (vector.length !== dimensions) {
+    if (vector.length !== expectedDimensions) {
       throw new Error(
-        `Embedding provider returned ${vector.length} dimensions; expected ${dimensions}.`,
+        `Embedding provider returned ${vector.length} dimensions; expected ${expectedDimensions}.`,
       );
     }
 
     await insertTextEmbeddingSegment(database, {
       archiveId: segment.archiveId,
       chapterId: segment.chapterId,
-      dimensions,
+      dimensions: expectedDimensions,
       endSentenceIndex: segment.endSentenceIndex,
       kind: segment.kind,
       model: input.embeddingProvider.model,
@@ -487,7 +517,7 @@ async function writeTextEmbeddingSegments(
     });
   }
 
-  return done;
+  return { dimensions: expectedDimensions, done };
 }
 
 function createTextEmbeddingSegments(
@@ -499,7 +529,7 @@ function createTextEmbeddingSegments(
     if (record.text.trim() === "") {
       continue;
     }
-    const key = [record.archiveId, record.kind, record.chapterId].join(":");
+    const key = createTextEmbeddingGroupKey(record);
     const group = groups.get(key) ?? [];
 
     group.push(record);
@@ -509,6 +539,12 @@ function createTextEmbeddingSegments(
   return [...groups.values()].flatMap((group) =>
     createTextEmbeddingSegmentsForGroup(group),
   );
+}
+
+function createTextEmbeddingGroupKey(
+  record: TextSentenceEmbeddingInput,
+): string {
+  return [record.archiveId, record.kind, record.chapterId].join(":");
 }
 
 function createTextEmbeddingSegmentsForGroup(
@@ -638,11 +674,54 @@ async function writeSearchIndexBuildState(
     `,
     [options.embeddingProvider.model],
   );
+  if (options.embeddingProvider.identity !== undefined) {
+    await database.run(
+      `
+        INSERT INTO search_index_state(key, value)
+        VALUES ('embeddingIdentity', ?)
+      `,
+      [options.embeddingProvider.identity],
+    );
+  }
   await database.run(
     `
       INSERT INTO search_index_state(key, value)
       VALUES ('embeddingDimensions', ?)
     `,
-    [String(options.embeddingProvider.dimensions ?? "")],
+    [
+      String(
+        options.embeddingProvider.dimensions ??
+          (await readStoredEmbeddingDimensions(database)) ??
+          "",
+      ),
+    ],
   );
+}
+
+async function readStoredEmbeddingDimensions(
+  database: Database,
+): Promise<number | undefined> {
+  const row = await database.queryOne(
+    `
+      SELECT MIN(dimensions) AS min_dimensions, MAX(dimensions) AS max_dimensions
+      FROM text_embedding_segments
+    `,
+    undefined,
+    (value) => ({
+      max: Number(value.max_dimensions),
+      min: Number(value.min_dimensions),
+    }),
+  );
+
+  if (
+    row === undefined ||
+    !Number.isInteger(row.min) ||
+    !Number.isInteger(row.max) ||
+    row.min <= 0 ||
+    row.min !== row.max
+  ) {
+    return undefined;
+  }
+
+  return row.min;
 }

--- a/packages/core/src/retrieval/search-index/search/helpers.ts
+++ b/packages/core/src/retrieval/search-index/search/helpers.ts
@@ -22,10 +22,11 @@ export function serializeTokens(
 
 export function createChapterSql(
   chapters: readonly number[] | undefined,
+  alias = "r.",
 ): string {
   return chapters === undefined || chapters.length === 0
     ? ""
-    : `AND r.chapter_id IN (${chapters.map(() => "?").join(", ")})`;
+    : `AND ${alias}chapter_id IN (${chapters.map(() => "?").join(", ")})`;
 }
 
 export function createChapterParams(

--- a/packages/core/src/retrieval/search-index/search/query.ts
+++ b/packages/core/src/retrieval/search-index/search/query.ts
@@ -160,7 +160,7 @@ export async function querySearchIndex(
       : [];
     const textHits =
       ftsTextHits.length > 0 && denseTextHits.length > 0
-        ? fuseTextHitsByRrf(ftsTextHits, denseTextHits, options.textHitLimit)
+        ? fuseTextHitsByRrf(ftsTextHits, denseTextHits)
         : denseTextHits.length > 0
           ? denseTextHits
           : ftsTextHits;
@@ -186,6 +186,8 @@ export async function querySearchIndex(
 
 interface SearchIndexQueryState {
   readonly denseDimensions?: number;
+  readonly embeddingIdentity?: string;
+  readonly embeddingModel?: string;
   readonly indexes: "dense" | "fts" | "fts,dense";
 }
 
@@ -219,10 +221,34 @@ async function readSearchIndexQueryState(
     undefined,
     (row) => Number(row.value),
   );
+  const embeddingModel = await database.queryOne(
+    `
+      SELECT value
+      FROM search_index_state
+      WHERE key = 'embeddingModel'
+    `,
+    undefined,
+    (row) => String(row.value),
+  );
+  const embeddingIdentity = await database.queryOne(
+    `
+      SELECT value
+      FROM search_index_state
+      WHERE key = 'embeddingIdentity'
+    `,
+    undefined,
+    (row) => String(row.value),
+  );
   const denseDimensions =
     dimensionsValue === undefined ? undefined : Number(dimensionsValue);
 
   const state: SearchIndexQueryState = {
+    ...(embeddingIdentity === undefined || embeddingIdentity === ""
+      ? {}
+      : { embeddingIdentity }),
+    ...(embeddingModel === undefined || embeddingModel === ""
+      ? {}
+      : { embeddingModel }),
     indexes: indexes === "dense" || indexes === "fts,dense" ? indexes : "fts",
   };
 
@@ -267,6 +293,30 @@ async function queryDenseTextRows(
       throw new Error(
         "Dense search requires embeddings configuration. Configure `wikg://local/config/embeddings` before querying a Dense-only index.",
       );
+    }
+    return [];
+  }
+
+  if (
+    state.embeddingModel !== undefined &&
+    options.embeddingProvider.model !== state.embeddingModel
+  ) {
+    const message = `Dense query embedding model is ${options.embeddingProvider.model}; index expects ${state.embeddingModel}.`;
+
+    if (state.indexes === "dense") {
+      throw new Error(message);
+    }
+    return [];
+  }
+  if (
+    state.embeddingIdentity !== undefined &&
+    options.embeddingProvider.identity !== undefined &&
+    options.embeddingProvider.identity !== state.embeddingIdentity
+  ) {
+    const message = "Dense query embedding identity does not match the index.";
+
+    if (state.indexes === "dense") {
+      throw new Error(message);
     }
     return [];
   }
@@ -340,7 +390,7 @@ async function queryDenseSegmentHits(
         vector
       FROM text_embedding_segments
       WHERE kind IN (${kinds.map(() => "?").join(", ")})
-        ${createChapterSql(options.chapters).replaceAll("r.", "")}
+        ${createChapterSql(options.chapters, "")}
     `,
     [...kinds, ...createChapterParams(options.chapters)],
     (row) => ({
@@ -447,7 +497,6 @@ async function expandDenseSegmentHits(
 function fuseTextHitsByRrf(
   ftsHits: readonly SearchIndexTextHit[],
   denseHits: readonly SearchIndexTextHit[],
-  limit: number | undefined,
 ): readonly SearchIndexTextHit[] {
   const fused = new Map<
     string,
@@ -486,7 +535,6 @@ function fuseTextHitsByRrf(
         left.hit.sentenceIndex - right.hit.sentenceIndex ||
         left.hit.kind - right.hit.kind,
     )
-    .slice(0, limit ?? SEARCH_INDEX_FTS_HIT_LIMIT)
     .map((entry, index) => ({
       ...entry.hit,
       rank: index + 1,

--- a/packages/core/src/retrieval/search-index/search/status.ts
+++ b/packages/core/src/retrieval/search-index/search/status.ts
@@ -64,7 +64,7 @@ export async function readSearchIndexCapabilityStatus(document: {
       if (indexes !== "dense" && indexes !== "fts,dense") {
         return {
           dense: { current: false },
-          indexes: indexes === "missing" ? "missing" : "fts",
+          indexes: indexes === undefined && !current ? "missing" : "fts",
         };
       }
 
@@ -72,12 +72,14 @@ export async function readSearchIndexCapabilityStatus(document: {
       const dimensions = parseOptionalPositiveInteger(
         await readStateValue(database, "embeddingDimensions"),
       );
+      const identity = await readStateValue(database, "embeddingIdentity");
       const model = await readStateValue(database, "embeddingModel");
 
       return {
         dense: {
           current: current && segmentCount > 0,
           ...(dimensions === undefined ? {} : { dimensions }),
+          ...(identity === undefined || identity === "" ? {} : { identity }),
           ...(model === undefined || model === "" ? {} : { model }),
         },
         indexes,

--- a/packages/core/src/retrieval/search-index/search/types.ts
+++ b/packages/core/src/retrieval/search-index/search/types.ts
@@ -54,6 +54,7 @@ export type SearchIndexSelection = "auto" | "dense" | "fts" | "fts,dense";
 
 export interface SearchIndexEmbeddingProvider {
   readonly dimensions?: number;
+  readonly identity?: string;
   readonly model: string;
   embedTexts(texts: readonly string[]): Promise<{
     readonly embeddings: readonly (readonly number[])[];
@@ -92,6 +93,7 @@ export interface SearchIndexCapabilityStatus {
   readonly dense: {
     readonly current: boolean;
     readonly dimensions?: number;
+    readonly identity?: string;
     readonly model?: string;
   };
   readonly indexes: "dense" | "fts" | "fts,dense" | "missing";

--- a/packages/core/src/storage/wikg/archive/write.ts
+++ b/packages/core/src/storage/wikg/archive/write.ts
@@ -5,11 +5,7 @@ import { finished } from "stream/promises";
 
 import { ZipFile as YazlZipFile } from "yazl";
 
-import {
-  LEGACY_SEARCH_INDEX_DATABASE_PATH,
-  WIKG_MANIFEST_PATH,
-  WIKG_MUTATION_TOKEN_PATH,
-} from "./constants.js";
+import { WIKG_MANIFEST_PATH, WIKG_MUTATION_TOKEN_PATH } from "./constants.js";
 import {
   listDocumentFiles,
   shouldEmbedSearchIndex,
@@ -93,11 +89,7 @@ export async function writeWikgArchiveWithOverlays(
   for (const entry of sourceEntries) {
     const archivePath = normalizeArchivePath(entry.fileName);
 
-    if (
-      archivePath !== "" &&
-      archivePath !== LEGACY_SEARCH_INDEX_DATABASE_PATH &&
-      isWikgArchivePath(archivePath)
-    ) {
+    if (archivePath !== "" && isWikgArchivePath(archivePath)) {
       entryPaths.add(archivePath);
     }
   }

--- a/packages/core/src/storage/wikg/wikg-coordinator/flusher.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/flusher.ts
@@ -109,7 +109,9 @@ export async function flushArchiveOverlays(
         await writeWikgArchiveWithOverlays(archivePath, temporaryArchivePath, [
           ...currentOverlays.map(toArchiveOverlay),
           ...(currentOverlays.some(
-            (overlay) => overlay.entryPath === SEARCH_INDEX_DATABASE_ENTRY_PATH,
+            (overlay) =>
+              overlay.entryPath === DATABASE_ENTRY_PATH ||
+              overlay.entryPath === SEARCH_INDEX_DATABASE_ENTRY_PATH,
           )
             ? [
                 {

--- a/test/core/storage/wikg/archive.test.ts
+++ b/test/core/storage/wikg/archive.test.ts
@@ -212,6 +212,36 @@ describe("wikg/archive", () => {
     });
   });
 
+  it("preserves legacy fts.db when unrelated overlays rewrite the archive", async () => {
+    await withTempDir("wikigraph-archive-", async (path) => {
+      const archivePath = `${path}/legacy.wikg`;
+      const rewrittenPath = `${path}/rewritten.wikg`;
+      const overlayPath = `${path}/toc.json`;
+      const zipFile = new ZipFile();
+
+      zipFile.addBuffer(
+        Buffer.from(VALID_MUTATION_TOKEN_CONTENT, "utf8"),
+        ".wikg-mutation-token",
+      );
+      zipFile.addBuffer(
+        Buffer.from('{"formatVersion":1,"schemaVersion":2}', "utf8"),
+        "manifest.json",
+      );
+      zipFile.addBuffer(Buffer.from("sqlite", "utf8"), "database.db");
+      zipFile.addBuffer(Buffer.from("legacy-index", "utf8"), "fts.db");
+      await writeZipFile(zipFile, archivePath);
+      await writeFile(overlayPath, '{"items":[]}', "utf8");
+
+      await writeWikgArchiveWithOverlays(archivePath, rewrittenPath, [
+        { entryPath: "toc.json", kind: "file", workspacePath: overlayPath },
+      ]);
+
+      await expect(
+        readWikgArchiveEntry(rewrittenPath, "fts.db"),
+      ).resolves.toEqual(Buffer.from("legacy-index", "utf8"));
+    });
+  });
+
   it("rejects archives that omit the mutation token", async () => {
     await withTempDir("wikigraph-archive-", async (path) => {
       const archivePath = `${path}/missing-token.wikg`;

--- a/test/core/storage/wikg/wiki-graph-archive-file.test.ts
+++ b/test/core/storage/wikg/wiki-graph-archive-file.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "crypto";
-import { access, mkdir, readFile, rename } from "fs/promises";
+import { access, mkdir, readFile, rename, writeFile } from "fs/promises";
 import { resolve } from "path";
 
 import { afterEach, describe, expect, it } from "vitest";
@@ -16,6 +16,10 @@ import {
 import { isSearchIndexCurrent } from "../../../../packages/core/src/retrieval/search-index/index.js";
 import { WikiGraphArchive } from "../../../../packages/core/src/api/wiki-graph-archive.js";
 import { WikiGraphArchiveFile } from "../../../../packages/core/src/storage/wikg/wiki-graph-archive-file.js";
+import {
+  readWikgArchiveEntry,
+  writeWikgArchiveWithOverlays,
+} from "../../../../packages/core/src/storage/wikg/archive/index.js";
 import { withTempDir } from "../../../helpers/temp.js";
 
 const originalStateDir = getWikiGraphStateDirectoryPathForTesting();
@@ -228,6 +232,37 @@ describe("wikg/wiki-graph-archive-file", () => {
           async (document) => {
             await expect(document.peekNextSerialId()).resolves.toBe(3);
           },
+        );
+      } finally {
+        restoreStateDir();
+      }
+    });
+  });
+
+  it("drops legacy fts.db when flushing mutated database overlays", async () => {
+    await withTempDir("wikigraph-facade-file-", async (path) => {
+      const restoreStateDir = useCoordinatorStateDir(`${path}/state`);
+      try {
+        const archivePath = await createSeedArchive(path);
+        const legacyIndexPath = `${path}/legacy-fts.db`;
+        const rewrittenPath = `${path}/legacy-search.wikg`;
+
+        await writeFile(legacyIndexPath, "legacy-index", "utf8");
+        await writeWikgArchiveWithOverlays(archivePath, rewrittenPath, [
+          { entryPath: "fts.db", kind: "file", workspacePath: legacyIndexPath },
+        ]);
+        await rename(rewrittenPath, archivePath);
+
+        await expect(
+          readWikgArchiveEntry(archivePath, "fts.db"),
+        ).resolves.toEqual(Buffer.from("legacy-index", "utf8"));
+
+        await new WikiGraphArchiveFile(archivePath).write(async (document) => {
+          await document.createSerial();
+        });
+
+        await expect(readWikgArchiveEntry(archivePath, "fts.db")).resolves.toBe(
+          undefined,
         );
       } finally {
         restoreStateDir();


### PR DESCRIPTION
## Summary
- guard incomplete embeddings config so FTS-only and auto paths do not fail early
- validate Dense query/build model and dimensions, preserve legacy fts.db rewrites, and report state-less indexes correctly
- update index docs/help wording for FTS/Dense index materialization and local Dense query config

## Verification
- pnpm lint
- pnpm format:check
- pnpm typecheck
- pnpm test:run

Follow-up to CodeRabbit review on #229.