### PR TITLE
fix: tighten source provenance boundaries

### DIFF
--- a/packages/core/data/help/commands/maintenance/chapter/set-source.jinja
+++ b/packages/core/data/help/commands/maintenance/chapter/set-source.jinja
@@ -11,6 +11,7 @@ Input:
   - Source text is read from a positional value, `--input <path>`, or `--input -` for stdin.
   - `--input-format jsonl` accepts provenance records with `type: "artifact"` and `type: "text"`.
   - JSONL text records are concatenated in order; each text record is bound to the most recently declared artifact.
+  - Artifact `digest` is exactly 64 hexadecimal characters. `identifier` is opaque and optional, with a maximum length of 1024 characters.
 
 Preconditions:
   - The chapter must be `planned`.

--- a/packages/core/src/document/stores/source-provenance.test.ts
+++ b/packages/core/src/document/stores/source-provenance.test.ts
@@ -99,4 +99,56 @@ describe("SourceProvenanceStore", () => {
       await rm(path, { force: true, recursive: true });
     }
   });
+
+  it("preflights invalid mappings before replacing source text", async () => {
+    const path = await mkdtemp(join(tmpdir(), "wikigraph-source-provenance-"));
+    try {
+      const document = await DirectoryDocument.open(path);
+      try {
+        await document.openSession(async (opened) => {
+          const serialId = await opened.createSerial();
+          const digest = "E".repeat(64);
+          await writeSerialSource(opened, serialId, ["original"], {
+            provenance: {
+              artifacts: [{ digest, mediaType: "application/pdf" }],
+              mappings: [
+                {
+                  artifactDigest: digest,
+                  locator: { pageIndex: 1, bbox: [0, 0, 1, 1] },
+                  sourceStart: 0,
+                  sourceEnd: 8,
+                },
+              ],
+            },
+          });
+          const revision = await opened.serials.getRevision(serialId);
+
+          await expect(
+            writeSerialSource(opened, serialId, ["replacement"], {
+              provenance: {
+                artifacts: [{ digest, mediaType: "application/pdf" }],
+                mappings: [
+                  {
+                    artifactDigest: "F".repeat(64),
+                    locator: { pageIndex: 1, bbox: [0, 0, 1, 1] },
+                    sourceStart: 0,
+                    sourceEnd: 11,
+                  },
+                ],
+              },
+            }),
+          ).rejects.toThrow(/undeclared artifact/iu);
+
+          expect(await opened.getSerialFragments(serialId).readText()).toBe(
+            "original",
+          );
+          expect(await opened.serials.getRevision(serialId)).toBe(revision);
+        });
+      } finally {
+        await document.release();
+      }
+    } finally {
+      await rm(path, { force: true, recursive: true });
+    }
+  });
 });

