### PR TITLE
docs: add agent-facing file import help

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-graph",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "CLI for building and querying .wikg knowledge-base archives from long-form text and ebooks.",
   "keywords": [
     "wiki-graph",
@@ -72,7 +72,7 @@
     "wiki-graph-core": "workspace:*"
   },
   "peerDependencies": {
-    "wiki-graph-core": "^0.5.0"
+    "wiki-graph-core": "^0.6.0"
   },
   "peerDependenciesMeta": {
     "wiki-graph-core": {

--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -297,7 +297,7 @@ describe("cli/args/help", () => {
 
   it("rejects invalid help usage", () => {
     expect(() => parseCLIArguments(["help", "unknown"])).toThrow(
-      "Invalid help topic: unknown. Expected one of format, config, runtime, uri, recipe, readiness, library.\nSee: wg --help",
+      "Invalid help topic: unknown. Expected one of format, file-import, config, runtime, uri, recipe, readiness, library.\nSee: wg --help",
     );
     expect(() =>
       parseCLIArguments(["help", "object", "entity", "extra"]),
@@ -316,11 +316,22 @@ describe("cli/args/help", () => {
   it("documents the layered help contract", () => {
     const rootHelpText = renderMainHelpText();
     const uriHelpText = renderHelpTopicText("uri");
+    const fileImportHelpText = renderHelpTopicText("file-import");
+    const archiveCreateHelpText = renderUriPredicateHelpText(
+      "archive-scope",
+      "create",
+      "wikg://book.wikg",
+    );
 
     expect(rootHelpText).toContain("wg help [topic]");
     expect(rootHelpText).toContain("wg help recipe");
     expect(rootHelpText).toContain("wg help readiness");
     expect(rootHelpText).toContain("wg help library");
+    expect(rootHelpText).not.toContain("wg help file-import");
+    expect(fileImportHelpText).toContain("Source-File Import");
+    expect(fileImportHelpText).toContain("source-text map");
+    expect(fileImportHelpText).toContain("OCR, layout analysis");
+    expect(archiveCreateHelpText).toContain("wg help file-import");
     expect(rootHelpText).toContain("Core concepts:");
     expect(rootHelpText).toContain("knowledge-base archives");
     expect(rootHelpText).toContain("Do not edit archive internals:");

--- a/packages/cli/src/args/help.ts
+++ b/packages/cli/src/args/help.ts
@@ -21,6 +21,7 @@ import { parseChapterTarget } from "./uri/chapter/target.js";
 
 export const HELP_TOPICS = [
   "format",
+  "file-import",
   "config",
   "runtime",
   "uri",
@@ -175,10 +176,16 @@ export const ARCHIVE_MAINTENANCE_COMMANDS = [
 const HELP_TOPIC_METADATA: readonly {
   readonly name: HelpTopic;
   readonly summary: string;
+  readonly rootVisible?: boolean;
 }[] = [
   {
     name: "format",
     summary: "Supported formats, inference rules, and IO constraints.",
+  },
+  {
+    name: "file-import",
+    rootVisible: false,
+    summary: "Advanced source-file import and source-text provenance behavior.",
   },
   {
     name: "config",
@@ -228,6 +235,7 @@ const ARCHIVE_MAINTENANCE_COMMAND_METADATA: readonly {
 
 const HELP_TOPIC_TEMPLATE_NAMES: Readonly<Record<HelpTopic, string>> = {
   format: "help/topics/format",
+  "file-import": "help/topics/file-import",
   config: "help/topics/config",
   runtime: "help/topics/runtime",
   uri: "help/topics/uri",

--- a/packages/core/data/help/commands/maintenance/chapter/set-source.jinja
+++ b/packages/core/data/help/commands/maintenance/chapter/set-source.jinja
@@ -29,6 +29,7 @@ Typical next step:
   {{ commandName }} wikg://local/job add --input <archive-uri|chapter-uri> --task reading-graph --accept-cost
 
 See also:
+  - {{ commandName }} help file-import
   - {{ commandName }} wikg://book.wikg/chapter/part/state --help
   - {{ commandName }} wikg://book.wikg/chapter/part reset --help
   - {{ commandName }} wikg://local/job --help

--- a/packages/core/data/help/commands/predicate.jinja
+++ b/packages/core/data/help/commands/predicate.jinja
@@ -54,13 +54,15 @@ Purpose:
   Create the archive at this URI.
 
 Usage:
-  {{ commandName }} {{ uri }} create [--import <epub-path>] [--replace] [--json]
+  {{ commandName }} {{ uri }} create [--import <source-file>] [--replace] [--json]
 
 Notes:
   - Without `--import`, create an empty `.wikg` archive.
-  - `--import <epub-path>` creates the archive and imports EPUB metadata, cover, chapter tree, and source text.
-  - `create` does not read stdin; `--import` only accepts EPUB input.
-  - EPUB import runs only the import/source stage and does not call an LLM provider.
+  - `--import <source-file>` creates the archive and imports the source file's metadata, structure, and source text.
+  - File import also records source provenance so normalized source text can be traced back to the imported file.
+  - The imported file itself is not embedded in the `.wikg` archive.
+  - `create` does not read stdin. Read `{{ commandName }} help file-import` for supported source files and import boundaries.
+  - File import runs only the import/source stage and does not call an LLM provider.
   - Existing archives are not overwritten by default. Use `--replace` only when the target archive should be discarded and recreated.
   - Parent directories must already exist.
   - On success, text output is the archive object (`<archive>`). With `--json`, output is `{"uri":"..."}`.
@@ -215,10 +217,11 @@ Purpose:
   Replace this chapter source text.
 
 Usage:
-  {{ commandName }} {{ uri }} set [text] [--input <path|->]
+  {{ commandName }} {{ uri }} set [text] [--input <path|->] [--input-format jsonl]
 
 Notes:
   - Source text is read from a positional value, `--input <path>`, or `--input -` for stdin.
+  - Use `--input-format jsonl` when an external importer supplies ordered text ranges and source locators; see `{{ commandName }} help file-import` for the input contract.
   - Source replacement invalidates later generated work for that chapter.
   - Use `{{ commandName }} {{ uri }} --help` to inspect the source object before replacing it.
 {% elif target.name == "chapter-summary-object" %}
@@ -634,6 +637,9 @@ Related help:
 {% endif %}
 {% if predicate == "create" or predicate == "export" %}
   - {{ commandName }} help format
+{% endif %}
+{% if predicate == "create" %}
+  - {{ commandName }} help file-import
 {% endif %}
 {% if target.name == "job-collection-scope" or target.name == "job-object" or target.name == "job-target-object" %}
   - {{ commandName }} help runtime

--- a/packages/core/data/help/commands/root.jinja
+++ b/packages/core/data/help/commands/root.jinja
@@ -82,8 +82,10 @@ Library entry point:
 
 Help topics:
 {% for topic in helpTopics %}
+{% if topic.rootVisible is not defined or topic.rootVisible %}
   - {{ commandName }} help {{ topic.name }}
     {{ topic.summary }}
+{% endif %}
 {% endfor %}
 
 Formats:

--- a/packages/core/data/help/topics/file-import.jinja
+++ b/packages/core/data/help/topics/file-import.jinja
@@ -1,0 +1,50 @@
+Help Type: topic
+Topic: file-import
+
+Source-File Import
+
+Purpose:
+  Import an external source file into a `.wikg` archive while keeping the
+  normalized source text traceable to the file that produced it.
+
+Usage:
+  {{ commandName }} wikg://book.wikg create --import ./book.epub
+  {{ commandName }} wikg://book.wikg create --import ./book.pdf
+
+Supported source files:
+  - EPUB
+  - PDF
+
+Import contract:
+  - The importer is responsible for reading or extracting text from the file.
+  - OCR, layout analysis, and format-specific interpretation are outside this
+    contract.
+  - WG stores the normalized source text and a source-text map that points
+    each imported text range back to its source file and locator.
+  - The source text is its own layer; the file's internal layout does not
+    determine how source text is later split into sentences or other objects.
+  - The original PDF or EPUB file is not embedded in the `.wikg` archive.
+
+Source identity and locator:
+  - Each imported file has a stable artifact identity.
+  - Each imported text range is mapped to a format-specific locator.
+  - WG preserves the locator for later evidence and does not require an Agent
+    to interpret the source file format.
+
+Advanced input:
+  - Use `--input-format jsonl` with `chapter/<path>/source set` only when an
+    external importer already provides ordered text ranges and locators.
+  - JSONL text ranges are concatenated in order and mapped by source-text
+    character offsets.
+  - For ordinary file import, use `create --import` instead.
+
+Boundaries:
+  - File import does not generate Reading Graph, Summary, or Knowledge Graph
+    data.
+  - Generation remains a separate, explicit workflow after import.
+  - A source file is an input and evidence origin, not an archive entry.
+
+See also:
+  - {{ commandName }} wikg://book.wikg create --help
+  - {{ commandName }} wikg://book.wikg/chapter/part/source set --help
+  - {{ commandName }} help format

--- a/packages/core/data/help/topics/format.jinja
+++ b/packages/core/data/help/topics/format.jinja
@@ -10,7 +10,7 @@ Managed archive format:
   wikg
 
 Archive create/import input:
-  epub via `{{ commandName }} <archive-uri> create --import <epub-path>`
+  source files via `{{ commandName }} <archive-uri> create --import <source-file>`
 
 Export formats:
   txt, markdown, epub
@@ -24,6 +24,7 @@ Inference rules:
   - Transform stdin requires an explicit `--input-format`.
   - Commands that accept content input use `--input <path>` for files and `--input -` for stdin.
   - Archive chapter/source text commands read plain source text by default; `chapter/<path>/source set` also accepts `--input-format jsonl` for source provenance input.
+  - Read `{{ commandName }} help file-import` for source-file import behavior and provenance boundaries.
   - Stdout text export requires an explicit or inferable output format.
   - `transform --stage` is only valid when creating `.wikg` from source input.
 

--- a/packages/core/data/help/topics/recipe.jinja
+++ b/packages/core/data/help/topics/recipe.jinja
@@ -32,9 +32,10 @@ Choose your starting point:
       {{ commandName }} help library
 
   - User gave you source content and needs a reusable knowledge-base archive:
-    Create an empty `.wikg` archive, or create one while importing an EPUB.
+    Create an empty `.wikg` archive, or create one while importing a source file.
       {{ commandName }} wikg://book.wikg create
       {{ commandName }} wikg://book.wikg create --import ./book.epub
+    Read `{{ commandName }} help file-import` when the source is a file.
 
   - User needs one-shot conversion without keeping an archive:
     Use transform. Source input usually requires LLM configuration.

--- a/packages/core/data/help/topics/runtime.jinja
+++ b/packages/core/data/help/topics/runtime.jinja
@@ -8,7 +8,7 @@ Purpose:
 
 Archive-first streams:
   - `{{ commandName }} <archive-uri> create` creates an empty archive; it does not read stdin.
-  - `{{ commandName }} <archive-uri> create --import <epub-path>` imports EPUB source into a new archive.
+  - `{{ commandName }} <archive-uri> create --import <source-file>` imports a source file into a new archive; read `{{ commandName }} help file-import` for the import contract.
   - `{{ commandName }} <archive-uri> export --output-format markdown|txt` can write text projections to stdout.
   - `{{ commandName }} transform --input-format markdown|txt --output-format markdown|txt` runs direct one-shot stream digest/export and usually requires LLM configuration.
   - Retrieval commands print human-readable text by default and support `--json` where documented.

--- a/packages/core/data/help/topics/uri.jinja
+++ b/packages/core/data/help/topics/uri.jinja
@@ -61,7 +61,8 @@ Common command shapes:
   {{ commandName }} <entity|triple|chunk-uri> evidence
   {{ commandName }} <located-chunk-uri|located-entity-uri> pack
   {{ commandName }} next <cursor>
-  {{ commandName }} <archive-uri> create [--import <epub-path>]
+  {{ commandName }} <archive-uri> create [--import <source-file>]
+  {{ commandName }} help file-import
   {{ commandName }} <archive-uri> export --output-format <format>
   {{ commandName }} <archive-uri> inspect
   {{ commandName }} transform [options]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-graph-core",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Core SDK for building and querying .wikg knowledge-base archives.",
   "keywords": [
     "wiki-graph",


### PR DESCRIPTION
## Summary

- Add a focused, hidden-by-default `file-import` help topic for EPUB/PDF source-file imports.
- Route create/source-set and related topics to the import contract and provenance-map guidance.
- Bump `wiki-graph` and `wiki-graph-core` packages to `0.6.0`.

## Verification

- `pnpm verify`
- `pnpm test:run` (145 files, 956 tests)
- Manual `pnpm dev` help-path review, including a second blind review through the CLI.

## Notes

The help describes the target source-file import contract. PDF runtime import support remains a follow-up implementation task.