### PR TITLE
refactor(cli): improve index jobs and query coverage UX

### DIFF
--- a/packages/cli/src/args/archive-index.test.ts
+++ b/packages/cli/src/args/archive-index.test.ts
@@ -28,6 +28,30 @@ describe("cli/args/archive index", () => {
       help: false,
       kind: "archive-index",
     });
+    expect(
+      parseCLIArguments([
+        "wikg:///tmp/book.wikg/index",
+        "sync",
+        "--jsonl",
+        "--skip-unindexed",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "sync",
+        archivePath: "/tmp/book.wikg",
+        jsonl: true,
+        skipUnindexed: true,
+      },
+      help: false,
+      kind: "archive-index",
+    });
+    expect(() =>
+      parseCLIArguments([
+        "wikg:///tmp/book.wikg/index",
+        "clean",
+        "--skip-unindexed",
+      ]),
+    ).toThrow("The `clean` command does not support --skip-unindexed.");
     expect(() =>
       parseCLIArguments([
         "wikg:///tmp/book.wikg/index",

--- a/packages/cli/src/args/archive.test.ts
+++ b/packages/cli/src/args/archive.test.ts
@@ -292,6 +292,24 @@ describe("cli/args/archive", () => {
       help: false,
       kind: "archive",
     });
+    expect(
+      parseCLIArguments([
+        "wikg://lib",
+        "--query",
+        "memory",
+        "--skip-unindexed",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "search",
+        archivePath: "wikg://lib",
+        format: "text",
+        query: "memory",
+        skipUnindexed: true,
+      },
+      help: false,
+      kind: "archive",
+    });
 
     expect(
       parseCLIArguments([
@@ -448,6 +466,26 @@ describe("cli/args/archive", () => {
       help: false,
       kind: "archive",
     });
+    expect(
+      parseCLIArguments([
+        "wikg://lib/entity/Q23",
+        "evidence",
+        "--query",
+        "memory",
+        "--skip-unindexed",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "evidence",
+        archivePath: "wikg://lib/entity/Q23",
+        format: "text",
+        objectId: "wikg://lib/entity/Q23",
+        query: "memory",
+        skipUnindexed: true,
+      },
+      help: false,
+      kind: "archive",
+    });
 
     expect(
       parseCLIArguments(["wikg://lib/entity/Q23", "related", "--cursor", "4"]),
@@ -458,6 +496,26 @@ describe("cli/args/archive", () => {
         cursor: "4",
         format: "text",
         objectId: "wikg://lib/entity/Q23",
+      },
+      help: false,
+      kind: "archive",
+    });
+    expect(
+      parseCLIArguments([
+        "wikg://lib/entity/Q23",
+        "related",
+        "--query",
+        "memory",
+        "--skip-unindexed",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "related",
+        archivePath: "wikg://lib/entity/Q23",
+        format: "text",
+        objectId: "wikg://lib/entity/Q23",
+        query: "memory",
+        skipUnindexed: true,
       },
       help: false,
       kind: "archive",
@@ -576,6 +634,26 @@ describe("cli/args/archive", () => {
       help: false,
       kind: "archive",
     });
+    expect(
+      parseCLIArguments([
+        "wikg://book.wikg/entity/Q1",
+        "related",
+        "--query",
+        "agents",
+        "--skip-unindexed",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "related",
+        archivePath: "wikg://book.wikg/entity/Q1",
+        format: "text",
+        objectId: "wikg://book.wikg/entity/Q1",
+        query: "agents",
+        skipUnindexed: true,
+      },
+      help: false,
+      kind: "archive",
+    });
 
     expect(
       parseCLIArguments([
@@ -614,6 +692,25 @@ describe("cli/args/archive", () => {
         format: "json",
         limit: 3,
         query: "RAG",
+      },
+      help: false,
+      kind: "archive",
+    });
+
+    expect(
+      parseCLIArguments([
+        "wikg:///Users/me/book.wikg",
+        "--query",
+        "RAG",
+        "--skip-unindexed",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "search",
+        archivePath: "wikg:///Users/me/book.wikg",
+        format: "text",
+        query: "RAG",
+        skipUnindexed: true,
       },
       help: false,
       kind: "archive",
@@ -709,6 +806,26 @@ describe("cli/args/archive", () => {
         format: "jsonl",
         objectId: "wikg://book.wikg/triple/Q1/mentions/Q2",
         query: "agents",
+      },
+      help: false,
+      kind: "archive",
+    });
+    expect(
+      parseCLIArguments([
+        "wikg://book.wikg/triple/Q1/mentions/Q2",
+        "evidence",
+        "--query",
+        "agents",
+        "--skip-unindexed",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "evidence",
+        archivePath: "wikg://book.wikg/triple/Q1/mentions/Q2",
+        format: "text",
+        objectId: "wikg://book.wikg/triple/Q1/mentions/Q2",
+        query: "agents",
+        skipUnindexed: true,
       },
       help: false,
       kind: "archive",
@@ -1006,6 +1123,24 @@ describe("cli/args/archive", () => {
         archivePath: `wikg://${archivePath}/chapter/part`,
         format: "text",
         query: "agent",
+      },
+      help: false,
+      kind: "archive",
+    });
+    expect(
+      parseCLIArguments([
+        "wikg://book.wikg/chapter/part",
+        "--query",
+        "agent",
+        "--skip-unindexed",
+      ]),
+    ).toStrictEqual({
+      args: {
+        action: "search",
+        archivePath: `wikg://${archivePath}/chapter/part`,
+        format: "text",
+        query: "agent",
+        skipUnindexed: true,
       },
       help: false,
       kind: "archive",

--- a/packages/cli/src/args/archive.ts
+++ b/packages/cli/src/args/archive.ts
@@ -74,6 +74,8 @@ export function parseArchiveArguments(
     );
   }
 
+  rejectNonQuerySkipUnindexedFlag(action, values, helpRoute);
+
   switch (action) {
     case "create": {
       rejectArchiveExtraPositionals(action, positionals, 1, helpRoute);
@@ -267,6 +269,7 @@ export function parseArchiveArguments(
                 ),
               }),
           query,
+          ...(values["skip-unindexed"] === true ? { skipUnindexed: true } : {}),
           ...(options.defaultKinds === undefined
             ? {}
             : { kinds: options.defaultKinds }),
@@ -405,6 +408,7 @@ export function parseArchiveArguments(
           objectId: archivePath,
           ...(values.query === undefined ? {} : { query: values.query }),
           ...(values.reverse === true ? { reverse: true } : {}),
+          ...(values["skip-unindexed"] === true ? { skipUnindexed: true } : {}),
           ...(relatedTarget === "entity"
             ? parseRelatedRoleFlag(values.role, helpRoute)
             : {}),
@@ -452,6 +456,7 @@ export function parseArchiveArguments(
           objectId: archivePath,
           ...(values.query === undefined ? {} : { query: values.query }),
           ...(values.reverse === true ? { reverse: true } : {}),
+          ...(values["skip-unindexed"] === true ? { skipUnindexed: true } : {}),
         },
         help: false,
         kind: "archive",
@@ -550,4 +555,28 @@ function rejectNonChapterDepthFlag(
   }
 
   rejectArchiveFlag(action, "--depth", depth, helpRoute);
+}
+
+function rejectNonQuerySkipUnindexedFlag(
+  action: CLIArchiveAction,
+  values: ArchiveArgumentValues,
+  helpRoute: string,
+): void {
+  if (values["skip-unindexed"] !== true) {
+    return;
+  }
+  if (
+    action === "search" ||
+    ((action === "related" || action === "evidence") &&
+      values.query !== undefined)
+  ) {
+    return;
+  }
+
+  rejectArchiveBooleanFlag(
+    action,
+    "--skip-unindexed",
+    values["skip-unindexed"],
+    helpRoute,
+  );
 }

--- a/packages/cli/src/args/gc.test.ts
+++ b/packages/cli/src/args/gc.test.ts
@@ -43,5 +43,11 @@ describe("cli/args/gc", () => {
     expect(() => parseCLIArguments(["gc", "--jsonl"])).toThrow(
       "The `gc` command does not support --jsonl",
     );
+    expect(() => parseCLIArguments(["gc", "--skip-unindexed"])).toThrow(
+      "The current command does not support --skip-unindexed.",
+    );
+    expect(() => parseCLIArguments(["transform", "--skip-unindexed"])).toThrow(
+      "The current command does not support --skip-unindexed.",
+    );
   });
 });

--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -487,6 +487,7 @@ describe("cli/args/help", () => {
       "Do not pass a bare filesystem path as a command target.",
     );
     expect(uriHelpText).toContain('wg <archive-uri> --query "term"');
+    expect(uriHelpText).toContain("--skip-unindexed");
     expect(uriHelpText).toContain(
       String.raw`C:\Users\me\book.wikg -> wikg://C:/Users/me/book.wikg`,
     );
@@ -813,6 +814,7 @@ describe("cli/args/help", () => {
     ).toThrow("does not support `list`");
     expect(scopeHelpText).toContain("wg wikg://lib [--json]");
     expect(scopeHelpText).toContain("wg wikg://lib --query <query>");
+    expect(scopeHelpText).toContain("--skip-unindexed");
     expect(scopeHelpText).toContain("searches library-wide objects");
     expect(scopeHelpText).not.toContain("searches archive members");
     expect(scopeHelpText).not.toContain("broad library index search");
@@ -942,6 +944,24 @@ describe("cli/args/help", () => {
     );
     expect(archiveMemberInspectHelp.helpText).toContain(
       "not a library-level health report",
+    );
+    const relatedHelpText = renderUriPredicateHelpText(
+      "entity-object",
+      "related",
+      "wikg://book.wikg/entity/Q23",
+    );
+    const evidenceHelpText = renderUriPredicateHelpText(
+      "entity-object",
+      "evidence",
+      "wikg://book.wikg/entity/Q23",
+    );
+    expect(relatedHelpText).toContain("[--skip-unindexed]");
+    expect(relatedHelpText).toContain(
+      "Add `--skip-unindexed` only with `--query`",
+    );
+    expect(evidenceHelpText).toContain("[--skip-unindexed]");
+    expect(evidenceHelpText).toContain(
+      "Add `--skip-unindexed` only with `--query`",
     );
     const registryHelpText = renderLibraryUriHelpText("wikg://lib/registry", {
       isDefault: true,

--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -538,6 +538,13 @@ describe("cli/args/help", () => {
       renderUriPredicateHelpText("index-object", "sync", "wikg://lib/index"),
     ).toContain("Sync this library index cache");
     expect(
+      renderUriPredicateHelpText(
+        "index-object",
+        "sync",
+        "wikg://book.wikg/index",
+      ),
+    ).toContain("[--skip-unindexed]");
+    expect(
       renderUriPredicateHelpText("index-object", "sync", "wikg://lib/index"),
     ).not.toContain(
       "Use `embed` when the index should travel with the archive",

--- a/packages/cli/src/args/parse.ts
+++ b/packages/cli/src/args/parse.ts
@@ -169,6 +169,9 @@ export function parseCLIArguments(
       reverse: {
         type: "boolean",
       },
+      "skip-unindexed": {
+        type: "boolean",
+      },
       stage: {
         type: "string",
       },

--- a/packages/cli/src/args/parse.ts
+++ b/packages/cli/src/args/parse.ts
@@ -236,6 +236,7 @@ export function parseCLIArguments(
 
   rejectNonGcForceFlag(positionals, values);
   rejectNonCreateReplaceFlag(positionals, values);
+  rejectNonWikiGraphSkipUnindexedFlag(positionals, values);
   rejectUnsupportedIndexesFlag(values.indexes);
 
   if (values.version === true) {
@@ -359,6 +360,30 @@ function rejectUnsupportedIndexesFlag(value: string | undefined): void {
   throw new Error(
     withHelpRoute(
       "The --indexes option has been removed. Build chapter index artifacts explicitly, then sync the archive or library index cache.",
+      CLI_HELP_ROUTES.root,
+    ),
+  );
+}
+
+function rejectNonWikiGraphSkipUnindexedFlag(
+  positionals: readonly string[],
+  values: { readonly "skip-unindexed"?: boolean },
+): void {
+  if (values["skip-unindexed"] !== true) {
+    return;
+  }
+
+  const command = positionals[0];
+  if (
+    command !== undefined &&
+    (isWikiGraphUri(command) || isWikiGraphLibraryUri(command))
+  ) {
+    return;
+  }
+
+  throw new Error(
+    withHelpRoute(
+      "The current command does not support --skip-unindexed.",
       CLI_HELP_ROUTES.root,
     ),
   );

--- a/packages/cli/src/args/types.ts
+++ b/packages/cli/src/args/types.ts
@@ -298,6 +298,7 @@ export interface CLIArchiveIndexArguments {
   readonly archivePath: string;
   readonly json?: boolean;
   readonly jsonl?: boolean;
+  readonly skipUnindexed?: boolean;
 }
 
 export interface ArchiveMetaFlagValues {

--- a/packages/cli/src/args/types.ts
+++ b/packages/cli/src/args/types.ts
@@ -289,6 +289,7 @@ export interface CLIArchiveArguments {
   readonly replace?: boolean;
   readonly reverse?: boolean;
   readonly role?: "any" | "object" | "self" | "subject";
+  readonly skipUnindexed?: boolean;
   readonly triplePattern?: ArchiveTriplePattern;
 }
 
@@ -359,6 +360,7 @@ export interface ArchiveArgumentValues extends ArchiveMetaFlagValues {
   readonly role?: string;
   readonly root?: boolean;
   readonly secret?: boolean;
+  readonly "skip-unindexed"?: boolean;
   readonly stage?: string;
   readonly last?: boolean;
   readonly task?: string;

--- a/packages/cli/src/args/uri/archive-objects.ts
+++ b/packages/cli/src/args/uri/archive-objects.ts
@@ -194,6 +194,12 @@ export function parseArchiveIndexUriArguments(
   } else {
     rejectArchiveFlag(action, "--indexes", values.indexes, helpRoute);
     rejectArchiveBooleanFlag(action, "--jsonl", values.jsonl, helpRoute);
+    rejectArchiveBooleanFlag(
+      action,
+      "--skip-unindexed",
+      values["skip-unindexed"],
+      helpRoute,
+    );
   }
   rejectArchiveBooleanFlag(action, "--last", values.last, helpRoute);
   rejectArchiveBooleanFlag(action, "--reverse", values.reverse, helpRoute);
@@ -207,6 +213,7 @@ export function parseArchiveIndexUriArguments(
       archivePath,
       ...(values.json === undefined ? {} : { json: values.json }),
       ...(values.jsonl === undefined ? {} : { jsonl: values.jsonl }),
+      ...(values["skip-unindexed"] === true ? { skipUnindexed: true } : {}),
     },
     help: false,
     kind: "archive-index",

--- a/packages/cli/src/commands/archive-command/chapter.ts
+++ b/packages/cli/src/commands/archive-command/chapter.ts
@@ -36,6 +36,7 @@ import {
 } from "../../support/index.js";
 import { formatCLIJSON } from "../../support/index.js";
 import { tryStartQueueWorker } from "../queue/add.js";
+import { writeJobSummary } from "../queue/output.js";
 import { readArchiveDocument, writeArchiveDocument } from "./run/document.js";
 import { resolveArchiveRuntimeLocation } from "./run/uri.js";
 
@@ -105,13 +106,7 @@ export async function runArchiveChapterCommand(
       });
 
       tryStartQueueWorker();
-      if (args.json === true) {
-        await writeTextToStdout(formatCLIJSON(job));
-        return;
-      }
-      await writeTextToStdout(
-        `Queued ${job.target} job ${job.jobId} for chapter ${job.chapterId}.\n`,
-      );
+      await writeJobSummary(job, { json: args.json ?? false, watch: true });
       return;
     }
     case "delete-index-artifact":

--- a/packages/cli/src/commands/archive-command/chapter.ts
+++ b/packages/cli/src/commands/archive-command/chapter.ts
@@ -35,6 +35,7 @@ import {
   writeTextToStdout,
 } from "../../support/index.js";
 import { formatCLIJSON } from "../../support/index.js";
+import { tryStartQueueWorker } from "../queue/add.js";
 import { readArchiveDocument, writeArchiveDocument } from "./run/document.js";
 import { resolveArchiveRuntimeLocation } from "./run/uri.js";
 
@@ -103,6 +104,7 @@ export async function runArchiveChapterCommand(
         target: requireIndexArtifactTarget(args.indexArtifactTarget),
       });
 
+      tryStartQueueWorker();
       if (args.json === true) {
         await writeTextToStdout(formatCLIJSON(job));
         return;

--- a/packages/cli/src/commands/archive-command/index.ts
+++ b/packages/cli/src/commands/archive-command/index.ts
@@ -303,6 +303,7 @@ export async function runArchiveCommand(
                   },
                 ),
               args.cursor,
+              context,
               args.format ?? "text",
             );
             return;
@@ -638,6 +639,7 @@ async function runLibraryIndexArchiveCommand(
               ...createOptionalSourceContext(args),
             }),
           args.cursor,
+          evidenceContext,
           args.format ?? "text",
         );
         return;

--- a/packages/cli/src/commands/archive-command/index.ts
+++ b/packages/cli/src/commands/archive-command/index.ts
@@ -15,10 +15,12 @@ import {
   readWikiGraphLibraryPage,
   resolveWikiGraphLibrary,
   findArchiveObjects,
+  listArchiveQueryableChapterIds,
   rebuildArchiveSearchIndex,
   WikiGraphArchiveFile,
   type ArchiveFindOptions,
   type ArchiveRelatedResult,
+  type ReadonlyDocument,
 } from "wiki-graph-core";
 
 import type { CLIArchiveArguments } from "../../args/index.js";
@@ -57,6 +59,7 @@ import {
   writeArchiveRoot,
 } from "./run/index.js";
 import { resolveArchiveChapterScope } from "./run/scope.js";
+import type { ChapterScopeResolution } from "./run/scope.js";
 
 export async function runArchiveCommand(
   args: CLIArchiveArguments,
@@ -106,15 +109,11 @@ export async function runArchiveCommand(
       );
       return;
     case "search":
-      await ensureArchiveQueryIndexCache(args.archivePath);
+      await ensureArchiveQueryIndexCache(args);
       await readArchiveDocument(
         getArchivePath(args.archivePath),
         async (document) => {
-          const scope = await resolveArchiveChapterScope(document, args);
-          const scopedArgs =
-            scope === undefined
-              ? args
-              : { ...args, chapters: scope.chapterIds };
+          const scopedArgs = await createScopedQueryArgs(document, args);
           const context = createArchiveOutputContext(scopedArgs);
           const findOptions = await createSearchFindOptions(scopedArgs);
 
@@ -141,7 +140,7 @@ export async function runArchiveCommand(
       return;
     case "list":
       if (args.query !== undefined) {
-        await ensureArchiveQueryIndexCache(args.archivePath);
+        await ensureArchiveQueryIndexCache(args);
       }
       await readArchiveDocument(
         getArchivePath(args.archivePath),
@@ -229,7 +228,7 @@ export async function runArchiveCommand(
       return;
     case "related":
       if (args.query !== undefined) {
-        await ensureArchiveQueryIndexCache(args.archivePath);
+        await ensureArchiveQueryIndexCache(args);
       }
       await readArchiveDocument(
         getArchivePath(args.archivePath),
@@ -251,6 +250,7 @@ export async function runArchiveCommand(
                 ...(args.reverse === true ? { order: "doc-desc" } : {}),
                 ...(args.query === undefined ? {} : { query: args.query }),
                 ...(args.role === undefined ? {} : { role: args.role }),
+                ...(args.skipUnindexed === true ? { skipUnindexed: true } : {}),
                 ...createOptionalSourceContext(args),
               },
             );
@@ -275,7 +275,7 @@ export async function runArchiveCommand(
       return;
     case "evidence":
       if (args.query !== undefined) {
-        await ensureArchiveQueryIndexCache(args.archivePath);
+        await ensureArchiveQueryIndexCache(args);
       }
       await readArchiveDocument(
         getArchivePath(args.archivePath),
@@ -296,6 +296,9 @@ export async function runArchiveCommand(
                     ...(args.limit === undefined ? {} : { limit: args.limit }),
                     ...(args.reverse === true ? { order: "doc-desc" } : {}),
                     ...(args.query === undefined ? {} : { query: args.query }),
+                    ...(args.skipUnindexed === true
+                      ? { skipUnindexed: true }
+                      : {}),
                     ...createOptionalSourceContext(args),
                   },
                 ),
@@ -311,6 +314,7 @@ export async function runArchiveCommand(
               ...(args.limit === undefined ? {} : { limit: args.limit }),
               ...(args.reverse === true ? { order: "doc-desc" } : {}),
               ...(args.query === undefined ? {} : { query: args.query }),
+              ...(args.skipUnindexed === true ? { skipUnindexed: true } : {}),
               ...createOptionalSourceContext(args),
             }),
             context,
@@ -342,20 +346,55 @@ export async function runArchiveCommand(
 }
 
 async function ensureArchiveQueryIndexCache(
-  archivePath: string,
+  args: CLIArchiveArguments,
 ): Promise<void> {
-  const location = await resolveArchiveRuntimeLocation(archivePath);
+  const location = await resolveArchiveRuntimeLocation(args.archivePath);
 
   await new WikiGraphArchiveFile(location.archivePath).write(
     async (document) => {
-      if (await isArchiveSearchIndexCurrent(document)) {
+      const scopedArgs = await createScopedQueryArgs(document, args);
+      const options =
+        scopedArgs.chapters === undefined
+          ? {}
+          : { chapters: scopedArgs.chapters };
+
+      if (await isArchiveSearchIndexCurrent(document, options)) {
         return;
       }
 
-      await rebuildArchiveSearchIndex(document);
+      await rebuildArchiveSearchIndex(document, undefined, options);
     },
     { searchIndexWritebackPolicy: "cache" },
   );
+}
+
+async function createScopedQueryArgs(
+  document: ReadonlyDocument,
+  args: CLIArchiveArguments,
+): Promise<CLIArchiveArguments> {
+  const scope = await resolveArchiveChapterScope(document, args);
+  if (args.skipUnindexed !== true) {
+    return applyChapterScope(args, scope);
+  }
+
+  const queryableChapters = await listArchiveQueryableChapterIds(document, {
+    ...(scope === undefined ? {} : { chapters: scope.chapterIds }),
+  });
+
+  if (queryableChapters.length === 0) {
+    throw new Error(
+      "Wiki Graph query is not ready. No chapters in this scope have a current FTS artifact or source embedding artifact.",
+    );
+  }
+
+  return { ...args, chapters: queryableChapters };
+}
+
+function applyChapterScope(
+  args: CLIArchiveArguments,
+  scope: ChapterScopeResolution | undefined,
+): CLIArchiveArguments {
+  return scope === undefined ? args : { ...args, chapters: scope.chapterIds };
 }
 
 async function runLibraryIndexArchiveCommand(
@@ -558,6 +597,7 @@ async function runLibraryIndexArchiveCommand(
           ...(args.reverse === true ? { order: "doc-desc" } : {}),
           ...(args.query === undefined ? {} : { query: args.query }),
           ...(args.role === undefined ? {} : { role: args.role }),
+          ...(args.skipUnindexed === true ? { skipUnindexed: true } : {}),
           ...createOptionalSourceContext(args),
         });
 
@@ -594,6 +634,7 @@ async function runLibraryIndexArchiveCommand(
               ...(args.limit === undefined ? {} : { limit: args.limit }),
               ...(args.reverse === true ? { order: "doc-desc" } : {}),
               ...(args.query === undefined ? {} : { query: args.query }),
+              ...(args.skipUnindexed === true ? { skipUnindexed: true } : {}),
               ...createOptionalSourceContext(args),
             }),
           args.cursor,
@@ -608,6 +649,7 @@ async function runLibraryIndexArchiveCommand(
           ...(args.limit === undefined ? {} : { limit: args.limit }),
           ...(args.reverse === true ? { order: "doc-desc" } : {}),
           ...(args.query === undefined ? {} : { query: args.query }),
+          ...(args.skipUnindexed === true ? { skipUnindexed: true } : {}),
           ...createOptionalSourceContext(args),
         }),
         evidenceContext,

--- a/packages/cli/src/commands/archive-command/inspect.ts
+++ b/packages/cli/src/commands/archive-command/inspect.ts
@@ -85,6 +85,7 @@ interface InspectReport {
   readonly performanceHints: readonly GenerationPerformanceHint[];
   readonly help: {
     readonly readiness: string;
+    readonly summaryCoverage: string;
   };
 }
 
@@ -246,7 +247,11 @@ async function createArchiveInspectReport(
     }),
     improvements,
     performanceHints,
-    help: { readiness: "wg help readiness" },
+    help: {
+      readiness: "wg help readiness",
+      summaryCoverage:
+        "Summary coverage means a current summary artifact exists for the chapter; it does not guarantee that every source topic is represented in the summary text.",
+    },
   };
 }
 
@@ -297,7 +302,8 @@ function formatArchiveInspectText(report: InspectReport): string {
       ),
       formatCoverageLine("Reading Graph", report.coverage.readingGraph),
       formatCoverageLine("Knowledge Graph", report.coverage.knowledgeGraph),
-      formatCoverageLine("Summary", report.coverage.summary),
+      formatCoverageLine("Summary Artifact", report.coverage.summary),
+      `Summary note: ${report.help.summaryCoverage}`,
       ...(report.queryBlockedChapters.length === 0
         ? []
         : [

--- a/packages/cli/src/commands/archive-command/run/next.ts
+++ b/packages/cli/src/commands/archive-command/run/next.ts
@@ -130,6 +130,9 @@ export async function runNextArchivePage(
             ? {}
             : { evidenceLimit: cursor.evidenceLimit }),
           limit,
+          ...(cursor.skipUnindexed === undefined
+            ? {}
+            : { skipUnindexed: cursor.skipUnindexed }),
           ...(cursor.sourceContext === undefined
             ? {}
             : { sourceContext: cursor.sourceContext }),
@@ -163,6 +166,9 @@ export async function runNextArchivePage(
             ...(cursor.sourceContext === undefined
               ? {}
               : { sourceContext: cursor.sourceContext }),
+            ...(cursor.skipUnindexed === undefined
+              ? {}
+              : { skipUnindexed: cursor.skipUnindexed }),
             ...(cursor.triplePattern === undefined
               ? {}
               : { triplePattern: cursor.triplePattern }),
@@ -179,6 +185,9 @@ export async function runNextArchivePage(
             limit,
             order: cursor.order,
             ...(cursor.query === undefined ? {} : { query: cursor.query }),
+            ...(cursor.skipUnindexed === undefined
+              ? {}
+              : { skipUnindexed: cursor.skipUnindexed }),
             ...(cursor.sourceContext === undefined
               ? {}
               : { sourceContext: cursor.sourceContext }),
@@ -192,6 +201,9 @@ export async function runNextArchivePage(
             limit,
             order: cursor.order,
             ...(cursor.query === undefined ? {} : { query: cursor.query }),
+            ...(cursor.skipUnindexed === undefined
+              ? {}
+              : { skipUnindexed: cursor.skipUnindexed }),
             ...(cursor.sourceContext === undefined
               ? {}
               : { sourceContext: cursor.sourceContext }),
@@ -212,6 +224,9 @@ export async function runNextArchivePage(
             order: cursor.order,
             ...(cursor.query === undefined ? {} : { query: cursor.query }),
             ...(cursor.role === undefined ? {} : { role: cursor.role }),
+            ...(cursor.skipUnindexed === undefined
+              ? {}
+              : { skipUnindexed: cursor.skipUnindexed }),
             ...(cursor.sourceContext === undefined
               ? {}
               : { sourceContext: cursor.sourceContext }),
@@ -229,6 +244,9 @@ export async function runNextArchivePage(
             order: cursor.order,
             ...(cursor.query === undefined ? {} : { query: cursor.query }),
             ...(cursor.role === undefined ? {} : { role: cursor.role }),
+            ...(cursor.skipUnindexed === undefined
+              ? {}
+              : { skipUnindexed: cursor.skipUnindexed }),
             ...(cursor.sourceContext === undefined
               ? {}
               : { sourceContext: cursor.sourceContext }),
@@ -322,6 +340,9 @@ async function runNextLibraryIndexPage(
           ? {}
           : { evidenceLimit: cursor.evidenceLimit }),
         limit,
+        ...(cursor.skipUnindexed === undefined
+          ? {}
+          : { skipUnindexed: cursor.skipUnindexed }),
         ...(cursor.sourceContext === undefined
           ? {}
           : { sourceContext: cursor.sourceContext }),
@@ -368,6 +389,9 @@ async function runNextLibraryIndexPage(
           limit,
           order: cursor.order,
           ...(cursor.query === undefined ? {} : { query: cursor.query }),
+          ...(cursor.skipUnindexed === undefined
+            ? {}
+            : { skipUnindexed: cursor.skipUnindexed }),
           ...(cursor.sourceContext === undefined
             ? {}
             : { sourceContext: cursor.sourceContext }),
@@ -377,6 +401,9 @@ async function runNextLibraryIndexPage(
           continuationKind: "evidence",
           order: cursor.order,
           ...(cursor.query === undefined ? {} : { query: cursor.query }),
+          ...(cursor.skipUnindexed === undefined
+            ? {}
+            : { skipUnindexed: cursor.skipUnindexed }),
           targetUri: cursor.targetUri,
         },
         format,
@@ -393,6 +420,9 @@ async function runNextLibraryIndexPage(
           order: cursor.order,
           ...(cursor.query === undefined ? {} : { query: cursor.query }),
           ...(cursor.role === undefined ? {} : { role: cursor.role }),
+          ...(cursor.skipUnindexed === undefined
+            ? {}
+            : { skipUnindexed: cursor.skipUnindexed }),
           ...(cursor.sourceContext === undefined
             ? {}
             : { sourceContext: cursor.sourceContext }),
@@ -406,6 +436,9 @@ async function runNextLibraryIndexPage(
           order: cursor.order,
           ...(cursor.query === undefined ? {} : { query: cursor.query }),
           ...(cursor.role === undefined ? {} : { role: cursor.role }),
+          ...(cursor.skipUnindexed === undefined
+            ? {}
+            : { skipUnindexed: cursor.skipUnindexed }),
           targetUri: cursor.targetUri,
         },
         format,
@@ -472,6 +505,9 @@ function createCursorOutputContext(
       ? cursor.query === undefined
         ? {}
         : { query: cursor.query }
+      : {}),
+    ...(cursor.kind === "search" && cursor.skipUnindexed !== undefined
+      ? { skipUnindexed: cursor.skipUnindexed }
       : {}),
   };
 }

--- a/packages/cli/src/commands/archive-command/run/options.ts
+++ b/packages/cli/src/commands/archive-command/run/options.ts
@@ -39,6 +39,7 @@ export function createFindOptions(
     ...createOptionalEvidenceLimit(args),
     ...(args.limit === undefined ? {} : { limit: args.limit }),
     ...(args.reverse === true ? { order: "doc-desc" } : {}),
+    ...(args.skipUnindexed === true ? { skipUnindexed: true } : {}),
     ...createOptionalSourceContext(args),
     ...(args.triplePattern === undefined
       ? {}
@@ -82,6 +83,7 @@ export function createArchiveOutputContext(
         ? {}
         : { query: args.query }),
     ...(args.role === undefined ? {} : { role: args.role }),
+    ...(args.skipUnindexed === true ? { skipUnindexed: true } : {}),
     ...(options.continuationKind === "collection"
       ? createScopeOptions(args)
       : {}),

--- a/packages/cli/src/commands/archive-command/run/uri.test.ts
+++ b/packages/cli/src/commands/archive-command/run/uri.test.ts
@@ -89,7 +89,7 @@ describe("archive-command URI runtime resolution", () => {
     });
   });
 
-  it("requires library index sync after unsynced archive writes through a library locator", async () => {
+  it("keeps library index current after archive writes through a library locator", async () => {
     const target = await createTestLibraryTarget();
     const archive = await addTestArchiveToLibrary(target);
 
@@ -104,12 +104,12 @@ describe("archive-command URI runtime resolution", () => {
 
     await expect(readWikiGraphLibraryIndexState(target)).resolves.toMatchObject(
       {
-        status: "dirty",
+        status: "current",
       },
     );
   });
 
-  it("requires explicit library index sync after unsynced archive writes through a library locator", async () => {
+  it("keeps explicit library index current after archive writes through a library locator", async () => {
     const library = await createWikiGraphLibrary({
       folderPath: join(tempDir, "team-library"),
     });
@@ -129,7 +129,7 @@ describe("archive-command URI runtime resolution", () => {
     await expect(
       readWikiGraphLibraryIndexState(target!),
     ).resolves.toMatchObject({
-      status: "dirty",
+      status: "current",
     });
   });
 

--- a/packages/cli/src/commands/archive-command/search-index.ts
+++ b/packages/cli/src/commands/archive-command/search-index.ts
@@ -1,6 +1,7 @@
 import {
   deleteArchiveSearchSessions,
   isArchiveSearchIndexCurrent,
+  listArchiveQueryableChapterIds,
   readSearchIndexCapabilityStatus,
   rebuildArchiveSearchIndex,
   WikiGraphArchiveFile,
@@ -65,32 +66,46 @@ async function syncIndexCache(args: CLIArchiveIndexArguments): Promise<void> {
         kind: "status",
         phase: "checking",
       });
+      const options =
+        args.skipUnindexed === true
+          ? { chapters: await listArchiveQueryableChapterIds(document) }
+          : {};
 
-      if (await isArchiveSearchIndexCurrent(document)) {
+      if (options.chapters?.length === 0) {
+        throw new Error(
+          "Wiki Graph index cache is not ready. No chapters have a current FTS artifact or source embedding artifact.",
+        );
+      }
+
+      if (await isArchiveSearchIndexCurrent(document, options)) {
         await writer.write({
           json: { type: "already-current" },
           kind: "lifecycle",
           text: "already current",
         });
       } else {
-        await rebuildArchiveSearchIndex(document, async (event) => {
-          await writer.write({
-            counters:
-              event.done === undefined || event.total === undefined
-                ? []
-                : [formatIndexCounter(event)],
-            json: {
+        await rebuildArchiveSearchIndex(
+          document,
+          async (event) => {
+            await writer.write({
               counters:
                 event.done === undefined || event.total === undefined
                   ? []
                   : [formatIndexCounter(event)],
+              json: {
+                counters:
+                  event.done === undefined || event.total === undefined
+                    ? []
+                    : [formatIndexCounter(event)],
+                phase: event.phase,
+                type: "status_snapshot",
+              },
+              kind: "status",
               phase: event.phase,
-              type: "status_snapshot",
-            },
-            kind: "status",
-            phase: event.phase,
-          });
-        });
+            });
+          },
+          options,
+        );
       }
 
       await writer.write({

--- a/packages/cli/src/commands/archive-output/object/cursor.ts
+++ b/packages/cli/src/commands/archive-output/object/cursor.ts
@@ -29,6 +29,9 @@ export async function createOutputContinuationCursor(
       kind: "evidence",
       order: context.order ?? "doc-asc",
       ...(context.query === undefined ? {} : { query: context.query }),
+      ...(context.skipUnindexed === undefined
+        ? {}
+        : { skipUnindexed: context.skipUnindexed }),
       ...(context.sourceContext === undefined
         ? {}
         : { sourceContext: context.sourceContext }),
@@ -52,6 +55,9 @@ export async function createOutputContinuationCursor(
       order: context.order ?? "doc-asc",
       ...(context.query === undefined ? {} : { query: context.query }),
       ...(context.role === undefined ? {} : { role: context.role }),
+      ...(context.skipUnindexed === undefined
+        ? {}
+        : { skipUnindexed: context.skipUnindexed }),
       ...(context.sourceContext === undefined
         ? {}
         : { sourceContext: context.sourceContext }),
@@ -98,6 +104,9 @@ export async function createOutputContinuationCursor(
       kind: "search",
       ...(context.chapters === undefined ? {} : { chapters: context.chapters }),
       ...(context.query === undefined ? {} : { query: context.query }),
+      ...(context.skipUnindexed === undefined
+        ? {}
+        : { skipUnindexed: context.skipUnindexed }),
       ...(context.sourceContext === undefined
         ? {}
         : { sourceContext: context.sourceContext }),

--- a/packages/cli/src/commands/archive-output/object/objects.ts
+++ b/packages/cli/src/commands/archive-output/object/objects.ts
@@ -17,6 +17,7 @@ import type {
   ArchiveOutputObject,
   ArchiveOutputResultPage,
   ArchiveOutputSource,
+  ArchiveOutputWarning,
 } from "./types.js";
 import {
   getTextStreamOutputType,
@@ -74,15 +75,18 @@ export function createObjectResultPage(
   objects: readonly ArchiveOutputObject[],
   nextCursor: string | null,
   limit: number,
+  warnings: readonly ArchiveOutputWarning[] = [],
 ): {
   readonly limit: number;
   readonly nextCursor: string | null;
   readonly objects: readonly ArchiveOutputObject[];
+  readonly warnings?: readonly ArchiveOutputWarning[];
 } {
   return {
     limit,
     nextCursor,
     objects,
+    ...(warnings.length === 0 ? {} : { warnings }),
   };
 }
 

--- a/packages/cli/src/commands/archive-output/object/types.ts
+++ b/packages/cli/src/commands/archive-output/object/types.ts
@@ -53,6 +53,12 @@ export interface ArchiveOutputResultPage {
   readonly limit: number;
   readonly nextCursor: string | null;
   readonly objects: readonly ArchiveOutputObject[];
+  readonly warnings?: readonly ArchiveOutputWarning[];
+}
+
+export interface ArchiveOutputWarning {
+  readonly message: string;
+  readonly type: "skip-unindexed";
 }
 
 export interface ArchiveOutputEvidencePreview {

--- a/packages/cli/src/commands/archive-output/object/types.ts
+++ b/packages/cli/src/commands/archive-output/object/types.ts
@@ -85,6 +85,7 @@ export interface ArchiveOutputContext {
   readonly order?: "doc-asc" | "doc-desc";
   readonly query?: string;
   readonly role?: CLIArchiveArguments["role"];
+  readonly skipUnindexed?: boolean;
   readonly sourceContext?: number;
   readonly targetUri?: string;
   readonly triplePattern?: CLIArchiveArguments["triplePattern"];

--- a/packages/cli/src/commands/archive-output/write/evidence.ts
+++ b/packages/cli/src/commands/archive-output/write/evidence.ts
@@ -10,6 +10,11 @@ import {
 } from "../object/objects.js";
 import { createPageCursorObject } from "../object/page-cursor.js";
 import type { ArchiveOutputContext, ResultFormat } from "../object/types.js";
+import {
+  createOutputWarnings,
+  createWarningJSONLObject,
+  formatOutputWarnings,
+} from "./warnings.js";
 
 export async function writeEvidence(
   evidence: ArchiveEvidence,
@@ -21,33 +26,39 @@ export async function writeEvidence(
     evidence.nextCursor,
   );
   const objects = evidence.items.map(createSourceObject);
+  const warnings = createOutputWarnings(context);
 
   if (format === "json") {
     await writeTextToStdout(
       formatCLIJSON(
-        createObjectResultPage(objects, nextCursor, evidence.limit),
+        createObjectResultPage(objects, nextCursor, evidence.limit, warnings),
       ),
     );
     return;
   }
   if (format === "jsonl") {
-    await writeJSONL([...objects, createPageCursorObject(nextCursor)]);
+    await writeJSONL([
+      ...warnings.map(createWarningJSONLObject),
+      ...objects,
+      createPageCursorObject(nextCursor),
+    ]);
     return;
   }
 
   if (evidence.items.length === 0) {
-    await writeTextToStdout("No evidence.\n");
+    await writeTextToStdout(`${formatOutputWarnings(warnings)}No evidence.\n`);
     return;
   }
 
   await writeTextToStdout(
-    `${evidence.items.map(formatEvidenceItem).join("\n\n")}${formatEvidenceNextCursor(nextCursor)}\n`,
+    `${formatOutputWarnings(warnings)}${evidence.items.map(formatEvidenceItem).join("\n\n")}${formatEvidenceNextCursor(nextCursor)}\n`,
   );
 }
 
 export async function writeAllEvidence(
   readPage: (cursor: string | undefined) => Promise<ArchiveEvidence>,
   initialCursor: string | undefined,
+  context: ArchiveOutputContext,
   format: ResultFormat,
 ): Promise<void> {
   const pages: ArchiveEvidence[] = [];
@@ -57,7 +68,7 @@ export async function writeAllEvidence(
     const page = await readPage(cursor);
 
     if (format === "jsonl") {
-      await writeEvidenceWithoutContinuation(page, format);
+      await writeEvidenceWithoutContinuation(page, context, format);
     } else {
       pages.push(page);
     }
@@ -73,33 +84,41 @@ export async function writeAllEvidence(
     return;
   }
 
-  await writeEvidenceWithoutContinuation(mergeEvidencePages(pages), format);
+  await writeEvidenceWithoutContinuation(
+    mergeEvidencePages(pages),
+    context,
+    format,
+  );
 }
 
 export async function writeEvidenceWithoutContinuation(
   evidence: ArchiveEvidence,
+  context: ArchiveOutputContext,
   format: ResultFormat,
 ): Promise<void> {
   const objects = evidence.items.map(createSourceObject);
+  const warnings = createOutputWarnings(context);
 
   if (format === "json") {
     await writeTextToStdout(
-      formatCLIJSON(createObjectResultPage(objects, null, evidence.limit)),
+      formatCLIJSON(
+        createObjectResultPage(objects, null, evidence.limit, warnings),
+      ),
     );
     return;
   }
   if (format === "jsonl") {
-    await writeJSONL(objects);
+    await writeJSONL([...warnings.map(createWarningJSONLObject), ...objects]);
     return;
   }
 
   if (evidence.items.length === 0) {
-    await writeTextToStdout("No evidence.\n");
+    await writeTextToStdout(`${formatOutputWarnings(warnings)}No evidence.\n`);
     return;
   }
 
   await writeTextToStdout(
-    `${evidence.items.map(formatEvidenceItem).join("\n\n")}\n`,
+    `${formatOutputWarnings(warnings)}${evidence.items.map(formatEvidenceItem).join("\n\n")}\n`,
   );
 }
 

--- a/packages/cli/src/commands/archive-output/write/evidence.ts
+++ b/packages/cli/src/commands/archive-output/write/evidence.ts
@@ -68,7 +68,9 @@ export async function writeAllEvidence(
     const page = await readPage(cursor);
 
     if (format === "jsonl") {
-      await writeEvidenceWithoutContinuation(page, context, format);
+      await writeEvidenceWithoutContinuation(page, context, format, {
+        emitWarnings: cursor === initialCursor,
+      });
     } else {
       pages.push(page);
     }
@@ -95,9 +97,11 @@ export async function writeEvidenceWithoutContinuation(
   evidence: ArchiveEvidence,
   context: ArchiveOutputContext,
   format: ResultFormat,
+  options: { readonly emitWarnings?: boolean } = {},
 ): Promise<void> {
   const objects = evidence.items.map(createSourceObject);
-  const warnings = createOutputWarnings(context);
+  const warnings =
+    (options.emitWarnings ?? true) ? createOutputWarnings(context) : [];
 
   if (format === "json") {
     await writeTextToStdout(

--- a/packages/cli/src/commands/archive-output/write/find.ts
+++ b/packages/cli/src/commands/archive-output/write/find.ts
@@ -14,6 +14,11 @@ import { writeJSONL } from "./jsonl.js";
 import { createFindObject, createObjectResultPage } from "../object/objects.js";
 import { createPageCursorObject } from "../object/page-cursor.js";
 import type { ArchiveOutputContext, ResultFormat } from "../object/types.js";
+import {
+  createOutputWarnings,
+  createWarningJSONLObject,
+  formatOutputWarnings,
+} from "./warnings.js";
 
 export async function writeFindHits(
   result: ArchiveFindResult,
@@ -27,25 +32,34 @@ export async function writeFindHits(
     context,
     result.nextCursor,
   );
+  const warnings = createOutputWarnings(context);
 
   if (format === "json") {
     await writeTextToStdout(
-      formatCLIJSON(createObjectResultPage(objects, nextCursor, result.limit)),
+      formatCLIJSON(
+        createObjectResultPage(objects, nextCursor, result.limit, warnings),
+      ),
     );
     return;
   }
   if (format === "jsonl") {
-    await writeJSONL([...objects, createPageCursorObject(nextCursor)]);
+    await writeJSONL([
+      ...warnings.map(createWarningJSONLObject),
+      ...objects,
+      createPageCursorObject(nextCursor),
+    ]);
     return;
   }
 
   if (objects.length === 0) {
-    await writeTextToStdout(formatNoMatches(result));
+    await writeTextToStdout(
+      `${formatOutputWarnings(warnings)}${formatNoMatches(result)}`,
+    );
     return;
   }
 
   await writeTextToStdout(
-    `${objects
+    `${formatOutputWarnings(warnings)}${objects
       .map((object) => formatFindObject(object))
       .join(
         getListObjectSeparator(objects),
@@ -93,25 +107,30 @@ export async function writeFindHitsWithoutContinuation(
   const objects = await Promise.all(
     result.items.map(async (item) => await createFindObject(item, context)),
   );
+  const warnings = createOutputWarnings(context);
 
   if (format === "json") {
     await writeTextToStdout(
-      formatCLIJSON(createObjectResultPage(objects, null, result.limit)),
+      formatCLIJSON(
+        createObjectResultPage(objects, null, result.limit, warnings),
+      ),
     );
     return;
   }
   if (format === "jsonl") {
-    await writeJSONL(objects);
+    await writeJSONL([...warnings.map(createWarningJSONLObject), ...objects]);
     return;
   }
 
   if (objects.length === 0) {
-    await writeTextToStdout(formatNoMatches(result));
+    await writeTextToStdout(
+      `${formatOutputWarnings(warnings)}${formatNoMatches(result)}`,
+    );
     return;
   }
 
   await writeTextToStdout(
-    `${objects
+    `${formatOutputWarnings(warnings)}${objects
       .map((object) => formatFindObject(object))
       .join(getListObjectSeparator(objects))}${formatFindLensHint(result)}\n`,
   );

--- a/packages/cli/src/commands/archive-output/write/find.ts
+++ b/packages/cli/src/commands/archive-output/write/find.ts
@@ -79,7 +79,9 @@ export async function writeAllFindHits(
     const page = await readPage(cursor);
 
     if (format === "jsonl") {
-      await writeFindHitsWithoutContinuation(page, context, format);
+      await writeFindHitsWithoutContinuation(page, context, format, {
+        emitWarnings: cursor === undefined,
+      });
     } else {
       pages.push(page);
     }
@@ -103,11 +105,13 @@ export async function writeFindHitsWithoutContinuation(
   result: ArchiveFindResult,
   context: ArchiveOutputContext,
   format: ResultFormat,
+  options: { readonly emitWarnings?: boolean } = {},
 ): Promise<void> {
   const objects = await Promise.all(
     result.items.map(async (item) => await createFindObject(item, context)),
   );
-  const warnings = createOutputWarnings(context);
+  const warnings =
+    (options.emitWarnings ?? true) ? createOutputWarnings(context) : [];
 
   if (format === "json") {
     await writeTextToStdout(

--- a/packages/cli/src/commands/archive-output/write/list.ts
+++ b/packages/cli/src/commands/archive-output/write/list.ts
@@ -12,6 +12,11 @@ import { writeJSONL } from "./jsonl.js";
 import { createListObject, createObjectResultPage } from "../object/objects.js";
 import { createPageCursorObject } from "../object/page-cursor.js";
 import type { ArchiveOutputContext, ResultFormat } from "../object/types.js";
+import {
+  createOutputWarnings,
+  createWarningJSONLObject,
+  formatOutputWarnings,
+} from "./warnings.js";
 
 export async function writeList(
   result: ArchiveRelatedResult,
@@ -25,25 +30,32 @@ export async function writeList(
     context,
     result.nextCursor,
   );
+  const warnings = createOutputWarnings(context);
 
   if (format === "json") {
     await writeTextToStdout(
-      formatCLIJSON(createObjectResultPage(objects, nextCursor, result.limit)),
+      formatCLIJSON(
+        createObjectResultPage(objects, nextCursor, result.limit, warnings),
+      ),
     );
     return;
   }
   if (format === "jsonl") {
-    await writeJSONL([...objects, createPageCursorObject(nextCursor)]);
+    await writeJSONL([
+      ...warnings.map(createWarningJSONLObject),
+      ...objects,
+      createPageCursorObject(nextCursor),
+    ]);
     return;
   }
 
   if (objects.length === 0) {
-    await writeTextToStdout("No objects.\n");
+    await writeTextToStdout(`${formatOutputWarnings(warnings)}No objects.\n`);
     return;
   }
 
   await writeTextToStdout(
-    `${objects.map(formatFindObject).join(getListObjectSeparator(objects))}${formatOpenShortUriHint(objects, context)}${formatNextCursor(nextCursor)}\n`,
+    `${formatOutputWarnings(warnings)}${objects.map(formatFindObject).join(getListObjectSeparator(objects))}${formatOpenShortUriHint(objects, context)}${formatNextCursor(nextCursor)}\n`,
   );
 }
 
@@ -87,25 +99,28 @@ export async function writeListWithoutContinuation(
   const objects = await Promise.all(
     result.items.map(async (item) => await createListObject(item, context)),
   );
+  const warnings = createOutputWarnings(context);
 
   if (format === "json") {
     await writeTextToStdout(
-      formatCLIJSON(createObjectResultPage(objects, null, result.limit)),
+      formatCLIJSON(
+        createObjectResultPage(objects, null, result.limit, warnings),
+      ),
     );
     return;
   }
   if (format === "jsonl") {
-    await writeJSONL(objects);
+    await writeJSONL([...warnings.map(createWarningJSONLObject), ...objects]);
     return;
   }
 
   if (objects.length === 0) {
-    await writeTextToStdout("No objects.\n");
+    await writeTextToStdout(`${formatOutputWarnings(warnings)}No objects.\n`);
     return;
   }
 
   await writeTextToStdout(
-    `${objects.map(formatFindObject).join(getListObjectSeparator(objects))}\n`,
+    `${formatOutputWarnings(warnings)}${objects.map(formatFindObject).join(getListObjectSeparator(objects))}\n`,
   );
 }
 

--- a/packages/cli/src/commands/archive-output/write/list.ts
+++ b/packages/cli/src/commands/archive-output/write/list.ts
@@ -72,7 +72,9 @@ export async function writeAllRelatedItems(
     const page = await readPage(cursor);
 
     if (format === "jsonl") {
-      await writeListWithoutContinuation(page, context, format);
+      await writeListWithoutContinuation(page, context, format, {
+        emitWarnings: cursor === initialCursor,
+      });
     } else {
       pages.push(page);
     }
@@ -95,11 +97,13 @@ export async function writeListWithoutContinuation(
   result: ArchiveRelatedResult,
   context: ArchiveOutputContext,
   format: ResultFormat,
+  options: { readonly emitWarnings?: boolean } = {},
 ): Promise<void> {
   const objects = await Promise.all(
     result.items.map(async (item) => await createListObject(item, context)),
   );
-  const warnings = createOutputWarnings(context);
+  const warnings =
+    (options.emitWarnings ?? true) ? createOutputWarnings(context) : [];
 
   if (format === "json") {
     await writeTextToStdout(

--- a/packages/cli/src/commands/archive-output/write/warnings.ts
+++ b/packages/cli/src/commands/archive-output/write/warnings.ts
@@ -1,0 +1,42 @@
+import type { ArchiveOutputContext } from "../object/types.js";
+
+export function createOutputWarnings(
+  context: ArchiveOutputContext,
+): readonly { readonly message: string; readonly type: "skip-unindexed" }[] {
+  if (context.skipUnindexed !== true) {
+    return [];
+  }
+
+  return [
+    {
+      message:
+        "--skip-unindexed was used; this command searched only chapters that already have a current FTS or source embedding index artifact. Run `inspect` to check index coverage before treating missing results as missing knowledge.",
+      type: "skip-unindexed",
+    },
+  ];
+}
+
+export function formatOutputWarnings(
+  warnings: readonly { readonly message: string }[],
+): string {
+  if (warnings.length === 0) {
+    return "";
+  }
+
+  return `${warnings.map((warning) => `Warning: ${warning.message}`).join("\n")}\n\n`;
+}
+
+export function createWarningJSONLObject(warning: {
+  readonly message: string;
+  readonly type: "skip-unindexed";
+}): {
+  readonly message: string;
+  readonly type: "warning";
+  readonly warning: "skip-unindexed";
+} {
+  return {
+    message: warning.message,
+    type: "warning",
+    warning: warning.type,
+  };
+}

--- a/packages/cli/src/commands/queue/output.ts
+++ b/packages/cli/src/commands/queue/output.ts
@@ -94,6 +94,14 @@ function formatJobJSON(job: BuildJob): Record<string, unknown> {
   };
 }
 
+export function formatJobQueuedNotice(job: BuildJob): string | undefined {
+  if (job.state !== "queued") {
+    return undefined;
+  }
+
+  return "Job is queued; the requested artifact or generated data is not ready until the job succeeds.";
+}
+
 function formatJobLLMJSON(value: string): unknown {
   let parsed: unknown;
 
@@ -162,6 +170,9 @@ export async function writeJobSummary(
     await writeTextToStdout(
       formatCLIJSON({
         ...formatJobJSON(job),
+        ...(formatJobQueuedNotice(job) === undefined
+          ? {}
+          : { notice: formatJobQueuedNotice(job) }),
         ...(options.estimate === undefined
           ? {}
           : { estimate: formatQueueAddEstimateJSON(options.estimate) }),
@@ -181,6 +192,9 @@ export async function writeJobSummary(
   await writeTextToStdout(
     [
       `Job ${job.jobId} ${job.state} ${job.target} chapter ${job.chapterId} ${job.archivePath}`,
+      ...(formatJobQueuedNotice(job) === undefined
+        ? []
+        : [formatJobQueuedNotice(job)!]),
       ...(options.watch === true
         ? [
             `Watch: ${formatCliCommand([

--- a/packages/cli/src/commands/queue/worker.ts
+++ b/packages/cli/src/commands/queue/worker.ts
@@ -45,6 +45,37 @@ import {
 import { buildSearchIndexEmbeddingProvider } from "../../runtime/embedding.js";
 import { CLI_HELP_ROUTES, withHelpRoute } from "../../support/index.js";
 
+interface IndexArtifactJobChunkSnapshot {
+  readonly content: string;
+  readonly id: number;
+  readonly label: string;
+  readonly wordsCount: number;
+}
+
+interface IndexArtifactJobMentionSnapshot {
+  readonly id: string;
+  readonly qid: string;
+  readonly surface: string;
+}
+
+interface IndexArtifactJobTocItemSnapshot {
+  readonly children: readonly IndexArtifactJobTocItemSnapshot[];
+  readonly serialId?: number | undefined;
+  readonly title?: string | null | undefined;
+}
+
+interface IndexArtifactJobSnapshot {
+  readonly chapterTitles: readonly {
+    readonly id: number;
+    readonly title: string;
+  }[];
+  readonly chunks: readonly IndexArtifactJobChunkSnapshot[];
+  readonly mentions: readonly IndexArtifactJobMentionSnapshot[];
+  readonly revision: number;
+  readonly sentences: readonly SentenceRecord[];
+  readonly summarySentences: readonly SentenceRecord[];
+}
+
 export async function runQueueWorker(): Promise<void> {
   const config = await loadCLIConfig();
 
@@ -360,9 +391,13 @@ async function executeIndexArtifactBuildJob(
     await writeIndexArtifactOutput(
       outputPath,
       createFtsIndexArtifactInput({
+        chapterTitles: snapshot.chapterTitles,
+        chunks: snapshot.chunks,
+        mentions: snapshot.mentions,
         sentences: snapshot.sentences,
         serialId: job.chapterId,
         sourceRevision: snapshot.revision,
+        summarySentences: snapshot.summarySentences,
       }),
     );
     const artifact = await readIndexArtifactOutput(outputPath);
@@ -433,10 +468,9 @@ async function completeIndexArtifactStep(
   assertJobStillRunning(await getBuildJob(job.jobId));
 }
 
-async function readIndexArtifactJobSnapshot(job: BuildJob): Promise<{
-  readonly revision: number;
-  readonly sentences: readonly SentenceRecord[];
-}> {
+async function readIndexArtifactJobSnapshot(
+  job: BuildJob,
+): Promise<IndexArtifactJobSnapshot> {
   return await new WikiGraphArchiveFile(job.archivePath).readDocument(
     async (document) => {
       await assertJobChapterExists(document, job.chapterId);
@@ -458,12 +492,70 @@ async function readIndexArtifactJobSnapshot(job: BuildJob): Promise<{
         throw new Error("Text stream does not expose sentence listing.");
       }
 
+      const sentences = await stream.listSentences();
+      if (job.target !== "index-fts") {
+        return {
+          chapterTitles: [],
+          chunks: [],
+          mentions: [],
+          revision,
+          sentences,
+          summarySentences: [],
+        };
+      }
+
       return {
+        chapterTitles: await readChapterTitles(document, job.chapterId),
+        chunks: await document.chunks.listBySerial(job.chapterId),
+        mentions: await document.mentions.listByChapter(job.chapterId),
         revision,
-        sentences: await stream.listSentences(),
+        sentences,
+        summarySentences: await listTextStreamSentences(
+          document.getSummaryFragments(job.chapterId),
+        ),
       };
     },
   );
+}
+
+async function listTextStreamSentences(stream: {
+  readonly listSentences?: () => Promise<readonly SentenceRecord[]>;
+}): Promise<readonly SentenceRecord[]> {
+  if (stream.listSentences === undefined) {
+    throw new Error("Text stream does not expose sentence listing.");
+  }
+
+  return await stream.listSentences();
+}
+
+async function readChapterTitles(
+  document: ReadonlyDocument,
+  serialId: number,
+): Promise<readonly { readonly id: number; readonly title: string }[]> {
+  const reader = document as ReadonlyDocument & {
+    readonly readToc?: () => Promise<
+      { readonly items: readonly IndexArtifactJobTocItemSnapshot[] } | undefined
+    >;
+  };
+  const toc = await reader.readToc?.();
+  if (toc === undefined) {
+    return [];
+  }
+
+  const chapter = collectTocItems(toc.items).find(
+    (item) => item.serialId === serialId,
+  );
+  if (chapter === undefined || typeof chapter.title !== "string") {
+    return [];
+  }
+
+  return [{ id: serialId, title: chapter.title }];
+}
+
+function collectTocItems(
+  items: readonly IndexArtifactJobTocItemSnapshot[],
+): readonly IndexArtifactJobTocItemSnapshot[] {
+  return items.flatMap((item) => [item, ...collectTocItems(item.children)]);
 }
 
 function resolveIndexArtifactOutputPath(job: BuildJob): string {

--- a/packages/cli/src/commands/queue/worker.ts
+++ b/packages/cli/src/commands/queue/worker.ts
@@ -8,10 +8,11 @@ import {
   commitChapterKnowledgeGraphArtifact,
   commitChapterSummaryArtifact,
   createEmbeddingIndexArtifactInput,
+  createFtsIndexArtifactInput,
   createDisambiguationProfileNormalizer,
   generateChapterKnowledgeGraphArtifactFromSnapshot,
   getBuildJob,
-  replaceChapterFtsIndexArtifact,
+  readIndexArtifactOutput,
   readChapterBuildInput,
   recordBuildJobInputRevision,
   runBuildJobWorker,
@@ -20,7 +21,9 @@ import {
   type BuildJob,
   type BuildJobExecutionContext,
   type BuildJobProgressReporter,
+  type IndexArtifactOutput,
   type SentenceRecord,
+  writeIndexArtifactOutput,
 } from "wiki-graph-core";
 import { WikiGraphArchiveFile } from "wiki-graph-core";
 import type {
@@ -29,6 +32,7 @@ import type {
   ReadonlyDocument,
 } from "wiki-graph-core";
 import type { LLMessage } from "wiki-graph-core";
+import { join } from "path";
 
 import { loadCLIConfig, type CLIConfig } from "../../runtime/config.js";
 import {
@@ -352,11 +356,26 @@ async function executeIndexArtifactBuildJob(
   });
 
   if (job.target === "index-fts") {
+    const outputPath = resolveIndexArtifactOutputPath(job);
+    await writeIndexArtifactOutput(
+      outputPath,
+      createFtsIndexArtifactInput({
+        sentences: snapshot.sentences,
+        serialId: job.chapterId,
+        sourceRevision: snapshot.revision,
+      }),
+    );
+    const artifact = await readIndexArtifactOutput(outputPath);
+
+    assertIndexArtifactOutputMatchesJob(job, snapshot.revision, artifact);
+    if (!("lexicalRows" in artifact)) {
+      throw new Error("Index artifact output is not an FTS artifact.");
+    }
     await new WikiGraphArchiveFile(job.archivePath).write(async (document) => {
       assertJobStillRunning(await getBuildJob(job.jobId));
       await assertJobChapterExists(document, job.chapterId);
       await assertCurrentBuildInputRevision(job, document);
-      await replaceChapterFtsIndexArtifact(document, job.chapterId);
+      await document.indexArtifacts.replaceFts(artifact);
     });
     await completeIndexArtifactStep(job, reporter);
     return;
@@ -371,6 +390,7 @@ async function executeIndexArtifactBuildJob(
       ),
     );
   }
+  const outputPath = resolveIndexArtifactOutputPath(job);
   const artifact = await createEmbeddingIndexArtifactInput({
     embeddingProvider: buildSearchIndexEmbeddingProvider(config.embedding),
     kind:
@@ -382,12 +402,19 @@ async function executeIndexArtifactBuildJob(
     signal: context.signal,
     sourceRevision: snapshot.revision,
   });
+  await writeIndexArtifactOutput(outputPath, artifact);
+  const output = await readIndexArtifactOutput(outputPath);
+
+  assertIndexArtifactOutputMatchesJob(job, snapshot.revision, output);
+  if ("lexicalRows" in output) {
+    throw new Error("Index artifact output is not an embedding artifact.");
+  }
 
   await new WikiGraphArchiveFile(job.archivePath).write(async (document) => {
     assertJobStillRunning(await getBuildJob(job.jobId));
     await assertJobChapterExists(document, job.chapterId);
     await assertCurrentBuildInputRevision(job, document);
-    await document.indexArtifacts.replaceEmbedding(artifact);
+    await document.indexArtifacts.replaceEmbedding(output);
   });
   await completeIndexArtifactStep(job, reporter);
 }
@@ -414,9 +441,6 @@ async function readIndexArtifactJobSnapshot(job: BuildJob): Promise<{
     async (document) => {
       await assertJobChapterExists(document, job.chapterId);
       const revision = await document.serials.getRevision(job.chapterId);
-      if (job.target === "index-fts") {
-        return { revision, sentences: [] };
-      }
       const stream =
         job.target === "index-embedding-summary"
           ? document.getSummaryFragments(job.chapterId)
@@ -439,6 +463,51 @@ async function readIndexArtifactJobSnapshot(job: BuildJob): Promise<{
         sentences: await stream.listSentences(),
       };
     },
+  );
+}
+
+function resolveIndexArtifactOutputPath(job: BuildJob): string {
+  return join(job.workspacePath, "index-artifact-output.jsonl");
+}
+
+function assertIndexArtifactOutputMatchesJob(
+  job: BuildJob,
+  inputRevision: number,
+  artifact: IndexArtifactOutput,
+): void {
+  if (artifact.serialId !== job.chapterId) {
+    throw new Error(
+      `Index artifact output targets chapter ${artifact.serialId}, expected chapter ${job.chapterId}.`,
+    );
+  }
+  if (artifact.sourceRevision !== inputRevision) {
+    throw new Error(
+      `Index artifact output targets input revision ${artifact.sourceRevision}, expected revision ${inputRevision}.`,
+    );
+  }
+
+  if (job.target === "index-fts") {
+    if ("lexicalRows" in artifact) {
+      return;
+    }
+
+    throw new Error("Index artifact output is not an FTS artifact.");
+  }
+  if ("lexicalRows" in artifact) {
+    throw new Error("Index artifact output is not an embedding artifact.");
+  }
+
+  const expectedKind =
+    job.target === "index-embedding-source"
+      ? "embedding-source"
+      : "embedding-summary";
+
+  if (artifact.kind === expectedKind) {
+    return;
+  }
+
+  throw new Error(
+    `Index artifact output kind ${artifact.kind} does not match ${job.target}.`,
   );
 }
 

--- a/packages/core/data/help/commands/library.jinja
+++ b/packages/core/data/help/commands/library.jinja
@@ -169,6 +169,7 @@ Default behavior:
   - `{{ commandName }} {{ uri }}` reads the library-wide scope collection.
   - Use `{{ commandName }} wikg://lib/registry` to list all library registries.
   - `{{ commandName }} {{ uri }} --query <query>` searches library-wide objects through the library index.
+  - Query is strict by default; add `--skip-unindexed` only to intentionally search indexed chapters and ignore uncovered chapters.
   - `{{ commandName }} {{ uri }}/arc scan` reconciles membership with `.wikg` files currently under the library folder.
   - Library-wide object scopes such as `/entity` and `/triple` query one object type through the library index after it is synced.
   - Archive object search must use an explicit lens such as `/entity`, `/triple`, `/chapter`, or `/chunk`.
@@ -192,6 +193,7 @@ Usage:
 {% if target.isDefault %}
   {{ commandName }} wikg://lib [--json]
   {{ commandName }} wikg://lib --query <query> [--limit <n>] [--cursor <cursor>] [--json]
+  {{ commandName }} wikg://lib --query <query> --skip-unindexed
   {{ commandName }} wikg://lib/chapter --query <query>
   {{ commandName }} wikg://lib/chunk --query <query>
   {{ commandName }} wikg://lib/registry add --path <folder> [--json]
@@ -206,6 +208,7 @@ Usage:
 {% else %}
   {{ commandName }} {{ uri }} [--json]
   {{ commandName }} {{ uri }} --query <query> [--limit <n>] [--cursor <cursor>] [--json]
+  {{ commandName }} {{ uri }} --query <query> --skip-unindexed
   {{ commandName }} {{ uri }}/chapter --query <query>
   {{ commandName }} {{ uri }}/chunk --query <query>
   {{ commandName }} {{ uri }}/arc scan [--json|--jsonl]

--- a/packages/core/data/help/commands/predicate.jinja
+++ b/packages/core/data/help/commands/predicate.jinja
@@ -14,12 +14,13 @@ Purpose:
   Expand from the current chunk or entity object to nearby objects.
 
 Usage:
-  {{ commandName }} {{ uri }} related [--query <query>] [--reverse] [--all] [--limit <n>] [--context <n>] [--cursor <token>] [--role <any|subject|object|self>] [--evidence [n]] [--json|--jsonl]
+  {{ commandName }} {{ uri }} related [--query <query>] [--skip-unindexed] [--reverse] [--all] [--limit <n>] [--context <n>] [--cursor <token>] [--role <any|subject|object|self>] [--evidence [n]] [--json|--jsonl]
 
 Notes:
   - Chunk targets return nearby Reading Graph chunks.
   - Entity targets return Knowledge Graph triples involving the entity.
   - `--query` filters and ranks related results with the current search index.
+  - Add `--skip-unindexed` only with `--query` when you intentionally want to search indexed chapters and ignore uncovered chapters.
   - Without `--query`, `--reverse` reads Document Flow order backward. See `{{ commandName }} help uri`.
   - `--role` only applies to entity targets.
   - Use `{{ commandName }} {{ uri }} evidence --help` when source grounding is the main goal.
@@ -28,11 +29,12 @@ Purpose:
   Trace the current object back to source-backed evidence.
 
 Usage:
-  {{ commandName }} {{ uri }} evidence [--query <query>] [--reverse] [--all] [--limit <n>] [--context <n>] [--cursor <token>] [--json|--jsonl]
+  {{ commandName }} {{ uri }} evidence [--query <query>] [--skip-unindexed] [--reverse] [--all] [--limit <n>] [--context <n>] [--json|--jsonl]
 
 Notes:
   - Evidence is for grounding, verification, and citation support.
   - `--query` filters and ranks evidence with the current search index.
+  - Add `--skip-unindexed` only with `--query` when you intentionally want to search indexed chapters and ignore uncovered chapters.
   - Without `--query`, `--reverse` reads Document Flow order backward. See `{{ commandName }} help uri`.
   - Evidence previews include nearby source context by default; use `--context 0` for exact cited ranges.
   - Source and scope URIs are not evidence targets.

--- a/packages/core/data/help/commands/predicate.jinja
+++ b/packages/core/data/help/commands/predicate.jinja
@@ -111,7 +111,8 @@ Usage:
   {{ commandName }} {{ uri }} build [--json]
 
 Notes:
-  - This command returns after the job is queued. Use the returned job id with `wg wikg://local/job/<job-id> watch` to follow progress.
+  - This command enqueues work; it does not wait for the artifact to be built.
+  - A queued response means the artifact is not ready yet. Use the returned job id with `wg wikg://local/job/<job-id> watch` to follow progress.
   - FTS artifacts are local compilation work and do not call a provider.
   - Source and summary embedding artifacts require `wikg://local/config/embeddings` and may call the configured provider.
   - Direct artifact build is an explicit build request; it does not use `--accept-cost`.
@@ -456,6 +457,11 @@ Purpose:
 
 Usage:
   {{ commandName }} {{ uri }} resume
+
+Notes:
+  - Paused jobs move back to queued.
+  - Queued jobs are already resumable work; `resume` leaves them queued and asks the local worker to pick up the queue.
+  - Finished, failed, canceled, and canceling jobs cannot be resumed.
 {% elif predicate == "cancel" %}
 Purpose:
   Cancel this local job.

--- a/packages/core/data/help/commands/predicate.jinja
+++ b/packages/core/data/help/commands/predicate.jinja
@@ -103,12 +103,13 @@ Notes:
 {% endif %}
 {% elif predicate == "build" and target.name == "chapter-index-artifact" %}
 Purpose:
-  Build or replace this chapter index artifact.
+  Queue a job to build or replace this chapter index artifact.
 
 Usage:
   {{ commandName }} {{ uri }} build [--json]
 
 Notes:
+  - This command returns after the job is queued. Use the returned job id with `wg wikg://local/job/<job-id> watch` to follow progress.
   - FTS artifacts are local compilation work and do not call a provider.
   - Source and summary embedding artifacts require `wikg://local/config/embeddings` and may call the configured provider.
   - Direct artifact build is an explicit build request; it does not use `--accept-cost`.

--- a/packages/core/data/help/commands/predicate.jinja
+++ b/packages/core/data/help/commands/predicate.jinja
@@ -403,12 +403,13 @@ Purpose:
   Sync this archive index cache from chapter index artifacts.
 
 Usage:
-  {{ commandName }} {{ uri }} sync [--jsonl]
+  {{ commandName }} {{ uri }} sync [--jsonl] [--skip-unindexed]
 
 Notes:
   - This initializes or repairs the local `index.db` cache outside the `.wikg` archive.
   - It reads chapter index artifacts from the archive and does not call an embeddings provider.
   - If required chapter artifacts are missing, sync reports that artifact readiness problem instead of building them.
+  - Add `--skip-unindexed` only when you intentionally want the cache to include indexed chapters and ignore uncovered chapters.
   - Free archive query can lazy-sync this cache, but explicit sync avoids the first-query delay.
   - With `--jsonl`, progress is emitted as line-delimited event records.
 {% endif %}

--- a/packages/core/data/help/commands/uri.jinja
+++ b/packages/core/data/help/commands/uri.jinja
@@ -13,6 +13,7 @@ URI type:
 Default behavior:
   - `{{ commandName }} {{ uri }}` enumerates archive-level objects.
   - `{{ commandName }} {{ uri }} --query <query>` applies search index retrieval across archive scopes.
+  - Query is strict by default; add `--skip-unindexed` only to intentionally search indexed chapters and ignore uncovered chapters.
 
 Use when:
   - You need the archive entry point before narrowing to chapters, chunks, entities, triples, source, or summaries.
@@ -29,6 +30,7 @@ URI type:
 Default behavior:
   - `{{ commandName }} {{ uri }}` enumerates chapters.
   - `{{ commandName }} {{ uri }} --query <query>` applies search index retrieval to chapter objects.
+  - Query is strict by default; add `--skip-unindexed` only to intentionally search indexed chapters and ignore uncovered chapters.
   - Chapter collection scope covers the full chapter tree by default; use `--depth 0` for root-level chapters only.
   - Chapter path URIs are the public CLI handles; internal chapter ids are not command targets.
 
@@ -41,6 +43,7 @@ URI type:
 Default behavior:
   - `{{ commandName }} {{ uri }}` enumerates objects inside this chapter subtree.
   - `{{ commandName }} {{ uri }} --query <query>` applies search index retrieval inside this chapter subtree.
+  - Query is strict by default; add `--skip-unindexed` only to intentionally search indexed chapters and ignore uncovered chapters.
   - Use `--depth 0` to restrict the scope to this chapter only; `--depth 1` includes direct children.
   - The path in this URI is the public CLI handle for the chapter; internal chapter ids are not command targets.
 
@@ -53,6 +56,7 @@ URI type:
 Default behavior:
   - `{{ commandName }} {{ uri }}` enumerates Reading Graph chunks.
   - `{{ commandName }} {{ uri }} --query <query>` applies search index retrieval to chunks in this scope.
+  - Query is strict by default; add `--skip-unindexed` only to intentionally search indexed chapters and ignore uncovered chapters.
 {% if uriContext.isChapterQualified %}
   - This chapter-qualified scope covers the selected chapter subtree by default.
   - Use `--depth 0` for only the selected chapter, or `--depth 1` for the selected chapter plus direct children.
@@ -70,6 +74,7 @@ URI type:
 Default behavior:
   - `{{ commandName }} {{ uri }}` enumerates Knowledge Graph entities.
   - `{{ commandName }} {{ uri }} --query <query>` applies search index retrieval to entities in this scope.
+  - Query is strict by default; add `--skip-unindexed` only to intentionally search indexed chapters and ignore uncovered chapters.
 {% if uriContext.isChapterQualified %}
   - This chapter-qualified scope covers the selected chapter subtree by default.
   - Use `--depth 0` for only the selected chapter, or `--depth 1` for the selected chapter plus direct children.
@@ -87,6 +92,7 @@ URI type:
 Default behavior:
   - `{{ commandName }} {{ uri }}` enumerates Knowledge Graph triples matching this scope or pattern.
   - `{{ commandName }} {{ uri }} --query <query>` applies search index retrieval to triples in this scope.
+  - Query is strict by default; add `--skip-unindexed` only to intentionally search indexed chapters and ignore uncovered chapters.
 {% if uriContext.isChapterQualified %}
   - This chapter-qualified scope covers the selected chapter subtree by default.
   - Use `--depth 0` for only the selected chapter, or `--depth 1` for the selected chapter plus direct children.

--- a/packages/core/data/help/topics/library.jinja
+++ b/packages/core/data/help/topics/library.jinja
@@ -54,6 +54,7 @@ Library-wide query:
   - `{{ commandName }} wikg://lib/entity --query <query>` searches across present archive members through the library index.
   - `{{ commandName }} wikg://lib/triple --query <query>` searches library-wide Knowledge Graph triples.
   - `{{ commandName }} wikg://lib/chunk --query <query>` searches library-wide Reading Graph chunks.
+  - Add `--skip-unindexed` only when you intentionally want to search indexed chapters and ignore uncovered chapters.
   - Library-wide object predicates such as `evidence`, `related`, and `pack` use the same aggregate library index.
   - Library-wide object URIs such as `wikg://lib/entity/<qid>` are aggregate views over matching objects from present archive members.
   - Evidence and related output should be interpreted with the returned archive/member provenance; cite the specific returned evidence or member, not just the library-wide URI.

--- a/packages/core/data/help/topics/readiness.jinja
+++ b/packages/core/data/help/topics/readiness.jinja
@@ -36,7 +36,8 @@ Archive index readiness:
     FTS artifact only: FTS query.
     Source embedding artifact only: semantic/Dense-only query.
     Both artifacts: Hybrid query with automatic fusion.
-    Missing both FTS and source embedding for any content chapter: ordinary query fails.
+    Missing both FTS and source embedding for any content chapter in scope: ordinary query fails.
+    Add `--skip-unindexed` to a scope query, `related --query`, or `evidence --query` only when you want to search indexed chapters and ignore uncovered chapters.
     Summary embedding artifacts are for summary semantic retrieval and are not the minimum requirement for ordinary source query.
 
   Commands:

--- a/packages/core/data/help/topics/uri.jinja
+++ b/packages/core/data/help/topics/uri.jinja
@@ -75,6 +75,8 @@ Common command shapes:
 Scope URIs:
   Scope URIs enumerate objects by default. With `--query <query>`, they apply search index retrieval within that scope.
   A chapter URI used as a scope covers that chapter's full subtree by default.
+  Query is strict by default: every chapter in scope must have a current FTS artifact or source embedding artifact.
+  Add `--skip-unindexed` only when you intentionally want to search indexed chapters and ignore uncovered chapters.
   Add `--depth <N>` to limit chapter subtree expansion:
     - no `--depth`: full subtree
     - `--depth 0`: only the current chapter, or root-level chapters for `<archive-uri>/chapter`
@@ -156,6 +158,7 @@ Literal source passages:
   Use `--query` on the narrowest useful scope when the task is to find source wording or passages mentioning a literal term:
     {{ commandName }} <archive-uri> --query "term"
     {{ commandName }} <archive-uri>/chapter/<path> --query "term"
+    {{ commandName }} <archive-uri> --query "term" --skip-unindexed
     {{ commandName }} <archive-uri>/chapter/<path>/source#20..30
 
 Entity-grounded evidence:

--- a/packages/core/src/api/chapter/generate.ts
+++ b/packages/core/src/api/chapter/generate.ts
@@ -31,7 +31,7 @@ export async function generateChapterGraph(
         ? {}
         : { logDirPath: options.logDirPath }),
     });
-    await openedDocument.clearSerialGraph(chapterId);
+    await openedDocument.clearSerialReadingGraph(chapterId);
 
     await generation.buildTopologyInto(
       chapterId,

--- a/packages/core/src/api/chapter/manage.ts
+++ b/packages/core/src/api/chapter/manage.ts
@@ -181,7 +181,7 @@ export async function resetChapter(
         await openedDocument.clearSerialSource(chapterId);
         break;
       case "sourced":
-        await openedDocument.clearSerialGraph(chapterId);
+        await openedDocument.clearSerialDerivedArtifacts(chapterId);
         break;
       case "graphed":
         await openedDocument.deleteSummary(chapterId);

--- a/packages/core/src/document/directory/core.ts
+++ b/packages/core/src/document/directory/core.ts
@@ -40,6 +40,8 @@ import {
 import { openSearchIndexDatabase } from "./search-index.js";
 import {
   deleteSerialGraphRecords,
+  deleteSerialKnowledgeGraphRecords,
+  deleteSerialReadingGraphRecords,
   deleteSerialResources,
   rollbackDocumentContext,
 } from "./serial-cleanup.js";
@@ -183,6 +185,11 @@ export class DirectoryDocument implements Document {
   }
 
   public async clearSerialGraph(serialId: number): Promise<void> {
+    await this.clearSerialDerivedArtifacts(serialId);
+  }
+
+  public async clearSerialDerivedArtifacts(serialId: number): Promise<void> {
+    await this.indexArtifacts.deleteBySerial(serialId);
     await this.deleteSummary(serialId);
     await deleteSerialGraphRecords({
       database: this.#database,
@@ -191,13 +198,33 @@ export class DirectoryDocument implements Document {
     });
     await this.serials.setTopologyReady(serialId, false);
     await this.serials.setKnowledgeGraphReady(serialId, false);
-    await this.serials.bumpRevision(serialId);
+    await this.graphBuildParameters.deleteUnreferenced();
+  }
+
+  public async clearSerialKnowledgeGraph(serialId: number): Promise<void> {
+    await this.indexArtifacts.delete(serialId, "fts");
+    await deleteSerialKnowledgeGraphRecords({
+      database: this.#database,
+      metadata: this.metadata,
+      serialId,
+    });
+    await this.serials.setKnowledgeGraphReady(serialId, false);
+    await this.graphBuildParameters.deleteUnreferenced();
+  }
+
+  public async clearSerialReadingGraph(serialId: number): Promise<void> {
+    await this.deleteSummary(serialId);
+    await deleteSerialReadingGraphRecords({
+      database: this.#database,
+      metadata: this.metadata,
+      serialId,
+    });
+    await this.serials.setTopologyReady(serialId, false);
     await this.graphBuildParameters.deleteUnreferenced();
   }
 
   public async clearSerialSource(serialId: number): Promise<void> {
-    await this.clearSerialGraph(serialId);
-    await this.indexArtifacts.deleteBySerial(serialId);
+    await this.clearSerialDerivedArtifacts(serialId);
     await this.#textStreams.getSerial(serialId).delete();
     await this.serials.bumpRevision(serialId);
   }
@@ -367,7 +394,6 @@ export class DirectoryDocument implements Document {
   public async writeSummary(serialId: number, summary: string): Promise<void> {
     await this.deleteSummary(serialId);
     await this.#textStreams.getSummarySerial(serialId).writeTextStream(summary);
-    await this.serials.bumpRevision(serialId);
   }
 
   public async writeToc(toc: TocFile): Promise<void> {

--- a/packages/core/src/document/directory/index-artifact-invalidation.test.ts
+++ b/packages/core/src/document/directory/index-artifact-invalidation.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 
 import type { Document } from "./index.js";
 import { DirectoryDocument } from "./index.js";
+import { writeSerialSource } from "../../text/serial/source.js";
 
 async function withDocument(
   operation: (document: DirectoryDocument) => Promise<void>,
@@ -30,11 +31,25 @@ describe("DirectoryDocument index artifact invalidation", () => {
       await document.openSession(async (openedDocument) => {
         const serialId = await openedDocument.createSerial();
 
+        await seedKnowledgeGraph(openedDocument, serialId);
+        await seedReadingGraph(openedDocument, serialId);
+        await openedDocument.writeSummary(serialId, "Summary.");
         await saveAllArtifactKinds(openedDocument, serialId);
+        const revision = await openedDocument.serials.getRevision(serialId);
 
         await openedDocument.clearSerialSource(serialId);
 
         expect(await openedDocument.indexArtifacts.list()).toStrictEqual([]);
+        expect(
+          await openedDocument.mentions.listByChapter(serialId),
+        ).toStrictEqual([]);
+        expect(
+          await openedDocument.readingEdges.listBySerial(serialId),
+        ).toStrictEqual([]);
+        expect(await openedDocument.readSummary(serialId)).toBeUndefined();
+        expect(await openedDocument.serials.getRevision(serialId)).toBe(
+          revision + 1,
+        );
       });
     });
   });
@@ -45,6 +60,9 @@ describe("DirectoryDocument index artifact invalidation", () => {
         const serialId = await openedDocument.createSerial();
 
         await saveAllArtifactKinds(openedDocument, serialId);
+        await seedKnowledgeGraph(openedDocument, serialId);
+        await seedReadingGraph(openedDocument, serialId);
+        const revision = await openedDocument.serials.getRevision(serialId);
 
         await openedDocument.writeSummary(serialId, "A new summary.");
 
@@ -60,6 +78,121 @@ describe("DirectoryDocument index artifact invalidation", () => {
             "embedding-summary",
           ),
         ).toBeUndefined();
+        expect(
+          await openedDocument.mentions.listByChapter(serialId),
+        ).toHaveLength(1);
+        expect(
+          await openedDocument.readingEdges.listBySerial(serialId),
+        ).toHaveLength(1);
+        expect(await openedDocument.serials.getRevision(serialId)).toBe(
+          revision,
+        );
+      });
+    });
+  });
+
+  it("keeps knowledge graph when reading graph is cleared", async () => {
+    await withDocument(async (document) => {
+      await document.openSession(async (openedDocument) => {
+        const serialId = await openedDocument.createSerial();
+
+        await seedKnowledgeGraph(openedDocument, serialId);
+        await seedReadingGraph(openedDocument, serialId);
+        await openedDocument.writeSummary(serialId, "Summary.");
+        await saveAllArtifactKinds(openedDocument, serialId);
+        const revision = await openedDocument.serials.getRevision(serialId);
+
+        await openedDocument.clearSerialReadingGraph(serialId);
+
+        expect(
+          await openedDocument.indexArtifacts.get(serialId, "fts"),
+        ).toBeUndefined();
+        expect(
+          await openedDocument.indexArtifacts.get(serialId, "embedding-source"),
+        ).toBeDefined();
+        expect(
+          await openedDocument.indexArtifacts.get(
+            serialId,
+            "embedding-summary",
+          ),
+        ).toBeUndefined();
+        expect(
+          await openedDocument.mentions.listByChapter(serialId),
+        ).toHaveLength(1);
+        expect(
+          await openedDocument.readingEdges.listBySerial(serialId),
+        ).toStrictEqual([]);
+        expect(await openedDocument.readSummary(serialId)).toBeUndefined();
+        expect(await openedDocument.serials.getRevision(serialId)).toBe(
+          revision,
+        );
+      });
+    });
+  });
+
+  it("keeps reading graph and summary when knowledge graph is cleared", async () => {
+    await withDocument(async (document) => {
+      await document.openSession(async (openedDocument) => {
+        const serialId = await openedDocument.createSerial();
+
+        await seedKnowledgeGraph(openedDocument, serialId);
+        await seedReadingGraph(openedDocument, serialId);
+        await openedDocument.writeSummary(serialId, "Summary.");
+        await saveAllArtifactKinds(openedDocument, serialId);
+        const revision = await openedDocument.serials.getRevision(serialId);
+
+        await openedDocument.clearSerialKnowledgeGraph(serialId);
+
+        expect(
+          await openedDocument.indexArtifacts.get(serialId, "fts"),
+        ).toBeUndefined();
+        expect(
+          await openedDocument.indexArtifacts.get(serialId, "embedding-source"),
+        ).toBeDefined();
+        expect(
+          await openedDocument.indexArtifacts.get(
+            serialId,
+            "embedding-summary",
+          ),
+        ).toBeDefined();
+        expect(
+          await openedDocument.mentions.listByChapter(serialId),
+        ).toStrictEqual([]);
+        expect(
+          await openedDocument.readingEdges.listBySerial(serialId),
+        ).toHaveLength(1);
+        expect(await openedDocument.readSummary(serialId)).toBe("Summary.");
+        expect(await openedDocument.serials.getRevision(serialId)).toBe(
+          revision,
+        );
+      });
+    });
+  });
+
+  it("deletes derived artifacts and bumps revision when source is replaced", async () => {
+    await withDocument(async (document) => {
+      await document.openSession(async (openedDocument) => {
+        const serialId = await openedDocument.createSerial();
+
+        await saveAllArtifactKinds(openedDocument, serialId);
+        await seedKnowledgeGraph(openedDocument, serialId);
+        await seedReadingGraph(openedDocument, serialId);
+        await openedDocument.writeSummary(serialId, "Summary.");
+        const revision = await openedDocument.serials.getRevision(serialId);
+
+        await writeSerialSource(openedDocument, serialId, ["Replacement."]);
+
+        expect(await openedDocument.indexArtifacts.list()).toStrictEqual([]);
+        expect(
+          await openedDocument.mentions.listByChapter(serialId),
+        ).toStrictEqual([]);
+        expect(
+          await openedDocument.readingEdges.listBySerial(serialId),
+        ).toStrictEqual([]);
+        expect(await openedDocument.readSummary(serialId)).toBeUndefined();
+        expect(await openedDocument.serials.getRevision(serialId)).toBe(
+          revision + 1,
+        );
       });
     });
   });
@@ -100,4 +233,52 @@ async function saveAllArtifactKinds(
     serialId,
     sourceRevision: 0,
   });
+}
+
+async function seedKnowledgeGraph(
+  document: Document,
+  serialId: number,
+): Promise<void> {
+  await document.mentions.save({
+    chapterId: serialId,
+    id: `mention-${serialId}`,
+    qid: `entity-${serialId}`,
+    rangeEnd: 5,
+    rangeStart: 0,
+    sentenceIndex: 0,
+    surface: "Entity",
+  });
+  await document.serials.setKnowledgeGraphReady(serialId, true);
+}
+
+async function seedReadingGraph(
+  document: Document,
+  serialId: number,
+): Promise<void> {
+  await document.chunks.save({
+    content: "Reading chunk",
+    generation: 0,
+    id: serialId * 100,
+    label: "Chunk",
+    sentenceId: [serialId, 0],
+    sentenceIds: [[serialId, 0]],
+    wordsCount: 2,
+    weight: 1,
+  });
+  await document.chunks.save({
+    content: "Next chunk",
+    generation: 0,
+    id: serialId * 100 + 1,
+    label: "Next",
+    sentenceId: [serialId, 1],
+    sentenceIds: [[serialId, 1]],
+    wordsCount: 2,
+    weight: 1,
+  });
+  await document.readingEdges.save({
+    fromId: serialId * 100,
+    toId: serialId * 100 + 1,
+    weight: 1,
+  });
+  await document.serials.setTopologyReady(serialId, true);
 }

--- a/packages/core/src/document/directory/serial-cleanup.ts
+++ b/packages/core/src/document/directory/serial-cleanup.ts
@@ -71,6 +71,17 @@ export async function deleteSerialGraphRecords(input: {
   readonly serialId: number;
 }): Promise<void> {
   await input.database.transaction(async () => {
+    await deleteSerialKnowledgeGraphRecords(input);
+    await deleteSerialReadingGraphRecords(input);
+  });
+}
+
+export async function deleteSerialKnowledgeGraphRecords(input: {
+  readonly database: Database;
+  readonly metadata: ObjectMetadataStore;
+  readonly serialId: number;
+}): Promise<void> {
+  await input.database.transaction(async () => {
     await input.database.run(
       `
         DELETE FROM mention_link_evidence_sentences
@@ -109,6 +120,16 @@ export async function deleteSerialGraphRecords(input: {
       `,
       [input.serialId],
     );
+    await input.metadata.deleteDeletedEntitiesAndTriples();
+  });
+}
+
+export async function deleteSerialReadingGraphRecords(input: {
+  readonly database: Database;
+  readonly metadata: ObjectMetadataStore;
+  readonly serialId: number;
+}): Promise<void> {
+  await input.database.transaction(async () => {
     await input.database.run(
       `
         DELETE FROM snake_edges
@@ -179,7 +200,6 @@ export async function deleteSerialGraphRecords(input: {
       [input.serialId],
     );
     await input.metadata.deleteDeletedChunks();
-    await input.metadata.deleteDeletedEntitiesAndTriples();
   });
 }
 

--- a/packages/core/src/document/directory/types.ts
+++ b/packages/core/src/document/directory/types.ts
@@ -112,7 +112,10 @@ export interface Document extends ReadonlyDocument {
   getSerialFragments(serialId: number): SerialTextStream;
   getSummaryFragments(serialId: number): SerialTextStream;
   createSerial(): Promise<number>;
+  clearSerialDerivedArtifacts(serialId: number): Promise<void>;
   clearSerialGraph(serialId: number): Promise<void>;
+  clearSerialKnowledgeGraph(serialId: number): Promise<void>;
+  clearSerialReadingGraph(serialId: number): Promise<void>;
   clearSerialSource(serialId: number): Promise<void>;
   deleteSerial(serialId: number): Promise<void>;
   deleteSearchIndexDatabase(): Promise<void>;

--- a/packages/core/src/document/fragments/sentence.ts
+++ b/packages/core/src/document/fragments/sentence.ts
@@ -1,3 +1,4 @@
+import { countTextWords } from "../../utils/text-word-count.js";
 import type { SentenceRecord } from "../types.js";
 
 export function splitTextIntoSentences(
@@ -9,12 +10,6 @@ export function splitTextIntoSentences(
     .filter((sentence) => sentence !== "")
     .map((sentence) => ({
       text: sentence,
-      wordsCount: countWords(sentence),
+      wordsCount: countTextWords(sentence),
     }));
-}
-
-function countWords(text: string): number {
-  const trimmed = text.trim();
-
-  return trimmed === "" ? 0 : trimmed.split(/\s+/u).length;
 }

--- a/packages/core/src/document/text-streams/sentence.ts
+++ b/packages/core/src/document/text-streams/sentence.ts
@@ -1,3 +1,4 @@
+import { countTextWords } from "../../utils/text-word-count.js";
 import { Sentence, type SentenceRecord } from "../types.js";
 import type { TextStreamSentenceSegmenter } from "./types.js";
 
@@ -29,7 +30,7 @@ export async function splitTextIntoSentenceSpans(
     if (rawText.trim() === "") {
       continue;
     }
-    const sentence = new Sentence(rawText, countWords(rawText));
+    const sentence = new Sentence(rawText, countTextWords(rawText));
 
     Object.assign(sentence, {
       byteLength: Buffer.byteLength(rawText, "utf8"),
@@ -98,12 +99,6 @@ function createSentenceSegmenter(): Intl.Segmenter {
   });
 
   return SENTENCE_SEGMENTER;
-}
-
-function countWords(text: string): number {
-  const trimmed = text.trim();
-
-  return trimmed === "" ? 0 : trimmed.split(/\s+/u).length;
 }
 
 export function getSentenceByteOffset(sentence: SentenceRecord): number {

--- a/packages/core/src/graph/knowledge-build/commit.ts
+++ b/packages/core/src/graph/knowledge-build/commit.ts
@@ -3,7 +3,7 @@ import {
   collectChapterKnowledgeGraphObjects,
   readWikgObjectsFromJsonl,
 } from "../../object-stream.js";
-import { refreshChapterFtsIndexArtifactIfPresent } from "../../retrieval/index-artifact/index.js";
+import { replaceChapterFtsIndexArtifact } from "../../retrieval/index-artifact/index.js";
 import { validateChapterKnowledgeGraphArtifact } from "./artifact-io.js";
 import type { ChapterKnowledgeGraphBuildArtifact } from "./types.js";
 
@@ -29,6 +29,9 @@ export async function commitChapterKnowledgeGraphArtifact(
     const existingLinks = await openedDocument.mentionLinks.listByChapter(
       artifact.chapterId,
     );
+    const hadFtsArtifact =
+      (await openedDocument.indexArtifacts.get(artifact.chapterId, "fts")) !==
+      undefined;
 
     if (existingLinks.length > 0 && mentionLinks.length === 0) {
       throw new Error(
@@ -36,8 +39,7 @@ export async function commitChapterKnowledgeGraphArtifact(
       );
     }
 
-    await openedDocument.mentionLinks.deleteByChapter(artifact.chapterId);
-    await openedDocument.mentions.deleteByChapter(artifact.chapterId);
+    await openedDocument.clearSerialKnowledgeGraph(artifact.chapterId);
     await openedDocument.mentions.saveMany(mentions);
     await openedDocument.mentionLinks.saveMany(mentionLinks);
     const savedParameter =
@@ -47,10 +49,9 @@ export async function commitChapterKnowledgeGraphArtifact(
       true,
       savedParameter.hash,
     );
-    await refreshChapterFtsIndexArtifactIfPresent(
-      openedDocument,
-      artifact.chapterId,
-    );
+    if (hadFtsArtifact) {
+      await replaceChapterFtsIndexArtifact(openedDocument, artifact.chapterId);
+    }
   });
 }
 
@@ -59,10 +60,6 @@ export async function clearChapterKnowledgeGraph(
   chapterId: number,
 ): Promise<void> {
   await document.openSession(async (openedDocument) => {
-    await openedDocument.mentionLinks.deleteByChapter(chapterId);
-    await openedDocument.mentions.deleteByChapter(chapterId);
-    await openedDocument.serials.setKnowledgeGraphReady(chapterId, false);
-    await openedDocument.graphBuildParameters.deleteUnreferenced();
-    await refreshChapterFtsIndexArtifactIfPresent(openedDocument, chapterId);
+    await openedDocument.clearSerialKnowledgeGraph(chapterId);
   });
 }

--- a/packages/core/src/graph/reading-build/artifact.ts
+++ b/packages/core/src/graph/reading-build/artifact.ts
@@ -101,7 +101,7 @@ export async function commitChapterGraphArtifact(
     const hadFtsArtifact =
       (await openedDocument.indexArtifacts.get(artifact.chapterId, "fts")) !==
       undefined;
-    await openedDocument.clearSerialGraph(artifact.chapterId);
+    await openedDocument.clearSerialReadingGraph(artifact.chapterId);
     await openedDocument.serials.ensure(artifact.chapterId);
 
     const chunkIdMap = new Map<string, number>();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -251,10 +251,13 @@ export {
   createEmbeddingIndexArtifactInput,
   createFtsIndexArtifactInput,
   refreshChapterFtsIndexArtifactIfPresent,
+  readIndexArtifactOutput,
   replaceChapterFtsIndexArtifact,
   replaceChapterSourceEmbeddingIndexArtifact,
   replaceChapterSummaryEmbeddingIndexArtifact,
+  writeIndexArtifactOutput,
 } from "./retrieval/index-artifact/index.js";
+export type { IndexArtifactOutput } from "./retrieval/index-artifact/index.js";
 export type {
   SearchIndexBuildOptions,
   SearchIndexEmbeddingProvider,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -228,6 +228,7 @@ export {
   assertArchiveIndexArtifactsReady,
   buildArchiveIndexProjection,
   isArchiveSearchIndexCurrent,
+  listArchiveQueryableChapterIds,
   writeArchiveIndexProjectionFromArtifacts,
 } from "./retrieval/query/index.js";
 export {

--- a/packages/core/src/library/query.ts
+++ b/packages/core/src/library/query.ts
@@ -51,6 +51,8 @@ import {
   type ParsedWikiGraphLibraryUri,
 } from "./registry.js";
 import {
+  assertWikiGraphLibraryHasQueryableArtifacts,
+  assertWikiGraphLibraryQueryArtifactsReady,
   assertWikiGraphLibraryIndexReady,
   listWikiGraphLibraryIndexArchiveIdsForObject,
   listWikiGraphLibrarySearchIndex,
@@ -68,6 +70,11 @@ export async function findWikiGraphLibraryObjects(
 ): Promise<ArchiveFindResult> {
   if (shouldUseLibraryBucketedSearch(options)) {
     return await findWikiGraphLibraryObjectsBucketed(target, query, options);
+  }
+  if (options.skipUnindexed !== true) {
+    await assertWikiGraphLibraryQueryArtifactsReady(target);
+  } else {
+    await assertWikiGraphLibraryHasQueryableArtifacts(target);
   }
 
   const indexHitLimit = createLibraryQueryIndexHitLimit(options);

--- a/packages/core/src/library/search-index.ts
+++ b/packages/core/src/library/search-index.ts
@@ -9,6 +9,7 @@ import { openSharedStateDatabase } from "../document/index.js";
 import { WikiGraphArchiveFile } from "../storage/wikg/index.js";
 import {
   assertArchiveIndexArtifactsReady,
+  listArchiveQueryableChapterIds,
   readArchiveEmbeddingState,
   readEmbeddingDimensions,
   readEmbeddingModel,
@@ -235,6 +236,55 @@ export async function assertWikiGraphLibraryIndexReady(
   }
 
   return state;
+}
+
+export async function assertWikiGraphLibraryQueryArtifactsReady(
+  target: ParsedWikiGraphLibraryUri,
+): Promise<void> {
+  const archives = await listWikiGraphLibraryArchives(target);
+
+  for (const archive of archives) {
+    if (!archive.exists || archive.status !== "present") {
+      continue;
+    }
+    await new WikiGraphArchiveFile(archive.path).readDocument(
+      async (archiveDocument) => {
+        try {
+          await assertArchiveIndexArtifactsReady(archiveDocument);
+        } catch (error) {
+          throw new Error(
+            `Wiki Graph library query is not ready. Archive ${archive.uri} has unindexed chapters. Build missing chapter index artifacts, or rerun with --skip-unindexed to search indexed chapters only.`,
+            { cause: error },
+          );
+        }
+      },
+    );
+  }
+}
+
+export async function assertWikiGraphLibraryHasQueryableArtifacts(
+  target: ParsedWikiGraphLibraryUri,
+): Promise<void> {
+  const archives = await listWikiGraphLibraryArchives(target);
+
+  for (const archive of archives) {
+    if (!archive.exists || archive.status !== "present") {
+      continue;
+    }
+    const queryableChapters = await new WikiGraphArchiveFile(
+      archive.path,
+    ).readDocument(
+      async (archiveDocument) =>
+        await listArchiveQueryableChapterIds(archiveDocument),
+    );
+    if (queryableChapters.length > 0) {
+      return;
+    }
+  }
+
+  throw new Error(
+    "Wiki Graph library query is not ready. No chapters in this library have a current FTS artifact or source embedding artifact.",
+  );
 }
 
 export async function queryWikiGraphLibrarySearchIndex(
@@ -478,8 +528,6 @@ async function replaceLibrarySearchIndex(
     for (const archive of archives) {
       await new WikiGraphArchiveFile(archive.path).readDocument(
         async (archiveDocument) => {
-          await assertArchiveIndexArtifactsReady(archiveDocument);
-
           for await (const batch of streamArchiveIndexProjection(
             archiveDocument,
             archive.id,

--- a/packages/core/src/library/search-query.ts
+++ b/packages/core/src/library/search-query.ts
@@ -49,6 +49,8 @@ import type {
 } from "../retrieval/query/archive-view/types.js";
 import type { ParsedWikiGraphLibraryUri } from "./registry.js";
 import {
+  assertWikiGraphLibraryHasQueryableArtifacts,
+  assertWikiGraphLibraryQueryArtifactsReady,
   assertWikiGraphLibraryIndexReady,
   queryWikiGraphLibrarySearchIndex,
 } from "./search-index.js";
@@ -88,6 +90,11 @@ export async function findWikiGraphLibraryObjectsBucketed(
     });
   }
 
+  if (options.skipUnindexed !== true) {
+    await assertWikiGraphLibraryQueryArtifactsReady(target);
+  } else {
+    await assertWikiGraphLibraryHasQueryableArtifacts(target);
+  }
   const state = await assertWikiGraphLibraryIndexReady(target);
   const archiveKey = createLibrarySearchArchiveKey(target);
   const types = options.types ?? null;

--- a/packages/core/src/retrieval/index-artifact/build.test.ts
+++ b/packages/core/src/retrieval/index-artifact/build.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, readFile, rm } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
+import { Writable } from "stream";
 import { describe, expect, it } from "vitest";
 
 import { DirectoryDocument } from "../../document/index.js";
@@ -15,6 +16,7 @@ import {
   replaceChapterSummaryEmbeddingIndexArtifact,
   writeIndexArtifactOutput,
 } from "./index.js";
+import { writeIndexArtifactOutputToStream } from "./output.js";
 
 async function withDocument(
   operation: (document: DirectoryDocument) => Promise<void>,
@@ -319,7 +321,40 @@ describe("index artifact builders", () => {
       await rm(path, { force: true, recursive: true });
     }
   });
+
+  it("keeps stream errors handled after a failed output write", async () => {
+    const artifact = createFtsIndexArtifactInput({
+      sentences: [{ text: "Alpha beta.", wordsCount: 2 }],
+      serialId: 12,
+      sourceRevision: 3,
+    });
+    const stream = new CallbackThenStreamErrorWritable();
+
+    await expect(
+      writeIndexArtifactOutputToStream(stream, artifact),
+    ).rejects.toThrow("write failed");
+    await new Promise((resolve) => setImmediate(resolve));
+  });
 });
+
+class CallbackThenStreamErrorWritable extends Writable {
+  readonly #error = new Error("write failed");
+
+  public override _final(callback: (error?: Error | null) => void): void {
+    setTimeout(() => callback(), 10);
+  }
+
+  public override _write(
+    _chunk: unknown,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    callback(this.#error);
+    setImmediate(() => {
+      this.emit("error", this.#error);
+    });
+  }
+}
 
 function createFakeEmbeddingProvider(
   options: { readonly identity?: string | undefined } = {

--- a/packages/core/src/retrieval/index-artifact/build.test.ts
+++ b/packages/core/src/retrieval/index-artifact/build.test.ts
@@ -283,16 +283,56 @@ describe("index artifact builders", () => {
       await rm(path, { force: true, recursive: true });
     }
   });
+
+  it("round-trips embedding output without provider identity", async () => {
+    const path = await mkdtemp(join(tmpdir(), "wikigraph-index-output-"));
+
+    try {
+      const outputPath = join(path, "index-artifact-output.jsonl");
+      const provider = createFakeEmbeddingProvider({ identity: undefined });
+      const artifact = await createEmbeddingIndexArtifactInput({
+        embeddingProvider: provider,
+        kind: "embedding-source",
+        sentences: [{ text: "Alpha beta.", wordsCount: 2 }],
+        serialId: 12,
+        sourceRevision: 3,
+      });
+
+      await writeIndexArtifactOutput(outputPath, artifact);
+
+      const output = await readIndexArtifactOutput(outputPath);
+      const lines = (await readFile(outputPath, "utf8")).trim().split("\n");
+
+      expect(JSON.parse(lines[0]!)).toStrictEqual({
+        artifactKind: "embedding-source",
+        chapterId: 12,
+        embedding: {
+          dimensions: 3,
+          model: "test-embedding",
+        },
+        inputRevision: 3,
+        protocol: "wikg-index-output/v1",
+        type: "manifest",
+      });
+      expect(output).toStrictEqual(artifact);
+    } finally {
+      await rm(path, { force: true, recursive: true });
+    }
+  });
 });
 
-function createFakeEmbeddingProvider(): SearchIndexEmbeddingProvider & {
+function createFakeEmbeddingProvider(
+  options: { readonly identity?: string | undefined } = {
+    identity: "provider=fake;model=test-embedding",
+  },
+): SearchIndexEmbeddingProvider & {
   readonly requests: string[][];
 } {
   const requests: string[][] = [];
 
   return {
     dimensions: 3,
-    identity: "provider=fake;model=test-embedding",
+    ...(options.identity === undefined ? {} : { identity: options.identity }),
     model: "test-embedding",
     requests,
     embedTexts(texts) {

--- a/packages/core/src/retrieval/index-artifact/build.test.ts
+++ b/packages/core/src/retrieval/index-artifact/build.test.ts
@@ -157,7 +157,7 @@ describe("index artifact builders", () => {
               "One two three four five.\n" +
               "山海之间有旧城。",
             vector: [1, 2, 3],
-            wordsCount: 11,
+            wordsCount: 17,
           },
         ]);
       });

--- a/packages/core/src/retrieval/index-artifact/build.test.ts
+++ b/packages/core/src/retrieval/index-artifact/build.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "fs/promises";
+import { mkdtemp, readFile, rm } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import { describe, expect, it } from "vitest";
@@ -7,9 +7,13 @@ import { DirectoryDocument } from "../../document/index.js";
 import type { SearchIndexEmbeddingProvider } from "../search-index/index.js";
 import {
   buildChapterEmbeddingIndexArtifact,
+  createEmbeddingIndexArtifactInput,
+  createFtsIndexArtifactInput,
+  readIndexArtifactOutput,
   replaceChapterFtsIndexArtifact,
   replaceChapterSourceEmbeddingIndexArtifact,
   replaceChapterSummaryEmbeddingIndexArtifact,
+  writeIndexArtifactOutput,
 } from "./index.js";
 
 async function withDocument(
@@ -205,6 +209,79 @@ describe("index artifact builders", () => {
         ).toBeDefined();
       });
     });
+  });
+
+  it("writes commit-ready FTS index artifact JSONL outputs", async () => {
+    const path = await mkdtemp(join(tmpdir(), "wikigraph-index-output-"));
+
+    try {
+      const outputPath = join(path, "index-artifact-output.jsonl");
+      const artifact = createFtsIndexArtifactInput({
+        sentences: [{ text: "Alpha beta.", wordsCount: 2 }],
+        serialId: 12,
+        sourceRevision: 3,
+      });
+
+      await writeIndexArtifactOutput(outputPath, artifact);
+
+      const output = await readIndexArtifactOutput(outputPath);
+      const lines = (await readFile(outputPath, "utf8")).trim().split("\n");
+
+      expect(lines).toHaveLength(2);
+      expect(JSON.parse(lines[0]!)).toStrictEqual({
+        artifactKind: "fts",
+        chapterId: 12,
+        inputRevision: 3,
+        protocol: "wikg-index-output/v1",
+        type: "manifest",
+      });
+      expect(lines.join("\n")).not.toContain('"job"');
+      expect(lines.join("\n")).not.toContain('"final"');
+      expect(output).toStrictEqual({
+        lexicalRows: artifact.lexicalRows,
+        serialId: 12,
+        sourceRevision: 3,
+      });
+    } finally {
+      await rm(path, { force: true, recursive: true });
+    }
+  });
+
+  it("writes commit-ready embedding index artifact JSONL outputs", async () => {
+    const path = await mkdtemp(join(tmpdir(), "wikigraph-index-output-"));
+
+    try {
+      const outputPath = join(path, "index-artifact-output.jsonl");
+      const provider = createFakeEmbeddingProvider();
+      const artifact = await createEmbeddingIndexArtifactInput({
+        embeddingProvider: provider,
+        kind: "embedding-source",
+        sentences: [{ text: "Alpha beta.", wordsCount: 2 }],
+        serialId: 12,
+        sourceRevision: 3,
+      });
+
+      await writeIndexArtifactOutput(outputPath, artifact);
+
+      const output = await readIndexArtifactOutput(outputPath);
+      const lines = (await readFile(outputPath, "utf8")).trim().split("\n");
+
+      expect(JSON.parse(lines[0]!)).toStrictEqual({
+        artifactKind: "embedding-source",
+        chapterId: 12,
+        embedding: {
+          dimensions: 3,
+          identity: "provider=fake;model=test-embedding",
+          model: "test-embedding",
+        },
+        inputRevision: 3,
+        protocol: "wikg-index-output/v1",
+        type: "manifest",
+      });
+      expect(output).toStrictEqual(artifact);
+    } finally {
+      await rm(path, { force: true, recursive: true });
+    }
   });
 });
 

--- a/packages/core/src/retrieval/index-artifact/index.ts
+++ b/packages/core/src/retrieval/index-artifact/index.ts
@@ -9,3 +9,8 @@ export {
   replaceChapterSummaryEmbeddingIndexArtifact,
 } from "./build.js";
 export type { EmbeddingIndexArtifactKind } from "./build.js";
+export {
+  readIndexArtifactOutput,
+  writeIndexArtifactOutput,
+  type IndexArtifactOutput,
+} from "./output.js";

--- a/packages/core/src/retrieval/index-artifact/output.ts
+++ b/packages/core/src/retrieval/index-artifact/output.ts
@@ -2,6 +2,7 @@ import { createReadStream, createWriteStream } from "fs";
 import { mkdir } from "fs/promises";
 import { dirname } from "path";
 import { createInterface } from "readline";
+import type { Writable } from "stream";
 import { z } from "zod";
 
 import type {
@@ -69,13 +70,22 @@ export async function writeIndexArtifactOutput(
   await mkdir(dirname(path), { recursive: true });
   const stream = createWriteStream(path, { encoding: "utf8", flags: "w" });
 
+  await writeIndexArtifactOutputToStream(stream, artifact);
+}
+
+export async function writeIndexArtifactOutputToStream(
+  stream: Writable,
+  artifact: IndexArtifactOutput,
+): Promise<void> {
+  const streamErrors = createWritableStreamErrorTracker(stream);
+
   try {
     const manifest = createOutputManifest(artifact);
 
-    await writeJSONLRecord(stream, manifest);
+    await writeJSONLRecord(stream, streamErrors, manifest);
     if ("lexicalRows" in artifact) {
       for (const row of artifact.lexicalRows) {
-        await writeJSONLRecord(stream, {
+        await writeJSONLRecord(stream, streamErrors, {
           type: "lexical-row",
           ...omitEmptyMetadata(row),
         });
@@ -84,10 +94,18 @@ export async function writeIndexArtifactOutput(
     }
 
     for (const segment of artifact.segments) {
-      await writeJSONLRecord(stream, { type: "segment", ...segment });
+      await writeJSONLRecord(stream, streamErrors, {
+        type: "segment",
+        ...segment,
+      });
     }
   } finally {
-    await closeWritableStream(stream);
+    try {
+      await closeWritableStream(stream, streamErrors);
+    } finally {
+      await waitForPendingWritableStreamErrors();
+      streamErrors.dispose();
+    }
   }
 }
 
@@ -379,70 +397,164 @@ function omitEmptyMetadata<T extends { readonly metadata: unknown }>(
   return record;
 }
 
-async function closeWritableStream(
-  stream: NodeJS.WritableStream,
-): Promise<void> {
-  await new Promise<void>((resolveClose, rejectClose) => {
-    stream.end((error?: Error | null) => {
-      if (error !== undefined && error !== null) {
-        rejectClose(error);
-        return;
+function createWritableStreamErrorTracker(stream: Writable): {
+  readonly dispose: () => void;
+  readonly race: <T>(operation: Promise<T>) => Promise<T>;
+} {
+  let streamError: Error | undefined;
+  const waiters = new Set<(error: Error) => void>();
+  const onError = (error: Error) => {
+    streamError ??= error;
+    for (const reject of waiters) {
+      reject(streamError);
+    }
+  };
+
+  stream.on("error", onError);
+
+  return {
+    dispose() {
+      stream.off("error", onError);
+      waiters.clear();
+    },
+    race<T>(operation: Promise<T>): Promise<T> {
+      if (streamError !== undefined) {
+        return Promise.reject(streamError);
       }
 
-      resolveClose();
-    });
+      return new Promise<T>((resolve, reject) => {
+        const rejectOnStreamError = (error: Error) => reject(error);
+        const cleanup = () => {
+          waiters.delete(rejectOnStreamError);
+        };
+
+        waiters.add(rejectOnStreamError);
+        operation.then(
+          (value) => {
+            cleanup();
+            resolve(value);
+          },
+          (error: unknown) => {
+            cleanup();
+            reject(toError(error));
+          },
+        );
+      });
+    },
+  };
+}
+
+async function closeWritableStream(
+  stream: Writable,
+  streamErrors: ReturnType<typeof createWritableStreamErrorTracker>,
+): Promise<void> {
+  if (stream.closed) {
+    return;
+  }
+
+  const closePromise = waitForWritableStreamClose(stream);
+
+  if (stream.destroyed) {
+    await streamErrors.race(closePromise);
+    return;
+  }
+
+  await streamErrors.race(
+    new Promise<void>((resolveClose, rejectClose) => {
+      try {
+        stream.end((error?: Error | null) => {
+          if (error !== undefined && error !== null) {
+            rejectClose(error);
+            return;
+          }
+
+          resolveClose();
+        });
+      } catch (error) {
+        rejectClose(toError(error));
+      }
+    }),
+  );
+
+  await streamErrors.race(closePromise);
+}
+
+function waitForWritableStreamClose(stream: Writable): Promise<void> {
+  if (stream.closed) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    stream.once("close", resolve);
   });
 }
 
+function waitForPendingWritableStreamErrors(): Promise<void> {
+  return new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+function toError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  return new Error(String(error));
+}
+
 async function writeJSONLRecord(
-  stream: NodeJS.WritableStream,
+  stream: Writable,
+  streamErrors: ReturnType<typeof createWritableStreamErrorTracker>,
   record: unknown,
 ): Promise<void> {
-  await new Promise<void>((resolveWrite, rejectWrite) => {
-    let drainDone = false;
-    let needsDrain = false;
-    let settled = false;
-    let writeDone = false;
+  await streamErrors.race(
+    new Promise<void>((resolveWrite, rejectWrite) => {
+      let drainDone = false;
+      let needsDrain = false;
+      let settled = false;
+      let writeDone = false;
 
-    const cleanup = () => {
-      stream.off("drain", onDrain);
-      stream.off("error", onError);
-    };
-    const settle = (error?: Error | null) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      cleanup();
-      if (error !== undefined && error !== null) {
-        rejectWrite(error);
-        return;
-      }
-      resolveWrite();
-    };
-    const maybeSettle = () => {
-      if (writeDone && (!needsDrain || drainDone)) {
-        settle();
-      }
-    };
-    const onDrain = () => {
-      drainDone = true;
-      maybeSettle();
-    };
-    const onError = (error: Error) => settle(error);
+      const cleanup = () => {
+        stream.off("drain", onDrain);
+      };
+      const settle = (error?: Error | null) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        if (error !== undefined && error !== null) {
+          rejectWrite(error);
+          return;
+        }
+        resolveWrite();
+      };
+      const maybeSettle = () => {
+        if (writeDone && (!needsDrain || drainDone)) {
+          settle();
+        }
+      };
+      const onDrain = () => {
+        drainDone = true;
+        maybeSettle();
+      };
 
-    stream.once("error", onError);
-    const canContinue = stream.write(`${JSON.stringify(record)}\n`, (error) => {
-      if (error !== undefined && error !== null) {
-        settle(error);
-        return;
+      const canContinue = stream.write(
+        `${JSON.stringify(record)}\n`,
+        (error) => {
+          if (error !== undefined && error !== null) {
+            settle(error);
+            return;
+          }
+          writeDone = true;
+          maybeSettle();
+        },
+      );
+      if (!canContinue) {
+        needsDrain = true;
+        stream.once("drain", onDrain);
       }
-      writeDone = true;
-      maybeSettle();
-    });
-    if (!canContinue) {
-      needsDrain = true;
-      stream.once("drain", onDrain);
-    }
-  });
+    }),
+  );
 }

--- a/packages/core/src/retrieval/index-artifact/output.ts
+++ b/packages/core/src/retrieval/index-artifact/output.ts
@@ -26,7 +26,7 @@ const manifestSchema = z.object({
   embedding: z
     .object({
       dimensions: z.number().int().nonnegative(),
-      identity: z.string(),
+      identity: z.string().optional(),
       model: z.string(),
     })
     .optional(),
@@ -72,18 +72,19 @@ export async function writeIndexArtifactOutput(
   try {
     const manifest = createOutputManifest(artifact);
 
-    stream.write(`${JSON.stringify(manifest)}\n`);
+    await writeJSONLRecord(stream, manifest);
     if ("lexicalRows" in artifact) {
       for (const row of artifact.lexicalRows) {
-        stream.write(
-          `${JSON.stringify({ type: "lexical-row", ...omitEmptyMetadata(row) })}\n`,
-        );
+        await writeJSONLRecord(stream, {
+          type: "lexical-row",
+          ...omitEmptyMetadata(row),
+        });
       }
       return;
     }
 
     for (const segment of artifact.segments) {
-      stream.write(`${JSON.stringify({ type: "segment", ...segment })}\n`);
+      await writeJSONLRecord(stream, { type: "segment", ...segment });
     }
   } finally {
     await closeWritableStream(stream);
@@ -150,7 +151,9 @@ export async function readIndexArtifactOutput(
     kind: manifest.artifactKind,
     metadata: {
       dimensions: manifest.embedding.dimensions,
-      identity: manifest.embedding.identity,
+      ...(manifest.embedding.identity === undefined
+        ? {}
+        : { identity: manifest.embedding.identity }),
       model: manifest.embedding.model,
       version: 1,
     },
@@ -173,16 +176,19 @@ function createOutputManifest(
     };
   }
 
-  const dimensions = readNumberMetadata(artifact.metadata, "dimensions");
+  const dimensions = readNonNegativeIntegerMetadata(
+    artifact.metadata,
+    "dimensions",
+  );
   const model = readRequiredStringMetadata(artifact.metadata, "model");
-  const identity = readRequiredStringMetadata(artifact.metadata, "identity");
+  const identity = readStringMetadata(artifact.metadata, "identity");
 
   return {
     artifactKind: artifact.kind,
     chapterId: artifact.serialId,
     embedding: {
       dimensions,
-      identity,
+      ...(identity === undefined ? {} : { identity }),
       model,
     },
     inputRevision: artifact.sourceRevision,
@@ -276,7 +282,7 @@ function assertEmbeddingManifest(
   readonly artifactKind: "embedding-source" | "embedding-summary";
   readonly embedding: {
     readonly dimensions: number;
-    readonly identity: string;
+    readonly identity?: string;
     readonly model: string;
   };
 } {
@@ -312,17 +318,19 @@ function isFtsOutputManifest(manifest: {
   return manifest.artifactKind === "fts";
 }
 
-function readNumberMetadata(
+function readNonNegativeIntegerMetadata(
   metadata: Readonly<Record<string, unknown>> | undefined,
   key: string,
 ): number {
   const value = metadata?.[key];
 
-  if (typeof value === "number" && Number.isFinite(value)) {
+  if (typeof value === "number" && Number.isInteger(value) && value >= 0) {
     return value;
   }
 
-  throw new Error(`Embedding index artifact metadata is missing ${key}.`);
+  throw new Error(
+    `Embedding index artifact metadata ${key} must be a nonnegative integer.`,
+  );
 }
 
 function readStringMetadata(
@@ -383,5 +391,58 @@ async function closeWritableStream(
 
       resolveClose();
     });
+  });
+}
+
+async function writeJSONLRecord(
+  stream: NodeJS.WritableStream,
+  record: unknown,
+): Promise<void> {
+  await new Promise<void>((resolveWrite, rejectWrite) => {
+    let drainDone = false;
+    let needsDrain = false;
+    let settled = false;
+    let writeDone = false;
+
+    const cleanup = () => {
+      stream.off("drain", onDrain);
+      stream.off("error", onError);
+    };
+    const settle = (error?: Error | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      if (error !== undefined && error !== null) {
+        rejectWrite(error);
+        return;
+      }
+      resolveWrite();
+    };
+    const maybeSettle = () => {
+      if (writeDone && (!needsDrain || drainDone)) {
+        settle();
+      }
+    };
+    const onDrain = () => {
+      drainDone = true;
+      maybeSettle();
+    };
+    const onError = (error: Error) => settle(error);
+
+    stream.once("error", onError);
+    const canContinue = stream.write(`${JSON.stringify(record)}\n`, (error) => {
+      if (error !== undefined && error !== null) {
+        settle(error);
+        return;
+      }
+      writeDone = true;
+      maybeSettle();
+    });
+    if (!canContinue) {
+      needsDrain = true;
+      stream.once("drain", onDrain);
+    }
   });
 }

--- a/packages/core/src/retrieval/index-artifact/output.ts
+++ b/packages/core/src/retrieval/index-artifact/output.ts
@@ -1,0 +1,387 @@
+import { createReadStream, createWriteStream } from "fs";
+import { mkdir } from "fs/promises";
+import { dirname } from "path";
+import { createInterface } from "readline";
+import { z } from "zod";
+
+import type {
+  IndexArtifactEmbeddingSegment,
+  IndexArtifactKind,
+  IndexArtifactLexicalRow,
+  ReplaceEmbeddingIndexArtifactInput,
+  ReplaceFtsIndexArtifactInput,
+} from "../../document/index.js";
+
+const INDEX_ARTIFACT_OUTPUT_PROTOCOL = "wikg-index-output/v1";
+
+const indexArtifactKindSchema = z.enum([
+  "fts",
+  "embedding-source",
+  "embedding-summary",
+]);
+
+const manifestSchema = z.object({
+  artifactKind: indexArtifactKindSchema,
+  chapterId: z.number().int().nonnegative(),
+  embedding: z
+    .object({
+      dimensions: z.number().int().nonnegative(),
+      identity: z.string(),
+      model: z.string(),
+    })
+    .optional(),
+  inputRevision: z.number().int().nonnegative(),
+  protocol: z.literal(INDEX_ARTIFACT_OUTPUT_PROTOCOL),
+  type: z.literal("manifest"),
+});
+
+const lexicalRowSchema = z.object({
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  objectId: z.string().min(1),
+  objectKind: z.string().min(1),
+  rowId: z.string().min(1),
+  sentenceIndex: z.number().int().nonnegative().optional(),
+  text: z.string(),
+  tokens: z.array(z.string()),
+  type: z.literal("lexical-row"),
+});
+
+const embeddingSegmentSchema = z.object({
+  endSentenceIndex: z.number().int().nonnegative(),
+  segmentIndex: z.number().int().nonnegative(),
+  startSentenceIndex: z.number().int().nonnegative(),
+  text: z.string(),
+  vector: z.array(z.number()),
+  wordsCount: z.number().int().nonnegative(),
+  type: z.literal("segment"),
+});
+
+type IndexArtifactOutputManifest = z.infer<typeof manifestSchema>;
+
+export type IndexArtifactOutput =
+  | ReplaceEmbeddingIndexArtifactInput
+  | ReplaceFtsIndexArtifactInput;
+
+export async function writeIndexArtifactOutput(
+  path: string,
+  artifact: IndexArtifactOutput,
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const stream = createWriteStream(path, { encoding: "utf8", flags: "w" });
+
+  try {
+    const manifest = createOutputManifest(artifact);
+
+    stream.write(`${JSON.stringify(manifest)}\n`);
+    if ("lexicalRows" in artifact) {
+      for (const row of artifact.lexicalRows) {
+        stream.write(
+          `${JSON.stringify({ type: "lexical-row", ...omitEmptyMetadata(row) })}\n`,
+        );
+      }
+      return;
+    }
+
+    for (const segment of artifact.segments) {
+      stream.write(`${JSON.stringify({ type: "segment", ...segment })}\n`);
+    }
+  } finally {
+    await closeWritableStream(stream);
+  }
+}
+
+export async function readIndexArtifactOutput(
+  path: string,
+): Promise<IndexArtifactOutput> {
+  const lines = createInterface({
+    crlfDelay: Infinity,
+    input: createReadStream(path, { encoding: "utf8" }),
+  });
+  let manifest: IndexArtifactOutputManifest | undefined;
+  const lexicalRows: IndexArtifactLexicalRow[] = [];
+  const segments: IndexArtifactEmbeddingSegment[] = [];
+  let lineNumber = 0;
+
+  for await (const line of lines) {
+    lineNumber += 1;
+    if (line.trim() === "") {
+      continue;
+    }
+
+    let record: unknown;
+
+    try {
+      record = JSON.parse(line);
+    } catch (error) {
+      throw new Error(`Invalid index artifact JSONL at ${path}:${lineNumber}`, {
+        cause: error,
+      });
+    }
+
+    if (manifest === undefined) {
+      manifest = parseOutputManifest(record, path, lineNumber);
+      continue;
+    }
+
+    if (isFtsOutputManifest(manifest)) {
+      lexicalRows.push(parseLexicalRow(record, path, lineNumber));
+      continue;
+    }
+
+    segments.push(parseEmbeddingSegment(record, path, lineNumber));
+  }
+
+  if (manifest === undefined) {
+    throw new Error(`Index artifact output ${path} has no manifest.`);
+  }
+
+  if (isFtsOutputManifest(manifest)) {
+    return {
+      lexicalRows,
+      serialId: manifest.chapterId,
+      sourceRevision: manifest.inputRevision,
+    };
+  }
+
+  assertEmbeddingManifest(manifest);
+  assertEmbeddingSegmentsMatchManifest(manifest, segments);
+
+  return {
+    kind: manifest.artifactKind,
+    metadata: {
+      dimensions: manifest.embedding.dimensions,
+      identity: manifest.embedding.identity,
+      model: manifest.embedding.model,
+      version: 1,
+    },
+    segments,
+    serialId: manifest.chapterId,
+    sourceRevision: manifest.inputRevision,
+  };
+}
+
+function createOutputManifest(
+  artifact: IndexArtifactOutput,
+): IndexArtifactOutputManifest {
+  if ("lexicalRows" in artifact) {
+    return {
+      artifactKind: "fts",
+      chapterId: artifact.serialId,
+      inputRevision: artifact.sourceRevision,
+      protocol: INDEX_ARTIFACT_OUTPUT_PROTOCOL,
+      type: "manifest",
+    };
+  }
+
+  const dimensions = readNumberMetadata(artifact.metadata, "dimensions");
+  const model = readRequiredStringMetadata(artifact.metadata, "model");
+  const identity = readRequiredStringMetadata(artifact.metadata, "identity");
+
+  return {
+    artifactKind: artifact.kind,
+    chapterId: artifact.serialId,
+    embedding: {
+      dimensions,
+      identity,
+      model,
+    },
+    inputRevision: artifact.sourceRevision,
+    protocol: INDEX_ARTIFACT_OUTPUT_PROTOCOL,
+    type: "manifest",
+  };
+}
+
+function parseOutputManifest(
+  record: unknown,
+  path: string,
+  lineNumber: number,
+): IndexArtifactOutputManifest {
+  try {
+    const manifest = manifestSchema.parse(record);
+
+    if (manifest.artifactKind === "fts" && manifest.embedding !== undefined) {
+      throw new Error("FTS output manifest must not include embedding data.");
+    }
+    if (manifest.artifactKind !== "fts" && manifest.embedding === undefined) {
+      throw new Error("Embedding output manifest must include embedding data.");
+    }
+
+    return manifest;
+  } catch (error) {
+    throw new Error(
+      `Invalid index artifact output manifest at ${path}:${lineNumber}`,
+      { cause: error },
+    );
+  }
+}
+
+function parseLexicalRow(
+  record: unknown,
+  path: string,
+  lineNumber: number,
+): IndexArtifactLexicalRow {
+  try {
+    const parsed = lexicalRowSchema.parse(record);
+
+    return {
+      metadata: parsed.metadata ?? {},
+      objectId: parsed.objectId,
+      objectKind: parsed.objectKind,
+      rowId: parsed.rowId,
+      ...(parsed.sentenceIndex === undefined
+        ? {}
+        : { sentenceIndex: parsed.sentenceIndex }),
+      text: parsed.text,
+      tokens: parsed.tokens,
+    };
+  } catch (error) {
+    throw new Error(
+      `Invalid index artifact lexical row at ${path}:${lineNumber}`,
+      { cause: error },
+    );
+  }
+}
+
+function parseEmbeddingSegment(
+  record: unknown,
+  path: string,
+  lineNumber: number,
+): IndexArtifactEmbeddingSegment {
+  try {
+    const parsed = embeddingSegmentSchema.parse(record);
+
+    if (parsed.endSentenceIndex < parsed.startSentenceIndex) {
+      throw new Error(`Segment ${parsed.segmentIndex} ends before it starts.`);
+    }
+
+    return {
+      endSentenceIndex: parsed.endSentenceIndex,
+      segmentIndex: parsed.segmentIndex,
+      startSentenceIndex: parsed.startSentenceIndex,
+      text: parsed.text,
+      vector: parsed.vector,
+      wordsCount: parsed.wordsCount,
+    };
+  } catch (error) {
+    throw new Error(
+      `Invalid index artifact embedding segment at ${path}:${lineNumber}`,
+      { cause: error },
+    );
+  }
+}
+
+function assertEmbeddingManifest(
+  manifest: IndexArtifactOutputManifest,
+): asserts manifest is IndexArtifactOutputManifest & {
+  readonly artifactKind: "embedding-source" | "embedding-summary";
+  readonly embedding: {
+    readonly dimensions: number;
+    readonly identity: string;
+    readonly model: string;
+  };
+} {
+  if (manifest.artifactKind === "fts" || manifest.embedding === undefined) {
+    throw new Error("Expected an embedding index artifact output manifest.");
+  }
+}
+
+function assertEmbeddingSegmentsMatchManifest(
+  manifest: IndexArtifactOutputManifest & {
+    readonly embedding: { readonly dimensions: number };
+  },
+  segments: readonly IndexArtifactEmbeddingSegment[],
+): void {
+  const segmentIndexes = new Set<number>();
+
+  for (const segment of segments) {
+    if (segmentIndexes.has(segment.segmentIndex)) {
+      throw new Error(`Duplicate embedding segment ${segment.segmentIndex}.`);
+    }
+    if (segment.vector.length !== manifest.embedding.dimensions) {
+      throw new Error(
+        `Embedding segment ${segment.segmentIndex} has ${segment.vector.length} dimensions; expected ${manifest.embedding.dimensions}.`,
+      );
+    }
+    segmentIndexes.add(segment.segmentIndex);
+  }
+}
+
+function isFtsOutputManifest(manifest: {
+  readonly artifactKind: IndexArtifactKind;
+}): boolean {
+  return manifest.artifactKind === "fts";
+}
+
+function readNumberMetadata(
+  metadata: Readonly<Record<string, unknown>> | undefined,
+  key: string,
+): number {
+  const value = metadata?.[key];
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  throw new Error(`Embedding index artifact metadata is missing ${key}.`);
+}
+
+function readStringMetadata(
+  metadata: Readonly<Record<string, unknown>> | undefined,
+  key: string,
+): string | undefined {
+  const value = metadata?.[key];
+
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+
+  throw new Error(`Embedding index artifact metadata ${key} must be a string.`);
+}
+
+function readRequiredStringMetadata(
+  metadata: Readonly<Record<string, unknown>> | undefined,
+  key: string,
+): string {
+  const value = readStringMetadata(metadata, key);
+
+  if (value !== undefined) {
+    return value;
+  }
+
+  throw new Error(`Embedding index artifact metadata is missing ${key}.`);
+}
+
+function omitEmptyMetadata<T extends { readonly metadata: unknown }>(
+  record: T,
+): Omit<T, "metadata"> | T {
+  if (
+    record.metadata !== undefined &&
+    typeof record.metadata === "object" &&
+    record.metadata !== null &&
+    Object.keys(record.metadata).length === 0
+  ) {
+    const { metadata: _metadata, ...rest } = record;
+
+    return rest;
+  }
+
+  return record;
+}
+
+async function closeWritableStream(
+  stream: NodeJS.WritableStream,
+): Promise<void> {
+  await new Promise<void>((resolveClose, rejectClose) => {
+    stream.end((error?: Error | null) => {
+      if (error !== undefined && error !== null) {
+        rejectClose(error);
+        return;
+      }
+
+      resolveClose();
+    });
+  });
+}

--- a/packages/core/src/retrieval/query/archive-view/evidence.ts
+++ b/packages/core/src/retrieval/query/archive-view/evidence.ts
@@ -104,6 +104,7 @@ export async function listArchiveEvidence(
           await createMentionEvidenceRanges(document, [mention]),
         (mention) => mention.id,
         options.query,
+        options.skipUnindexed,
       );
 
       return await createSourceEvidenceCandidatePage(document, {
@@ -167,6 +168,7 @@ export async function listArchiveEvidence(
         (link) => createMentionLinkEvidenceRanges(document, [link]),
         (link) => link.id,
         options.query,
+        options.skipUnindexed,
       );
 
       return await createSourceEvidenceCandidatePage(document, {

--- a/packages/core/src/retrieval/query/archive-view/index-state.test.ts
+++ b/packages/core/src/retrieval/query/archive-view/index-state.test.ts
@@ -274,6 +274,49 @@ describe("archive search index state", () => {
     });
   });
 
+  it("does not write stale artifact rows during scoped cache sync", async () => {
+    await withTempDocument(async (document) => {
+      await writeSourceChapter(document);
+      const provider = createFakeEmbeddingProvider();
+
+      await replaceChapterFtsIndexArtifact(document, 1);
+      await document.openSession(async (openedDocument) => {
+        await openedDocument.serials.bumpRevision(1);
+      });
+      await replaceChapterSourceEmbeddingIndexArtifact(document, 1, provider);
+
+      await rebuildArchiveSearchIndex(document, undefined, { chapters: [1] });
+
+      await expect(
+        readSearchIndexCapabilityStatus(document),
+      ).resolves.toStrictEqual({
+        dense: {
+          current: true,
+          dimensions: 3,
+          model: "test-embedding",
+        },
+        indexes: "dense",
+      });
+      await expect(
+        document.readSearchIndexDatabase(async (database) => ({
+          objectFtsRows: await database.queryOne(
+            "SELECT COUNT(*) AS count FROM search_object_properties_fts",
+            undefined,
+            (row) => getNumber(row, "count"),
+          ),
+          textFtsRows: await database.queryOne(
+            "SELECT COUNT(*) AS count FROM text_sentence_fts",
+            undefined,
+            (row) => getNumber(row, "count"),
+          ),
+        })),
+      ).resolves.toStrictEqual({
+        objectFtsRows: 0,
+        textFtsRows: 0,
+      });
+    });
+  });
+
   it("does not report dense current when the cache is dirty", async () => {
     await withTempDocument(async (document) => {
       await writeSourceChapter(document);

--- a/packages/core/src/retrieval/query/archive-view/index-state.test.ts
+++ b/packages/core/src/retrieval/query/archive-view/index-state.test.ts
@@ -229,6 +229,51 @@ describe("archive search index state", () => {
     });
   });
 
+  it("checks query readiness against the requested chapter scope", async () => {
+    await withTempDocument(async (document) => {
+      await writeSourceChapters(document, ["Unindexed", "Indexed"]);
+      const provider = createFakeEmbeddingProvider();
+
+      await replaceChapterSourceEmbeddingIndexArtifact(document, 2, provider);
+
+      await expect(assertArchiveIndexArtifactsReady(document)).rejects.toThrow(
+        "Wiki Graph query is not ready. Chapters 1 need a current FTS artifact or source embedding artifact before query.",
+      );
+      await expect(
+        assertArchiveIndexArtifactsReady(document, { chapters: [2] }),
+      ).resolves.toBeUndefined();
+
+      await rebuildArchiveSearchIndex(document, undefined, { chapters: [2] });
+
+      await expect(isArchiveSearchIndexCurrent(document)).resolves.toBe(false);
+      await expect(
+        isArchiveSearchIndexCurrent(document, { chapters: [2] }),
+      ).resolves.toBe(true);
+      await expect(
+        querySearchIndex(document, "semantic vectors", {
+          chapters: [2],
+          embeddingProvider: provider,
+          types: ["source"],
+        }),
+      ).resolves.toMatchObject({
+        textHits: [
+          {
+            archiveId: 0,
+            chapterId: 2,
+            kind: TEXT_SENTENCE_KIND.source,
+            sentenceIndex: 0,
+          },
+          {
+            archiveId: 0,
+            chapterId: 2,
+            kind: TEXT_SENTENCE_KIND.source,
+            sentenceIndex: 1,
+          },
+        ],
+      });
+    });
+  });
+
   it("does not report dense current when the cache is dirty", async () => {
     await withTempDocument(async (document) => {
       await writeSourceChapter(document);
@@ -278,14 +323,32 @@ function createFakeEmbeddingProvider() {
 }
 
 async function writeSourceChapter(document: DirectoryDocument): Promise<void> {
+  await writeSourceChapters(document, ["Dense"]);
+}
+
+async function writeSourceChapters(
+  document: DirectoryDocument,
+  titles: readonly string[],
+): Promise<void> {
   await document.openSession(async (openedDocument) => {
-    await openedDocument.createSerial();
-    const draft = await openedDocument.getSerialFragments(1).createDraft();
-    draft.addSentence("Dense indexing writes vectors.", 4);
-    draft.addSentence("FTS still indexes the same text.", 6);
-    await draft.commit();
+    const serialIds: number[] = [];
+
+    for (const title of titles) {
+      const serialId = await openedDocument.createSerial();
+      serialIds.push(serialId);
+      const draft = await openedDocument
+        .getSerialFragments(serialId)
+        .createDraft();
+      draft.addSentence(`${title} dense indexing writes vectors.`, 5);
+      draft.addSentence(`${title} FTS still indexes the same text.`, 7);
+      await draft.commit();
+    }
     await openedDocument.writeToc({
-      items: [{ children: [], serialId: 1, title: "Dense" }],
+      items: titles.map((title, index) => ({
+        children: [],
+        serialId: serialIds[index]!,
+        title,
+      })),
       version: 1,
     });
   });

--- a/packages/core/src/retrieval/query/archive-view/index-state.ts
+++ b/packages/core/src/retrieval/query/archive-view/index-state.ts
@@ -1,5 +1,6 @@
 import type {
   Document,
+  IndexArtifactRecord,
   IndexArtifactLexicalRow,
   ReadonlyDocument,
 } from "../../../document/index.js";
@@ -39,11 +40,19 @@ export async function rebuildArchiveSearchIndex(
 ): Promise<void> {
   for (let attempt = 0; attempt < SEARCH_INDEX_REBUILD_ATTEMPTS; attempt += 1) {
     await assertArchiveIndexArtifactsReady(document, options);
-    const input = await buildArchiveIndexProjection(document, progress);
+    const input = await buildArchiveIndexProjection(
+      document,
+      progress,
+      options,
+    );
     const fingerprint = createSearchIndexFingerprint(input);
 
     if ((await readSearchIndexStatus(document, input)) === "dirty") {
-      const beforeDeleteInput = await buildArchiveIndexProjection(document);
+      const beforeDeleteInput = await buildArchiveIndexProjection(
+        document,
+        undefined,
+        options,
+      );
 
       if (createSearchIndexFingerprint(beforeDeleteInput) !== fingerprint) {
         continue;
@@ -52,9 +61,13 @@ export async function rebuildArchiveSearchIndex(
       await document.deleteSearchIndexDatabase();
     }
 
-    await writeArchiveIndexProjectionFromArtifacts(document, progress);
+    await writeArchiveIndexProjectionFromArtifacts(document, progress, options);
 
-    const verifiedInput = await buildArchiveIndexProjection(document);
+    const verifiedInput = await buildArchiveIndexProjection(
+      document,
+      undefined,
+      options,
+    );
     if (
       createSearchIndexFingerprint(verifiedInput) === fingerprint &&
       (await readSearchIndexStatus(document, verifiedInput)) === "current"
@@ -87,7 +100,7 @@ export async function readArchiveSearchIndexStatus(
 
   return await readSearchIndexStatus(
     document,
-    await buildArchiveIndexProjection(document),
+    await buildArchiveIndexProjection(document, undefined, options),
   );
 }
 
@@ -110,6 +123,7 @@ export async function createArchiveSearchIndexFingerprint(
 export async function buildArchiveIndexProjection(
   document: ReadonlyDocument,
   progress?: SearchIndexProgressReporter,
+  options: ArchiveSearchIndexScopeOptions = {},
 ): Promise<SearchIndexInput> {
   const objectProperties: SearchIndexInput["objectProperties"][number][] = [];
   const textSentences: SearchIndexInput["textSentences"][number][] = [];
@@ -118,6 +132,7 @@ export async function buildArchiveIndexProjection(
     document,
     SINGLE_ARCHIVE_INDEX_ID,
     progress,
+    options,
   )) {
     objectProperties.push(...batch.objectProperties);
     textSentences.push(...batch.textSentences);
@@ -192,13 +207,18 @@ async function resolveArchiveQueryChapterIds(
 export async function writeArchiveIndexProjectionFromArtifacts(
   document: Document,
   progress?: SearchIndexProgressReporter,
+  options: ArchiveSearchIndexScopeOptions = {},
 ): Promise<void> {
   const chaptersRevision = await document.serials.getChaptersRevision();
+  const chapterIds = await resolveArchiveQueryChapterIds(document, options);
   const fingerprint = createSearchIndexFingerprint(
-    await buildArchiveIndexProjection(document),
+    await buildArchiveIndexProjection(document, undefined, options),
   );
-  const embeddingState = await readArchiveEmbeddingState(document);
-  const hasFts = (await document.indexArtifacts.list("fts")).length > 0;
+  const embeddingState = await readArchiveEmbeddingState(document, options);
+  const ftsCoverage = await document.indexArtifacts.listCoverage("fts");
+  const hasFts = ftsCoverage.some(
+    (artifact) => chapterIds.has(artifact.serialId) && artifact.current,
+  );
 
   await document.writeSearchIndexDatabase(async (database) => {
     await prepareSearchIndexReplacement(database, progress);
@@ -207,6 +227,9 @@ export async function writeArchiveIndexProjectionFromArtifacts(
     let vectorDone = 0;
 
     for (const chapter of await listChapters(document)) {
+      if (!chapterIds.has(chapter.chapterId)) {
+        continue;
+      }
       for (const record of await streamIndexArtifactProjectionRecords(
         document,
         SINGLE_ARCHIVE_INDEX_ID,
@@ -251,6 +274,12 @@ export async function writeArchiveIndexProjectionFromArtifacts(
       "embedding-summary",
     ] as const) {
       for (const artifact of await document.indexArtifacts.list(artifactKind)) {
+        if (!chapterIds.has(artifact.serialId)) {
+          continue;
+        }
+        if (!(await isCurrentIndexArtifact(document, artifact))) {
+          continue;
+        }
         const segments = await document.indexArtifacts.listEmbeddingSegments(
           artifact.serialId,
           artifactKind,
@@ -330,12 +359,17 @@ export async function* streamArchiveIndexProjection(
   document: ReadonlyDocument,
   archiveId: number,
   progress?: SearchIndexProgressReporter,
+  options: ArchiveSearchIndexScopeOptions = {},
 ): AsyncIterable<SearchIndexWriteBatch> {
   const chapters = await listChapters(document);
+  const chapterIds = await resolveArchiveQueryChapterIds(document, options);
   let chapterDone = 0;
   let batch = createEmptySearchIndexBatch();
 
   for (const chapter of chapters) {
+    if (!chapterIds.has(chapter.chapterId)) {
+      continue;
+    }
     for (const record of await streamIndexArtifactProjectionRecords(
       document,
       archiveId,
@@ -355,7 +389,7 @@ export async function* streamArchiveIndexProjection(
     await progress?.({
       done: chapterDone,
       phase: "collecting",
-      total: chapters.length,
+      total: chapterIds.size,
       unit: "chapter",
     });
   }
@@ -391,25 +425,31 @@ async function streamIndexArtifactProjectionRecords(
         readonly value: SearchIndexWriteBatch["textSentences"][number];
       }
   )[] = [];
+  const ftsArtifact = await document.indexArtifacts.get(serialId, "fts");
 
-  for (const row of await document.indexArtifacts.listLexicalRows(
-    serialId,
-    "fts",
-  )) {
-    const textRecord = mapLexicalRowToTextSentence(archiveId, serialId, row);
-
-    if (textRecord !== undefined) {
-      records.push({ kind: "text", value: textRecord });
-      continue;
-    }
-
-    const objectRecord = mapLexicalRowToObjectProperty(
-      archiveId,
+  if (
+    ftsArtifact !== undefined &&
+    (await isCurrentIndexArtifact(document, ftsArtifact))
+  ) {
+    for (const row of await document.indexArtifacts.listLexicalRows(
       serialId,
-      row,
-    );
-    if (objectRecord !== undefined) {
-      records.push({ kind: "object", value: objectRecord });
+      "fts",
+    )) {
+      const textRecord = mapLexicalRowToTextSentence(archiveId, serialId, row);
+
+      if (textRecord !== undefined) {
+        records.push({ kind: "text", value: textRecord });
+        continue;
+      }
+
+      const objectRecord = mapLexicalRowToObjectProperty(
+        archiveId,
+        serialId,
+        row,
+      );
+      if (objectRecord !== undefined) {
+        records.push({ kind: "object", value: objectRecord });
+      }
     }
   }
 
@@ -419,6 +459,9 @@ async function streamIndexArtifactProjectionRecords(
   ] as const) {
     const artifact = await document.indexArtifacts.get(serialId, artifactKind);
     if (artifact === undefined) {
+      continue;
+    }
+    if (!(await isCurrentIndexArtifact(document, artifact))) {
       continue;
     }
     const textKind =
@@ -557,14 +600,22 @@ function countSearchIndexBatchRecords(batch: SearchIndexWriteBatch): number {
 
 export async function readArchiveEmbeddingState(
   document: ReadonlyDocument,
+  options: ArchiveSearchIndexScopeOptions = {},
 ): Promise<SearchIndexStoredEmbeddingState | undefined> {
   let state: SearchIndexStoredEmbeddingState | undefined;
+  const chapterIds = await resolveArchiveQueryChapterIds(document, options);
 
   for (const artifactKind of [
     "embedding-source",
     "embedding-summary",
   ] as const) {
     for (const artifact of await document.indexArtifacts.list(artifactKind)) {
+      if (!chapterIds.has(artifact.serialId)) {
+        continue;
+      }
+      if (!(await isCurrentIndexArtifact(document, artifact))) {
+        continue;
+      }
       const dimensions = readEmbeddingDimensions(artifact.metadata);
       const model = readEmbeddingModel(artifact.metadata);
       const label = artifactKind === "embedding-source" ? "Source" : "Summary";
@@ -597,6 +648,16 @@ export async function readArchiveEmbeddingState(
   }
 
   return state;
+}
+
+async function isCurrentIndexArtifact(
+  document: ReadonlyDocument,
+  artifact: IndexArtifactRecord,
+): Promise<boolean> {
+  return (
+    artifact.sourceRevision ===
+    (await document.serials.getRevision(artifact.serialId))
+  );
 }
 
 function readWordsCount(metadata: Readonly<Record<string, unknown>>): number {

--- a/packages/core/src/retrieval/query/archive-view/index-state.ts
+++ b/packages/core/src/retrieval/query/archive-view/index-state.ts
@@ -28,13 +28,17 @@ import { createSearchTokenPlan } from "../../search-index/search/tokenizer.js";
 const SEARCH_INDEX_REBUILD_ATTEMPTS = 2;
 const ARCHIVE_INDEX_BATCH_RECORDS = 512;
 
+export interface ArchiveSearchIndexScopeOptions {
+  readonly chapters?: readonly number[];
+}
+
 export async function rebuildArchiveSearchIndex(
   document: Document,
   progress?: SearchIndexProgressReporter,
-  _options: SearchIndexBuildOptions = {},
+  options: SearchIndexBuildOptions & ArchiveSearchIndexScopeOptions = {},
 ): Promise<void> {
   for (let attempt = 0; attempt < SEARCH_INDEX_REBUILD_ATTEMPTS; attempt += 1) {
-    await assertArchiveIndexArtifactsReady(document);
+    await assertArchiveIndexArtifactsReady(document, options);
     const input = await buildArchiveIndexProjection(document, progress);
     const fingerprint = createSearchIndexFingerprint(input);
 
@@ -66,15 +70,17 @@ export async function rebuildArchiveSearchIndex(
 
 export async function isArchiveSearchIndexCurrent(
   document: ReadonlyDocument,
+  options: ArchiveSearchIndexScopeOptions = {},
 ): Promise<boolean> {
-  return (await readArchiveSearchIndexStatus(document)) === "current";
+  return (await readArchiveSearchIndexStatus(document, options)) === "current";
 }
 
 export async function readArchiveSearchIndexStatus(
   document: ReadonlyDocument,
+  options: ArchiveSearchIndexScopeOptions = {},
 ): Promise<"current" | "dirty" | "missing"> {
   try {
-    await assertArchiveIndexArtifactsReady(document);
+    await assertArchiveIndexArtifactsReady(document, options);
   } catch {
     return "dirty";
   }
@@ -122,10 +128,9 @@ export async function buildArchiveIndexProjection(
 
 export async function assertArchiveIndexArtifactsReady(
   document: ReadonlyDocument,
+  options: ArchiveSearchIndexScopeOptions = {},
 ): Promise<void> {
-  const chapterIds = new Set(
-    (await listChapters(document)).map((chapter) => chapter.chapterId),
-  );
+  const chapterIds = await resolveArchiveQueryChapterIds(document, options);
   const [ftsCoverage, sourceEmbeddingCoverage] = await Promise.all([
     document.indexArtifacts.listCoverage("fts"),
     document.indexArtifacts.listCoverage("embedding-source"),
@@ -148,6 +153,40 @@ export async function assertArchiveIndexArtifactsReady(
   throw new Error(
     `Wiki Graph query is not ready. Chapters ${serials} need a current FTS artifact or source embedding artifact before query.`,
   );
+}
+
+export async function listArchiveQueryableChapterIds(
+  document: ReadonlyDocument,
+  options: ArchiveSearchIndexScopeOptions = {},
+): Promise<readonly number[]> {
+  const chapterIds = await resolveArchiveQueryChapterIds(document, options);
+  const [ftsCoverage, sourceEmbeddingCoverage] = await Promise.all([
+    document.indexArtifacts.listCoverage("fts"),
+    document.indexArtifacts.listCoverage("embedding-source"),
+  ]);
+  const sourceEmbeddingBySerial = new Map(
+    sourceEmbeddingCoverage.map((record) => [record.serialId, record]),
+  );
+
+  return ftsCoverage
+    .filter(
+      (record) =>
+        chapterIds.has(record.serialId) &&
+        (record.current ||
+          sourceEmbeddingBySerial.get(record.serialId)?.current === true),
+    )
+    .map((record) => record.serialId);
+}
+
+async function resolveArchiveQueryChapterIds(
+  document: ReadonlyDocument,
+  options: ArchiveSearchIndexScopeOptions,
+): Promise<ReadonlySet<number>> {
+  return options.chapters === undefined
+    ? new Set(
+        (await listChapters(document)).map((chapter) => chapter.chapterId),
+      )
+    : new Set(options.chapters);
 }
 
 export async function writeArchiveIndexProjectionFromArtifacts(

--- a/packages/core/src/retrieval/query/archive-view/index.ts
+++ b/packages/core/src/retrieval/query/archive-view/index.ts
@@ -13,6 +13,7 @@ export {
   buildArchiveIndexProjection,
   createArchiveSearchIndexFingerprint,
   isArchiveSearchIndexCurrent,
+  listArchiveQueryableChapterIds,
   readArchiveSearchIndexStatus,
   rebuildArchiveSearchIndex,
   writeArchiveIndexProjectionFromArtifacts,

--- a/packages/core/src/retrieval/query/archive-view/related/core.ts
+++ b/packages/core/src/retrieval/query/archive-view/related/core.ts
@@ -108,7 +108,17 @@ export async function listRelatedArchiveObjects(
 
   return await hydrateRelatedItemsEvidence(
     document,
-    await filterAndSortChunkRelatedItemsByQuery(document, items, options.query),
+    await filterAndSortChunkRelatedItemsByQuery(
+      document,
+      items,
+      options.query,
+      {
+        chapters: [chapterId],
+        ...(options.skipUnindexed === undefined
+          ? {}
+          : { skipUnindexed: options.skipUnindexed }),
+      },
+    ),
     options,
   );
 }
@@ -155,6 +165,12 @@ async function listRelatedWikiGraphObjects(
           document,
           items,
           options.query,
+          {
+            chapters: [chapterId],
+            ...(options.skipUnindexed === undefined
+              ? {}
+              : { skipUnindexed: options.skipUnindexed }),
+          },
         ),
         options,
       );

--- a/packages/core/src/retrieval/query/archive-view/related/entity.ts
+++ b/packages/core/src/retrieval/query/archive-view/related/entity.ts
@@ -96,6 +96,11 @@ export async function listRelatedEntityObjects(
       ),
       reference.qid,
       options.query,
+      {
+        ...(options.skipUnindexed === undefined
+          ? {}
+          : { skipUnindexed: options.skipUnindexed }),
+      },
     ),
     options,
   );

--- a/packages/core/src/retrieval/query/archive-view/related/query.ts
+++ b/packages/core/src/retrieval/query/archive-view/related/query.ts
@@ -4,6 +4,7 @@ import type {
 } from "../../../../document/index.js";
 
 import { aggregateEvidenceScores } from "../helpers.js";
+import { listArchiveQueryableChapterIds } from "../index-state.js";
 import { parseArchiveReference } from "../references.js";
 import { queryRequiredSearchIndex } from "../search/hydration.js";
 import { createSentenceHitKey } from "../search/cache-input.js";
@@ -18,12 +19,21 @@ export async function filterAndSortChunkRelatedItemsByQuery(
   document: ReadonlyDocument,
   items: readonly ArchiveListItem[],
   query: string | undefined,
+  options: {
+    readonly chapters?: readonly number[];
+    readonly skipUnindexed?: boolean;
+  } = {},
 ): Promise<readonly ArchiveListItem[]> {
   if (query === undefined) {
     return items;
   }
+  const chapters = await resolveRelatedQueryableChapters(document, options);
+  if (chapters?.length === 0) {
+    return [];
+  }
 
   const indexResult = await queryRequiredSearchIndex(document, query, {
+    ...(chapters === undefined ? {} : { chapters }),
     types: ["node"],
   });
 
@@ -82,14 +92,24 @@ export async function filterAndSortEntityRelatedTriplesByQuery(
   items: readonly ArchiveListItem[],
   anchorQid: string,
   query: string | undefined,
+  options: { readonly skipUnindexed?: boolean } = {},
 ): Promise<readonly ArchiveListItem[]> {
   if (query === undefined) {
     return items;
   }
   const scope = await createEntityRelatedQueryScope(document, items, anchorQid);
+  const chapters = await resolveRelatedQueryableChapters(document, {
+    chapters: [...scope.chapterIds],
+    ...(options.skipUnindexed === undefined
+      ? {}
+      : { skipUnindexed: options.skipUnindexed }),
+  });
+  if (chapters?.length === 0) {
+    return [];
+  }
 
   const indexResult = await queryRequiredSearchIndex(document, query, {
-    chapters: [...scope.chapterIds],
+    ...(chapters === undefined ? {} : { chapters }),
     types: ["entity", "source"],
   });
 
@@ -152,6 +172,22 @@ export async function filterAndSortEntityRelatedTriplesByQuery(
         : [{ ...item, score: aggregateEvidenceScores(scores) }];
     })
     .sort(compareRelatedQueryItems);
+}
+
+async function resolveRelatedQueryableChapters(
+  document: ReadonlyDocument,
+  options: {
+    readonly chapters?: readonly number[];
+    readonly skipUnindexed?: boolean;
+  },
+): Promise<readonly number[] | undefined> {
+  if (options.skipUnindexed !== true) {
+    return options.chapters;
+  }
+
+  return await listArchiveQueryableChapterIds(document, {
+    ...(options.chapters === undefined ? {} : { chapters: options.chapters }),
+  });
 }
 
 async function createEntityRelatedQueryScope(

--- a/packages/core/src/retrieval/query/archive-view/search/core.ts
+++ b/packages/core/src/retrieval/query/archive-view/search/core.ts
@@ -225,7 +225,13 @@ export async function findArchiveObjects(
   }
 
   if (usesBucketedSearch) {
-    if (!(await isArchiveSearchIndexCurrent(document))) {
+    if (
+      !(await isArchiveSearchIndexCurrent(document, {
+        ...(options.chapters === undefined
+          ? {}
+          : { chapters: options.chapters }),
+      }))
+    ) {
       throw new Error(
         "Wiki Graph index cache is missing or outdated. Run `<archive-uri>/index sync` before searching.",
       );

--- a/packages/core/src/retrieval/query/archive-view/search/hydration.ts
+++ b/packages/core/src/retrieval/query/archive-view/search/hydration.ts
@@ -39,7 +39,11 @@ export async function findArchiveObjectsIndexed(
     }
   | undefined
 > {
-  if (!(await isArchiveSearchIndexCurrent(document))) {
+  if (
+    !(await isArchiveSearchIndexCurrent(document, {
+      ...(options.chapters === undefined ? {} : { chapters: options.chapters }),
+    }))
+  ) {
     throw new Error(
       "Wiki Graph index cache is missing or outdated. Run `<archive-uri>/index sync` before searching.",
     );
@@ -71,7 +75,15 @@ export async function queryRequiredSearchIndex(
   query: string,
   options: Parameters<typeof querySearchIndex>[2],
 ): Promise<SearchIndexQueryResult | undefined> {
-  if (!(await isArchiveSearchIndexCurrent(document))) {
+  const queryOptions = options ?? {};
+
+  if (
+    !(await isArchiveSearchIndexCurrent(document, {
+      ...(queryOptions.chapters === undefined
+        ? {}
+        : { chapters: queryOptions.chapters }),
+    }))
+  ) {
     throw new Error(
       "Wiki Graph index cache is missing or outdated. Run `<archive-uri>/index sync` before searching.",
     );

--- a/packages/core/src/retrieval/query/archive-view/source-evidence/core.ts
+++ b/packages/core/src/retrieval/query/archive-view/source-evidence/core.ts
@@ -5,6 +5,7 @@ import type {
 } from "../../../../document/index.js";
 
 import { TEXT_SENTENCE_KIND } from "../../../search-index/search/index.js";
+import { listArchiveQueryableChapterIds } from "../index-state.js";
 import {
   DEFAULT_FIND_LIMIT,
   compareNumbers,
@@ -244,6 +245,7 @@ export async function createSourceEvidencePage(
     ranges,
     options.query,
     options.order ?? "doc-asc",
+    options.skipUnindexed,
   );
   const pageRanges = evidenceRanges.slice(start, start + limit);
   const nextOffset = start + pageRanges.length;
@@ -265,6 +267,7 @@ export async function filterAndSortSourceEvidenceRangesByFtsQuery(
   ranges: readonly SourceEvidenceRange[],
   queryText: string | undefined,
   order: ArchiveFindOrder,
+  skipUnindexed = false,
 ): Promise<readonly SourceEvidenceRange[]> {
   const documentOrders = await document.serials.listDocumentOrders();
 
@@ -274,8 +277,16 @@ export async function filterAndSortSourceEvidenceRangesByFtsQuery(
     );
   }
 
+  const queryRanges =
+    skipUnindexed === true
+      ? await filterQueryableSourceEvidenceRanges(document, ranges)
+      : ranges;
+  if (queryRanges.length === 0) {
+    return [];
+  }
+
   const indexResult = await queryRequiredSearchIndex(document, queryText, {
-    chapters: [...new Set(ranges.map((range) => range.chapterId))],
+    chapters: [...new Set(queryRanges.map((range) => range.chapterId))],
     types: ["source"],
   });
 
@@ -286,7 +297,7 @@ export async function filterAndSortSourceEvidenceRangesByFtsQuery(
   const matchedRanges = new Map<string, SourceEvidenceRange>();
   const rangesByChapterId = new Map<number, SourceEvidenceRange[]>();
 
-  for (const range of ranges) {
+  for (const range of queryRanges) {
     const chapterRanges = rangesByChapterId.get(range.chapterId) ?? [];
 
     chapterRanges.push(range);
@@ -335,8 +346,9 @@ export async function filterAndSortSourceEvidenceCandidatesByFtsQuery<T>(
   ) => Promise<readonly SourceEvidenceRange[]> | readonly SourceEvidenceRange[],
   stableIdentity: (candidate: T) => string,
   queryText: string,
+  skipUnindexed = false,
 ): Promise<readonly SourceEvidenceCandidateQueryMatch<T>[]> {
-  const keyed = await Promise.all(
+  let keyed: readonly SourceEvidenceCandidateQueryItem<T>[] = await Promise.all(
     candidates.map(async (candidate) => ({
       candidate,
       ranges: await createRanges(candidate),
@@ -344,6 +356,12 @@ export async function filterAndSortSourceEvidenceCandidatesByFtsQuery<T>(
       stableIdentity: stableIdentity(candidate),
     })),
   );
+  if (skipUnindexed === true) {
+    keyed = await filterQueryableSourceEvidenceCandidates(document, keyed);
+  }
+  if (keyed.length === 0) {
+    return [];
+  }
   const indexResult = await queryRequiredSearchIndex(document, queryText, {
     chapters: [
       ...new Set(
@@ -416,9 +434,55 @@ export async function filterAndSortSourceEvidenceCandidatesByFtsQuery<T>(
     .map((item) => ({ candidate: item.candidate, score: item.score }));
 }
 
+async function filterQueryableSourceEvidenceRanges(
+  document: ReadonlyDocument,
+  ranges: readonly SourceEvidenceRange[],
+): Promise<readonly SourceEvidenceRange[]> {
+  const queryableChapters = new Set(
+    await listArchiveQueryableChapterIds(document, {
+      chapters: [...new Set(ranges.map((range) => range.chapterId))],
+    }),
+  );
+
+  return ranges.filter((range) => queryableChapters.has(range.chapterId));
+}
+
+async function filterQueryableSourceEvidenceCandidates<T>(
+  document: ReadonlyDocument,
+  candidates: readonly SourceEvidenceCandidateQueryItem<T>[],
+): Promise<readonly SourceEvidenceCandidateQueryItem<T>[]> {
+  const queryableChapters = new Set(
+    await listArchiveQueryableChapterIds(document, {
+      chapters: [
+        ...new Set(
+          candidates.flatMap((item) =>
+            item.ranges.map((range) => range.chapterId),
+          ),
+        ),
+      ],
+    }),
+  );
+
+  return candidates
+    .map((item) => ({
+      ...item,
+      ranges: item.ranges.filter((range) =>
+        queryableChapters.has(range.chapterId),
+      ),
+    }))
+    .filter((item) => item.ranges.length > 0);
+}
+
 export interface SourceEvidenceCandidateQueryMatch<T> {
   readonly candidate: T;
   readonly score: number;
+}
+
+interface SourceEvidenceCandidateQueryItem<T> {
+  readonly candidate: T;
+  readonly ranges: readonly SourceEvidenceRange[];
+  readonly stableIdentity: string;
+  score: number;
 }
 
 function firstSourceEvidenceRange(

--- a/packages/core/src/retrieval/query/archive-view/text-streams.ts
+++ b/packages/core/src/retrieval/query/archive-view/text-streams.ts
@@ -2,6 +2,7 @@ import type {
   ReadonlyDocument,
   ReadonlySerialTextStream,
 } from "../../../document/index.js";
+import { countTextWords } from "../../../utils/text-word-count.js";
 
 import { createSnippet } from "./helpers.js";
 import {
@@ -246,7 +247,5 @@ export async function createTextStreamIndex(
 }
 
 export function countWords(text: string): number {
-  const trimmed = text.trim();
-
-  return trimmed === "" ? 0 : trimmed.split(/\s+/u).length;
+  return countTextWords(text);
 }

--- a/packages/core/src/retrieval/query/archive-view/types.ts
+++ b/packages/core/src/retrieval/query/archive-view/types.ts
@@ -146,6 +146,7 @@ export interface ArchiveFindOptions {
   readonly limit?: number;
   readonly match?: ArchiveFindMatch;
   readonly order?: ArchiveFindOrder;
+  readonly skipUnindexed?: boolean;
   readonly sourceContext?: number;
   readonly triplePattern?: ArchiveTriplePattern;
   readonly types?: readonly ArchiveFindFilterType[];
@@ -376,6 +377,7 @@ export interface ArchiveRelatedOptions {
   readonly order?: ArchiveFindOrder;
   readonly query?: string;
   readonly role?: ArchiveRelatedRole;
+  readonly skipUnindexed?: boolean;
   readonly sourceContext?: number;
 }
 
@@ -461,5 +463,6 @@ export interface ArchiveEvidenceOptions {
   readonly limit?: number;
   readonly order?: ArchiveFindOrder;
   readonly query?: string;
+  readonly skipUnindexed?: boolean;
   readonly sourceContext?: number;
 }

--- a/packages/core/src/retrieval/query/continuation-cursor/payload.test.ts
+++ b/packages/core/src/retrieval/query/continuation-cursor/payload.test.ts
@@ -83,6 +83,71 @@ describe("continuation cursor payload", () => {
     });
   });
 
+  it("round-trips skip-unindexed search cursors", () => {
+    const cursor: ContinuationCursor = {
+      archiveKey: "archive-key",
+      archivePath: "/tmp/book.wikg",
+      backlinks: false,
+      chapters: [1],
+      cursor: "raw-cursor",
+      format: "json",
+      indexScope: {
+        archiveKey: "archive-key",
+        archivePath: "/tmp/book.wikg",
+        kind: "archive-index",
+      },
+      kind: "search",
+      query: "alpha",
+      skipUnindexed: true,
+      types: null,
+    };
+
+    expect(roundTripCursor(cursor)).toStrictEqual(cursor);
+  });
+
+  it("round-trips skip-unindexed evidence cursors", () => {
+    const cursor: ContinuationCursor = {
+      archiveKey: "archive-key",
+      archivePath: "/tmp/book.wikg",
+      cursor: "raw-cursor",
+      format: "jsonl",
+      indexScope: {
+        archiveKey: "archive-key",
+        archivePath: "/tmp/book.wikg",
+        kind: "archive-index",
+      },
+      kind: "evidence",
+      order: "doc-asc",
+      query: "alpha",
+      skipUnindexed: true,
+      targetUri: "wikg://source/1/0",
+    };
+
+    expect(roundTripCursor(cursor)).toStrictEqual(cursor);
+  });
+
+  it("round-trips skip-unindexed related cursors", () => {
+    const cursor: ContinuationCursor = {
+      archiveKey: "archive-key",
+      archivePath: "/tmp/book.wikg",
+      cursor: "raw-cursor",
+      format: "text",
+      indexScope: {
+        archiveKey: "archive-key",
+        archivePath: "/tmp/book.wikg",
+        kind: "archive-index",
+      },
+      kind: "related",
+      order: "doc-desc",
+      query: "alpha",
+      role: "subject",
+      skipUnindexed: true,
+      targetUri: "wikg://entity/Q1",
+    };
+
+    expect(roundTripCursor(cursor)).toStrictEqual(cursor);
+  });
+
   it("rejects malformed and mismatched archive index scopes", () => {
     expect(() =>
       parseContinuationCursorRecord({
@@ -119,3 +184,13 @@ describe("continuation cursor payload", () => {
     ).toThrow("Invalid continuation cursor payload");
   });
 });
+
+function roundTripCursor(cursor: ContinuationCursor): ContinuationCursor {
+  return parseContinuationCursorRecord({
+    archiveKey: cursor.archiveKey,
+    archivePath: cursor.archivePath,
+    format: cursor.format,
+    kind: cursor.kind,
+    payloadJSON: JSON.stringify(createCursorPayload(cursor)),
+  });
+}

--- a/packages/core/src/retrieval/query/continuation-cursor/payload.ts
+++ b/packages/core/src/retrieval/query/continuation-cursor/payload.ts
@@ -34,6 +34,9 @@ export function createCursorPayload(input: ContinuationCursor): object {
           ? {}
           : { evidenceLimit: input.evidenceLimit }),
         ...(input.query === undefined ? {} : { query: input.query }),
+        ...(input.skipUnindexed === undefined
+          ? {}
+          : { skipUnindexed: input.skipUnindexed }),
         ...(input.sourceContext === undefined
           ? {}
           : { sourceContext: input.sourceContext }),
@@ -48,6 +51,9 @@ export function createCursorPayload(input: ContinuationCursor): object {
         cursor: input.cursor,
         order: input.order,
         ...(input.query === undefined ? {} : { query: input.query }),
+        ...(input.skipUnindexed === undefined
+          ? {}
+          : { skipUnindexed: input.skipUnindexed }),
         ...(input.sourceContext === undefined
           ? {}
           : { sourceContext: input.sourceContext }),
@@ -63,6 +69,9 @@ export function createCursorPayload(input: ContinuationCursor): object {
         order: input.order,
         ...(input.query === undefined ? {} : { query: input.query }),
         ...(input.role === undefined ? {} : { role: input.role }),
+        ...(input.skipUnindexed === undefined
+          ? {}
+          : { skipUnindexed: input.skipUnindexed }),
         ...(input.sourceContext === undefined
           ? {}
           : { sourceContext: input.sourceContext }),
@@ -113,6 +122,7 @@ export function parseContinuationCursorRecord(record: {
       indexScope,
       kind: "search",
       ...getPayloadOptionalString(payload, "query"),
+      ...getPayloadOptionalBoolean(payload, "skipUnindexed"),
       ...getPayloadOptionalInteger(payload, "sourceContext", "sourceContext"),
       ...getPayloadOptionalTriplePattern(payload),
       types: getPayloadStringArrayOrNull(payload, "types"),
@@ -129,6 +139,7 @@ export function parseContinuationCursorRecord(record: {
       kind: "evidence",
       order: getPayloadOrder(payload),
       ...getPayloadOptionalString(payload, "query"),
+      ...getPayloadOptionalBoolean(payload, "skipUnindexed"),
       ...getPayloadOptionalInteger(payload, "sourceContext", "sourceContext"),
       targetUri: getPayloadString(payload, "targetUri"),
     };
@@ -146,6 +157,7 @@ export function parseContinuationCursorRecord(record: {
       order: getPayloadOrder(payload),
       ...getPayloadOptionalString(payload, "query"),
       ...getPayloadOptionalRelatedRole(payload),
+      ...getPayloadOptionalBoolean(payload, "skipUnindexed"),
       ...getPayloadOptionalInteger(payload, "sourceContext", "sourceContext"),
       targetUri: getPayloadString(payload, "targetUri"),
     };

--- a/packages/core/src/retrieval/query/continuation-cursor/payload.ts
+++ b/packages/core/src/retrieval/query/continuation-cursor/payload.ts
@@ -334,17 +334,17 @@ function getPayloadOptionalInteger<K extends string>(
   throw new Error("Invalid continuation cursor payload.");
 }
 
-function getPayloadOptionalBoolean(
+function getPayloadOptionalBoolean<Key extends string>(
   payload: Readonly<Record<string, unknown>>,
-  key: string,
-): { readonly backlinks?: boolean } {
+  key: Key,
+): { readonly [Property in Key]?: boolean } {
   const value = payload[key];
 
   if (value === undefined) {
     return {};
   }
   if (typeof value === "boolean") {
-    return { backlinks: value };
+    return { [key]: value } as { readonly [Property in Key]?: boolean };
   }
 
   throw new Error("Invalid continuation cursor payload.");

--- a/packages/core/src/retrieval/query/continuation-cursor/types.ts
+++ b/packages/core/src/retrieval/query/continuation-cursor/types.ts
@@ -42,6 +42,7 @@ export type ContinuationCursor =
       readonly format: "json" | "jsonl" | "text";
       readonly kind: "search";
       readonly query?: string;
+      readonly skipUnindexed?: boolean;
       readonly sourceContext?: number;
       readonly triplePattern?: {
         readonly objectQid?: string;
@@ -56,6 +57,7 @@ export type ContinuationCursor =
       readonly kind: "evidence";
       readonly order: "doc-asc" | "doc-desc";
       readonly query?: string;
+      readonly skipUnindexed?: boolean;
       readonly sourceContext?: number;
       readonly targetUri: string;
     })
@@ -67,6 +69,7 @@ export type ContinuationCursor =
       readonly order: "doc-asc" | "doc-desc";
       readonly query?: string;
       readonly role?: "any" | "object" | "self" | "subject";
+      readonly skipUnindexed?: boolean;
       readonly sourceContext?: number;
       readonly targetUri: string;
     });

--- a/packages/core/src/retrieval/query/index.ts
+++ b/packages/core/src/retrieval/query/index.ts
@@ -11,6 +11,7 @@ export {
   createArchiveSearchIndexFingerprint,
   clearDirtyArchiveSearchIndex,
   isArchiveSearchIndexCurrent,
+  listArchiveQueryableChapterIds,
   readArchiveSearchIndexStatus,
   listAllArchiveLinks,
   listArchiveCollection,

--- a/packages/core/src/retrieval/query/search-cache/sessions.ts
+++ b/packages/core/src/retrieval/query/search-cache/sessions.ts
@@ -13,7 +13,7 @@ import { createEntitySearchSessionId, createSearchSessionId } from "./ids.js";
 import { parseSearchResultItem } from "./parsing.js";
 import { SEARCH_SESSION_TTL_MS } from "./schema.js";
 import {
-  deleteSearchSession,
+  deleteSearchSessionRows,
   hasSearchSession,
   readSearchSessionMetadata,
   touchSearchSession,
@@ -85,7 +85,7 @@ export async function createSearchSession(
     });
 
     await database.transaction(async () => {
-      await deleteSearchSession(database, sessionId);
+      await deleteSearchSessionRows(database, sessionId);
       await database.run(
         `
           INSERT INTO search_sessions (
@@ -93,6 +93,20 @@ export async function createSearchSession(
             match, created_at, expires_at, accessed_at
           )
           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(session_id) DO UPDATE SET
+            archive_key = excluded.archive_key,
+            query = excluded.query,
+            options_json = excluded.options_json,
+            terms_json = excluded.terms_json,
+            lens = excluded.lens,
+            match = excluded.match,
+            created_at = CASE
+              WHEN search_sessions.expires_at >= ? THEN search_sessions.created_at
+              ELSE excluded.created_at
+            END,
+            expires_at = excluded.expires_at,
+            accessed_at = excluded.accessed_at,
+            object_caches_populated = 0
         `,
         [
           sessionId,
@@ -104,6 +118,7 @@ export async function createSearchSession(
           input.match,
           now,
           now + SEARCH_SESSION_TTL_MS,
+          now,
           now,
         ],
       );
@@ -152,7 +167,7 @@ export async function createEntitySearchSession(
     });
 
     await database.transaction(async () => {
-      await deleteSearchSession(database, sessionId);
+      await deleteSearchSessionRows(database, sessionId);
       await database.run(
         `
           INSERT INTO search_sessions (
@@ -160,6 +175,20 @@ export async function createEntitySearchSession(
             match, created_at, expires_at, accessed_at
           )
           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(session_id) DO UPDATE SET
+            archive_key = excluded.archive_key,
+            query = excluded.query,
+            options_json = excluded.options_json,
+            terms_json = excluded.terms_json,
+            lens = excluded.lens,
+            match = excluded.match,
+            created_at = CASE
+              WHEN search_sessions.expires_at >= ? THEN search_sessions.created_at
+              ELSE excluded.created_at
+            END,
+            expires_at = excluded.expires_at,
+            accessed_at = excluded.accessed_at,
+            object_caches_populated = 0
         `,
         [
           sessionId,
@@ -171,6 +200,7 @@ export async function createEntitySearchSession(
           input.match,
           now,
           now + SEARCH_SESSION_TTL_MS,
+          now,
           now,
         ],
       );

--- a/packages/core/src/retrieval/query/search-cache/store.ts
+++ b/packages/core/src/retrieval/query/search-cache/store.ts
@@ -108,6 +108,16 @@ export async function deleteSearchSession(
   database: Database,
   sessionId: string,
 ): Promise<void> {
+  await deleteSearchSessionRows(database, sessionId);
+  await database.run("DELETE FROM search_sessions WHERE session_id = ?", [
+    sessionId,
+  ]);
+}
+
+export async function deleteSearchSessionRows(
+  database: Database,
+  sessionId: string,
+): Promise<void> {
   await database.run("DELETE FROM search_results WHERE session_id = ?", [
     sessionId,
   ]);
@@ -122,9 +132,6 @@ export async function deleteSearchSession(
     sessionId,
   ]);
   await database.run("DELETE FROM search_chunk_hits WHERE session_id = ?", [
-    sessionId,
-  ]);
-  await database.run("DELETE FROM search_sessions WHERE session_id = ?", [
     sessionId,
   ]);
 }

--- a/packages/core/src/runtime/jobs/jobs.ts
+++ b/packages/core/src/runtime/jobs/jobs.ts
@@ -345,19 +345,41 @@ export async function resumeBuildJob(jobId: string): Promise<BuildJob> {
 
   try {
     await recoverStaleBuildJobs(state);
-    const job = await requireBuildJobById(state, jobId);
+    return await state.transaction(async () => {
+      const job = await requireBuildJobById(state, jobId);
 
-    if (job.state === "queued") {
-      return job;
-    }
+      if (job.state === "queued") {
+        return job;
+      }
+      if (job.state !== "paused") {
+        throw new Error(`Cannot resume ${job.state} job ${jobId}.`);
+      }
+
+      const now = Date.now();
+      await state.run(
+        `
+UPDATE build_jobs
+SET state = ?, updated_at = ?, finished_at = ?,
+    owner_id = NULL,
+    owner_pid = NULL
+WHERE job_id = ?
+`,
+        ["queued", now, null, jobId],
+      );
+
+      const updated = await requireBuildJobById(state, jobId);
+      await appendBuildJobEvent(updated, {
+        at: now,
+        jobId,
+        seq: 0,
+        state: "queued",
+        type: "resumed",
+      });
+      return updated;
+    });
   } finally {
     await state.close();
   }
-
-  return await updateBuildJobState(jobId, "queued", "resumed", {
-    allowedStates: ["paused"],
-    clearOwner: true,
-  });
 }
 
 export async function cancelBuildJob(jobId: string): Promise<BuildJob> {

--- a/packages/core/src/runtime/jobs/jobs.ts
+++ b/packages/core/src/runtime/jobs/jobs.ts
@@ -341,6 +341,19 @@ export async function pauseBuildJob(jobId: string): Promise<BuildJob> {
 }
 
 export async function resumeBuildJob(jobId: string): Promise<BuildJob> {
+  const state = await openBuildQueueDatabase();
+
+  try {
+    await recoverStaleBuildJobs(state);
+    const job = await requireBuildJobById(state, jobId);
+
+    if (job.state === "queued") {
+      return job;
+    }
+  } finally {
+    await state.close();
+  }
+
   return await updateBuildJobState(jobId, "queued", "resumed", {
     allowedStates: ["paused"],
     clearOwner: true,
@@ -491,7 +504,9 @@ async function updateBuildJobState(
       const job = await requireBuildJobById(state, jobId);
 
       if (!options.allowedStates.includes(job.state)) {
-        throw new Error(`Cannot ${eventType} ${job.state} job ${jobId}.`);
+        throw new Error(
+          `Cannot ${formatBuildJobAction(eventType)} ${job.state} job ${jobId}.`,
+        );
       }
 
       const now = Date.now();
@@ -526,4 +541,10 @@ WHERE job_id = ?
   } finally {
     await state.close();
   }
+}
+
+function formatBuildJobAction(
+  eventType: Extract<BuildJobEvent["type"], "paused" | "resumed">,
+): "pause" | "resume" {
+  return eventType === "paused" ? "pause" : "resume";
 }

--- a/packages/core/src/storage/schema-upgrade/index.ts
+++ b/packages/core/src/storage/schema-upgrade/index.ts
@@ -6,12 +6,14 @@ import { dirname, join, resolve } from "path";
 import { Database, DirectoryDocument } from "../../document/index.js";
 import { ensureChapterKeys } from "../../document/chapter/toc.js";
 import type { MutableTocFile } from "../../document/chapter/tree.js";
+import { TEXT_STREAM_KIND } from "../../document/text-streams/types.js";
 import { ensureWikiGraphHomeSchemaCurrent } from "../../document/home-schema-upgrade.js";
 import { replaceChapterFtsIndexArtifact } from "../../retrieval/index-artifact/index.js";
 import {
   resolveWikiGraphHomeDirectoryPath,
   resolveWikiGraphStagingDirectoryPath,
 } from "../../runtime/common/wiki-graph/dir.js";
+import { countTextWords } from "../../utils/text-word-count.js";
 import {
   SEARCH_INDEX_DATABASE_PATH,
   LEGACY_SEARCH_INDEX_DATABASE_PATH,
@@ -40,6 +42,7 @@ const LOCK_STALE_TIMEOUT_MS = 5 * 60 * 1000;
 export interface WikiGraphArchiveSchemaUpgradeResult {
   readonly changed: boolean;
   readonly repairedToc: boolean;
+  readonly repairedTextWords: boolean;
   readonly schemaChanged: boolean;
 }
 
@@ -103,11 +106,21 @@ export async function upgradeWikiGraphArchiveSchema(
       temporaryDirectories,
     );
     const schemaChanged = schemaVersion < CURRENT_ARCHIVE_SCHEMA_VERSION;
+    const archiveDatabaseUpgrade = await createArchiveDatabaseUpgradeOverlay(
+      resolvedArchivePath,
+      temporaryDirectories,
+      { refreshArtifacts: schemaChanged },
+    );
 
-    if (!schemaChanged && tocOverlay === undefined) {
+    if (
+      !schemaChanged &&
+      tocOverlay === undefined &&
+      archiveDatabaseUpgrade.overlay === undefined
+    ) {
       return {
         changed: false,
         repairedToc: false,
+        repairedTextWords: false,
         schemaChanged: false,
       };
     }
@@ -116,12 +129,6 @@ export async function upgradeWikiGraphArchiveSchema(
 
     const archiveKey = createArchiveKey(resolvedArchivePath);
     await assertArchiveUpgradeSafe(archiveKey);
-    const archiveDatabaseOverlay = schemaChanged
-      ? await createArchiveDatabaseUpgradeOverlay(
-          resolvedArchivePath,
-          temporaryDirectories,
-        )
-      : undefined;
 
     const temporaryPath = join(
       dirname(resolvedArchivePath),
@@ -144,9 +151,9 @@ export async function upgradeWikiGraphArchiveSchema(
               },
             ]
           : []),
-        ...(archiveDatabaseOverlay === undefined
+        ...(archiveDatabaseUpgrade.overlay === undefined
           ? []
-          : [archiveDatabaseOverlay]),
+          : [archiveDatabaseUpgrade.overlay]),
         ...(tocOverlay === undefined ? [] : [tocOverlay]),
       ],
       { preserveMutationToken: true },
@@ -157,6 +164,7 @@ export async function upgradeWikiGraphArchiveSchema(
     return {
       changed: true,
       repairedToc: tocOverlay !== undefined,
+      repairedTextWords: archiveDatabaseUpgrade.repairedTextWords,
       schemaChanged,
     };
   } finally {
@@ -232,14 +240,17 @@ async function createChapterTocUpgradeOverlay(
 async function createArchiveDatabaseUpgradeOverlay(
   archivePath: string,
   temporaryDirectories: string[],
-): Promise<
-  | {
-      readonly entryPath: typeof DATABASE_ENTRY_PATH;
-      readonly kind: "file";
-      readonly workspacePath: string;
-    }
-  | undefined
-> {
+  options: { readonly refreshArtifacts: boolean },
+): Promise<{
+  readonly overlay:
+    | {
+        readonly entryPath: typeof DATABASE_ENTRY_PATH;
+        readonly kind: "file";
+        readonly workspacePath: string;
+      }
+    | undefined;
+  readonly repairedTextWords: boolean;
+}> {
   const temporaryDirectory = await mkdtemp(
     join(tmpdir(), "wikigraph-archive-upgrade-"),
   );
@@ -247,22 +258,32 @@ async function createArchiveDatabaseUpgradeOverlay(
   await extractWikgArchive(archivePath, temporaryDirectory);
 
   const document = await DirectoryDocument.open(temporaryDirectory);
+  let repairedTextWords = false;
 
   try {
-    await refreshChapterArtifacts(document);
+    repairedTextWords = await repairTextSentenceWordCounts(document);
+    if (options.refreshArtifacts) {
+      await refreshChapterArtifacts(document);
+    }
   } finally {
     await document.release();
   }
 
   const databasePath = join(temporaryDirectory, DATABASE_ENTRY_PATH);
   if (!(await pathExists(databasePath))) {
-    return undefined;
+    return { overlay: undefined, repairedTextWords };
+  }
+  if (!options.refreshArtifacts && !repairedTextWords) {
+    return { overlay: undefined, repairedTextWords: false };
   }
 
   return {
-    entryPath: DATABASE_ENTRY_PATH,
-    kind: "file",
-    workspacePath: databasePath,
+    overlay: {
+      entryPath: DATABASE_ENTRY_PATH,
+      kind: "file",
+      workspacePath: databasePath,
+    },
+    repairedTextWords,
   };
 }
 
@@ -288,6 +309,112 @@ async function refreshChapterArtifacts(
   await document.readDatabase(async (database) => {
     await database.run("DROP TABLE IF EXISTS archive_index_settings");
   });
+}
+
+async function repairTextSentenceWordCounts(
+  document: DirectoryDocument,
+): Promise<boolean> {
+  const rows = await document.readDatabase(async (database) =>
+    database.queryAll(
+      `
+        SELECT kind, chapter_id, sentence_index, words_count, byte_offset, byte_length
+        FROM text_sentence_records
+        ORDER BY kind, chapter_id, sentence_index
+      `,
+      undefined,
+      (row) => ({
+        byteLength: Number(row.byte_length),
+        byteOffset: Number(row.byte_offset),
+        chapterId: Number(row.chapter_id),
+        kind: Number(row.kind),
+        sentenceIndex: Number(row.sentence_index),
+        wordsCount: Number(row.words_count),
+      }),
+    ),
+  );
+  const textCache = new Map<string, Buffer | undefined>();
+  const updates: Array<{
+    readonly chapterId: number;
+    readonly kind: number;
+    readonly sentenceIndex: number;
+    readonly wordsCount: number;
+  }> = [];
+
+  for (const row of rows) {
+    const streamName = getTextStreamName(row.kind);
+    if (streamName === undefined) {
+      continue;
+    }
+
+    const textKey = `${streamName}:${row.chapterId}`;
+    let textBuffer = textCache.get(textKey);
+
+    if (textBuffer === undefined) {
+      const text =
+        streamName === "source"
+          ? await document.getSerialFragments(row.chapterId).readText()
+          : await document.getSummaryFragments(row.chapterId).readText();
+
+      textBuffer = text === undefined ? undefined : Buffer.from(text, "utf8");
+      textCache.set(textKey, textBuffer);
+    }
+    if (textBuffer === undefined) {
+      continue;
+    }
+
+    const sentenceText = textBuffer
+      .subarray(row.byteOffset, row.byteOffset + row.byteLength)
+      .toString("utf8");
+    const wordsCount = countTextWords(sentenceText);
+
+    if (wordsCount === row.wordsCount) {
+      continue;
+    }
+
+    updates.push({
+      chapterId: row.chapterId,
+      kind: row.kind,
+      sentenceIndex: row.sentenceIndex,
+      wordsCount,
+    });
+  }
+
+  if (updates.length === 0) {
+    return false;
+  }
+
+  await document.readDatabase(async (database) => {
+    await database.transaction(async () => {
+      for (const update of updates) {
+        await database.run(
+          `
+            UPDATE text_sentence_records
+            SET words_count = ?
+            WHERE kind = ? AND chapter_id = ? AND sentence_index = ?
+          `,
+          [
+            update.wordsCount,
+            update.kind,
+            update.chapterId,
+            update.sentenceIndex,
+          ],
+        );
+      }
+    });
+  });
+
+  return true;
+}
+
+function getTextStreamName(kind: number): "source" | "summary" | undefined {
+  if (kind === TEXT_STREAM_KIND.source) {
+    return "source";
+  }
+  if (kind === TEXT_STREAM_KIND.summary) {
+    return "summary";
+  }
+
+  return undefined;
 }
 
 async function cleanupArchiveDerivedData(archiveKey: string): Promise<void> {

--- a/packages/core/src/storage/schema-upgrade/index.ts
+++ b/packages/core/src/storage/schema-upgrade/index.ts
@@ -332,7 +332,8 @@ async function repairTextSentenceWordCounts(
       }),
     ),
   );
-  const textCache = new Map<string, Buffer | undefined>();
+  let cachedTextKey: string | undefined;
+  let cachedTextBuffer: Buffer | undefined;
   const updates: Array<{
     readonly chapterId: number;
     readonly kind: number;
@@ -347,22 +348,21 @@ async function repairTextSentenceWordCounts(
     }
 
     const textKey = `${streamName}:${row.chapterId}`;
-    let textBuffer = textCache.get(textKey);
-
-    if (textBuffer === undefined) {
+    if (textKey !== cachedTextKey) {
+      cachedTextKey = textKey;
       const text =
         streamName === "source"
           ? await document.getSerialFragments(row.chapterId).readText()
           : await document.getSummaryFragments(row.chapterId).readText();
 
-      textBuffer = text === undefined ? undefined : Buffer.from(text, "utf8");
-      textCache.set(textKey, textBuffer);
+      cachedTextBuffer =
+        text === undefined ? undefined : Buffer.from(text, "utf8");
     }
-    if (textBuffer === undefined) {
+    if (cachedTextBuffer === undefined) {
       continue;
     }
 
-    const sentenceText = textBuffer
+    const sentenceText = cachedTextBuffer
       .subarray(row.byteOffset, row.byteOffset + row.byteLength)
       .toString("utf8");
     const wordsCount = countTextWords(sentenceText);

--- a/packages/core/src/text/reader/segment/intl-segmenter.ts
+++ b/packages/core/src/text/reader/segment/intl-segmenter.ts
@@ -3,19 +3,14 @@ import type {
   SentenceStreamItem,
   TextStream,
 } from "./types.js";
+import { countTextWords } from "../../../utils/text-word-count.js";
 
 const SENTENCE_BOUNDARY_PATTERN =
   /(?:[.!?。！？…]+|(?:\r?\n)\s*(?:\r?\n)?|[.!?。！？…]+["'”’」』】）》〉〕〗]*)$/u;
 
 class IntlSegmenterSentenceStreamAdapter implements SentenceStreamAdapter {
-  readonly #graphemeSegmenter = new Intl.Segmenter(undefined, {
-    granularity: "grapheme",
-  });
   readonly #sentenceSegmenter = new Intl.Segmenter(undefined, {
     granularity: "sentence",
-  });
-  readonly #wordSegmenter = new Intl.Segmenter(undefined, {
-    granularity: "word",
   });
 
   public async *pipe(stream: TextStream): AsyncIterable<SentenceStreamItem> {
@@ -36,7 +31,7 @@ class IntlSegmenterSentenceStreamAdapter implements SentenceStreamAdapter {
         yield {
           offset,
           text: sentenceText,
-          wordsCount: this.#countWords(sentenceText),
+          wordsCount: countTextWords(sentenceText),
         };
         offset += sentenceText.length;
       }
@@ -48,7 +43,7 @@ class IntlSegmenterSentenceStreamAdapter implements SentenceStreamAdapter {
       yield {
         offset,
         text: sentenceText,
-        wordsCount: this.#countWords(sentenceText),
+        wordsCount: countTextWords(sentenceText),
       };
       offset += sentenceText.length;
     }
@@ -102,32 +97,6 @@ class IntlSegmenterSentenceStreamAdapter implements SentenceStreamAdapter {
         .map((segment) => segment.segment.trim())
         .filter((segment) => segment !== ""),
     };
-  }
-
-  #countWords(text: string): number {
-    let wordsCount = 0;
-
-    for (const segment of this.#wordSegmenter.segment(text)) {
-      if ("isWordLike" in segment && segment.isWordLike) {
-        wordsCount += 1;
-      }
-    }
-
-    if (wordsCount > 0) {
-      return wordsCount;
-    }
-
-    return this.#countGraphemes(text);
-  }
-
-  #countGraphemes(text: string): number {
-    let unitCount = 0;
-
-    for (const _segment of this.#graphemeSegmenter.segment(text)) {
-      unitCount += 1;
-    }
-
-    return unitCount;
   }
 
   #endsWithSentenceBoundary(buffer: string): boolean {

--- a/packages/core/src/text/serial/generation.ts
+++ b/packages/core/src/text/serial/generation.ts
@@ -258,7 +258,6 @@ export class SerialGeneration {
     await this.#writeSemaphore.use(async () => {
       await topology.finalize();
       await this.#serials.setTopologyReady(serialId);
-      await this.#serials.bumpRevision(serialId);
     });
   }
 

--- a/packages/core/src/text/serial/source.ts
+++ b/packages/core/src/text/serial/source.ts
@@ -11,6 +11,7 @@ export async function writeSerialSource(
 ): Promise<void> {
   const serialFragments = document.getSerialFragments(serialId);
 
+  await document.clearSerialDerivedArtifacts(serialId);
   await serialFragments.writeTextStream(await collectTextStream(stream), {
     ...(options.segmenter === undefined
       ? {}

--- a/packages/core/src/text/source/epub/content.ts
+++ b/packages/core/src/text/source/epub/content.ts
@@ -2,6 +2,7 @@ import type { Readable } from "stream";
 
 import { Parser } from "htmlparser2";
 
+import { countTextWords } from "../../../utils/text-word-count.js";
 import type { SourceTextStream } from "../types.js";
 import type { EpubArchive } from "./archive.js";
 
@@ -110,7 +111,7 @@ export async function analyzeSectionTargets(
 
       analyses.set(target.id, {
         hasContent: text.trim() !== "",
-        wordsCount: countWords(text),
+        wordsCount: countTextWords(text),
       });
     }
   }
@@ -258,22 +259,4 @@ function toTextChunk(chunk: unknown): string {
   }
 
   throw new Error("Unexpected HTML stream chunk type");
-}
-
-function countWords(text: string): number {
-  return [...createWordSegmenter().segment(text)].filter(
-    (segment) => segment.isWordLike,
-  ).length;
-}
-
-let WORD_SEGMENTER: Intl.Segmenter | undefined;
-
-function createWordSegmenter(): Intl.Segmenter {
-  if (WORD_SEGMENTER === undefined) {
-    WORD_SEGMENTER = new Intl.Segmenter(undefined, {
-      granularity: "word",
-    });
-  }
-
-  return WORD_SEGMENTER;
 }

--- a/packages/core/src/utils/text-word-count.test.ts
+++ b/packages/core/src/utils/text-word-count.test.ts
@@ -13,4 +13,10 @@ describe("countTextWords", () => {
     expect(countTextWords("  中文，English!  ")).toBe(3);
     expect(countTextWords(" \n\t ")).toBe(0);
   });
+
+  it("keeps combining marks inside the current word", () => {
+    expect(countTextWords("e\u0301clair")).toBe(1);
+    expect(countTextWords("عَرَبِيّ")).toBe(1);
+    expect(countTextWords("\u0301")).toBe(0);
+  });
 });

--- a/packages/core/src/utils/text-word-count.test.ts
+++ b/packages/core/src/utils/text-word-count.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { countTextWords } from "./text-word-count.js";
+
+describe("countTextWords", () => {
+  it("counts Latin words and Han characters on the same scale", () => {
+    expect(countTextWords("Alpha beta 123")).toBe(3);
+    expect(countTextWords("朱元璋占据应天")).toBe(7);
+    expect(countTextWords("Alpha朱元璋 beta")).toBe(5);
+  });
+
+  it("ignores whitespace and punctuation", () => {
+    expect(countTextWords("  中文，English!  ")).toBe(3);
+    expect(countTextWords(" \n\t ")).toBe(0);
+  });
+});

--- a/packages/core/src/utils/text-word-count.ts
+++ b/packages/core/src/utils/text-word-count.ts
@@ -1,0 +1,27 @@
+const HAN_CHARACTER_PATTERN = /\p{Script=Han}/u;
+const WORD_CHARACTER_PATTERN = /[\p{Letter}\p{Number}]/u;
+
+export function countTextWords(text: string): number {
+  let words = 0;
+  let inWord = false;
+
+  for (const character of text.trim()) {
+    if (HAN_CHARACTER_PATTERN.test(character)) {
+      words += 1;
+      inWord = false;
+      continue;
+    }
+
+    if (WORD_CHARACTER_PATTERN.test(character)) {
+      if (!inWord) {
+        words += 1;
+      }
+      inWord = true;
+      continue;
+    }
+
+    inWord = false;
+  }
+
+  return words;
+}

--- a/packages/core/src/utils/text-word-count.ts
+++ b/packages/core/src/utils/text-word-count.ts
@@ -1,5 +1,6 @@
 const HAN_CHARACTER_PATTERN = /\p{Script=Han}/u;
 const WORD_CHARACTER_PATTERN = /[\p{Letter}\p{Number}]/u;
+const WORD_MARK_PATTERN = /\p{Mark}/u;
 
 export function countTextWords(text: string): number {
   let words = 0;
@@ -17,6 +18,10 @@ export function countTextWords(text: string): number {
         words += 1;
       }
       inWord = true;
+      continue;
+    }
+
+    if (inWord && WORD_MARK_PATTERN.test(character)) {
       continue;
     }
 

--- a/test/cli/archive/chapter.test.ts
+++ b/test/cli/archive/chapter.test.ts
@@ -438,7 +438,12 @@ describe("cli/archive-chapter", () => {
       },
     ]);
     expect(chapterMockState.textWrites).toStrictEqual([
-      "Queued index-embedding-source job job-index-1 for chapter 2.\n",
+      [
+        "Job job-index-1 queued index-embedding-source chapter 2 /tmp/book.wikg",
+        "Job is queued; the requested artifact or generated data is not ready until the job succeeds.",
+        "Watch: wg wikg://local/job/job-index-1 watch",
+        "",
+      ].join("\n"),
     ]);
     expect(chapterMockState.workerStartCalls).toBe(1);
   });

--- a/test/cli/archive/chapter.test.ts
+++ b/test/cli/archive/chapter.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type * as CLIQueueAdd from "../../../packages/cli/src/commands/queue/add.js";
 import type * as CLISupport from "../../../packages/cli/src/support/index.js";
 
 const chapterMockState = vi.hoisted(() => ({
@@ -11,6 +12,7 @@ const chapterMockState = vi.hoisted(() => ({
   inputFileContent: "file content",
   moveCalls: [] as unknown[],
   treeApplyCalls: [] as unknown[],
+  workerStartCalls: 0,
   tree: {
     chapters: [
       {
@@ -104,6 +106,20 @@ vi.mock(
       }
     },
   }),
+);
+
+vi.mock(
+  "../../../packages/cli/src/commands/queue/add.js",
+  async (importOriginal) => {
+    const actual = await importOriginal<typeof CLIQueueAdd>();
+
+    return {
+      ...actual,
+      tryStartQueueWorker: vi.fn(() => {
+        chapterMockState.workerStartCalls += 1;
+      }),
+    };
+  },
 );
 
 vi.mock("../../../packages/core/src/api/index.js", () => ({
@@ -323,6 +339,7 @@ describe("cli/archive-chapter", () => {
     chapterMockState.setTitleCalls.length = 0;
     chapterMockState.treeApplyCalls.length = 0;
     chapterMockState.textWrites.length = 0;
+    chapterMockState.workerStartCalls = 0;
     setStdinTTY(false);
   });
 
@@ -423,6 +440,7 @@ describe("cli/archive-chapter", () => {
     expect(chapterMockState.textWrites).toStrictEqual([
       "Queued index-embedding-source job job-index-1 for chapter 2.\n",
     ]);
+    expect(chapterMockState.workerStartCalls).toBe(1);
   });
 
   it("adds a sourced chapter from --input", async () => {

--- a/test/cli/archive/evidence-pack.test.ts
+++ b/test/cli/archive/evidence-pack.test.ts
@@ -95,6 +95,25 @@ describe("cli/archive/evidence pack", () => {
     expect(archiveMockState.textWrites[0]).toContain('"score": 2.5');
   });
 
+  it("warns when evidence query skips unindexed chapters", async () => {
+    await runArchiveCommand({
+      action: "evidence",
+      archivePath: "wikg:///tmp/book.wikg",
+      format: "text",
+      objectId: "wikg:///tmp/book.wikg/entity/Q1",
+      query: "paragraph",
+      skipUnindexed: true,
+    });
+
+    expect(listArchiveEvidence).toHaveBeenCalledWith({}, "wikg://entity/Q1", {
+      query: "paragraph",
+      skipUnindexed: true,
+    });
+    expect(archiveMockState.textWrites[0]).toContain(
+      "Warning: --skip-unindexed was used; this command searched only chapters that already have a current FTS or source embedding index artifact.",
+    );
+  });
+
   it("creates evidence continuation cursors with the target URI", async () => {
     vi.mocked(listArchiveEvidence).mockResolvedValueOnce({
       ...archiveMockState.evidence,

--- a/test/cli/archive/mock.ts
+++ b/test/cli/archive/mock.ts
@@ -519,6 +519,7 @@ vi.mock("wiki-graph-core", async (importOriginal) => {
     isArchiveSearchIndexCurrent: vi.fn(() =>
       Promise.resolve(archiveMockState.ftsCurrent),
     ),
+    listArchiveQueryableChapterIds: vi.fn(() => Promise.resolve([1, 2])),
     rebuildArchiveSearchIndex: vi.fn(() => Promise.resolve()),
     resolveWikiGraphLibraryArchivePath: vi.fn((uri: string) => {
       const archiveId = uri.split("/").at(-1) ?? "archive";
@@ -620,6 +621,7 @@ vi.mock("../../../packages/core/src/api/index.js", () => ({
     },
   ),
   getArchiveIndex: vi.fn(() => Promise.resolve(archiveMockState.index)),
+  listArchiveQueryableChapterIds: vi.fn(() => Promise.resolve([1, 2])),
   listRelatedArchiveObjects: vi.fn(() =>
     Promise.resolve({
       items: archiveMockState.listItems,

--- a/test/cli/archive/object.test.ts
+++ b/test/cli/archive/object.test.ts
@@ -228,7 +228,10 @@ describe("cli/archive/object", () => {
       "Knowledge Graph: 1/2 chapters, 800/1200 words, 66.7%",
     );
     expect(archiveMockState.textWrites[0]).toContain(
-      "Summary: 1/2 chapters, 800/1200 words, 66.7%",
+      "Summary Artifact: 1/2 chapters, 800/1200 words, 66.7%",
+    );
+    expect(archiveMockState.textWrites[0]).toContain(
+      "Summary note: Summary coverage means a current summary artifact exists for the chapter; it does not guarantee that every source topic is represented in the summary text.",
     );
     expect(archiveMockState.textWrites[0]).toContain(
       "Command: wg wikg:///tmp/book.wikg/index sync",
@@ -539,7 +542,7 @@ describe("cli/archive/object", () => {
       "Knowledge Graph: n/a, no source content",
     );
     expect(archiveMockState.textWrites[0]).toContain(
-      "Summary: n/a, no source content",
+      "Summary Artifact: n/a, no source content",
     );
     expect(archiveMockState.textWrites[0]).not.toContain("0%");
   });

--- a/test/cli/archive/object.test.ts
+++ b/test/cli/archive/object.test.ts
@@ -477,7 +477,11 @@ describe("cli/archive/object", () => {
           totalWords: 1200,
         },
       },
-      help: { readiness: "wg help readiness" },
+      help: {
+        readiness: "wg help readiness",
+        summaryCoverage:
+          "Summary coverage means a current summary artifact exists for the chapter; it does not guarantee that every source topic is represented in the summary text.",
+      },
     });
     expect(output.retrievalGuidance).toEqual(
       expect.arrayContaining([

--- a/test/cli/archive/query.test.ts
+++ b/test/cli/archive/query.test.ts
@@ -49,6 +49,64 @@ describe("cli/archive/query", () => {
     });
   });
 
+  it("warns when search skips unindexed chapters", async () => {
+    await runArchiveCommand({
+      action: "search",
+      archivePath: "wikg:///tmp/book.wikg",
+      format: "text",
+      kinds: ["chunk"],
+      query: "RAG",
+      skipUnindexed: true,
+    });
+
+    expect(archiveMockState.textWrites[0]).toContain(
+      "Warning: --skip-unindexed was used; this command searched only chapters that already have a current FTS or source embedding index artifact.",
+    );
+    expect(findArchiveObjects).toHaveBeenCalledWith({}, "RAG", {
+      archiveKey: "/tmp/book.wikg",
+      chapters: [1, 2],
+      skipUnindexed: true,
+      types: ["node"],
+    });
+  });
+
+  it("includes skip-unindexed warnings in JSON search output", async () => {
+    await runArchiveCommand({
+      action: "search",
+      archivePath: "wikg:///tmp/book.wikg",
+      format: "json",
+      kinds: ["chunk"],
+      query: "RAG",
+      skipUnindexed: true,
+    });
+
+    expect(JSON.parse(archiveMockState.textWrites[0] ?? "")).toMatchObject({
+      warnings: [
+        {
+          type: "skip-unindexed",
+        },
+      ],
+    });
+  });
+
+  it("includes skip-unindexed warnings in JSONL search output", async () => {
+    await runArchiveCommand({
+      action: "search",
+      archivePath: "wikg:///tmp/book.wikg",
+      format: "jsonl",
+      kinds: ["chunk"],
+      query: "RAG",
+      skipUnindexed: true,
+    });
+
+    expect(
+      JSON.parse(archiveMockState.textWrites[0]!.split("\n")[0]!),
+    ).toMatchObject({
+      type: "warning",
+      warning: "skip-unindexed",
+    });
+  });
+
   it("prints source search hits as citation blocks", async () => {
     await runArchiveCommand({
       action: "search",

--- a/test/cli/archive/related.test.ts
+++ b/test/cli/archive/related.test.ts
@@ -40,6 +40,33 @@ describe("cli/archive/related", () => {
     expect(archiveMockState.textWrites[0]).not.toContain("Q1 mentions Q2");
   });
 
+  it("warns when related query skips unindexed chapters", async () => {
+    await runArchiveCommand({
+      action: "related",
+      archivePath: "wikg:///tmp/book.wikg",
+      format: "json",
+      objectId: "wikg:///tmp/book.wikg/chunk/9",
+      query: "agent",
+      skipUnindexed: true,
+    });
+
+    expect(listRelatedArchiveObjects).toHaveBeenCalledWith(
+      {},
+      "wikg://chunk/9",
+      {
+        query: "agent",
+        skipUnindexed: true,
+      },
+    );
+    expect(JSON.parse(archiveMockState.textWrites[0] ?? "")).toMatchObject({
+      warnings: [
+        {
+          type: "skip-unindexed",
+        },
+      ],
+    });
+  });
+
   it("prints related triples as structured JSON", async () => {
     await runArchiveCommand({
       action: "related",

--- a/test/cli/queue.test.ts
+++ b/test/cli/queue.test.ts
@@ -1023,7 +1023,7 @@ describe("cli/queue", () => {
     expect(queueMockState.loadRequiredStageConfigCalls).toStrictEqual([]);
     expect(queueMockState.embeddingRequests).toStrictEqual([]);
     expect(queueMockState.serialFragmentsSentenceListCalls).toBe(1);
-    expect(queueMockState.summaryFragmentsSentenceListCalls).toBe(1);
+    expect(queueMockState.summaryFragmentsSentenceListCalls).toBe(0);
     expect(queueMockState.stepLog).toStrictEqual([
       "read:start",
       "read:end",
@@ -1048,22 +1048,6 @@ describe("cli/queue", () => {
       {
         rowId: "source-sentence:0",
         text: "Alpha beta.",
-      },
-      {
-        rowId: "summary-sentence:0",
-        text: "Summary text.",
-      },
-      {
-        rowId: "chunk-label:123",
-        text: "Chunk label",
-      },
-      {
-        rowId: "chunk-content:123",
-        text: "Chunk content.",
-      },
-      {
-        rowId: "mention-surface:mention-1",
-        text: "Alpha",
       },
     ]);
     expect(reporter.stepStarted).toHaveBeenCalledWith("index-fts");
@@ -1137,6 +1121,55 @@ describe("cli/queue", () => {
         ownerId: "owner-1",
       },
     ]);
+  });
+
+  it("runs summary embedding index artifact jobs through JSONL output", async () => {
+    queueMockState.cliConfig = {
+      embedding: {
+        model: "test-embedding",
+        provider: "openai-compatible",
+      },
+    };
+    queueMockState.job = {
+      ...queueMockState.job,
+      state: "running",
+      target: "index-embedding-summary",
+    };
+
+    await runQueueWorker();
+
+    const reporter = {
+      addOutputCharacters: vi.fn(() => Promise.resolve()),
+      setTotals: vi.fn(() => Promise.resolve()),
+      stepCompleted: vi.fn(() => Promise.resolve()),
+      stepStarted: vi.fn(() => Promise.resolve()),
+      updatePhase: vi.fn(() => Promise.resolve()),
+      updateWords: vi.fn(() => Promise.resolve()),
+    };
+
+    await queueMockState.runWorkerOptions!.executeJob(
+      queueMockState.job,
+      reporter,
+      { signal: new AbortController().signal },
+    );
+
+    expect(queueMockState.serialFragmentsSentenceListCalls).toBe(0);
+    expect(queueMockState.summaryFragmentsSentenceListCalls).toBe(1);
+    expect(queueMockState.embeddingRequests).toStrictEqual([["Summary text."]]);
+    expect(queueMockState.indexArtifactWrites[0]).toMatchObject({
+      artifact: {
+        kind: "embedding-summary",
+        segments: [
+          {
+            text: "Summary text.",
+            vector: [1, 2, 3],
+          },
+        ],
+        serialId: 12,
+        sourceRevision: 1,
+      },
+      kind: "embedding",
+    });
   });
 
   it("rejects embedding index artifact jobs when the chapter is gone", async () => {

--- a/test/cli/queue.test.ts
+++ b/test/cli/queue.test.ts
@@ -155,6 +155,16 @@ function createQueueMockDocument() {
     },
     readSummary: () =>
       Promise.resolve(queueMockState.hasSummary ? "Summary text." : undefined),
+    readToc: () =>
+      Promise.resolve({
+        items: [
+          {
+            children: [],
+            serialId: 12,
+            title: "Chapter title",
+          },
+        ],
+      }),
     serials: {
       getById: () =>
         Promise.resolve(queueMockState.serialExists ? { id: 12 } : undefined),
@@ -1046,7 +1056,7 @@ describe("cli/queue", () => {
     expect(queueMockState.loadRequiredStageConfigCalls).toStrictEqual([]);
     expect(queueMockState.embeddingRequests).toStrictEqual([]);
     expect(queueMockState.serialFragmentsSentenceListCalls).toBe(1);
-    expect(queueMockState.summaryFragmentsSentenceListCalls).toBe(0);
+    expect(queueMockState.summaryFragmentsSentenceListCalls).toBe(1);
     expect(queueMockState.stepLog).toStrictEqual([
       "read:start",
       "read:end",
@@ -1069,8 +1079,28 @@ describe("cli/queue", () => {
       ).artifact.lexicalRows,
     ).toMatchObject([
       {
+        rowId: "chapter-title:12",
+        text: "Chapter title",
+      },
+      {
         rowId: "source-sentence:0",
         text: "Alpha beta.",
+      },
+      {
+        rowId: "summary-sentence:0",
+        text: "Summary text.",
+      },
+      {
+        rowId: "chunk-label:123",
+        text: "Chunk label",
+      },
+      {
+        rowId: "chunk-content:123",
+        text: "Chunk content.",
+      },
+      {
+        rowId: "mention-surface:mention-1",
+        text: "Alpha",
       },
     ]);
     expect(reporter.stepStarted).toHaveBeenCalledWith("index-fts");

--- a/test/cli/queue.test.ts
+++ b/test/cli/queue.test.ts
@@ -324,7 +324,7 @@ vi.mock("../../packages/core/src/api/index.js", () => ({
     queueMockState.resolveJobIds.push(jobId);
     return Promise.resolve(jobId === "job-1-short" ? "job-1-full" : jobId);
   }),
-  resumeBuildJob: vi.fn(),
+  resumeBuildJob: vi.fn(() => Promise.resolve(queueMockState.job)),
   runBuildJobWorker: vi.fn(
     (options: typeof queueMockState.runWorkerOptions) => {
       queueMockState.runWorkerOptions = {
@@ -577,6 +577,9 @@ describe("cli/queue", () => {
     ]);
     expect(queueMockState.loadRequiredStageConfigCalls).toStrictEqual([{}]);
     expect(queueMockState.textWrites.join("")).toContain("Job job-1 queued");
+    expect(queueMockState.textWrites.join("")).toContain(
+      "Job is queued; the requested artifact or generated data is not ready until the job succeeds.",
+    );
     expect(queueMockState.textWrites.join("")).toContain("Estimate:");
     expect(queueMockState.textWrites.join("")).toContain(
       "Work: reading-graph over 1 chapter / 800 words",
@@ -612,6 +615,8 @@ describe("cli/queue", () => {
         words: 800,
       },
       jobId: "job-1",
+      notice:
+        "Job is queued; the requested artifact or generated data is not ready until the job succeeds.",
       state: "queued",
       target: "reading-summary",
       watchCommand: "wg wikg://local/job/job-1 watch",
@@ -908,6 +913,24 @@ describe("cli/queue", () => {
       },
       state: "succeeded",
     });
+  });
+
+  it("prints queued resume as resumable work", async () => {
+    queueMockState.job = {
+      ...queueMockState.job,
+      state: "queued",
+    };
+
+    await runQueueCommand({
+      action: "resume",
+      jobId: "job-1-short",
+    });
+
+    expect(queueMockState.resolveJobIds).toStrictEqual(["job-1-short"]);
+    expect(queueMockState.textWrites.join("")).toContain("Job job-1 queued");
+    expect(queueMockState.textWrites.join("")).toContain(
+      "Job is queued; the requested artifact or generated data is not ready until the job succeeds.",
+    );
   });
 
   it("runs LLM build work outside archive write scopes", async () => {

--- a/test/core/api/build-queue.test.ts
+++ b/test/core/api/build-queue.test.ts
@@ -9,6 +9,7 @@ import {
   assertNoActiveBuildJobConflicts,
   getBuildJob,
   listBuildJobs,
+  pauseBuildJob,
   readBuildJobEvents,
   resolveBuildJobId,
   resumeBuildJob,
@@ -118,6 +119,27 @@ describe("facade/build-queue", () => {
         state: "queued",
       });
       await expect(readBuildJobEvents(job)).resolves.toHaveLength(1);
+    });
+  });
+
+  it("treats concurrent resume calls as idempotent", async () => {
+    await withTempDir("wikigraph-build-queue-", async (path) => {
+      useStateDir(`${path}/state`);
+
+      const job = await addBuildJob({
+        archivePath: `${path}/book.wikg`,
+        chapterId: 1,
+        target: "reading-summary",
+      });
+      const paused = await pauseBuildJob(job.jobId);
+
+      await expect(
+        Promise.all([resumeBuildJob(job.jobId), resumeBuildJob(job.jobId)]),
+      ).resolves.toEqual([
+        expect.objectContaining({ jobId: job.jobId, state: "queued" }),
+        expect.objectContaining({ jobId: job.jobId, state: "queued" }),
+      ]);
+      await expect(readBuildJobEvents(paused)).resolves.toHaveLength(3);
     });
   });
 

--- a/test/core/api/build-queue.test.ts
+++ b/test/core/api/build-queue.test.ts
@@ -917,7 +917,7 @@ describe("facade/build-queue", () => {
       releaseJob();
       await worker;
     });
-  });
+  }, 10_000);
 
   async function waitForRunningJob(message: string): Promise<void> {
     await waitForRunningJobCount(1, message);

--- a/test/core/api/build-queue.test.ts
+++ b/test/core/api/build-queue.test.ts
@@ -11,6 +11,7 @@ import {
   listBuildJobs,
   readBuildJobEvents,
   resolveBuildJobId,
+  resumeBuildJob,
   runBuildJobWorker,
   boostBuildJob,
   updateBuildJobTarget,
@@ -99,6 +100,24 @@ describe("facade/build-queue", () => {
         second.jobId,
         first.jobId,
       ]);
+    });
+  });
+
+  it("treats resume on an already queued job as an idempotent no-op", async () => {
+    await withTempDir("wikigraph-build-queue-", async (path) => {
+      useStateDir(`${path}/state`);
+
+      const job = await addBuildJob({
+        archivePath: `${path}/book.wikg`,
+        chapterId: 1,
+        target: "reading-summary",
+      });
+
+      await expect(resumeBuildJob(job.jobId)).resolves.toMatchObject({
+        jobId: job.jobId,
+        state: "queued",
+      });
+      await expect(readBuildJobEvents(job)).resolves.toHaveLength(1);
     });
   });
 

--- a/test/core/api/knowledge-graph-build.test.ts
+++ b/test/core/api/knowledge-graph-build.test.ts
@@ -565,6 +565,15 @@ describe("facade/knowledge-graph-build", () => {
           },
         ]);
 
+        await document.openSession(async (openedDocument) => {
+          await openedDocument.writeSummary(1, "Keep this summary.");
+          await openedDocument.indexArtifacts.replaceFts({
+            lexicalRows: [],
+            serialId: 1,
+            sourceRevision: await openedDocument.serials.getRevision(1),
+          });
+        });
+
         await clearChapterKnowledgeGraph(document, 1);
 
         expect((await document.serials.getById(1))?.knowledgeGraphReady).toBe(
@@ -579,6 +588,12 @@ describe("facade/knowledge-graph-build", () => {
           ),
         ).resolves.toBeUndefined();
         expect(await document.mentions.listByChapter(1)).toStrictEqual([]);
+        await expect(
+          document.indexArtifacts.get(1, "fts"),
+        ).resolves.toBeUndefined();
+        await expect(document.readSummary(1)).resolves.toBe(
+          "Keep this summary.",
+        );
       } finally {
         await document.release();
       }

--- a/test/core/library/query.test.ts
+++ b/test/core/library/query.test.ts
@@ -98,9 +98,11 @@ vi.mock("../../../packages/core/src/library/membership.js", () => ({
 }));
 
 vi.mock("../../../packages/core/src/library/search-index.js", () => ({
+  assertWikiGraphLibraryHasQueryableArtifacts: vi.fn(() => Promise.resolve()),
   assertWikiGraphLibraryIndexReady: vi.fn(() =>
     Promise.resolve({ status: "current" }),
   ),
+  assertWikiGraphLibraryQueryArtifactsReady: vi.fn(() => Promise.resolve()),
   listWikiGraphLibrarySearchIndex: vi.fn(() =>
     Promise.resolve(mocks.listIndexResult),
   ),
@@ -607,6 +609,37 @@ describe("wiki graph library object query aggregation", () => {
         types: ["source", "summary"],
       }),
     );
+  });
+
+  it("skips library query artifact readiness when requested explicitly", async () => {
+    const [{ findWikiGraphLibraryObjects }, searchIndex] = await Promise.all([
+      import("../../../packages/core/src/library/query.js"),
+      import("../../../packages/core/src/library/search-index.js"),
+    ]);
+    vi.mocked(
+      searchIndex.assertWikiGraphLibraryHasQueryableArtifacts,
+    ).mockClear();
+    vi.mocked(
+      searchIndex.assertWikiGraphLibraryQueryArtifactsReady,
+    ).mockClear();
+
+    mocks.listIndexResult = {
+      objectHits: [createIndexObjectHit(1, "1")],
+      terms: ["chapter"],
+      textHits: [],
+    };
+
+    await findWikiGraphLibraryObjects(target, "chapter", {
+      limit: 5,
+      skipUnindexed: true,
+    });
+
+    expect(
+      searchIndex.assertWikiGraphLibraryQueryArtifactsReady,
+    ).not.toHaveBeenCalled();
+    expect(
+      searchIndex.assertWikiGraphLibraryHasQueryableArtifacts,
+    ).toHaveBeenCalledWith(target);
   });
 
   it("keeps library bucket searches scoped to requested chapters", async () => {

--- a/test/core/retrieval/query/archive-view/helpers.ts
+++ b/test/core/retrieval/query/archive-view/helpers.ts
@@ -76,11 +76,12 @@ export {
 
 export async function rebuildArchiveSearchIndex(
   document: DirectoryDocument,
+  options: Parameters<typeof rebuildArchiveSearchIndexCore>[2] = {},
 ): Promise<void> {
   for (const serialId of listTocSerialIdsForTest(await document.readToc())) {
     await replaceChapterFtsIndexArtifact(document, serialId);
   }
-  await rebuildArchiveSearchIndexCore(document);
+  await rebuildArchiveSearchIndexCore(document, undefined, options);
 }
 
 export async function seedSourcedDocument(

--- a/test/core/retrieval/query/archive-view/text-search.test.ts
+++ b/test/core/retrieval/query/archive-view/text-search.test.ts
@@ -552,14 +552,14 @@ describe("archive/query/archive-view/text search", () => {
             version: 1,
           });
         });
-        await rebuildArchiveSearchIndex(document);
-
         const archiveKey = `${path}/book.wikg`;
+        await rebuildArchiveSearchIndex(document, { chapters: [1] });
         const chapterOne = await findArchiveObjects(document, "Cache Split", {
           archiveKey,
           chapters: [1],
           types: ["entity"],
         });
+        await rebuildArchiveSearchIndex(document, { chapters: [2] });
         const chapterTwo = await findArchiveObjects(document, "Cache Split", {
           archiveKey,
           chapters: [2],

--- a/test/core/retrieval/query/search-cache.test.ts
+++ b/test/core/retrieval/query/search-cache.test.ts
@@ -8,6 +8,8 @@ import {
   createSearchSession,
   deleteArchiveSearchSessions,
   readEntitySearchSessionPage,
+  readSearchSessionDescriptor,
+  readSearchSessionMetadataForCursor,
   readSearchSessionObjectBucketPage,
 } from "../../../../packages/core/src/retrieval/query/search-cache/index.js";
 import { getObjectBucketCursorId } from "../../../../packages/core/src/retrieval/query/archive-view/search/bucket-order.js";
@@ -137,6 +139,88 @@ describe("archive/query/search-cache", () => {
       await deleteArchiveSearchSessions("archive-a");
 
       await expect(listPredicates(path)).resolves.toStrictEqual(["mentions"]);
+    });
+  });
+
+  it("preserves cursor creation time when recreating the same search session", async () => {
+    await withTempDir("wikigraph-search-cache-", async (path) => {
+      setWikiGraphStateDirectoryPathForTesting(path);
+
+      const input = {
+        archiveKey: "archive-key",
+        chapters: null,
+        items: [],
+        lens: "broad",
+        match: "any",
+        order: "rank",
+        query: "query",
+        revisionScope: JSON.stringify({ chaptersRevision: 0, scope: "all" }),
+        terms: ["query"],
+        types: null,
+      } as const;
+      const sessionId = await createSearchSession(input);
+      const first = await readSearchSessionDescriptor(sessionId, "archive-key");
+
+      await createSearchSession(input);
+
+      await expect(
+        readSearchSessionMetadataForCursor(
+          sessionId,
+          "archive-key",
+          first.createdAt,
+        ),
+      ).resolves.toMatchObject({
+        createdAt: first.createdAt,
+        sessionId,
+      });
+    });
+  });
+
+  it("does not revive an expired cursor when recreating the same search session", async () => {
+    await withTempDir("wikigraph-search-cache-", async (path) => {
+      setWikiGraphStateDirectoryPathForTesting(path);
+
+      const input = {
+        archiveKey: "archive-key",
+        chapters: null,
+        items: [],
+        lens: "broad",
+        match: "any",
+        order: "rank",
+        query: "query",
+        revisionScope: JSON.stringify({ chaptersRevision: 0, scope: "all" }),
+        terms: ["query"],
+        types: null,
+      } as const;
+      const sessionId = await createSearchSession(input);
+      const first = await readSearchSessionDescriptor(sessionId, "archive-key");
+      const database = await Database.open(
+        join(path, "cache", "search-sessions.sqlite"),
+        "",
+      );
+
+      try {
+        await database.run(
+          `
+            UPDATE search_sessions
+            SET expires_at = 0
+            WHERE session_id = ?
+          `,
+          [sessionId],
+        );
+      } finally {
+        await database.close();
+      }
+
+      await createSearchSession(input);
+
+      await expect(
+        readSearchSessionMetadataForCursor(
+          sessionId,
+          "archive-key",
+          first.createdAt,
+        ),
+      ).rejects.toThrow("Search cursor expired. Run the search again.");
     });
   });
 

--- a/test/core/storage/schema-upgrade/index.test.ts
+++ b/test/core/storage/schema-upgrade/index.test.ts
@@ -51,6 +51,7 @@ import {
   setWikiGraphStateDirectoryPathForTesting,
   withWikiGraphRuntimeStateDirectoryPath,
 } from "../../../../packages/core/src/runtime/common/wiki-graph/dir.js";
+import { countTextWords } from "../../../../packages/core/src/utils/text-word-count.js";
 import { withTempDir } from "../../../helpers/temp.js";
 
 describe("schema-upgrade", () => {
@@ -227,6 +228,7 @@ describe("schema-upgrade", () => {
       ).resolves.toStrictEqual({
         changed: true,
         repairedToc: true,
+        repairedTextWords: false,
         schemaChanged: false,
       });
       await expect(
@@ -259,6 +261,55 @@ describe("schema-upgrade", () => {
       ).resolves.toStrictEqual({
         changed: false,
         repairedToc: false,
+        repairedTextWords: false,
+        schemaChanged: false,
+      });
+    });
+  });
+
+  it("repairs stale text sentence word counts in a current archive", async () => {
+    await withTempDir("wikigraph-schema-upgrade-text-words-", async (root) => {
+      setWikiGraphStateDirectoryPathForTesting(join(root, "home"));
+      const archivePath = join(root, "book.wikg");
+      const sourceText = "朱元璋攻克应天。陈友谅进攻采石。";
+
+      await writeBadWordCountArchive(archivePath, 3, sourceText);
+
+      await expect(
+        upgradeWikiGraphArchiveSchema(archivePath),
+      ).resolves.toStrictEqual({
+        changed: true,
+        repairedToc: false,
+        repairedTextWords: true,
+        schemaChanged: false,
+      });
+
+      await extractWikgArchive(archivePath, join(root, "unpacked"));
+      const database = await Database.open(
+        join(root, "unpacked", "database.db"),
+      );
+      try {
+        await expect(
+          database.queryOne(
+            `
+              SELECT SUM(words_count) AS words
+              FROM text_sentence_records
+              WHERE kind = 1 AND chapter_id = 1
+            `,
+            undefined,
+            (row) => Number(row.words),
+          ),
+        ).resolves.toBe(countTextWords(sourceText));
+      } finally {
+        await database.close();
+      }
+
+      await expect(
+        upgradeWikiGraphArchiveSchema(archivePath),
+      ).resolves.toStrictEqual({
+        changed: false,
+        repairedToc: false,
+        repairedTextWords: false,
         schemaChanged: false,
       });
     });
@@ -1087,6 +1138,51 @@ async function writeSourcedArchiveWithSchemaVersion(
       schemaVersion,
     );
   });
+}
+
+async function writeBadWordCountArchive(
+  archivePath: string,
+  schemaVersion: number,
+  sourceText: string,
+): Promise<void> {
+  await withTempDir(
+    "wikigraph-schema-bad-words-archive-",
+    async (sourceDir) => {
+      const document = await DirectoryDocument.open(sourceDir);
+
+      try {
+        await document.openSession(async (openedDocument) => {
+          const serialId = await openedDocument.createSerial();
+          const draft = await openedDocument
+            .getSerialFragments(serialId)
+            .createDraft();
+
+          draft.addSentence(sourceText, 1);
+          await draft.commit();
+          await openedDocument.writeToc({
+            items: [
+              {
+                children: [],
+                key: "bad-words",
+                serialId,
+                title: "Bad Words",
+              },
+            ],
+            version: 1,
+          });
+        });
+        await createLegacyArchiveIndexSettings(document);
+      } finally {
+        await document.release();
+      }
+
+      await writeArchiveDirectoryWithSchemaVersion(
+        sourceDir,
+        archivePath,
+        schemaVersion,
+      );
+    },
+  );
 }
 
 async function writeArchiveWithSchemaVersion(


### PR DESCRIPTION
## Summary
- keep index artifact build jobs queued but make build output/help explicit about queued work and watch commands
- make queued job resume idempotent and fix resume wording
- clarify Summary Artifact coverage in inspect output and JSON help
- add --skip-unindexed coverage warnings to search, related, and evidence outputs across text/json/jsonl

## Validation
- pnpm test:run test/cli/archive/related.test.ts test/cli/archive/evidence-pack.test.ts test/cli/archive/query.test.ts test/cli/archive/object.test.ts test/cli/archive/chapter.test.ts test/cli/queue.test.ts test/core/api/build-queue.test.ts packages/cli/src/args/help.test.ts
- pnpm exec tsc --noEmit
- pnpm run lint:fix
- git diff --check

## Notes
- SQL_READONLY, KG estimate, and worker autostart are intentionally deferred.