--- a/packages/core/src/document/stores/source-provenance.ts
+++ b/packages/core/src/document/stores/source-provenance.ts
@@ -219,11 +219,25 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
   /** Validate all artifact constraints without changing provenance records. */
   public async validate(
     input: SourceTextProvenanceInput | undefined,
+    options: { readonly sourceTextLength?: number } = {},
   ): Promise<void> {
     if (input === undefined) return;
     const seen = new Map<string, string>();
+    const declared = new Set<string>();
     for (const artifact of input.artifacts) {
       const digest = normalizeDigest(artifact.digest);
+      if (artifact.mediaType.length === 0) {
+        throw new Error("Source artifact mediaType must not be empty.");
+      }
+      if (
+        artifact.identifier !== undefined &&
+        Array.from(artifact.identifier).length > 1024
+      ) {
+        throw new Error(
+          "Source artifact identifier must be at most 1024 characters.",
+        );
+      }
+      declared.add(digest);
       const prior = seen.get(digest);
       if (prior !== undefined && prior !== artifact.mediaType) {
         throw new Error(
@@ -239,6 +253,32 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
       if (existing !== undefined && existing !== artifact.mediaType) {
         throw new Error(
           `Source artifact ${digest} already exists with mediaType ${existing}; received ${artifact.mediaType}.`,
+        );
+      }
+    }
+
+    if (input.artifacts.length === 0 || input.mappings.length === 0) {
+      throw new Error(
+        "Source provenance must contain artifacts and source text mappings.",
+      );
+    }
+
+    for (const mapping of input.mappings) {
+      if (
+        !Number.isInteger(mapping.sourceStart) ||
+        !Number.isInteger(mapping.sourceEnd) ||
+        mapping.sourceStart < 0 ||
+        mapping.sourceEnd < mapping.sourceStart ||
+        (options.sourceTextLength !== undefined &&
+          mapping.sourceEnd > options.sourceTextLength)
+      ) {
+        throw new Error(
+          "Source text map offsets must be non-negative character ranges within source text.",
+        );
+      }
+      if (!declared.has(normalizeDigest(mapping.artifactDigest))) {
+        throw new Error(
+          `Source mapping references undeclared artifact ${mapping.artifactDigest}.`,
         );
       }
     }

--- a/packages/core/src/text/serial/source.ts
+++ b/packages/core/src/text/serial/source.ts
@@ -10,13 +10,16 @@ export async function writeSerialSource(
   options: WriteSerialSourceOptions = {},
 ): Promise<void> {
   const serialFragments = document.getSerialFragments(serialId);
+  const text = await collectTextStream(stream);
 
   // Validate conflicts before touching text, derived artifacts, or revision.
   // File writes are coordinated separately from the database transaction, so
   // this preflight preserves the all-or-nothing source replacement contract.
-  await document.sourceProvenance.validate(options.provenance);
+  await document.sourceProvenance.validate(options.provenance, {
+    sourceTextLength: Array.from(text).length,
+  });
   await document.markSerialDerivedArtifactsStale(serialId);
-  await serialFragments.writeTextStream(await collectTextStream(stream), {
+  await serialFragments.writeTextStream(text, {
     ...(options.segmenter === undefined
       ? {}
       : { segmenter: options.segmenter }),

--- a/packages/core/src/text/source/provenance.test.ts
+++ b/packages/core/src/text/source/provenance.test.ts
@@ -33,6 +33,28 @@ describe("parseSourceTextJsonl", () => {
     ]);
   });
 
+  it("counts source offsets as Unicode characters", () => {
+    const result = parseSourceTextJsonl(
+      [
+        JSON.stringify({
+          type: "artifact",
+          digest: "D".repeat(64),
+          mediaType: "application/pdf",
+        }),
+        JSON.stringify({
+          type: "text",
+          text: "😀a",
+          locator: { pageIndex: 1, bbox: [0, 0, 1, 1] },
+        }),
+      ].join("\n"),
+    );
+
+    expect(result.provenance.mappings[0]).toMatchObject({
+      sourceStart: 0,
+      sourceEnd: 2,
+    });
+  });
+
   it("rejects malformed records", () => {
     expect(() => parseSourceTextJsonl('{"type":"text","text":"x"}')).toThrow(
       /must follow an artifact/,
@@ -52,26 +74,42 @@ describe("parseSourceTextJsonl", () => {
           }),
       ),
     ).toThrow(/1-based integer/);
+    expect(() =>
+      parseSourceTextJsonl(
+        [
+          JSON.stringify({
+            type: "artifact",
+            digest: "E".repeat(64),
+            mediaType: "application/epub+zip",
+          }),
+          JSON.stringify({
+            type: "text",
+            text: "x",
+            locator: { cfi: "epubcfi(x)" },
+          }),
+        ].join("\n"),
+      ),
+    ).toThrow(/syntactically valid epubcfi/iu);
   });
 
-  it("preserves long opaque identifiers", () => {
+  it("rejects oversized opaque identifiers", () => {
     const identifier = "opaque:" + "x".repeat(5000);
-    const result = parseSourceTextJsonl(
-      [
-        JSON.stringify({
-          type: "artifact",
-          digest: "C".repeat(64),
-          identifier,
-          mediaType: "application/epub+zip",
-        }),
-        JSON.stringify({
-          type: "text",
-          text: "content",
-          locator: { cfi: "epubcfi(/6/2)" },
-        }),
-      ].join("\n"),
-    );
-
-    expect(result.provenance.artifacts[0]?.identifier).toBe(identifier);
+    expect(() =>
+      parseSourceTextJsonl(
+        [
+          JSON.stringify({
+            type: "artifact",
+            digest: "C".repeat(64),
+            identifier,
+            mediaType: "application/epub+zip",
+          }),
+          JSON.stringify({
+            type: "text",
+            text: "content",
+            locator: { cfi: "epubcfi(/6/2)" },
+          }),
+        ].join("\n"),
+      ),
+    ).toThrow(/Invalid source artifact record/iu);
   });
 });

--- a/packages/core/src/text/source/provenance.ts
+++ b/packages/core/src/text/source/provenance.ts
@@ -10,7 +10,7 @@ const artifactRecordSchema = z.object({
   digest: z.string().regex(/^[0-9a-f]{64}$/iu),
   mediaType: z.string().min(1),
   name: z.string().optional(),
-  identifier: z.string().optional(),
+  identifier: z.string().max(1024).optional(),
 });
 
 const textRecordSchema = z.object({
@@ -84,7 +84,7 @@ export function parseSourceTextJsonl(input: string): ParsedSourceTextJsonl {
     const record = parseTextRecord(value, index + 1);
     validateLocator(currentArtifact.mediaType, record.locator, index + 1);
     const sourceStart = sourceOffset;
-    sourceOffset += record.text.length;
+    sourceOffset += countCharacters(record.text);
     textParts.push(record.text);
     mappings.push({
       artifactDigest: currentArtifact.digest,
@@ -200,10 +200,58 @@ function validateEpubLocator(
 ): void {
   if (
     typeof locator.cfi !== "string" ||
-    !/^epubcfi\(.+\)$/u.test(locator.cfi)
+    !isSyntacticallyValidCfi(locator.cfi)
   ) {
     throw new Error(
       `EPUB locator cfi at line ${lineNumber} must be a syntactically valid epubcfi(...).`,
     );
   }
+}
+
+function countCharacters(text: string): number {
+  return Array.from(text).length;
+}
+
+function isSyntacticallyValidCfi(value: string): boolean {
+  if (!value.startsWith("epubcfi(") || !value.endsWith(")")) return false;
+  const body = value.slice("epubcfi(".length, -1);
+  if (!body.startsWith("/")) return false;
+
+  // Validate the structural shape without interpreting CFI assertions.
+  // Assertions may contain escaped characters; the locator remains opaque.
+  const step = /\/\d+(?:\[[^\[\]\r\n]*\])?/gu;
+  let cursor = 0;
+  while (cursor < body.length) {
+    if (body[cursor] === "/") {
+      step.lastIndex = cursor;
+      const match = step.exec(body);
+      if (match === null || match.index !== cursor) return false;
+      cursor = step.lastIndex;
+      continue;
+    }
+    if (body[cursor] === "!") {
+      cursor += 1;
+      continue;
+    }
+    if (body[cursor] === ":" || body[cursor] === "@" || body[cursor] === "~") {
+      const match = /^(?::\d+|@\d+(?::\d+)?|~\d+(?:@\d+(?::\d+)?)?)/u.exec(
+        body.slice(cursor),
+      );
+      if (match === null) return false;
+      cursor += match[0].length;
+      if (body[cursor] === "[") {
+        const assertionEnd = body.indexOf("]", cursor + 1);
+        if (assertionEnd < 0) return false;
+        cursor = assertionEnd + 1;
+      }
+      continue;
+    }
+    if (body[cursor] === ",") {
+      cursor += 1;
+      continue;
+    }
+    return false;
+  }
+
+  return cursor > 0;
 }

--- a/packages/core/src/text/source/provenance.ts
+++ b/packages/core/src/text/source/provenance.ts
@@ -219,7 +219,7 @@ function isSyntacticallyValidCfi(value: string): boolean {
 
   // Validate the structural shape without interpreting CFI assertions.
   // Assertions may contain escaped characters; the locator remains opaque.
-  const step = /\/\d+(?:\[[^\[\]\r\n]*\])?/gu;
+  const step = /\/\d+(?:\[[^\r\n]*\])?/gu;
   let cursor = 0;
   while (cursor < body.length) {
     if (body[cursor] === "/") {

--- a/test/core/api/source-provenance.test.ts
+++ b/test/core/api/source-provenance.test.ts
@@ -1,0 +1,72 @@
+import { createHash } from "crypto";
+import { readFile } from "fs/promises";
+import { resolve } from "path";
+
+import { describe, expect, it } from "vitest";
+
+import { DirectoryDocument } from "../../../packages/core/src/document/index.js";
+import {
+  addChapter,
+  setChapterSource,
+} from "../../../packages/core/src/api/chapter/index.js";
+import { parseSourceTextJsonl } from "../../../packages/core/src/text/source/index.js";
+import { withTempDir } from "../../helpers/temp.js";
+
+describe("source provenance workflow", () => {
+  it("imports a real EPUB fixture through JSONL and persists its map", async () => {
+    await withTempDir("wikigraph-source-provenance-e2e-", async (path) => {
+      const epubPath = resolve(
+        "test/fixtures/sources/sample-observatory-guide.epub",
+      );
+      const epub = await readFile(epubPath);
+      const digest = createHash("sha256").update(epub).digest("hex");
+      const sourceText = "A real EPUB-backed source text.";
+      const jsonl = [
+        JSON.stringify({
+          type: "artifact",
+          digest,
+          mediaType: "application/epub+zip",
+          name: "sample-observatory-guide.epub",
+          identifier: "fixture:sample-observatory-guide",
+        }),
+        JSON.stringify({
+          type: "text",
+          text: sourceText,
+          locator: { cfi: "epubcfi(/6/2[body]!/4/2/1:0)" },
+        }),
+      ].join("\n");
+      const parsed = parseSourceTextJsonl(jsonl);
+      const document = await DirectoryDocument.open(path);
+
+      try {
+        await document.openSession(async (opened) => {
+          await opened.writeToc({ items: [], version: 1 });
+        });
+        const chapter = await addChapter(document, { title: "Fixture" });
+        await setChapterSource(document, chapter.chapterId, [parsed.text], {
+          provenance: parsed.provenance,
+        });
+
+        expect(
+          await document.getSerialFragments(chapter.chapterId).readText(),
+        ).toBe(sourceText);
+        expect(
+          await document.sourceProvenance.listMap(chapter.chapterId),
+        ).toMatchObject([
+          {
+            artifact: {
+              digest,
+              identifier: "fixture:sample-observatory-guide",
+              mediaType: "application/epub+zip",
+            },
+            locator: { cfi: "epubcfi(/6/2[body]!/4/2/1:0)" },
+            sourceStart: 0,
+            sourceEnd: sourceText.length,
+          },
+        ]);
+      } finally {
+        await document.release();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- count source provenance offsets as Unicode characters and validate SDK mappings before source replacement
- bound opaque identifiers and validate PDF bbox / EPUB CFI locator inputs
- add real EPUB fixture coverage for JSONL provenance persistence
- document the JSONL digest and identifier constraints

## Verification

- `pnpm run test:run` (145 files, 956 tests)
- `pnpm run typecheck`
- `pnpm run lint`