### PR TITLE
chore: bump package versions to 0.5.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-graph",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "CLI for building and querying .wikg knowledge-base archives from long-form text and ebooks.",
   "keywords": [
     "wiki-graph",
@@ -72,7 +72,7 @@
     "wiki-graph-core": "workspace:*"
   },
   "peerDependencies": {
-    "wiki-graph-core": "^0.4.1"
+    "wiki-graph-core": "^0.5.0"
   },
   "peerDependenciesMeta": {
     "wiki-graph-core": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-graph-core",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Core SDK for building and querying .wikg knowledge-base archives.",
   "keywords": [
     "wiki-graph",


### PR DESCRIPTION
## Summary
- bump wiki-graph and wiki-graph-core package versions to 0.5.0
- update the CLI peer dependency range for wiki-graph-core to ^0.5.0

## Validation
- package JSON files parse successfully
- PR checks will run verify, tests, build, smoke pack install, and publish dry-runs