### PR TITLE
fix: address index artifact review notes

### DIFF
--- a/packages/cli/src/args/uri/chapter/routing.ts
+++ b/packages/cli/src/args/uri/chapter/routing.ts
@@ -198,7 +198,7 @@ function parseChapterIndexArtifactUriArguments(
       throw new Error(
         withHelpRoute(
           `The chapter index artifact does not support \`${action}\`. Use get, build, or delete.`,
-          "wg <chapter-uri>/index --help",
+          helpRoute,
         ),
       );
   }

--- a/packages/cli/src/commands/library.ts
+++ b/packages/cli/src/commands/library.ts
@@ -147,7 +147,7 @@ export async function runLibraryCommand(
       await writer.write({
         json: { type: "started" },
         kind: "lifecycle",
-        text: "library index cache sync started\nsteps: collecting -> clearing -> indexing-text -> indexing-dense -> finalizing",
+        text: "library index cache sync started\nsteps: collecting -> clearing -> indexing-text -> indexing-objects -> indexing-dense -> finalizing",
       });
       const state = await rebuildWikiGraphLibraryIndex(
         args.target,

--- a/packages/cli/src/commands/queue/worker.ts
+++ b/packages/cli/src/commands/queue/worker.ts
@@ -26,6 +26,7 @@ import { WikiGraphArchiveFile } from "wiki-graph-core";
 import type {
   GuaranteedRequest,
   GuaranteedRequestController,
+  ReadonlyDocument,
 } from "wiki-graph-core";
 import type { LLMessage } from "wiki-graph-core";
 
@@ -73,7 +74,7 @@ async function executeBuildJobWithLogging(
   context: BuildJobExecutionContext,
 ): Promise<void> {
   if (isIndexArtifactBuildTarget(job.target)) {
-    await executeIndexArtifactBuildJob(job, reporter);
+    await executeIndexArtifactBuildJob(job, reporter, context);
     return;
   }
 
@@ -334,6 +335,7 @@ async function executeGenerationBuildJob(
 async function executeIndexArtifactBuildJob(
   job: BuildJob,
   reporter: BuildJobProgressReporter,
+  context: BuildJobExecutionContext,
 ): Promise<void> {
   await reporter.stepStarted(job.target);
   const snapshot = await readIndexArtifactJobSnapshot(job);
@@ -352,6 +354,7 @@ async function executeIndexArtifactBuildJob(
   if (job.target === "index-fts") {
     await new WikiGraphArchiveFile(job.archivePath).write(async (document) => {
       assertJobStillRunning(await getBuildJob(job.jobId));
+      await assertJobChapterExists(document, job.chapterId);
       await assertCurrentBuildInputRevision(job, document);
       await replaceChapterFtsIndexArtifact(document, job.chapterId);
     });
@@ -376,11 +379,13 @@ async function executeIndexArtifactBuildJob(
         : "embedding-summary",
     sentences: snapshot.sentences,
     serialId: job.chapterId,
+    signal: context.signal,
     sourceRevision: snapshot.revision,
   });
 
   await new WikiGraphArchiveFile(job.archivePath).write(async (document) => {
     assertJobStillRunning(await getBuildJob(job.jobId));
+    await assertJobChapterExists(document, job.chapterId);
     await assertCurrentBuildInputRevision(job, document);
     await document.indexArtifacts.replaceEmbedding(artifact);
   });
@@ -407,7 +412,11 @@ async function readIndexArtifactJobSnapshot(job: BuildJob): Promise<{
 }> {
   return await new WikiGraphArchiveFile(job.archivePath).readDocument(
     async (document) => {
+      await assertJobChapterExists(document, job.chapterId);
       const revision = await document.serials.getRevision(job.chapterId);
+      if (job.target === "index-fts") {
+        return { revision, sentences: [] };
+      }
       const stream =
         job.target === "index-embedding-summary"
           ? document.getSummaryFragments(job.chapterId)
@@ -430,6 +439,19 @@ async function readIndexArtifactJobSnapshot(job: BuildJob): Promise<{
         sentences: await stream.listSentences(),
       };
     },
+  );
+}
+
+async function assertJobChapterExists(
+  document: ReadonlyDocument,
+  chapterId: number,
+): Promise<void> {
+  if ((await document.serials.getById(chapterId)) !== undefined) {
+    return;
+  }
+
+  throw new Error(
+    `Chapter ${chapterId} no longer exists. Queue a new build job for an existing chapter.`,
   );
 }
 

--- a/packages/cli/src/runtime/embedding.ts
+++ b/packages/cli/src/runtime/embedding.ts
@@ -92,12 +92,16 @@ export function buildSearchIndexEmbeddingProvider(
       : { dimensions: config.dimensions }),
     identity: createEmbeddingIdentity(provider, model, config),
     model,
-    embedTexts: async (texts) => {
+    embedTexts: async (texts, options) => {
       const embeddings: number[][] = [];
       let tokens = 0;
 
       for (const batch of chunkTexts(texts, EMBEDDING_BATCH_SIZE)) {
+        options?.signal?.throwIfAborted();
         const result = await embedMany({
+          ...(options?.signal === undefined
+            ? {}
+            : { abortSignal: options.signal }),
           model: embeddingModel,
           ...(providerOptions === undefined ? {} : { providerOptions }),
           values: [...batch],

--- a/packages/core/data/help/topics/readiness.jinja
+++ b/packages/core/data/help/topics/readiness.jinja
@@ -36,7 +36,7 @@ Archive index readiness:
     FTS artifact only: FTS query.
     Source embedding artifact only: semantic/Dense-only query.
     Both artifacts: Hybrid query with automatic fusion.
-    Missing both FTS and source embedding for any content chapter: ordinary query fails in strict mode.
+    Missing both FTS and source embedding for any content chapter: ordinary query fails.
     Summary embedding artifacts are for summary semantic retrieval and are not the minimum requirement for ordinary source query.
 
   Commands:

--- a/packages/core/src/library/search-index.ts
+++ b/packages/core/src/library/search-index.ts
@@ -9,7 +9,9 @@ import { openSharedStateDatabase } from "../document/index.js";
 import { WikiGraphArchiveFile } from "../storage/wikg/index.js";
 import {
   assertArchiveIndexArtifactsReady,
-  buildArchiveIndexProjection,
+  readArchiveEmbeddingState,
+  readEmbeddingDimensions,
+  readEmbeddingModel,
   streamArchiveIndexProjection,
 } from "../retrieval/query/archive-view/index-state.js";
 import type {
@@ -478,11 +480,6 @@ async function replaceLibrarySearchIndex(
         async (archiveDocument) => {
           await assertArchiveIndexArtifactsReady(archiveDocument);
 
-          const archiveInput =
-            await buildArchiveIndexProjection(archiveDocument);
-          hasFts =
-            hasFts || archiveInput.textSentences.some((row) => row.text !== "");
-
           for await (const batch of streamArchiveIndexProjection(
             archiveDocument,
             archive.id,
@@ -491,6 +488,7 @@ async function replaceLibrarySearchIndex(
               const rowId = await insertTextSentenceRecord(database, record);
 
               if (record.text !== "") {
+                hasFts = true;
                 await insertFtsRecord(
                   database,
                   "text_sentence_fts",
@@ -604,39 +602,6 @@ function createLibraryIndexSearchFingerprint(
     .digest("hex");
 }
 
-async function readArchiveEmbeddingState(
-  document: Parameters<typeof assertArchiveIndexArtifactsReady>[0],
-): Promise<SearchIndexStoredEmbeddingState | undefined> {
-  let state: SearchIndexStoredEmbeddingState | undefined;
-
-  for (const artifactKind of [
-    "embedding-source",
-    "embedding-summary",
-  ] as const) {
-    for (const artifact of await document.indexArtifacts.list(artifactKind)) {
-      const dimensions = readEmbeddingDimensions(artifact.metadata);
-      const model = readEmbeddingModel(artifact.metadata);
-      const label = artifactKind === "embedding-source" ? "Source" : "Summary";
-
-      if (dimensions === undefined || model === undefined) {
-        throw new Error(
-          `${label} embedding artifact for chapter ${artifact.serialId} is missing embedding metadata.`,
-        );
-      }
-
-      state = mergeEmbeddingState(state, {
-        dimensions,
-        ...(readEmbeddingIdentity(artifact.metadata) === undefined
-          ? {}
-          : { identity: readEmbeddingIdentity(artifact.metadata)! }),
-        model,
-      });
-    }
-  }
-
-  return state;
-}
-
 function mergeEmbeddingState(
   current: SearchIndexStoredEmbeddingState | undefined,
   next: SearchIndexStoredEmbeddingState,
@@ -650,37 +615,11 @@ function mergeEmbeddingState(
     current.identity !== next.identity
   ) {
     throw new Error(
-      "Source embedding artifacts use different embedding providers or dimensions; rebuild them with one embeddings configuration.",
+      "Embedding artifacts use different embedding configurations; rebuild them with one embeddings configuration.",
     );
   }
 
   return current;
-}
-
-function readEmbeddingDimensions(
-  metadata: Readonly<Record<string, unknown>>,
-): number | undefined {
-  const value = metadata.dimensions;
-
-  return Number.isInteger(value) && Number(value) > 0
-    ? Number(value)
-    : undefined;
-}
-
-function readEmbeddingIdentity(
-  metadata: Readonly<Record<string, unknown>>,
-): string | undefined {
-  const value = metadata.identity;
-
-  return typeof value === "string" && value !== "" ? value : undefined;
-}
-
-function readEmbeddingModel(
-  metadata: Readonly<Record<string, unknown>>,
-): string | undefined {
-  const value = metadata.model;
-
-  return typeof value === "string" && value !== "" ? value : undefined;
 }
 
 function formatLibraryHitSource(

--- a/packages/core/src/retrieval/index-artifact/build.ts
+++ b/packages/core/src/retrieval/index-artifact/build.ts
@@ -206,6 +206,7 @@ export async function createEmbeddingIndexArtifactInput(input: {
   readonly kind: EmbeddingIndexArtifactKind;
   readonly sentences: readonly SentenceRecord[];
   readonly serialId: number;
+  readonly signal?: AbortSignal;
   readonly sourceRevision: number;
 }): Promise<ReplaceEmbeddingIndexArtifactInput> {
   const segments = createEmbeddingSegments(input.sentences);
@@ -215,6 +216,7 @@ export async function createEmbeddingIndexArtifactInput(input: {
       : (
           await input.embeddingProvider.embedTexts(
             segments.map((segment) => segment.text),
+            input.signal === undefined ? undefined : { signal: input.signal },
           )
         ).embeddings;
 
@@ -358,11 +360,12 @@ function collectTocItems(items: readonly TocItem[]): readonly TocItem[] {
 function createEmbeddingSegments(
   sentences: readonly SentenceRecord[],
 ): readonly Omit<IndexArtifactEmbeddingSegment, "vector">[] {
+  assertDenseSegmentConstants();
   const records = sentences
     .map((sentence, sentenceIndex) => ({
       sentenceIndex,
       text: sentence.text,
-      wordsCount: sentence.wordsCount,
+      wordsCount: requireNonNegativeWordsCount(sentence.wordsCount),
     }))
     .filter((record) => record.text.trim() !== "");
   const segments: Omit<IndexArtifactEmbeddingSegment, "vector">[] = [];
@@ -387,11 +390,6 @@ function createEmbeddingSegments(
       if (wordsCount >= DENSE_SEGMENT_TARGET_WORDS) {
         break;
       }
-    }
-
-    if (end <= start) {
-      end = start + 1;
-      wordsCount = Math.max(0, records[start]!.wordsCount);
     }
 
     const segmentRecords = records.slice(start, end);
@@ -423,6 +421,25 @@ function createEmbeddingSegments(
     ...segment,
     segmentIndex,
   }));
+}
+
+function assertDenseSegmentConstants(): void {
+  if (
+    DENSE_SEGMENT_MIN_WORDS < 0 ||
+    DENSE_SEGMENT_OVERLAP_WORDS < 0 ||
+    DENSE_SEGMENT_TARGET_WORDS < DENSE_SEGMENT_MIN_WORDS ||
+    DENSE_SEGMENT_MAX_WORDS < DENSE_SEGMENT_TARGET_WORDS
+  ) {
+    throw new Error("Invalid Dense segment word-count configuration.");
+  }
+}
+
+function requireNonNegativeWordsCount(wordsCount: number): number {
+  if (!Number.isFinite(wordsCount) || wordsCount < 0) {
+    throw new Error("Sentence word count must be non-negative.");
+  }
+
+  return wordsCount;
 }
 
 function createEmbeddingSegment(

--- a/packages/core/src/retrieval/query/archive-view/index-state.ts
+++ b/packages/core/src/retrieval/query/archive-view/index-state.ts
@@ -516,7 +516,7 @@ function countSearchIndexBatchRecords(batch: SearchIndexWriteBatch): number {
   return batch.objectProperties.length + batch.textSentences.length;
 }
 
-async function readArchiveEmbeddingState(
+export async function readArchiveEmbeddingState(
   document: ReadonlyDocument,
 ): Promise<SearchIndexStoredEmbeddingState | undefined> {
   let state: SearchIndexStoredEmbeddingState | undefined;
@@ -550,7 +550,7 @@ async function readArchiveEmbeddingState(
           state.identity !== next.identity)
       ) {
         throw new Error(
-          "Embedding artifacts use different embedding providers or dimensions; rebuild them with one embeddings configuration.",
+          "Embedding artifacts use different embedding configurations; rebuild them with one embeddings configuration.",
         );
       }
       state = next;
@@ -566,7 +566,7 @@ function readWordsCount(metadata: Readonly<Record<string, unknown>>): number {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }
 
-function readEmbeddingDimensions(
+export function readEmbeddingDimensions(
   metadata: Readonly<Record<string, unknown>>,
 ): number | undefined {
   const value = metadata.dimensions;
@@ -576,7 +576,7 @@ function readEmbeddingDimensions(
     : undefined;
 }
 
-function readEmbeddingIdentity(
+export function readEmbeddingIdentity(
   metadata: Readonly<Record<string, unknown>>,
 ): string | undefined {
   const value = metadata.identity;
@@ -584,7 +584,7 @@ function readEmbeddingIdentity(
   return typeof value === "string" && value !== "" ? value : undefined;
 }
 
-function readEmbeddingModel(
+export function readEmbeddingModel(
   metadata: Readonly<Record<string, unknown>>,
 ): string | undefined {
   const value = metadata.model;

--- a/packages/core/src/retrieval/search-index/search/build.ts
+++ b/packages/core/src/retrieval/search-index/search/build.ts
@@ -589,6 +589,7 @@ function createTextEmbeddingGroupKey(
 function createTextEmbeddingSegmentsForGroup(
   records: readonly TextSentenceEmbeddingInput[],
 ): readonly TextEmbeddingSegmentInput[] {
+  assertDenseSegmentConstants();
   const sorted = [...records].sort(
     (left, right) => left.sentenceIndex - right.sentenceIndex,
   );
@@ -600,7 +601,7 @@ function createTextEmbeddingSegmentsForGroup(
     let wordsCount = 0;
 
     while (end < sorted.length) {
-      const nextWords = Math.max(0, sorted[end]!.wordsCount);
+      const nextWords = requireNonNegativeWordsCount(sorted[end]!.wordsCount);
 
       if (
         end > start &&
@@ -614,11 +615,6 @@ function createTextEmbeddingSegmentsForGroup(
       if (wordsCount >= DENSE_SEGMENT_TARGET_WORDS) {
         break;
       }
-    }
-
-    if (end <= start) {
-      end = start + 1;
-      wordsCount = Math.max(0, sorted[start]!.wordsCount);
     }
 
     const segmentRecords = sorted.slice(start, end);
@@ -650,6 +646,25 @@ function createTextEmbeddingSegmentsForGroup(
   }
 
   return segments;
+}
+
+function assertDenseSegmentConstants(): void {
+  if (
+    DENSE_SEGMENT_MIN_WORDS < 0 ||
+    DENSE_SEGMENT_OVERLAP_WORDS < 0 ||
+    DENSE_SEGMENT_TARGET_WORDS < DENSE_SEGMENT_MIN_WORDS ||
+    DENSE_SEGMENT_MAX_WORDS < DENSE_SEGMENT_TARGET_WORDS
+  ) {
+    throw new Error("Invalid Dense segment word-count configuration.");
+  }
+}
+
+function requireNonNegativeWordsCount(wordsCount: number): number {
+  if (!Number.isFinite(wordsCount) || wordsCount < 0) {
+    throw new Error("Sentence word count must be non-negative.");
+  }
+
+  return wordsCount;
 }
 
 function createTextEmbeddingSegment(
@@ -746,7 +761,9 @@ async function writeStoredSearchIndexBuildState(
 ): Promise<void> {
   const indexes =
     input.embedding === undefined
-      ? "fts"
+      ? input.hasFts
+        ? "fts"
+        : "missing"
       : input.hasFts
         ? "fts,dense"
         : "dense";

--- a/packages/core/src/retrieval/search-index/search/types.ts
+++ b/packages/core/src/retrieval/search-index/search/types.ts
@@ -56,7 +56,10 @@ export interface SearchIndexEmbeddingProvider {
   readonly dimensions?: number;
   readonly identity?: string;
   readonly model: string;
-  embedTexts(texts: readonly string[]): Promise<{
+  embedTexts(
+    texts: readonly string[],
+    options?: { readonly signal?: AbortSignal },
+  ): Promise<{
     readonly embeddings: readonly (readonly number[])[];
     readonly tokens?: number;
   }>;

--- a/packages/core/src/storage/wikg/wikg-coordinator/flusher.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/flusher.ts
@@ -131,10 +131,19 @@ export async function flushArchiveOverlays(
             (overlay) => overlay.entryPath === DATABASE_ENTRY_PATH,
           )
         ) {
-          await refreshOverlayArchiveState(
+          const releaseSearchIndexLock = await acquireEntryLock(
             archiveKey,
             SEARCH_INDEX_DATABASE_ENTRY_PATH,
+            "state",
           );
+          try {
+            await refreshOverlayArchiveState(
+              archiveKey,
+              SEARCH_INDEX_DATABASE_ENTRY_PATH,
+            );
+          } finally {
+            await releaseSearchIndexLock();
+          }
         }
       } finally {
         await rm(temporaryDirectoryPath, { force: true, recursive: true });

--- a/test/cli/archive/mock.ts
+++ b/test/cli/archive/mock.ts
@@ -566,9 +566,11 @@ vi.mock(
         return await operation(createArchiveMockDocument());
       }
 
-      public async write(operation: () => Promise<unknown>): Promise<unknown> {
+      public async write(
+        operation: (document: unknown) => Promise<unknown>,
+      ): Promise<unknown> {
         archiveMockState.writeCalls.push(this.#path);
-        return await operation();
+        return await operation(createArchiveMockDocument());
       }
     },
   }),

--- a/test/cli/queue.test.ts
+++ b/test/cli/queue.test.ts
@@ -25,6 +25,9 @@ const queueMockState = vi.hoisted(() => ({
   ftsArtifactCurrent: true,
   hasSummary: true,
   embeddingRequests: [] as string[][],
+  embeddingRequestSignals: [] as Array<AbortSignal | undefined>,
+  serialFragmentsSentenceListCalls: 0,
+  summaryFragmentsSentenceListCalls: 0,
   cliConfig: {} as {
     readonly concurrent?: {
       readonly job?: number;
@@ -67,10 +70,15 @@ const queueMockState = vi.hoisted(() => ({
   readChapterStageError: undefined as Error | undefined,
   openPaths: [] as string[],
   resolveJobIds: [] as string[],
+  serialExists: true,
   runWorkerOptions: undefined as
     | {
         readonly concurrency: number;
-        readonly executeJob: (job: unknown, reporter: unknown) => Promise<void>;
+        readonly executeJob: (
+          job: unknown,
+          reporter: unknown,
+          context?: { readonly signal: AbortSignal },
+        ) => Promise<void>;
       }
     | undefined,
   stepLog: [] as string[],
@@ -92,22 +100,26 @@ function createQueueMockDocument() {
         ]),
     },
     getSerialFragments: () => ({
-      listSentences: () =>
-        Promise.resolve([
+      listSentences: () => {
+        queueMockState.serialFragmentsSentenceListCalls += 1;
+        return Promise.resolve([
           {
             text: "Alpha beta.",
             wordsCount: 2,
           },
-        ]),
+        ]);
+      },
     }),
     getSummaryFragments: () => ({
-      listSentences: () =>
-        Promise.resolve([
+      listSentences: () => {
+        queueMockState.summaryFragmentsSentenceListCalls += 1;
+        return Promise.resolve([
           {
             text: "Summary text.",
             wordsCount: 2,
           },
-        ]),
+        ]);
+      },
     }),
     indexArtifacts: {
       get: () =>
@@ -144,6 +156,8 @@ function createQueueMockDocument() {
     readSummary: () =>
       Promise.resolve(queueMockState.hasSummary ? "Summary text." : undefined),
     serials: {
+      getById: () =>
+        Promise.resolve(queueMockState.serialExists ? { id: 12 } : undefined),
       getRevision: () => Promise.resolve(queueMockState.revision),
     },
   };
@@ -313,7 +327,15 @@ vi.mock("../../packages/core/src/api/index.js", () => ({
   resumeBuildJob: vi.fn(),
   runBuildJobWorker: vi.fn(
     (options: typeof queueMockState.runWorkerOptions) => {
-      queueMockState.runWorkerOptions = options;
+      queueMockState.runWorkerOptions = {
+        ...options!,
+        executeJob: async (job, reporter, context) =>
+          await options!.executeJob(
+            job,
+            reporter,
+            context ?? { signal: new AbortController().signal },
+          ),
+      };
       return Promise.resolve();
     },
   ),
@@ -368,8 +390,12 @@ vi.mock("../../packages/cli/src/runtime/embedding.js", () => ({
     dimensions: 3,
     identity: "provider=test",
     model: "test-embedding",
-    embedTexts: (texts: readonly string[]) => {
+    embedTexts: (
+      texts: readonly string[],
+      options?: { readonly signal?: AbortSignal },
+    ) => {
       queueMockState.embeddingRequests.push([...texts]);
+      queueMockState.embeddingRequestSignals.push(options?.signal);
       return Promise.resolve({
         embeddings: texts.map(() => [1, 2, 3]),
       });
@@ -435,6 +461,9 @@ describe("cli/queue", () => {
     queueMockState.ftsArtifactCurrent = true;
     queueMockState.hasSummary = true;
     queueMockState.embeddingRequests.length = 0;
+    queueMockState.embeddingRequestSignals.length = 0;
+    queueMockState.serialFragmentsSentenceListCalls = 0;
+    queueMockState.summaryFragmentsSentenceListCalls = 0;
     queueMockState.cliConfig = {};
     queueMockState.loadRequiredStageConfigCalls.length = 0;
     queueMockState.loadRequiredStageConfigError = undefined;
@@ -461,6 +490,7 @@ describe("cli/queue", () => {
     queueMockState.revision = 1;
     queueMockState.resolveJobIds.length = 0;
     queueMockState.runWorkerOptions = undefined;
+    queueMockState.serialExists = true;
     queueMockState.stepLog.length = 0;
     queueMockState.textWrites.length = 0;
     queueMockState.writeCalls.length = 0;
@@ -900,6 +930,7 @@ describe("cli/queue", () => {
     await queueMockState.runWorkerOptions!.executeJob(
       queueMockState.job,
       reporter,
+      { signal: new AbortController().signal } as never,
     );
 
     expect(queueMockState.stepLog).toStrictEqual([
@@ -982,13 +1013,17 @@ describe("cli/queue", () => {
       updateWords: vi.fn(() => Promise.resolve()),
     };
 
+    const signal = new AbortController().signal;
     await queueMockState.runWorkerOptions!.executeJob(
       queueMockState.job,
       reporter,
+      { signal },
     );
 
     expect(queueMockState.loadRequiredStageConfigCalls).toStrictEqual([]);
     expect(queueMockState.embeddingRequests).toStrictEqual([]);
+    expect(queueMockState.serialFragmentsSentenceListCalls).toBe(1);
+    expect(queueMockState.summaryFragmentsSentenceListCalls).toBe(1);
     expect(queueMockState.stepLog).toStrictEqual([
       "read:start",
       "read:end",
@@ -1059,9 +1094,11 @@ describe("cli/queue", () => {
       updateWords: vi.fn(() => Promise.resolve()),
     };
 
+    const signal = new AbortController().signal;
     await queueMockState.runWorkerOptions!.executeJob(
       queueMockState.job,
       reporter,
+      { signal },
     );
 
     expect(queueMockState.stepLog).toStrictEqual([
@@ -1071,6 +1108,7 @@ describe("cli/queue", () => {
       "write:end",
     ]);
     expect(queueMockState.embeddingRequests).toStrictEqual([["Alpha beta."]]);
+    expect(queueMockState.embeddingRequestSignals[0]).toBe(signal);
     expect(queueMockState.indexArtifactWrites[0]).toMatchObject({
       artifact: {
         kind: "embedding-source",
@@ -1099,6 +1137,38 @@ describe("cli/queue", () => {
         ownerId: "owner-1",
       },
     ]);
+  });
+
+  it("rejects embedding index artifact jobs when the chapter is gone", async () => {
+    queueMockState.cliConfig = {
+      embedding: {
+        model: "test-embedding",
+        provider: "openai-compatible",
+      },
+    };
+    queueMockState.serialExists = false;
+    queueMockState.job = {
+      ...queueMockState.job,
+      state: "running",
+      target: "index-embedding-source",
+    };
+
+    await runQueueWorker();
+
+    const reporter = {
+      addOutputCharacters: vi.fn(() => Promise.resolve()),
+      setTotals: vi.fn(() => Promise.resolve()),
+      stepCompleted: vi.fn(() => Promise.resolve()),
+      stepStarted: vi.fn(() => Promise.resolve()),
+      updatePhase: vi.fn(() => Promise.resolve()),
+      updateWords: vi.fn(() => Promise.resolve()),
+    };
+
+    await expect(
+      queueMockState.runWorkerOptions!.executeJob(queueMockState.job, reporter),
+    ).rejects.toThrow("no longer exists");
+    expect(queueMockState.embeddingRequests).toStrictEqual([]);
+    expect(queueMockState.indexArtifactWrites).toStrictEqual([]);
   });
 
   it("uses default queue concurrency for worker slots", async () => {


### PR DESCRIPTION
## Summary
- fix CodeRabbit review notes from the index artifact/cache PR
- thread abort signals through embedding index jobs and validate chapter existence before index artifact writes
- avoid redundant FTS snapshot/projection work and share embedding metadata readers
- tighten readiness/help text, overlay locking, empty index state, and CLI test mocks

## Validation
- pnpm test:run test/cli/queue.test.ts packages/core/src/retrieval/index-artifact/build.test.ts packages/cli/src/runtime/embedding.test.ts packages/cli/src/args/help.test.ts test/cli/archive/object.test.ts packages/core/src/library/membership.test.ts
- pnpm verify
- pnpm test:run