### PR TITLE
feat(schema): add v3 cache invalidation

### DIFF
--- a/docs/schema-upgrade.md
+++ b/docs/schema-upgrade.md
@@ -43,9 +43,18 @@ across query/list/search/evidence business paths.
 
 The v1 -> v2 archive upgrader removes embedded archive `index.db` and legacy
 `fts.db` as derived search index data and preserves important archive content
-and the mutation token. It must refuse active coordinator state for the target
-archive and non-search-index overlays, because those can represent uncommitted
-important data.
+and the mutation token.
+
+The v2 -> v3 archive upgrader separates index artifacts from index caches. It
+keeps important archive data, rebuilds chapter FTS index artifacts from the
+archive source/summary/object data already present in `database.db`, drops the
+old `archive_index_settings` table, and deletes embedded `index.db` / legacy
+`fts.db` caches. It does not create embedding artifacts, because older schemas
+never stored them as important data.
+
+Archive upgraders must refuse active coordinator state for the target archive
+and non-search-index overlays, because those can represent uncommitted important
+data.
 
 ## Home Gate
 
@@ -78,17 +87,24 @@ code and tests when adding new home SQLite files:
   - archive coordinator external search index cache workspace referenced by
     `entry_overlays(entry_path = 'index.db')`.
 
-For v1 -> v2, derived home data is deleted or invalidated: query/search caches,
-external cache, GC state, build queue SQLite/cache when safe, library aggregate
-indexes, external archive search index overlays/workspaces for `index.db` or
-legacy `fts.db`, and
-orphaned SQLite materialization cache overlays whose archive file no longer
-exists. The upgrader must block when active GC, build job, worker lease,
+For home schema upgrades, derived home data is deleted or invalidated:
+query/search caches, external cache, GC state, build queue SQLite/cache when
+safe, library aggregate indexes, external archive search index
+overlays/workspaces for `index.db` or legacy `fts.db`, and orphaned SQLite
+materialization cache overlays whose archive file no longer exists. The v2 -> v3
+home upgrader uses the same cleanup boundary because the index-cache semantics
+changed. The upgrader must block when active GC, build job, worker lease,
 coordinator owner/lock/sqlite lease/commit lock, or remaining non-derived
 overlay state is present.
 
 Pure information commands such as `wg --version` and help rendering must not open
 home SQLite and must not trigger schema upgrade.
+
+Search index caches also carry their own `search_index_state.version`. Opening a
+cache whose version is missing, unreadable, or different from the current search
+index version must delete that cache and treat it as missing. Write paths may
+then recreate the cache from artifacts; read paths must report the missing-cache
+state instead of querying stale SQLite.
 
 After a home `core.sqlite` file is confirmed current, the home gate may memoize
 that result inside the current process for hot gated access. The memo must be

--- a/packages/cli/src/commands/archive-command/index.test.ts
+++ b/packages/cli/src/commands/archive-command/index.test.ts
@@ -1,10 +1,15 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   findWikiGraphLibraryObjects,
   listWikiGraphLibraryObjects,
 } from "wiki-graph-core";
 import type * as WikiGraphCore from "wiki-graph-core";
+import { setWikiGraphStateDirectoryPathForTesting } from "../../../../core/src/runtime/common/wiki-graph/dir.js";
 import { parseCLIArguments } from "../../args/index.js";
 import { writeFindHits } from "../archive-output/index.js";
 import { runArchiveCommand } from "./index.js";
@@ -66,7 +71,11 @@ vi.mock("./run/index.js", async (importOriginal) => {
 });
 vi.mock("./run/scope.js", () => ({ resolveArchiveChapterScope: vi.fn() }));
 
