### PR TITLE
fix(core): query cache concurrency and hybrid bucket ranking

### DIFF
--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -388,7 +388,13 @@ describe("cli/args/help", () => {
       "`wg <archive-uri>/index sync` builds or repairs local `index.db` cache from artifacts",
     );
     expect(renderHelpTopicText("readiness")).toContain(
-      "Free archive query can lazy-sync the cache on first use",
+      "Archive-level query can create a missing cache from current artifacts on first use",
+    );
+    expect(renderHelpTopicText("readiness")).toContain(
+      "Broad query is grouped by result type first",
+    );
+    expect(renderHelpTopicText("readiness")).toContain(
+      "FTS, Dense, and Hybrid ranking affect ordering inside those result groups",
     );
     expect(renderHelpTopicText("readiness")).toContain(
       "wg <archive-uri>/index sync --help",
@@ -572,6 +578,15 @@ describe("cli/args/help", () => {
     expect(
       renderUriHelpText("job-collection-scope", "wikg://local/job"),
     ).toContain("generation jobs can consume model/runtime cost");
+    expect(
+      renderUriHelpText("job-collection-scope", "wikg://local/job"),
+    ).toContain("Job list does not support `--jsonl`");
+    expect(
+      renderUriHelpText(
+        "chapter-summary-object",
+        "wikg://book.wikg/chapter/part/summary",
+      ),
+    ).toContain("does not guarantee the prose answers every question");
     expect(
       renderUriPredicateHelpText(
         "job-collection-scope",

--- a/packages/cli/src/runtime/entry-context.ts
+++ b/packages/cli/src/runtime/entry-context.ts
@@ -16,7 +16,7 @@ export interface WikiGraphEntryRuntimeContext {
   readonly stateDir?: string | undefined;
 }
 
-const DANGEROUS_RUNTIME_ENV_NAMES = [
+export const DANGEROUS_RUNTIME_ENV_NAMES = [
   "WIKIGRAPH_DEV",
   "WIKIGRAPH_ENV_POLICY",
   "WIKIGRAPH_QUEUE_DISABLE_AUTOSTART",

--- a/packages/cli/src/runtime/internal-child.test.ts
+++ b/packages/cli/src/runtime/internal-child.test.ts
@@ -5,7 +5,10 @@ import {
   withWikiGraphCLIRuntimeContext,
   type WikiGraphCLIRuntimeContext,
 } from "./context.js";
-import { createInternalChildCommandForTesting } from "./internal-child.js";
+import {
+  createInternalChildCommandForTesting,
+  createInternalChildEnvironmentForTesting,
+} from "./internal-child.js";
 
 describe("runtime/internal-child", () => {
   it("uses source worker entries from the development runtime context", async () => {
@@ -50,6 +53,30 @@ describe("runtime/internal-child", () => {
         join(process.cwd(), "packages", "cli", "dist", "gc-worker.js"),
       );
     });
+  });
+
+  it("does not pass parent runtime override env to internal children", async () => {
+    await withRuntimeContext(
+      {
+        env: {
+          ...process.env,
+          WIKIGRAPH_DEV: "/tmp/dev-state",
+          WIKIGRAPH_ENV_POLICY: "development",
+          WIKIGRAPH_QUEUE_DISABLE_AUTOSTART: "1",
+          WIKIGRAPH_STATE_DIR: "/tmp/state",
+          WIKIGRAPH_TEST_VALUE: "kept",
+        },
+      },
+      () => {
+        const environment = createInternalChildEnvironmentForTesting();
+
+        expect(environment.WIKIGRAPH_TEST_VALUE).toBe("kept");
+        expect(environment.WIKIGRAPH_DEV).toBeUndefined();
+        expect(environment.WIKIGRAPH_ENV_POLICY).toBeUndefined();
+        expect(environment.WIKIGRAPH_QUEUE_DISABLE_AUTOSTART).toBeUndefined();
+        expect(environment.WIKIGRAPH_STATE_DIR).toBeUndefined();
+      },
+    );
   });
 });
 

--- a/packages/cli/src/runtime/internal-child.ts
+++ b/packages/cli/src/runtime/internal-child.ts
@@ -8,6 +8,7 @@ import {
   getCLIEnv,
   getCLIStateDir,
 } from "./context.js";
+import { DANGEROUS_RUNTIME_ENV_NAMES } from "./entry-context.js";
 
 export type InternalChildKind = "gc-worker" | "queue-worker";
 
@@ -29,9 +30,13 @@ export function spawnInternalChild(
   return spawn(command.command, command.args, {
     cwd: getCLICwd(),
     detached: options.detached === true,
-    env: getCLIEnv(),
+    env: createInternalChildEnvironment(),
     stdio: options.detached === true ? "ignore" : ["ignore", "pipe", "pipe"],
   });
+}
+
+export function createInternalChildEnvironmentForTesting(): NodeJS.ProcessEnv {
+  return createInternalChildEnvironment();
 }
 
 export async function runInternalChildJSON<T>(
@@ -108,6 +113,16 @@ function createInternalChildCommand(
     ],
     command: process.execPath,
   };
+}
+
+function createInternalChildEnvironment(): NodeJS.ProcessEnv {
+  const environment = { ...getCLIEnv() };
+
+  for (const name of DANGEROUS_RUNTIME_ENV_NAMES) {
+    delete environment[name];
+  }
+
+  return environment;
 }
 
 function resolveProductionEntryPath(kind: InternalChildKind): string {

--- a/packages/core/data/help/commands/predicate.jinja
+++ b/packages/core/data/help/commands/predicate.jinja
@@ -112,15 +112,18 @@ Usage:
 
 Notes:
   - This command enqueues work; it does not wait for the artifact to be built.
-  - A queued response means the artifact is not ready yet. Use the returned job id with `wg wikg://local/job/<job-id> watch` to follow progress.
+  - A queued response means the artifact is not ready yet. Use the returned job id with `{{ commandName }} wikg://local/job/<job-id> watch` to follow progress.
+{% if "/index/fts" in uri %}
   - FTS artifacts are local compilation work and do not call a provider.
+{% else %}
   - Source and summary embedding artifacts require `wikg://local/config/embeddings` and may call the configured provider.
-  - Direct artifact build is an explicit build request; it does not use `--accept-cost`.
   - Building an embedding artifact can immediately enqueue or run provider-backed work and may incur provider cost.
+{% endif %}
+  - Direct artifact build is an explicit build request; it does not use `--accept-cost`.
 {% if "/index/embedding/summary" in uri %}
   - Summary embedding artifacts require an existing non-empty chapter summary.
 {% endif %}
-  - After artifacts change, sync the archive or library index cache before library query; free archive query can lazy-sync on first use.
+  - After artifacts change, sync the archive or library index cache before library query; archive-level query can create a missing archive cache from current artifacts on first use.
 {% elif predicate == "add" and target.name == "chapter-collection-scope" %}
 Purpose:
   Add a chapter to the archive.
@@ -411,7 +414,8 @@ Notes:
   - It reads chapter index artifacts from the archive and does not call an embeddings provider.
   - If required chapter artifacts are missing, sync reports that artifact readiness problem instead of building them.
   - Add `--skip-unindexed` only when you intentionally want the cache to include indexed chapters and ignore uncovered chapters.
-  - Free archive query can lazy-sync this cache, but explicit sync avoids the first-query delay.
+  - Archive-level query can create a missing cache from current artifacts on first use, but explicit sync avoids the first-query delay.
+  - If query reports a missing or outdated cache, run this sync command before retrying.
   - With `--jsonl`, progress is emitted as line-delimited event records.
 {% endif %}
 {% elif predicate == "clean" and target.name == "index-object" %}
@@ -424,7 +428,7 @@ Usage:
 Notes:
   - This removes local `index.db` cache data only.
   - It does not delete chapter index artifacts, Knowledge Graph, Reading Graph, Summary, source text, or library membership.
-  - Free archive query can recreate an archive cache from artifacts.
+  - Archive query can recreate an archive cache from artifacts when the selected scope supports lazy cache creation.
 {% elif predicate == "clean" %}
 Purpose:
   Remove completed local generation jobs.

--- a/packages/core/data/help/commands/uri.jinja
+++ b/packages/core/data/help/commands/uri.jinja
@@ -13,6 +13,7 @@ URI type:
 Default behavior:
   - `{{ commandName }} {{ uri }}` enumerates archive-level objects.
   - `{{ commandName }} {{ uri }} --query <query>` applies search index retrieval across archive scopes.
+  - Broad query results are bucketed by object family: chapter/title hits, graph objects, chunks, then text streams.
   - Query is strict by default; add `--skip-unindexed` only to intentionally search indexed chapters and ignore uncovered chapters.
 
 Use when:
@@ -43,6 +44,7 @@ URI type:
 Default behavior:
   - `{{ commandName }} {{ uri }}` enumerates objects inside this chapter subtree.
   - `{{ commandName }} {{ uri }} --query <query>` applies search index retrieval inside this chapter subtree.
+  - Broad query results are bucketed by object family: chapter/title hits, graph objects, chunks, then text streams.
   - Query is strict by default; add `--skip-unindexed` only to intentionally search indexed chapters and ignore uncovered chapters.
   - Use `--depth 0` to restrict the scope to this chapter only; `--depth 1` includes direct children.
   - The path in this URI is the public CLI handle for the chapter; internal chapter ids are not command targets.
@@ -135,6 +137,7 @@ Default behavior:
   - Summary range fragments such as `#4..8` read sentence numbers 4 through 8, inclusive.
   - Range sentence numbers are 1-based. `#1` is the first sentence; `#1..2` is the first two sentences.
   - Whole summary reads are plain text streams and do not support `--json`; summary range fragments are structured range objects and support `--json`.
+  - Summary readiness means a summary object exists and is current for the chapter source. It does not guarantee the prose answers every question about the chapter.
 
 Use when:
   - You need compact readable prose before tracing source evidence.
@@ -186,6 +189,7 @@ Default behavior:
 Use when:
   - You need to build or delete one chapter-level index artifact stored in the `.wikg` archive.
   - Use `/index/fts` for lexical retrieval, `/index/embedding/source` for Dense source retrieval, or `/index/embedding/summary` for Dense summary retrieval.
+  - Build enqueues a local job; read the returned job status or watch the job before assuming the artifact is ready.
 {% elif target.name == "chunk-object" %}
 URI type:
   Chunk object
@@ -247,6 +251,7 @@ URI type:
 
 Default behavior:
   - `{{ commandName }} {{ uri }}` shows local generation jobs.
+  - Use `--json` for a machine-readable job list. Job list does not support `--jsonl`; `watch --jsonl` is the streaming job interface.
 
 Use when:
   - You need to inspect, add, or clean local generation jobs.

--- a/packages/core/data/help/topics/readiness.jinja
+++ b/packages/core/data/help/topics/readiness.jinja
@@ -146,7 +146,7 @@ WikiSpine readiness:
 How to choose:
   - Need lexical retrieval: build chapter FTS artifacts, then sync cache if you do not want lazy sync.
   - Need semantic retrieval: configure embeddings, build source embedding artifacts, then sync cache.
-  - Need both lexical and semantic retrieval: build both FTS and source embedding artifacts; query chooses Hybrid automatically.
+  - Need both lexical and semantic retrieval: build both FTS and source embedding artifacts, then sync the archive index cache if it already exists or query reports it outdated; query can create a missing archive cache and chooses Hybrid automatically once the cache is current.
   - Need searchable retrieval across a managed folder: sync the library index cache.
   - Need to intentionally drop local cache: clean index cache; artifacts remain in the archive.
   - Need generated Reading Graph or summaries: configure LLM and use local jobs.

--- a/packages/core/data/help/topics/readiness.jinja
+++ b/packages/core/data/help/topics/readiness.jinja
@@ -29,15 +29,19 @@ Archive index readiness:
   Cache behavior:
     `{{ commandName }} <archive-uri>/index sync` builds or repairs local `index.db` cache from artifacts.
     Sync does not build missing artifacts and does not call an embeddings provider.
-    Free archive query can lazy-sync the cache on first use, but explicit sync avoids the first-query delay.
+    Archive-level query can create a missing cache from current artifacts on first use, but explicit sync avoids the first-query delay.
+    If query reports a missing or outdated cache, run `{{ commandName }} <archive-uri>/index sync`; library query always requires a current library cache.
     `{{ commandName }} <archive-uri>/index clean` deletes only the local cache.
 
   Query behavior:
     FTS artifact only: FTS query.
     Source embedding artifact only: semantic/Dense-only query.
     Both artifacts: Hybrid query with automatic fusion.
+    Broad query is grouped by result type first: chapter/title, object, chunk, then source/summary text.
+    FTS, Dense, and Hybrid ranking affect ordering inside those result groups and evidence-backed object ranking; they do not flatten the type groups into one global rerank.
     Missing both FTS and source embedding for any content chapter in scope: ordinary query fails.
     Add `--skip-unindexed` to a scope query, `related --query`, or `evidence --query` only when you want to search indexed chapters and ignore uncovered chapters.
+    Results produced with `--skip-unindexed` are intentionally partial; inspect coverage before treating absent chapters as negative evidence.
     Summary embedding artifacts are for summary semantic retrieval and are not the minimum requirement for ordinary source query.
 
   Commands:
@@ -142,6 +146,7 @@ WikiSpine readiness:
 How to choose:
   - Need lexical retrieval: build chapter FTS artifacts, then sync cache if you do not want lazy sync.
   - Need semantic retrieval: configure embeddings, build source embedding artifacts, then sync cache.
+  - Need both lexical and semantic retrieval: build both FTS and source embedding artifacts; query chooses Hybrid automatically.
   - Need searchable retrieval across a managed folder: sync the library index cache.
   - Need to intentionally drop local cache: clean index cache; artifacts remain in the archive.
   - Need generated Reading Graph or summaries: configure LLM and use local jobs.

--- a/packages/core/data/help/topics/uri.jinja
+++ b/packages/core/data/help/topics/uri.jinja
@@ -77,7 +77,7 @@ Scope URIs:
   A chapter URI used as a scope covers that chapter's full subtree by default.
   Query is strict by default: every chapter in scope must have a current FTS artifact or source embedding artifact.
   Add `--skip-unindexed` only when you intentionally want to search indexed chapters and ignore uncovered chapters.
-  Broad query is grouped by result type before ranking within each group. Use `/chunk`, `/entity`, `/triple`, `/source`, or `/summary` lenses when you want one object family instead of the mixed broad result.
+  Broad query is grouped by result type before ranking within each group. Use `/chunk`, `/entity`, or `/triple` lenses when you want one object family instead of the mixed broad result. Query an archive or chapter scope to find source or summary text, then read the returned `/source` or `/summary` object.
   Search uses FTS-only, Dense-only, or Hybrid automatically from the current artifacts and index cache; use `{{ commandName }} help readiness` to inspect what must exist.
   Add `--depth <N>` to limit chapter subtree expansion:
     - no `--depth`: full subtree

--- a/packages/core/data/help/topics/uri.jinja
+++ b/packages/core/data/help/topics/uri.jinja
@@ -77,6 +77,8 @@ Scope URIs:
   A chapter URI used as a scope covers that chapter's full subtree by default.
   Query is strict by default: every chapter in scope must have a current FTS artifact or source embedding artifact.
   Add `--skip-unindexed` only when you intentionally want to search indexed chapters and ignore uncovered chapters.
+  Broad query is grouped by result type before ranking within each group. Use `/chunk`, `/entity`, `/triple`, `/source`, or `/summary` lenses when you want one object family instead of the mixed broad result.
+  Search uses FTS-only, Dense-only, or Hybrid automatically from the current artifacts and index cache; use `{{ commandName }} help readiness` to inspect what must exist.
   Add `--depth <N>` to limit chapter subtree expansion:
     - no `--depth`: full subtree
     - `--depth 0`: only the current chapter, or root-level chapters for `<archive-uri>/chapter`

--- a/packages/core/src/retrieval/query/archive-view/search/buckets.ts
+++ b/packages/core/src/retrieval/query/archive-view/search/buckets.ts
@@ -245,7 +245,7 @@ async function readObjectBucketPage(
   readonly nextCursor: BucketSearchCursor | undefined;
 }> {
   if (!session.objectCachesPopulated) {
-    await populateObjectBucketCaches(document, session, limit, options);
+    await populateObjectBucketCaches(document, session, options);
   }
   const page = await readSearchSessionObjectBucketPage(
     session.sessionId,
@@ -279,7 +279,6 @@ async function readObjectBucketPage(
 async function populateObjectBucketCaches(
   document: ReadonlyDocument,
   session: SearchSessionDescriptor,
-  limit: number,
   options: ArchiveFindOptions,
 ): Promise<void> {
   const search = createLexicalQuery(session.query);
@@ -299,7 +298,7 @@ async function populateObjectBucketCaches(
         : { embeddingProvider: options.embeddingProvider }),
       match: parseFindMatch(session.match),
       objectHitLimit: SEARCH_INDEX_FTS_HIT_LIMIT,
-      textHitLimit: createBucketQueryWindow(limit),
+      textHitLimit: SEARCH_INDEX_FTS_HIT_LIMIT,
       types: null,
     }),
   ]);

--- a/packages/core/src/retrieval/query/archive-view/search/buckets.ts
+++ b/packages/core/src/retrieval/query/archive-view/search/buckets.ts
@@ -37,6 +37,7 @@ import {
 import {
   assertSearchCursorTypesMatch,
   createEntitySearchCacheInput,
+  createSentenceEvidenceSearchCacheInput,
 } from "./cache-input.js";
 import { findEntities, findTriples } from "../find.js";
 import {
@@ -244,7 +245,7 @@ async function readObjectBucketPage(
   readonly nextCursor: BucketSearchCursor | undefined;
 }> {
   if (!session.objectCachesPopulated) {
-    await populateObjectBucketCaches(document, session, options);
+    await populateObjectBucketCaches(document, session, limit, options);
   }
   const page = await readSearchSessionObjectBucketPage(
     session.sessionId,
@@ -278,6 +279,7 @@ async function readObjectBucketPage(
 async function populateObjectBucketCaches(
   document: ReadonlyDocument,
   session: SearchSessionDescriptor,
+  limit: number,
   options: ArchiveFindOptions,
 ): Promise<void> {
   const search = createLexicalQuery(session.query);
@@ -297,7 +299,7 @@ async function populateObjectBucketCaches(
         : { embeddingProvider: options.embeddingProvider }),
       match: parseFindMatch(session.match),
       objectHitLimit: SEARCH_INDEX_FTS_HIT_LIMIT,
-      textHitLimit: 0,
+      textHitLimit: createBucketQueryWindow(limit),
       types: null,
     }),
   ]);
@@ -309,11 +311,24 @@ async function populateObjectBucketCaches(
     structuredHits,
     indexed,
   );
+  const sentenceCacheInput = await createSentenceEvidenceSearchCacheInput(
+    document,
+    indexed,
+    options,
+  );
 
   await populateSearchSessionObjectCaches({
-    entityHits: entityCacheInput.entityHits,
-    evidenceEvents: entityCacheInput.evidenceEvents,
+    chunkHits: sentenceCacheInput.chunkHits,
+    entityHits: [
+      ...entityCacheInput.entityHits,
+      ...sentenceCacheInput.entityHits,
+    ],
+    evidenceEvents: [
+      ...entityCacheInput.evidenceEvents,
+      ...sentenceCacheInput.evidenceEvents,
+    ],
     sessionId: session.sessionId,
+    tripleHits: sentenceCacheInput.tripleHits,
   });
 }
 

--- a/packages/core/src/storage/wikg/wikg-coordinator/file-store.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/file-store.ts
@@ -296,67 +296,77 @@ export class WikgDocumentFileStore implements DocumentFileStore {
       await ensureWikiGraphHomeSchemaCurrent();
     }
 
-    return await withEntryLock(
-      this.#archiveKey,
+    await acquireSqliteLease({
+      archiveKey: this.#archiveKey,
       entryPath,
-      "state",
-      async () => {
-        let overlay = await this.#readOverlay(entryPath);
+      mode: options.readonly ? "read" : "write",
+      ownerId: this.#sqliteLeaseOwnerId,
+    });
 
-        if (
-          entryPath === SEARCH_INDEX_DATABASE_ENTRY_PATH &&
-          overlay?.kind !== "file"
-        ) {
-          await tryAdoptSearchIndexCacheOverlay({
-            targetArchiveKey: this.#archiveKey,
-            targetArchivePath: this.#archivePath,
-          });
-          overlay = await this.#readOverlay(entryPath);
-        }
+    try {
+      return await withEntryLock(
+        this.#archiveKey,
+        entryPath,
+        "state",
+        async () => {
+          let overlay = await this.#readOverlay(entryPath);
 
-        if (overlay?.kind !== "file") {
-          const content =
-            (await readWikgArchiveEntry(this.#archivePath, entryPath)) ??
-            (entryPath === SEARCH_INDEX_DATABASE_ENTRY_PATH
-              ? await readWikgArchiveEntry(
-                  this.#archivePath,
-                  LEGACY_SEARCH_INDEX_DATABASE_ENTRY_PATH,
-                )
-              : undefined);
-
-          if (content === undefined && !options.createIfMissing) {
-            throw new Error(`Archive SQLite entry is missing: ${entryPath}`);
+          if (
+            entryPath === SEARCH_INDEX_DATABASE_ENTRY_PATH &&
+            overlay?.kind !== "file"
+          ) {
+            await tryAdoptSearchIndexCacheOverlay({
+              targetArchiveKey: this.#archiveKey,
+              targetArchivePath: this.#archivePath,
+            });
+            overlay = await this.#readOverlay(entryPath);
           }
-          const workspacePath = await createWorkspaceFilePath(
-            this.#archiveKey,
-            entryPath,
-          );
 
-          await mkdir(dirname(workspacePath), { recursive: true });
-          await writeFile(workspacePath, content ?? new Uint8Array());
-          await upsertOverlay({
-            archiveKey: this.#archiveKey,
-            archivePath: this.#archivePath,
-            entryPath,
-            kind: "file",
-            workspacePath,
-          });
-          overlay = await this.#readOverlay(entryPath);
-        }
+          if (overlay?.kind !== "file") {
+            const content =
+              (await readWikgArchiveEntry(this.#archivePath, entryPath)) ??
+              (entryPath === SEARCH_INDEX_DATABASE_ENTRY_PATH
+                ? await readWikgArchiveEntry(
+                    this.#archivePath,
+                    LEGACY_SEARCH_INDEX_DATABASE_ENTRY_PATH,
+                  )
+                : undefined);
 
-        if (overlay?.workspacePath === undefined) {
-          throw new Error("Could not materialize SQLite database.");
-        }
+            if (content === undefined && !options.createIfMissing) {
+              throw new Error(`Archive SQLite entry is missing: ${entryPath}`);
+            }
+            const workspacePath = await createWorkspaceFilePath(
+              this.#archiveKey,
+              entryPath,
+            );
 
-        await acquireSqliteLease({
-          archiveKey: this.#archiveKey,
-          entryPath,
-          mode: options.readonly ? "read" : "write",
-          ownerId: this.#sqliteLeaseOwnerId,
-        });
-        return overlay.workspacePath;
-      },
-    );
+            await mkdir(dirname(workspacePath), { recursive: true });
+            await writeFile(workspacePath, content ?? new Uint8Array());
+            await upsertOverlay({
+              archiveKey: this.#archiveKey,
+              archivePath: this.#archivePath,
+              entryPath,
+              kind: "file",
+              workspacePath,
+            });
+            overlay = await this.#readOverlay(entryPath);
+          }
+
+          if (overlay?.workspacePath === undefined) {
+            throw new Error("Could not materialize SQLite database.");
+          }
+
+          return overlay.workspacePath;
+        },
+      );
+    } catch (error) {
+      await releaseSqliteLease({
+        archiveKey: this.#archiveKey,
+        entryPath,
+        ownerId: this.#sqliteLeaseOwnerId,
+      });
+      throw error;
+    }
   }
 
   public async writeFile(

--- a/packages/core/src/storage/wikg/wikg-coordinator/file-store.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/file-store.ts
@@ -19,6 +19,7 @@ import {
 import {
   acquireSqliteLease,
   releaseSqliteLease,
+  waitForSqliteLeasesToDrain,
   withEntryLock,
 } from "./locks.js";
 import {
@@ -116,6 +117,15 @@ export class WikgDocumentFileStore implements DocumentFileStore {
     const entryPath = this.#toEntryPath(path);
 
     await withEntryLock(this.#archiveKey, entryPath, "write", async () => {
+      if (
+        entryPath === DATABASE_ENTRY_PATH ||
+        entryPath === SEARCH_INDEX_DATABASE_ENTRY_PATH ||
+        entryPath === LEGACY_SEARCH_INDEX_DATABASE_ENTRY_PATH
+      ) {
+        await waitForSqliteLeasesToDrain(this.#archiveKey, entryPath, {
+          exceptOwnerId: this.#sqliteLeaseOwnerId,
+        });
+      }
       await withEntryLock(this.#archiveKey, entryPath, "state", async () => {
         const overlay = await this.#readOverlay(entryPath);
 

--- a/packages/core/src/storage/wikg/wikg-coordinator/locks.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/locks.ts
@@ -3,6 +3,7 @@ import { LOCK_POLL_INTERVAL_MS, LOCK_STALE_TIMEOUT_MS } from "./constants.js";
 import {
   cleanupStaleState,
   getNumber,
+  getString,
   mapArchiveCommitLock,
   mapEntryLock,
   withStateDatabase,
@@ -169,25 +170,76 @@ export async function acquireSqliteLease(input: {
   readonly mode: SqliteLeaseMode;
   readonly ownerId: string;
 }): Promise<void> {
-  await withStateDatabase(async (state) => {
-    await cleanupStaleState(state);
-    await state.run(
-      `
+  while (true) {
+    const acquired = await withStateDatabase(async (state) => {
+      await cleanupStaleState(state);
+      return await state.transaction(async () => {
+        const locks = await state.queryAll(
+          `
+SELECT *
+FROM entry_locks
+WHERE archive_key = ?
+  AND entry_path = ?
+`,
+          [input.archiveKey, input.entryPath],
+          mapEntryLock,
+        );
+        const requestedLockMode = sqliteLeaseToEntryLockMode(input.mode);
+
+        if (locks.some((lock) => locksConflict(requestedLockMode, lock.mode))) {
+          return false;
+        }
+
+        const leases = await state.queryAll(
+          `
+SELECT owner_id, mode
+FROM entry_sqlite_leases
+WHERE archive_key = ?
+  AND entry_path = ?
+`,
+          [input.archiveKey, input.entryPath],
+          (row) => ({
+            mode: getSqliteLeaseMode(row),
+            ownerId: getString(row, "owner_id"),
+          }),
+        );
+
+        if (
+          leases.some(
+            (lease) =>
+              lease.ownerId !== input.ownerId &&
+              sqliteLeasesConflict(input.mode, lease.mode),
+          )
+        ) {
+          return false;
+        }
+
+        await state.run(
+          `
 INSERT OR REPLACE INTO entry_sqlite_leases (
   archive_key, entry_path, mode, owner_id, owner_pid, heartbeat_at, created_at
 ) VALUES (?, ?, ?, ?, ?, ?, ?)
 `,
-      [
-        input.archiveKey,
-        input.entryPath,
-        input.mode,
-        input.ownerId,
-        process.pid,
-        Date.now(),
-        Date.now(),
-      ],
-    );
-  });
+          [
+            input.archiveKey,
+            input.entryPath,
+            input.mode,
+            input.ownerId,
+            process.pid,
+            Date.now(),
+            Date.now(),
+          ],
+        );
+        return true;
+      });
+    });
+
+    if (acquired) {
+      return;
+    }
+
+    await delay(LOCK_POLL_INTERVAL_MS);
+  }
 }
 
 export async function releaseSqliteLease(input: {
@@ -209,6 +261,7 @@ WHERE archive_key = ? AND entry_path = ? AND owner_id = ?
 export async function waitForSqliteLeasesToDrain(
   archiveKey: string,
   entryPath: string,
+  options: { readonly exceptOwnerId?: string } = {},
 ): Promise<void> {
   while (true) {
     const count = await withStateDatabase(async (state) => {
@@ -222,12 +275,18 @@ LEFT JOIN archive_owners AS owner
  AND owner.owner_id = lease.owner_id
 WHERE lease.archive_key = ?
   AND lease.entry_path = ?
+  AND lease.owner_id <> ?
   AND (
     owner.owner_id IS NULL
     OR owner.heartbeat_at > ?
   )
 `,
-        [archiveKey, entryPath, Date.now() - LOCK_STALE_TIMEOUT_MS],
+        [
+          archiveKey,
+          entryPath,
+          options.exceptOwnerId ?? "",
+          Date.now() - LOCK_STALE_TIMEOUT_MS,
+        ],
         (row) => getNumber(row, "count"),
       );
     });
@@ -238,4 +297,29 @@ WHERE lease.archive_key = ?
 
     await delay(LOCK_POLL_INTERVAL_MS);
   }
+}
+
+function sqliteLeaseToEntryLockMode(mode: SqliteLeaseMode): EntryLockMode {
+  return mode === "read" ? "read" : "write";
+}
+
+function sqliteLeasesConflict(
+  requested: SqliteLeaseMode,
+  existing: SqliteLeaseMode,
+): boolean {
+  if (requested === "read" && existing === "read") {
+    return false;
+  }
+
+  return true;
+}
+
+function getSqliteLeaseMode(row: Record<string, unknown>): SqliteLeaseMode {
+  const mode = String(row.mode);
+
+  if (mode === "read" || mode === "write") {
+    return mode;
+  }
+
+  throw new Error(`Unsupported SQLite lease mode: ${mode}.`);
 }

--- a/packages/core/src/storage/wikg/wikg-coordinator/locks.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/locks.ts
@@ -170,6 +170,8 @@ export async function acquireSqliteLease(input: {
   readonly mode: SqliteLeaseMode;
   readonly ownerId: string;
 }): Promise<void> {
+  const deadline = Date.now() + LOCK_STALE_TIMEOUT_MS;
+
   while (true) {
     const acquired = await withStateDatabase(async (state) => {
       await cleanupStaleState(state);
@@ -238,6 +240,11 @@ INSERT OR REPLACE INTO entry_sqlite_leases (
       return;
     }
 
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Timed out waiting for SQLite ${input.mode} lease: ${input.entryPath}.`,
+      );
+    }
     await delay(LOCK_POLL_INTERVAL_MS);
   }
 }
@@ -263,6 +270,8 @@ export async function waitForSqliteLeasesToDrain(
   entryPath: string,
   options: { readonly exceptOwnerId?: string } = {},
 ): Promise<void> {
+  const deadline = Date.now() + LOCK_STALE_TIMEOUT_MS;
+
   while (true) {
     const count = await withStateDatabase(async (state) => {
       await cleanupStaleState(state);
@@ -295,6 +304,9 @@ WHERE lease.archive_key = ?
       return;
     }
 
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for SQLite leases: ${entryPath}.`);
+    }
     await delay(LOCK_POLL_INTERVAL_MS);
   }
 }
@@ -315,7 +327,7 @@ function sqliteLeasesConflict(
 }
 
 function getSqliteLeaseMode(row: Record<string, unknown>): SqliteLeaseMode {
-  const mode = String(row.mode);
+  const mode = getString(row, "mode");
 
   if (mode === "read" || mode === "write") {
     return mode;

--- a/test/core/retrieval/query/archive-view/graph-search.test.ts
+++ b/test/core/retrieval/query/archive-view/graph-search.test.ts
@@ -116,6 +116,74 @@ describe("archive/query/archive-view/graph search", () => {
     });
   });
 
+  it("promotes object bucket hits from matching source sentence evidence", async () => {
+    await withTempDir("wikigraph-archive-view-", async (path) => {
+      const previousStateDir = getWikiGraphStateDirectoryPathForTesting();
+      setWikiGraphStateDirectoryPathForTesting(`${path}/state`);
+      const document = await DirectoryDocument.open(`${path}/document`);
+
+      try {
+        await document.openSession(async (openedDocument) => {
+          await openedDocument.createSerial();
+          const draft = await openedDocument
+            .getSerialFragments(1)
+            .createDraft();
+
+          draft.addSentence("alpha beta appears beside an unnamed person.", 7);
+          await draft.commit();
+          await openedDocument.mentions.save({
+            chapterId: 1,
+            id: "mention-gamma",
+            qid: "QGamma",
+            rangeEnd: 31,
+            rangeStart: 17,
+            sentenceIndex: 0,
+            surface: "unnamed person",
+          });
+          await openedDocument.writeBookMeta({
+            authors: [],
+            description: null,
+            identifier: null,
+            language: "en",
+            publishedAt: null,
+            publisher: null,
+            sourceFormat: "markdown",
+            title: "Evidence Ranking Fixture",
+            version: 1,
+          });
+          await openedDocument.writeToc({
+            items: [
+              {
+                children: [],
+                serialId: 1,
+                title: "Evidence",
+              },
+            ],
+            version: 1,
+          });
+        });
+        await rebuildArchiveSearchIndex(document);
+
+        const result = await findArchiveObjects(document, "alpha beta", {
+          evidenceLimit: 3,
+          limit: 3,
+        });
+
+        expect(result.items[0]).toMatchObject({
+          id: "wikg://entity/QGamma",
+          type: "entity",
+        });
+        expect(result.items[0]?.evidence).toMatchObject({
+          shown: 1,
+          total: 1,
+        });
+      } finally {
+        restoreWikiGraphStateDir(previousStateDir);
+        await document.release();
+      }
+    });
+  });
+
   it("hydrates entity evidence after reading a search session page", async () => {
     await withTempDir("wikigraph-archive-view-", async (path) => {
       const previousStateDir = getWikiGraphStateDirectoryPathForTesting();

--- a/test/core/retrieval/query/archive-view/graph-search.test.ts
+++ b/test/core/retrieval/query/archive-view/graph-search.test.ts
@@ -129,15 +129,18 @@ describe("archive/query/archive-view/graph search", () => {
             .getSerialFragments(1)
             .createDraft();
 
-          draft.addSentence("alpha beta appears beside an unnamed person.", 7);
+          for (let index = 0; index < 120; index += 1) {
+            draft.addSentence(`alpha beta filler candidate ${index}.`, 5);
+          }
+          draft.addSentence("alpha beta mentions unnamed person.", 5);
           await draft.commit();
           await openedDocument.mentions.save({
             chapterId: 1,
             id: "mention-gamma",
             qid: "QGamma",
-            rangeEnd: 31,
-            rangeStart: 17,
-            sentenceIndex: 0,
+            rangeEnd: 34,
+            rangeStart: 20,
+            sentenceIndex: 120,
             surface: "unnamed person",
           });
           await openedDocument.writeBookMeta({
@@ -166,7 +169,7 @@ describe("archive/query/archive-view/graph search", () => {
 
         const result = await findArchiveObjects(document, "alpha beta", {
           evidenceLimit: 3,
-          limit: 3,
+          limit: 1,
         });
 
         expect(result.items[0]).toMatchObject({

--- a/test/core/storage/wikg/wiki-graph-archive-file.test.ts
+++ b/test/core/storage/wikg/wiki-graph-archive-file.test.ts
@@ -1,6 +1,7 @@
 import { createHash } from "crypto";
 import { access, mkdir, readFile, rename, writeFile } from "fs/promises";
 import { dirname, resolve } from "path";
+import { setTimeout as sleep } from "timers/promises";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -165,6 +166,69 @@ describe("wikg/wiki-graph-archive-file", () => {
               ),
           ),
         );
+      } finally {
+        restoreStateDir();
+      }
+    });
+  });
+
+  it("blocks search index cache writes while another session holds a read lease", async () => {
+    await withTempDir("wikigraph-facade-file-", async (path) => {
+      const restoreStateDir = useCoordinatorStateDir(`${path}/state`);
+      try {
+        const archivePath = await createSeedArchive(path);
+        await new WikiGraphArchiveFile(archivePath).write(
+          async (document) => {
+            await rebuildArchiveSearchIndex(document);
+          },
+          { searchIndexWritebackPolicy: "cache" },
+        );
+        let releaseReader!: () => void;
+        let resolveReaderEntered!: () => void;
+        let writerEntered = false;
+        const readerEntered = new Promise<void>((resolveEntered) => {
+          resolveReaderEntered = resolveEntered;
+        });
+        const reader = new WikiGraphArchiveFile(archivePath).readDocument(
+          async (document) => {
+            await document.readSearchIndexDatabase(async (database) => {
+              await database.queryOne(
+                "SELECT value FROM search_index_state WHERE key = 'version'",
+                undefined,
+                (row) => expectString(row.value),
+              );
+              resolveReaderEntered();
+              await new Promise<void>((resolveReader) => {
+                releaseReader = resolveReader;
+              });
+            });
+          },
+        );
+
+        try {
+          await readerEntered;
+
+          const writer = new WikiGraphArchiveFile(archivePath).write(
+            async (document) => {
+              await document.writeSearchIndexDatabase(() => {
+                writerEntered = true;
+              });
+            },
+            { searchIndexWritebackPolicy: "cache" },
+          );
+
+          await sleep(250);
+          expect(writerEntered).toBe(false);
+
+          releaseReader();
+          await expect(writer).resolves.toBeUndefined();
+          await expect(reader).resolves.toBeUndefined();
+          expect(writerEntered).toBe(true);
+        } catch (error) {
+          releaseReader?.();
+          await reader.catch(() => undefined);
+          throw error;
+        }
       } finally {
         restoreStateDir();
       }

--- a/test/core/storage/wikg/wiki-graph-archive-file.test.ts
+++ b/test/core/storage/wikg/wiki-graph-archive-file.test.ts
@@ -204,11 +204,12 @@ describe("wikg/wiki-graph-archive-file", () => {
             });
           },
         );
+        let writer: Promise<void> | undefined;
 
         try {
           await readerEntered;
 
-          const writer = new WikiGraphArchiveFile(archivePath).write(
+          writer = new WikiGraphArchiveFile(archivePath).write(
             async (document) => {
               await document.writeSearchIndexDatabase(() => {
                 writerEntered = true;
@@ -227,6 +228,7 @@ describe("wikg/wiki-graph-archive-file", () => {
         } catch (error) {
           releaseReader?.();
           await reader.catch(() => undefined);
+          await writer?.catch(() => undefined);
           throw error;
         }
       } finally {


### PR DESCRIPTION
## Summary
- serialize SQLite index-cache leases so concurrent query/cache access does not reuse write paths through readonly leases
- sanitize internal worker process environment before spawning queue workers
- feed text sentence evidence into bucketed object ranking and clarify query/index help docs

## Validation
- pnpm verify
- pnpm test:run
- pnpm build
- pnpm smoke:pack-install
- pnpm publish:dry-run:cli
- pnpm publish:dry-run:core
- pnpm test:run test/core/storage/schema-upgrade/index.test.ts
- pnpm test:run packages/core/src/document/directory/search-index.test.ts test/core/storage/wikg/wiki-graph-archive-file.test.ts
- pnpm test:run test/cli/archive/maintenance.test.ts
- pnpm vitest run test/core/retrieval/query/archive-view/graph-search.test.ts -t "promotes object bucket hits"