-beforeEach(() => {
+let testStateDir: string | undefined;
+
+beforeEach(async () => {
+  testStateDir = await mkdtemp(join(tmpdir(), "wikigraph-archive-command-"));
+  setWikiGraphStateDirectoryPathForTesting(testStateDir);
   vi.clearAllMocks();
   vi.mocked(findWikiGraphLibraryObjects).mockResolvedValue({
     chapters: null,
@@ -90,6 +99,14 @@ beforeEach(() => {
     order: "doc-asc",
     types: ["triple"],
   });
+});
+
+afterEach(async () => {
+  setWikiGraphStateDirectoryPathForTesting(undefined);
+  if (testStateDir !== undefined) {
+    await rm(testStateDir, { force: true, recursive: true });
+    testStateDir = undefined;
+  }
 });
 
 describe("runArchiveCommand library nested scopes", () => {

--- a/packages/core/src/document/directory/search-index.test.ts
+++ b/packages/core/src/document/directory/search-index.test.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 import { describe, expect, it } from "vitest";
 
 import { DirectoryDocument } from "./index.js";
+import { SEARCH_INDEX_VERSION } from "../../retrieval/search-index/search/types.js";
 
 async function withDocument(
   operation: (document: DirectoryDocument, path: string) => Promise<void>,
@@ -54,6 +55,61 @@ describe("DirectoryDocument search index cache", () => {
       );
 
       expect(version).toBeUndefined();
+    });
+  });
+
+  it("serializes concurrent incompatible cache reads and writes", async () => {
+    await withDocument(async (document, path) => {
+      await writeIncompatibleCache(document);
+
+      let releaseWriter!: () => void;
+      let resolveWriterEntered!: () => void;
+      const writerEntered = new Promise<void>((resolveEntered) => {
+        resolveWriterEntered = resolveEntered;
+      });
+      const writer = document.writeSearchIndexDatabase(async (database) => {
+        resolveWriterEntered();
+        await new Promise<void>((resolveWriter) => {
+          releaseWriter = resolveWriter;
+        });
+        await database.run(
+          `
+            INSERT OR REPLACE INTO search_index_state(key, value)
+            VALUES ('version', ?), ('concurrent', 'writer')
+          `,
+          [SEARCH_INDEX_VERSION],
+        );
+      });
+      void writer.catch(() => {
+        resolveWriterEntered();
+      });
+
+      try {
+        await writerEntered;
+        const reader = document.readSearchIndexDatabase(async (database) => {
+          const value = await database.queryOne(
+            `
+              SELECT value
+              FROM search_index_state
+              WHERE key = 'concurrent'
+            `,
+            undefined,
+            (row) => String(row.value),
+          );
+
+          return value;
+        });
+
+        releaseWriter();
+
+        await expect(reader).resolves.toBe("writer");
+        await expect(writer).resolves.toBeUndefined();
+        await expect(stat(join(path, "index.db"))).resolves.toBeDefined();
+      } catch (error) {
+        releaseWriter?.();
+        await writer.catch(() => undefined);
+        throw error;
+      }
     });
   });
 });

--- a/packages/core/src/document/directory/search-index.test.ts
+++ b/packages/core/src/document/directory/search-index.test.ts
@@ -30,7 +30,7 @@ describe("DirectoryDocument search index cache", () => {
       await writeIncompatibleCache(document);
 
       await expect(
-        document.readSearchIndexDatabase(async () => "unreachable"),
+        document.readSearchIndexDatabase(() => "unreachable"),
       ).rejects.toThrow("Search index cache is missing: index.db");
       await expect(stat(join(path, "index.db"))).rejects.toThrow();
     });

--- a/packages/core/src/document/directory/search-index.test.ts
+++ b/packages/core/src/document/directory/search-index.test.ts
@@ -1,0 +1,72 @@
+import { mkdtemp, rm, stat } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { describe, expect, it } from "vitest";
+
+import { DirectoryDocument } from "./index.js";
+
+async function withDocument(
+  operation: (document: DirectoryDocument, path: string) => Promise<void>,
+): Promise<void> {
+  const path = await mkdtemp(join(tmpdir(), "wikigraph-search-index-"));
+
+  try {
+    const document = await DirectoryDocument.open(path);
+
+    try {
+      await operation(document, path);
+    } finally {
+      await document.release();
+    }
+  } finally {
+    await rm(path, { force: true, recursive: true });
+  }
+}
+
+describe("DirectoryDocument search index cache", () => {
+  it("deletes incompatible cache on read", async () => {
+    await withDocument(async (document, path) => {
+      await writeIncompatibleCache(document);
+
+      await expect(
+        document.readSearchIndexDatabase(async () => "unreachable"),
+      ).rejects.toThrow("Search index cache is missing: index.db");
+      await expect(stat(join(path, "index.db"))).rejects.toThrow();
+    });
+  });
+
+  it("reinitializes incompatible cache on write", async () => {
+    await withDocument(async (document) => {
+      await writeIncompatibleCache(document);
+
+      const version = await document.writeSearchIndexDatabase(
+        async (database) =>
+          await database.queryOne(
+            `
+              SELECT value
+              FROM search_index_state
+              WHERE key = 'version'
+            `,
+            undefined,
+            (row) => String(row.value),
+          ),
+      );
+
+      expect(version).toBeUndefined();
+    });
+  });
+});
+
+async function writeIncompatibleCache(
+  document: DirectoryDocument,
+): Promise<void> {
+  await document.writeSearchIndexDatabase(async (database) => {
+    await database.run(
+      `
+        INSERT INTO search_index_state(key, value)
+        VALUES ('version', 'old')
+      `,
+    );
+  });
+}

--- a/packages/core/src/document/directory/search-index.ts
+++ b/packages/core/src/document/directory/search-index.ts
@@ -1,5 +1,5 @@
 import { stat } from "fs/promises";
-import { join } from "path";
+import { join, resolve } from "path";
 
 import { isNodeError } from "../../utils/node-error.js";
 import { Database } from "../database.js";
@@ -10,7 +10,20 @@ import {
 import type { DocumentFileStore } from "./types.js";
 import { SEARCH_INDEX_VERSION } from "../../retrieval/search-index/search/types.js";
 
+const searchIndexLifecycleLocks = new Map<string, Promise<void>>();
+
 export async function openSearchIndexDatabase<T>(input: {
+  readonly documentPath: string;
+  readonly fileStore: DocumentFileStore;
+  readonly operation: (database: Database) => Promise<T> | T;
+  readonly readonly: boolean;
+}): Promise<T> {
+  return await withSearchIndexLifecycleLock(resolve(input.documentPath), () =>
+    openSearchIndexDatabaseLocked(input),
+  );
+}
+
+async function openSearchIndexDatabaseLocked<T>(input: {
   readonly documentPath: string;
   readonly fileStore: DocumentFileStore;
   readonly operation: (database: Database) => Promise<T> | T;
@@ -61,6 +74,30 @@ export async function openSearchIndexDatabase<T>(input: {
     return await input.operation(database);
   } finally {
     await database.close();
+  }
+}
+
+async function withSearchIndexLifecycleLock<T>(
+  key: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const previous = searchIndexLifecycleLocks.get(key) ?? Promise.resolve();
+  let release!: () => void;
+  const lock = new Promise<void>((resolveLock) => {
+    release = resolveLock;
+  });
+  const current = previous.then(() => lock);
+  searchIndexLifecycleLocks.set(key, current);
+
+  await previous;
+
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (searchIndexLifecycleLocks.get(key) === current) {
+      searchIndexLifecycleLocks.delete(key);
+    }
   }
 }
 

--- a/packages/core/src/document/directory/search-index.ts
+++ b/packages/core/src/document/directory/search-index.ts
@@ -8,6 +8,7 @@ import {
   SEARCH_INDEX_TEXT_SENTENCE_RECORDS_COLUMNS_SQL,
 } from "../schema.js";
 import type { DocumentFileStore } from "./types.js";
+import { SEARCH_INDEX_VERSION } from "../../retrieval/search-index/search/types.js";
 
 export async function openSearchIndexDatabase<T>(input: {
   readonly documentPath: string;
@@ -15,14 +16,32 @@ export async function openSearchIndexDatabase<T>(input: {
   readonly operation: (database: Database) => Promise<T> | T;
   readonly readonly: boolean;
 }): Promise<T> {
-  const databasePath =
+  let databasePath =
     input.fileStore.resolveSearchIndexDatabasePath === undefined
       ? join(input.documentPath, "index.db")
       : await input.fileStore.resolveSearchIndexDatabasePath(
           input.documentPath,
         );
-  const shouldInitialize =
+  let shouldInitialize =
     !input.readonly && (await isMissingOrEmptyFile(databasePath));
+
+  if (
+    !shouldInitialize &&
+    !(await isSearchIndexDatabaseCompatible(databasePath))
+  ) {
+    await deleteSearchIndexDatabaseFile(input.fileStore, input.documentPath);
+    if (input.readonly) {
+      throw new Error("Search index cache is missing: index.db");
+    }
+    databasePath =
+      input.fileStore.resolveSearchIndexDatabasePath === undefined
+        ? join(input.documentPath, "index.db")
+        : await input.fileStore.resolveSearchIndexDatabasePath(
+            input.documentPath,
+          );
+    shouldInitialize = true;
+  }
+
   const database = await Database.open(
     databasePath,
     shouldInitialize ? SEARCH_INDEX_SCHEMA_SQL : "",
@@ -55,6 +74,51 @@ async function isMissingOrEmptyFile(path: string): Promise<boolean> {
   });
 
   return stats === undefined || stats.size === 0;
+}
+
+async function isSearchIndexDatabaseCompatible(
+  databasePath: string,
+): Promise<boolean> {
+  const database = await Database.open(databasePath, "", {
+    readonly: true,
+  }).catch(() => undefined);
+
+  if (database === undefined) {
+    return false;
+  }
+
+  try {
+    const version = await database
+      .queryOne(
+        `
+          SELECT value
+          FROM search_index_state
+          WHERE key = 'version'
+        `,
+        undefined,
+        (row) => String(row.value),
+      )
+      .catch(() => undefined);
+
+    return version === SEARCH_INDEX_VERSION;
+  } finally {
+    await database.close();
+  }
+}
+
+async function deleteSearchIndexDatabaseFile(
+  fileStore: DocumentFileStore,
+  documentPath: string,
+): Promise<void> {
+  try {
+    await fileStore.deleteFile(join(documentPath, "index.db"));
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return;
+    }
+
+    throw error;
+  }
 }
 
 async function migrateSearchIndexSchema(database: Database): Promise<void> {

--- a/packages/core/src/document/home-schema-upgrade.ts
+++ b/packages/core/src/document/home-schema-upgrade.ts
@@ -13,7 +13,7 @@ import { isNodeError } from "../utils/node-error.js";
 
 import { Database } from "./database.js";
 
-const CURRENT_HOME_SCHEMA_VERSION = 2;
+const CURRENT_HOME_SCHEMA_VERSION = 3;
 const LOCK_STALE_TIMEOUT_MS = 5 * 60 * 1000;
 const SEARCH_INDEX_DATABASE_PATH = "index.db";
 const LEGACY_SEARCH_INDEX_DATABASE_PATH = "fts.db";

--- a/packages/core/src/document/schema.ts
+++ b/packages/core/src/document/schema.ts
@@ -21,11 +21,6 @@ export const SCHEMA_SQL = `
     value INTEGER NOT NULL
   );
 
-  CREATE TABLE IF NOT EXISTS archive_index_settings (
-    id INTEGER PRIMARY KEY CHECK (id = 1),
-    fts_embedded INTEGER NOT NULL DEFAULT 0
-  );
-
   CREATE TABLE IF NOT EXISTS graph_build_parameters (
     hash TEXT PRIMARY KEY,
     prompt TEXT NOT NULL,

--- a/packages/core/src/retrieval/search-index/search/errors.ts
+++ b/packages/core/src/retrieval/search-index/search/errors.ts
@@ -9,6 +9,7 @@ export function isMissingSearchIndexError(error: unknown): boolean {
     (error instanceof Error &&
       (error.message.includes("Archive SQLite entry is missing: index.db") ||
         error.message.includes("Archive SQLite entry is missing: fts.db") ||
+        error.message.includes("Search index cache is missing: index.db") ||
         error.message.includes("no such table: search_index_state")))
   );
 }

--- a/packages/core/src/runtime/common/wiki-graph/dir.ts
+++ b/packages/core/src/runtime/common/wiki-graph/dir.ts
@@ -8,20 +8,12 @@ const testingStateDirectoryPath = new AsyncLocalStorage<{
 const runtimeStateDirectoryPath = new AsyncLocalStorage<{
   readonly path: string | undefined;
 }>();
-let testingStateDirectoryPathOverride: string | undefined;
 
 export function resolveWikiGraphHomeDirectoryPath(): string {
   const testingStateDirPath = testingStateDirectoryPath.getStore()?.path;
 
   if (testingStateDirPath !== undefined && testingStateDirPath.trim() !== "") {
     return resolve(testingStateDirPath);
-  }
-
-  if (
-    testingStateDirectoryPathOverride !== undefined &&
-    testingStateDirectoryPathOverride.trim() !== ""
-  ) {
-    return resolve(testingStateDirectoryPathOverride);
   }
 
   const runtimeStateDirPath = runtimeStateDirectoryPath.getStore()?.path;
@@ -36,7 +28,6 @@ export function resolveWikiGraphHomeDirectoryPath(): string {
 export function setWikiGraphStateDirectoryPathForTesting(
   path: string | undefined,
 ): void {
-  testingStateDirectoryPathOverride = path;
   testingStateDirectoryPath.enterWith({ path });
 }
 
@@ -44,14 +35,7 @@ export async function withWikiGraphStateDirectoryPathForTesting<T>(
   path: string | undefined,
   operation: () => Promise<T> | T,
 ): Promise<T> {
-  const previous = testingStateDirectoryPathOverride;
-  testingStateDirectoryPathOverride = path;
-
-  try {
-    return await testingStateDirectoryPath.run({ path }, operation);
-  } finally {
-    testingStateDirectoryPathOverride = previous;
-  }
+  return await testingStateDirectoryPath.run({ path }, operation);
 }
 
 export async function withWikiGraphRuntimeStateDirectoryPath<T>(
@@ -73,10 +57,7 @@ export async function withWikiGraphRuntimeEnvironment<T>(
 }
 
 export function getWikiGraphStateDirectoryPathForTesting(): string | undefined {
-  return (
-    testingStateDirectoryPath.getStore()?.path ??
-    testingStateDirectoryPathOverride
-  );
+  return testingStateDirectoryPath.getStore()?.path;
 }
 
 export function resolveWikiGraphCoreDatabasePath(): string {

--- a/packages/core/src/runtime/common/wiki-graph/dir.ts
+++ b/packages/core/src/runtime/common/wiki-graph/dir.ts
@@ -8,12 +8,20 @@ const testingStateDirectoryPath = new AsyncLocalStorage<{
 const runtimeStateDirectoryPath = new AsyncLocalStorage<{
   readonly path: string | undefined;
 }>();
+let testingStateDirectoryPathOverride: string | undefined;
 
 export function resolveWikiGraphHomeDirectoryPath(): string {
   const testingStateDirPath = testingStateDirectoryPath.getStore()?.path;
 
   if (testingStateDirPath !== undefined && testingStateDirPath.trim() !== "") {
     return resolve(testingStateDirPath);
+  }
+
+  if (
+    testingStateDirectoryPathOverride !== undefined &&
+    testingStateDirectoryPathOverride.trim() !== ""
+  ) {
+    return resolve(testingStateDirectoryPathOverride);
   }
 
   const runtimeStateDirPath = runtimeStateDirectoryPath.getStore()?.path;
@@ -28,6 +36,7 @@ export function resolveWikiGraphHomeDirectoryPath(): string {
 export function setWikiGraphStateDirectoryPathForTesting(
   path: string | undefined,
 ): void {
+  testingStateDirectoryPathOverride = path;
   testingStateDirectoryPath.enterWith({ path });
 }
 
@@ -35,7 +44,14 @@ export async function withWikiGraphStateDirectoryPathForTesting<T>(
   path: string | undefined,
   operation: () => Promise<T> | T,
 ): Promise<T> {
-  return await testingStateDirectoryPath.run({ path }, operation);
+  const previous = testingStateDirectoryPathOverride;
+  testingStateDirectoryPathOverride = path;
+
+  try {
+    return await testingStateDirectoryPath.run({ path }, operation);
+  } finally {
+    testingStateDirectoryPathOverride = previous;
+  }
 }
 
 export async function withWikiGraphRuntimeStateDirectoryPath<T>(
@@ -57,7 +73,10 @@ export async function withWikiGraphRuntimeEnvironment<T>(
 }
 
 export function getWikiGraphStateDirectoryPathForTesting(): string | undefined {
-  return testingStateDirectoryPath.getStore()?.path;
+  return (
+    testingStateDirectoryPath.getStore()?.path ??
+    testingStateDirectoryPathOverride
+  );
 }
 
 export function resolveWikiGraphCoreDatabasePath(): string {

--- a/packages/core/src/storage/schema-upgrade/index.ts
+++ b/packages/core/src/storage/schema-upgrade/index.ts
@@ -17,6 +17,7 @@ import {
   LEGACY_SEARCH_INDEX_DATABASE_PATH,
   WIKG_MANIFEST_PATH,
 } from "../wikg/archive/constants.js";
+import { DATABASE_ENTRY_PATH } from "../wikg/wikg-coordinator/constants.js";
 import { extractWikgArchive } from "../wikg/archive/extract.js";
 import { parseWikgManifest } from "../wikg/archive/manifest.js";
 import { normalizeArchivePath } from "../wikg/archive/paths.js";
@@ -233,7 +234,7 @@ async function createArchiveDatabaseUpgradeOverlay(
   temporaryDirectories: string[],
 ): Promise<
   | {
-      readonly entryPath: "database.db";
+      readonly entryPath: typeof DATABASE_ENTRY_PATH;
       readonly kind: "file";
       readonly workspacePath: string;
     }
@@ -253,13 +254,13 @@ async function createArchiveDatabaseUpgradeOverlay(
     await document.release();
   }
 
-  const databasePath = join(temporaryDirectory, "database.db");
+  const databasePath = join(temporaryDirectory, DATABASE_ENTRY_PATH);
   if (!(await pathExists(databasePath))) {
     return undefined;
   }
 
   return {
-    entryPath: "database.db",
+    entryPath: DATABASE_ENTRY_PATH,
     kind: "file",
     workspacePath: databasePath,
   };

--- a/packages/core/src/storage/schema-upgrade/index.ts
+++ b/packages/core/src/storage/schema-upgrade/index.ts
@@ -3,19 +3,21 @@ import { mkdtemp, rename, rm, stat, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { dirname, join, resolve } from "path";
 
-import { Database } from "../../document/database.js";
+import { Database, DirectoryDocument } from "../../document/index.js";
 import { ensureChapterKeys } from "../../document/chapter/toc.js";
 import type { MutableTocFile } from "../../document/chapter/tree.js";
 import { ensureWikiGraphHomeSchemaCurrent } from "../../document/home-schema-upgrade.js";
+import { replaceChapterFtsIndexArtifact } from "../../retrieval/index-artifact/index.js";
 import {
   resolveWikiGraphHomeDirectoryPath,
   resolveWikiGraphStagingDirectoryPath,
 } from "../../runtime/common/wiki-graph/dir.js";
 import {
-  LEGACY_SEARCH_INDEX_DATABASE_PATH,
   SEARCH_INDEX_DATABASE_PATH,
+  LEGACY_SEARCH_INDEX_DATABASE_PATH,
   WIKG_MANIFEST_PATH,
 } from "../wikg/archive/constants.js";
+import { extractWikgArchive } from "../wikg/archive/extract.js";
 import { parseWikgManifest } from "../wikg/archive/manifest.js";
 import { normalizeArchivePath } from "../wikg/archive/paths.js";
 import {
@@ -31,7 +33,7 @@ export {
   readWikiGraphHomeSchemaVersion,
 } from "../../document/home-schema-upgrade.js";
 
-export const CURRENT_ARCHIVE_SCHEMA_VERSION = 2;
+export const CURRENT_ARCHIVE_SCHEMA_VERSION = 3;
 const LOCK_STALE_TIMEOUT_MS = 5 * 60 * 1000;
 
 export interface WikiGraphArchiveSchemaUpgradeResult {
@@ -113,6 +115,12 @@ export async function upgradeWikiGraphArchiveSchema(
 
     const archiveKey = createArchiveKey(resolvedArchivePath);
     await assertArchiveUpgradeSafe(archiveKey);
+    const archiveDatabaseOverlay = schemaChanged
+      ? await createArchiveDatabaseUpgradeOverlay(
+          resolvedArchivePath,
+          temporaryDirectories,
+        )
+      : undefined;
 
     const temporaryPath = join(
       dirname(resolvedArchivePath),
@@ -135,6 +143,9 @@ export async function upgradeWikiGraphArchiveSchema(
               },
             ]
           : []),
+        ...(archiveDatabaseOverlay === undefined
+          ? []
+          : [archiveDatabaseOverlay]),
         ...(tocOverlay === undefined ? [] : [tocOverlay]),
       ],
       { preserveMutationToken: true },
@@ -215,6 +226,67 @@ async function createChapterTocUpgradeOverlay(
   } finally {
     zipFile.close();
   }
+}
+
+async function createArchiveDatabaseUpgradeOverlay(
+  archivePath: string,
+  temporaryDirectories: string[],
+): Promise<
+  | {
+      readonly entryPath: "database.db";
+      readonly kind: "file";
+      readonly workspacePath: string;
+    }
+  | undefined
+> {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "wikigraph-archive-upgrade-"),
+  );
+  temporaryDirectories.push(temporaryDirectory);
+  await extractWikgArchive(archivePath, temporaryDirectory);
+
+  const document = await DirectoryDocument.open(temporaryDirectory);
+
+  try {
+    await refreshChapterArtifacts(document);
+  } finally {
+    await document.release();
+  }
+
+  const databasePath = join(temporaryDirectory, "database.db");
+  if (!(await pathExists(databasePath))) {
+    return undefined;
+  }
+
+  return {
+    entryPath: "database.db",
+    kind: "file",
+    workspacePath: databasePath,
+  };
+}
+
+async function refreshChapterArtifacts(
+  document: DirectoryDocument,
+): Promise<void> {
+  const serialIds = await document.readDatabase(async (database) =>
+    database.queryAll(
+      `
+        SELECT id
+        FROM serials
+        ORDER BY document_order, id
+      `,
+      undefined,
+      (row) => Number(row.id),
+    ),
+  );
+
+  for (const serialId of serialIds) {
+    await replaceChapterFtsIndexArtifact(document, serialId);
+  }
+
+  await document.readDatabase(async (database) => {
+    await database.run("DROP TABLE IF EXISTS archive_index_settings");
+  });
 }
 
 async function cleanupArchiveDerivedData(archiveKey: string): Promise<void> {

--- a/packages/core/src/storage/wikg/archive/manifest.ts
+++ b/packages/core/src/storage/wikg/archive/manifest.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { WIKG_MANIFEST_PATH, WIKG_MUTATION_TOKEN_PATH } from "./constants.js";
 
 export const WIKG_FORMAT_VERSION = 1;
-export const WIKG_SCHEMA_VERSION = 2;
+export const WIKG_SCHEMA_VERSION = 3;
 export const WIKG_MANIFEST_CONTENT = `${JSON.stringify({
   formatVersion: WIKG_FORMAT_VERSION,
   schemaVersion: WIKG_SCHEMA_VERSION,

--- a/test/core/library/query.test.ts
+++ b/test/core/library/query.test.ts
@@ -1,4 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { setWikiGraphStateDirectoryPathForTesting } from "../../../packages/core/src/runtime/common/wiki-graph/dir.js";
 
 const mocks = vi.hoisted(() => {
   const archives = new Map<number, Record<string, unknown>>();
@@ -178,6 +184,7 @@ vi.mock(
 );
 
 const target = { isDefault: true, kind: "scope" as const };
+let testStateDir: string | undefined;
 
 function seedArchive(id: number, status = "present") {
   mocks.archives.set(id, {
@@ -190,10 +197,20 @@ function seedArchive(id: number, status = "present") {
 }
 
 describe("wiki graph library object query aggregation", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    testStateDir = await mkdtemp(join(tmpdir(), "wikigraph-library-query-"));
+    setWikiGraphStateDirectoryPathForTesting(testStateDir);
     mocks.reset();
     seedArchive(1);
     seedArchive(2);
+  });
+
+  afterEach(async () => {
+    setWikiGraphStateDirectoryPathForTesting(undefined);
+    if (testStateDir !== undefined) {
+      await rm(testStateDir, { force: true, recursive: true });
+      testStateDir = undefined;
+    }
   });
 
   it("returns all archive sources for a library get", async () => {

--- a/test/core/retrieval/query/archive-view/index.test.ts
+++ b/test/core/retrieval/query/archive-view/index.test.ts
@@ -178,7 +178,7 @@ describe("archive/query/archive-view/index", () => {
     });
   });
 
-  it("migrates legacy search index uniqueness to include archive_id", async () => {
+  it("reinitializes incompatible legacy search index cache", async () => {
     await withTempDir("wikigraph-archive-view-", async (path) => {
       const documentPath = `${path}/document`;
       await mkdir(documentPath, { recursive: true });
@@ -247,13 +247,6 @@ describe("archive/query/archive-view/index", () => {
           );
 
           expect(rows).toStrictEqual([
-            {
-              archiveId: 0,
-              chapterId: 1,
-              kind: 1,
-              sentenceIndex: 0,
-              wordsCount: 3,
-            },
             {
               archiveId: 1,
               chapterId: 1,

--- a/test/core/storage/schema-upgrade/index.test.ts
+++ b/test/core/storage/schema-upgrade/index.test.ts
@@ -1,12 +1,15 @@
 import { createWriteStream } from "fs";
-import { mkdir, readFile, rm, stat, writeFile } from "fs/promises";
-import { dirname, join } from "path";
+import { mkdir, readdir, readFile, rm, stat, writeFile } from "fs/promises";
+import { dirname, join, posix, relative, sep } from "path";
 import { finished } from "stream/promises";
 
 import { ZipFile } from "yazl";
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 
-import { Database } from "../../../../packages/core/src/document/index.js";
+import {
+  Database,
+  DirectoryDocument,
+} from "../../../../packages/core/src/document/index.js";
 import { WikipageCache } from "../../../../packages/core/src/external/wikipage/cache.js";
 import {
   ensureDefaultWikiGraphLibrary,
@@ -25,12 +28,14 @@ import {
   upgradeWikiGraphArchiveSchema,
 } from "../../../../packages/core/src/storage/schema-upgrade/index.js";
 import {
+  LEGACY_SEARCH_INDEX_DATABASE_PATH,
   WIKG_MANIFEST_PATH,
   WIKG_MUTATION_TOKEN_PATH,
   SEARCH_INDEX_DATABASE_PATH,
 } from "../../../../packages/core/src/storage/wikg/archive/constants.js";
 import { createWikgMutationTokenContent } from "../../../../packages/core/src/storage/wikg/archive/manifest.js";
 import {
+  extractWikgArchive,
   readWikgArchiveEntry,
   readWikgArchiveMutationToken,
 } from "../../../../packages/core/src/storage/wikg/index.js";
@@ -68,7 +73,7 @@ describe("schema-upgrade", () => {
       );
       await expect(
         readWikiGraphArchiveSchemaVersion(archivePath),
-      ).resolves.toBe(2);
+      ).resolves.toBe(3);
       await expect(
         readWikgArchiveEntry(archivePath, SEARCH_INDEX_DATABASE_PATH),
       ).resolves.toBeUndefined();
@@ -78,6 +83,54 @@ describe("schema-upgrade", () => {
       await expect(
         readWikgArchiveEntry(archivePath, WIKG_MANIFEST_PATH),
       ).resolves.toBeInstanceOf(Uint8Array);
+    });
+  });
+
+  it("upgrades v2 source indexes into v3 FTS artifacts", async () => {
+    await withTempDir("wikigraph-schema-upgrade-v2-artifact-", async (root) => {
+      setWikiGraphStateDirectoryPathForTesting(join(root, "home"));
+      const archivePath = join(root, "book.wikg");
+      const unpackedPath = join(root, "unpacked");
+
+      await writeSourcedArchiveWithSchemaVersion(archivePath, 2);
+
+      await upgradeWikiGraphArchiveSchema(archivePath);
+
+      await expect(
+        readWikiGraphArchiveSchemaVersion(archivePath),
+      ).resolves.toBe(3);
+      await expect(
+        readWikgArchiveEntry(archivePath, SEARCH_INDEX_DATABASE_PATH),
+      ).resolves.toBeUndefined();
+      await expect(
+        readWikgArchiveEntry(archivePath, LEGACY_SEARCH_INDEX_DATABASE_PATH),
+      ).resolves.toBeUndefined();
+
+      await extractWikgArchive(archivePath, unpackedPath);
+      const document = await DirectoryDocument.open(unpackedPath);
+      try {
+        const ftsArtifact = await document.indexArtifacts.get(1, "fts");
+        const lexicalRows = await document.indexArtifacts.listLexicalRows(1);
+
+        expect(ftsArtifact).toMatchObject({
+          kind: "fts",
+          serialId: 1,
+          sourceRevision: expect.any(Number),
+        });
+        expect(lexicalRows.some((row) => row.text.includes("Salvaged"))).toBe(
+          true,
+        );
+        await expect(
+          document.indexArtifacts.get(1, "embedding-source"),
+        ).resolves.toBeUndefined();
+        await expect(
+          document.readDatabase(async (database) =>
+            hasTable(database, "archive_index_settings"),
+          ),
+        ).resolves.toBe(false);
+      } finally {
+        await document.release();
+      }
     });
   });
 
@@ -138,7 +191,7 @@ describe("schema-upgrade", () => {
       const archivePath = join(root, "book.wikg");
       await writeArchiveWithSchemaVersion(
         archivePath,
-        2,
+        3,
         `${JSON.stringify({
           version: 1,
           items: [
@@ -166,7 +219,7 @@ describe("schema-upgrade", () => {
       });
       await expect(
         readWikiGraphArchiveSchemaVersion(archivePath),
-      ).resolves.toBe(2);
+      ).resolves.toBe(3);
 
       const upgradedTocEntry = await readWikgArchiveEntry(
         archivePath,
@@ -247,7 +300,7 @@ describe("schema-upgrade", () => {
         await writeLegacyCoreDatabase(home);
         await ensureWikiGraphHomeSchemaCurrent();
 
-        await expect(readHomeSchemaVersion(home)).resolves.toBe(2);
+        await expect(readHomeSchemaVersion(home)).resolves.toBe(3);
       },
     );
   });
@@ -366,7 +419,7 @@ describe("schema-upgrade", () => {
             ["home"],
             (row) => Number(row.version),
           ),
-        ).resolves.toBe(2);
+        ).resolves.toBe(3);
       } finally {
         await upgradedCore.close();
       }
@@ -408,6 +461,42 @@ describe("schema-upgrade", () => {
       } finally {
         await upgradedStaging.close();
       }
+    });
+  });
+
+  it("upgrades an explicit v2 home and clears derived state", async () => {
+    await withTempDir("wikigraph-schema-home-v2-", async (home) => {
+      setWikiGraphStateDirectoryPathForTesting(home);
+      const cacheDirectoryPath = join(home, "cache");
+      const stagingDirectoryPath = join(home, "staging");
+      const jobsDirectoryPath = join(home, "jobs");
+
+      await writeHomeSchemaVersion(home, 2);
+      await mkdir(cacheDirectoryPath, { recursive: true });
+      await mkdir(join(stagingDirectoryPath, "library", "1", "index"), {
+        recursive: true,
+      });
+      await mkdir(join(jobsDirectoryPath, "cache"), { recursive: true });
+      await writeFile(join(cacheDirectoryPath, "search-sessions.sqlite"), "x");
+      await writeFile(
+        join(cacheDirectoryPath, "continuation-cursors.sqlite"),
+        "x",
+      );
+      await writeFile(join(jobsDirectoryPath, "cache", "artifact.json"), "x");
+
+      await ensureWikiGraphHomeSchemaCurrent();
+
+      await expect(readHomeSchemaVersion(home)).resolves.toBe(3);
+      await expect(
+        stat(join(cacheDirectoryPath, "search-sessions.sqlite")),
+      ).rejects.toThrow();
+      await expect(
+        stat(join(cacheDirectoryPath, "continuation-cursors.sqlite")),
+      ).rejects.toThrow();
+      await expect(
+        stat(join(stagingDirectoryPath, "library")),
+      ).rejects.toThrow();
+      await expect(stat(join(jobsDirectoryPath, "cache"))).rejects.toThrow();
     });
   });
 
@@ -473,7 +562,7 @@ describe("schema-upgrade", () => {
         setWikiGraphStateDirectoryPathForTesting(join(root, "home"));
         const archivePath = join(root, "book.wikg");
         await writeLegacyArchive(archivePath);
-        await writeHomeSchemaVersion(join(root, "home"), 2);
+        await writeHomeSchemaVersion(join(root, "home"), 3);
         await writeCoordinatorOverlay(join(root, "home"), {
           archiveKey: createArchiveKey(archivePath),
           entryPath: "database.db",
@@ -569,7 +658,7 @@ describe("schema-upgrade", () => {
 
         await ensureWikiGraphHomeSchemaCurrent();
 
-        await expect(readHomeSchemaVersion(home)).resolves.toBe(2);
+        await expect(readHomeSchemaVersion(home)).resolves.toBe(3);
         await expect(stat(workspacePath)).rejects.toThrow();
         await expect(countCoordinatorOverlays(home)).resolves.toBe(0);
       },
@@ -643,7 +732,7 @@ describe("schema-upgrade", () => {
   ])("opens %s only after the home schema gate", async (_name, open) => {
     await withLegacyHome("wikigraph-schema-gate-", async (home) => {
       await open();
-      await expect(readHomeSchemaVersion(home)).resolves.toBe(2);
+      await expect(readHomeSchemaVersion(home)).resolves.toBe(3);
     });
   });
 
@@ -944,10 +1033,97 @@ async function writeLegacyArchive(archivePath: string): Promise<void> {
   await writeArchiveWithSchemaVersion(archivePath, 1);
 }
 
+async function writeSourcedArchiveWithSchemaVersion(
+  archivePath: string,
+  schemaVersion: number,
+): Promise<void> {
+  await withTempDir("wikigraph-schema-source-archive-", async (sourceDir) => {
+    const document = await DirectoryDocument.open(sourceDir);
+
+    try {
+      await document.openSession(async (openedDocument) => {
+        const serialId = await openedDocument.createSerial();
+        const draft = await openedDocument
+          .getSerialFragments(serialId)
+          .createDraft();
+
+        draft.addSentence(
+          "Salvaged source text should become FTS artifact.",
+          7,
+        );
+        await draft.commit();
+        await openedDocument.writeToc({
+          items: [
+            {
+              children: [],
+              key: "salvaged",
+              serialId,
+              title: "Salvaged",
+            },
+          ],
+          version: 1,
+        });
+      });
+      await createLegacyArchiveIndexSettings(document);
+    } finally {
+      await document.release();
+    }
+
+    await writeArchiveDirectoryWithSchemaVersion(
+      sourceDir,
+      archivePath,
+      schemaVersion,
+    );
+  });
+}
+
 async function writeArchiveWithSchemaVersion(
   archivePath: string,
   schemaVersion: number,
   tocContent = "legacy toc",
+): Promise<void> {
+  await withTempDir("wikigraph-schema-empty-archive-", async (sourceDir) => {
+    const document = await DirectoryDocument.open(sourceDir);
+
+    try {
+      await createLegacyArchiveIndexSettings(document);
+    } finally {
+      await document.release();
+    }
+    await writeFile(join(sourceDir, "toc.json"), tocContent, "utf8");
+    await writeArchiveDirectoryWithSchemaVersion(
+      sourceDir,
+      archivePath,
+      schemaVersion,
+    );
+  });
+}
+
+async function createLegacyArchiveIndexSettings(
+  document: DirectoryDocument,
+): Promise<void> {
+  await document.readDatabase(async (database) => {
+    await database.run(`
+      CREATE TABLE IF NOT EXISTS archive_index_settings (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        fts_embedded INTEGER NOT NULL DEFAULT 0
+      )
+    `);
+    await database.run(
+      `
+        INSERT INTO archive_index_settings(id, fts_embedded)
+        VALUES (1, 1)
+        ON CONFLICT(id)
+        DO UPDATE SET fts_embedded = excluded.fts_embedded
+      `,
+    );
+  });
+}
+
+async function writeArchiveDirectoryWithSchemaVersion(
+  sourceDir: string,
+  archivePath: string,
+  schemaVersion: number,
 ): Promise<void> {
   await mkdir(dirname(archivePath), { recursive: true });
 
@@ -969,12 +1145,12 @@ async function writeArchiveWithSchemaVersion(
       compress: false,
     },
   );
-  zipFile.addBuffer(Buffer.from("legacy db", "utf8"), "database.db", {
-    compress: false,
-  });
-  zipFile.addBuffer(Buffer.from(tocContent, "utf8"), "toc.json", {
-    compress: false,
-  });
+
+  for (const file of await listTestArchiveFiles(sourceDir)) {
+    zipFile.addFile(file.absolutePath, file.archivePath, {
+      compress: false,
+    });
+  }
   zipFile.addBuffer(
     Buffer.from("legacy index", "utf8"),
     SEARCH_INDEX_DATABASE_PATH,
@@ -982,9 +1158,58 @@ async function writeArchiveWithSchemaVersion(
       compress: false,
     },
   );
+  zipFile.addBuffer(
+    Buffer.from("legacy fts", "utf8"),
+    LEGACY_SEARCH_INDEX_DATABASE_PATH,
+    {
+      compress: false,
+    },
+  );
 
   zipFile.end();
   await writeZipFile(zipFile, archivePath);
+}
+
+async function listTestArchiveFiles(
+  rootDirectoryPath: string,
+  currentDirectoryPath = rootDirectoryPath,
+): Promise<Array<{ absolutePath: string; archivePath: string }>> {
+  const entries = await readdir(currentDirectoryPath, { withFileTypes: true });
+  const files: Array<{ absolutePath: string; archivePath: string }> = [];
+
+  for (const entry of entries) {
+    const absolutePath = join(currentDirectoryPath, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(
+        ...(await listTestArchiveFiles(rootDirectoryPath, absolutePath)),
+      );
+      continue;
+    }
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    const archivePath = relative(rootDirectoryPath, absolutePath)
+      .split(sep)
+      .join(posix.sep);
+
+    if (isTestArchiveDocumentPath(archivePath)) {
+      files.push({ absolutePath, archivePath });
+    }
+  }
+
+  return files.sort((left, right) =>
+    left.archivePath.localeCompare(right.archivePath),
+  );
+}
+
+function isTestArchiveDocumentPath(archivePath: string): boolean {
+  return (
+    archivePath === "database.db" ||
+    archivePath === "toc.json" ||
+    /^texts\/(?:source|summary)\/\d+\.txt$/u.test(archivePath)
+  );
 }
 
 async function writeZipFile(

--- a/test/core/storage/schema-upgrade/index.test.ts
+++ b/test/core/storage/schema-upgrade/index.test.ts
@@ -39,6 +39,11 @@ import {
   readWikgArchiveEntry,
   readWikgArchiveMutationToken,
 } from "../../../../packages/core/src/storage/wikg/index.js";
+import { isWikgArchivePath } from "../../../../packages/core/src/storage/wikg/archive/paths.js";
+import {
+  openIndexedArchive,
+  readArchiveEntryBuffer,
+} from "../../../../packages/core/src/storage/wikg/archive/zip.js";
 import { createArchiveKey } from "../../../../packages/core/src/storage/wikg/wikg-coordinator/archive-key.js";
 import { withStateDatabase } from "../../../../packages/core/src/storage/wikg/wikg-coordinator/state.js";
 import {
@@ -93,9 +98,16 @@ describe("schema-upgrade", () => {
       const unpackedPath = join(root, "unpacked");
 
       await writeSourcedArchiveWithSchemaVersion(archivePath, 2);
+      const mutationTokenBefore = await readRawWikgArchiveEntry(
+        archivePath,
+        WIKG_MUTATION_TOKEN_PATH,
+      );
 
       await upgradeWikiGraphArchiveSchema(archivePath);
 
+      await expect(
+        readWikgArchiveEntry(archivePath, WIKG_MUTATION_TOKEN_PATH),
+      ).resolves.toEqual(mutationTokenBefore);
       await expect(
         readWikiGraphArchiveSchemaVersion(archivePath),
       ).resolves.toBe(3);
@@ -1205,11 +1217,24 @@ async function listTestArchiveFiles(
 }
 
 function isTestArchiveDocumentPath(archivePath: string): boolean {
-  return (
-    archivePath === "database.db" ||
-    archivePath === "toc.json" ||
-    /^texts\/(?:source|summary)\/\d+\.txt$/u.test(archivePath)
-  );
+  return isWikgArchivePath(archivePath);
+}
+
+async function readRawWikgArchiveEntry(
+  archivePath: string,
+  entryPath: string,
+): Promise<Buffer | undefined> {
+  const { entries, zipFile } = await openIndexedArchive(archivePath);
+
+  try {
+    const entry = entries.find((candidate) => candidate.fileName === entryPath);
+
+    return entry === undefined
+      ? undefined
+      : await readArchiveEntryBuffer(archivePath, entry);
+  } finally {
+    zipFile.close();
+  }
 }
 
 async function writeZipFile(

--- a/test/core/storage/schema-upgrade/index.test.ts
+++ b/test/core/storage/schema-upgrade/index.test.ts
@@ -115,8 +115,8 @@ describe("schema-upgrade", () => {
         expect(ftsArtifact).toMatchObject({
           kind: "fts",
           serialId: 1,
-          sourceRevision: expect.any(Number),
         });
+        expect(typeof ftsArtifact?.sourceRevision).toBe("number");
         expect(lexicalRows.some((row) => row.text.includes("Salvaged"))).toBe(
           true,
         );

--- a/test/core/storage/wikg/archive.test.ts
+++ b/test/core/storage/wikg/archive.test.ts
@@ -51,7 +51,7 @@ describe("wikg/archive", () => {
       ).toMatch(/^wikg-mutation-token:v1\n[A-Za-z0-9_-]{43}\n$/u);
       expect(
         JSON.parse(await readFile(`${extractDir}/manifest.json`, "utf8")),
-      ).toEqual({ formatVersion: 1, schemaVersion: 2 });
+      ).toEqual({ formatVersion: 1, schemaVersion: 3 });
       expect(await readFile(`${extractDir}/database.db`, "utf8")).toBe(
         "sqlite",
       );
@@ -110,6 +110,14 @@ describe("wikg/archive", () => {
 
       try {
         await document.readDatabase(async (database) => {
+          await database.run(
+            `
+              CREATE TABLE archive_index_settings (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                fts_embedded INTEGER NOT NULL DEFAULT 0
+              )
+            `,
+          );
           await database.run(
             `
               INSERT INTO archive_index_settings(id, fts_embedded)
@@ -182,7 +190,7 @@ describe("wikg/archive", () => {
 
       expect(
         JSON.parse(await readFile(`${extractDir}/manifest.json`, "utf8")),
-      ).toEqual({ formatVersion: 1, schemaVersion: 2 });
+      ).toEqual({ formatVersion: 1, schemaVersion: 3 });
     });
   });
 

--- a/test/core/storage/wikg/wiki-graph-archive-file.test.ts
+++ b/test/core/storage/wikg/wiki-graph-archive-file.test.ts
@@ -1,10 +1,13 @@
 import { createHash } from "crypto";
 import { access, mkdir, readFile, rename, writeFile } from "fs/promises";
-import { resolve } from "path";
+import { dirname, resolve } from "path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { DirectoryDocument } from "../../../../packages/core/src/document/index.js";
+import {
+  Database,
+  DirectoryDocument,
+} from "../../../../packages/core/src/document/index.js";
 import {
   getWikiGraphStateDirectoryPathForTesting,
   setWikiGraphStateDirectoryPathForTesting,
@@ -15,12 +18,18 @@ import {
 } from "../../../../packages/core/src/retrieval/query/view.js";
 import { replaceChapterFtsIndexArtifact } from "../../../../packages/core/src/retrieval/index-artifact/index.js";
 import { isSearchIndexCurrent } from "../../../../packages/core/src/retrieval/search-index/index.js";
+import { SEARCH_INDEX_VERSION } from "../../../../packages/core/src/retrieval/search-index/search/types.js";
 import { WikiGraphArchive } from "../../../../packages/core/src/api/wiki-graph-archive.js";
 import { WikiGraphArchiveFile } from "../../../../packages/core/src/storage/wikg/wiki-graph-archive-file.js";
 import {
   readWikgArchiveEntry,
   writeWikgArchiveWithOverlays,
 } from "../../../../packages/core/src/storage/wikg/archive/index.js";
+import {
+  createArchiveKey as createCoordinatorArchiveKey,
+  createArchiveSignature,
+} from "../../../../packages/core/src/storage/wikg/wikg-coordinator/archive-key.js";
+import { withStateDatabase } from "../../../../packages/core/src/storage/wikg/wikg-coordinator/state.js";
 import { withTempDir } from "../../../helpers/temp.js";
 
 const originalStateDir = getWikiGraphStateDirectoryPathForTesting();
@@ -76,29 +85,36 @@ describe("wikg/wiki-graph-archive-file", () => {
 
   it("keeps a custom extraction directory when one is provided", async () => {
     await withTempDir("wikigraph-facade-file-", async (path) => {
-      const document = await DirectoryDocument.open(`${path}/document`);
-
+      const restoreStateDir = useCoordinatorStateDir(`${path}/state`);
       try {
-        await seedDocument(document);
+        const document = await DirectoryDocument.open(`${path}/document`);
 
-        const archivePath = `${path}/fixture/book.wikg`;
-        const readDir = `${path}/opened-read`;
+        try {
+          await seedDocument(document);
 
-        await new WikiGraphArchive(document, document.path).saveAs(archivePath);
+          const archivePath = `${path}/fixture/book.wikg`;
+          const readDir = `${path}/opened-read`;
 
-        const digestFile = new WikiGraphArchiveFile(archivePath);
-        await digestFile.read(
-          async (digest) => {
-            expect(await digest.readMeta()).toMatchObject({
-              title: "Session Fixture",
-            });
-          },
-          {
-            documentDirPath: readDir,
-          },
-        );
+          await new WikiGraphArchive(document, document.path).saveAs(
+            archivePath,
+          );
+
+          const digestFile = new WikiGraphArchiveFile(archivePath);
+          await digestFile.read(
+            async (digest) => {
+              expect(await digest.readMeta()).toMatchObject({
+                title: "Session Fixture",
+              });
+            },
+            {
+              documentDirPath: readDir,
+            },
+          );
+        } finally {
+          await document.release();
+        }
       } finally {
-        await document.release();
+        restoreStateDir();
       }
     });
   });
@@ -396,6 +412,83 @@ describe("wikg/wiki-graph-archive-file", () => {
     });
   });
 
+  it("treats an incompatible archive-backed index cache as missing on read", async () => {
+    await withTempDir("wikigraph-facade-file-", async (path) => {
+      const restoreStateDir = useCoordinatorStateDir(`${path}/state`);
+      try {
+        const archivePath = await createSeedArchive(path);
+
+        await createIncompatibleSearchIndexOverlay(path, archivePath);
+        await expect(readCoordinatorOverlays(path)).resolves.toContainEqual(
+          expect.objectContaining({
+            archivePath,
+            entryPath: "index.db",
+            kind: "file",
+          }),
+        );
+
+        await expect(
+          new WikiGraphArchiveFile(archivePath).readDocument(
+            async (document) => await isSearchIndexCurrent(document),
+            { searchIndexWritebackPolicy: "cache" },
+          ),
+        ).resolves.toBe(false);
+
+        await expect(readCoordinatorOverlays(path)).resolves.toContainEqual(
+          expect.objectContaining({
+            archivePath,
+            entryPath: "index.db",
+            kind: "deleted",
+          }),
+        );
+      } finally {
+        restoreStateDir();
+      }
+    });
+  });
+
+  it("reinitializes an incompatible archive-backed index cache on write", async () => {
+    await withTempDir("wikigraph-facade-file-", async (path) => {
+      const restoreStateDir = useCoordinatorStateDir(`${path}/state`);
+      try {
+        const archivePath = await createSeedArchive(path);
+
+        await createIncompatibleSearchIndexOverlay(path, archivePath);
+
+        await new WikiGraphArchiveFile(archivePath).write(
+          async (document) => {
+            await document.writeSearchIndexDatabase(async (database) => {
+              await database.run(
+                `
+                  INSERT INTO search_index_state(key, value)
+                  VALUES ('version', ?)
+                `,
+                [SEARCH_INDEX_VERSION],
+              );
+            });
+            await expect(
+              document.readSearchIndexDatabase(
+                async (database) =>
+                  await database.queryOne(
+                    `
+                      SELECT value
+                      FROM search_index_state
+                      WHERE key = 'version'
+                    `,
+                    undefined,
+                    (row) => String(row.value),
+                  ),
+              ),
+            ).resolves.toBe(SEARCH_INDEX_VERSION);
+          },
+          { searchIndexWritebackPolicy: "cache" },
+        );
+      } finally {
+        restoreStateDir();
+      }
+    });
+  });
+
   it("does not let unrelated stale overlays fail archive writes", async () => {
     await withTempDir("wikigraph-facade-file-", async (path) => {
       const restoreStateDir = useCoordinatorStateDir(`${path}/state`);
@@ -677,6 +770,61 @@ ORDER BY archive_path, entry_path
   } finally {
     await database.close();
   }
+}
+
+async function createIncompatibleSearchIndexOverlay(
+  path: string,
+  archivePath: string,
+): Promise<void> {
+  const archiveKey = createCoordinatorArchiveKey(archivePath);
+  const workspacePath = `${path}/state/staging/work/${archiveKey}/index.db`;
+
+  await mkdir(dirname(workspacePath), { recursive: true });
+  const database = await Database.open(
+    workspacePath,
+    `
+      CREATE TABLE search_index_state (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+    `,
+  );
+
+  try {
+    await database.run(
+      `
+        INSERT INTO search_index_state(key, value)
+        VALUES ('version', 'old')
+      `,
+    );
+  } finally {
+    await database.close();
+  }
+
+  await withStateDatabase(async (state) => {
+    await state.run(
+      `
+        INSERT INTO entry_overlays (
+          archive_key,
+          archive_path,
+          entry_path,
+          kind,
+          workspace_path,
+          archive_signature,
+          mutation_token,
+          updated_at
+        )
+        VALUES (?, ?, 'index.db', 'file', ?, ?, NULL, ?)
+      `,
+      [
+        archiveKey,
+        archivePath,
+        workspacePath,
+        await createArchiveSignature(archivePath),
+        Date.now(),
+      ],
+    );
+  });
 }
 
 async function createStaleOverlay(path: string): Promise<void> {


### PR DESCRIPTION
## Summary
- bump archive/home schema handling to v3 and invalidate incompatible index caches
- salvage v2 FTS index data into chapter index artifacts while dropping legacy embedded index cache files
- add upgrade coverage for archive, home, directory cache, and library cache paths

## Verification
- pnpm run lint:fix
- pnpm exec vitest run packages/core/src/document/directory/search-index.test.ts test/core/storage/schema-upgrade/index.test.ts
- pnpm test:run
- pnpm exec tsc --noEmit --pretty false
- real archive smoke: copied 三国演义.wikg and 客体关系.wikg from iCloud to temp dirs, upgraded v2 -> v3, verified FTS artifacts, no embedded index.db/fts.db, imported into a temp library, synced wikg://lib/index, and queried 刘备 successfully