### PR TITLE
fix: 修正 EPUB 来源映射的 CFI 标准兼容性

### DIFF
--- a/packages/core/src/text/source/epub/content.ts
+++ b/packages/core/src/text/source/epub/content.ts
@@ -646,15 +646,85 @@ function createNormalizedLocator(
     throw new Error("EPUB text mapping is missing a CFI locator.");
   }
 
-  const range = /^epubcfi\((.*):(\d+),(.*):(\d+)\)$/u.exec(cfi);
-  if (range === null) {
+  const range = parseCfiRange(cfi);
+  if (range === undefined) {
     throw new Error("EPUB text mapping has an invalid CFI range locator.");
   }
 
   return {
     ...locator,
-    cfi: `epubcfi(${range[1]}:${start},${range[3]}:${end})`,
+    cfi: `epubcfi(${range.parentPath},${replaceCfiOffset(range.startPath, start)},${replaceCfiOffset(range.endPath, end)})`,
   };
+}
+
+interface CfiRange {
+  readonly endPath: string;
+  readonly parentPath: string;
+  readonly startPath: string;
+}
+
+function parseCfiRange(value: string): CfiRange | undefined {
+  if (!value.startsWith("epubcfi(") || !value.endsWith(")")) {
+    return undefined;
+  }
+
+  const parts = splitCfiComponents(value.slice("epubcfi(".length, -1));
+  if (parts.length !== 3 || parts.some((part) => part === "")) {
+    return undefined;
+  }
+
+  const [parentPath, startPath, endPath] = parts;
+  if (
+    parentPath === undefined ||
+    startPath === undefined ||
+    endPath === undefined
+  ) {
+    return undefined;
+  }
+
+  return { endPath, parentPath, startPath };
+}
+
+function splitCfiComponents(value: string): string[] {
+  const components: string[] = [];
+  let componentStart = 0;
+  let assertionDepth = 0;
+  let escaped = false;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "^") {
+      escaped = true;
+      continue;
+    }
+    if (character === "[") {
+      assertionDepth += 1;
+      continue;
+    }
+    if (character === "]") {
+      assertionDepth -= 1;
+      continue;
+    }
+    if (character === "," && assertionDepth === 0) {
+      components.push(value.slice(componentStart, index));
+      componentStart = index + 1;
+    }
+  }
+
+  components.push(value.slice(componentStart));
+  return components;
+}
+
+function replaceCfiOffset(path: string, offset: number): string {
+  if (!/:\d+$/u.test(path)) {
+    throw new Error("EPUB text mapping has an invalid CFI offset.");
+  }
+
+  return path.replace(/:\d+$/u, `:${offset}`);
 }
 
 function getHtmlTagName(node: HtmlNode): string | undefined {
@@ -688,10 +758,32 @@ function createTextLocator(
   start: number,
   end: number,
 ): Readonly<Record<string, unknown>> {
-  const prefix = createCfiPrefix(spineIndex);
+  const packagePath = createCfiPackagePath(spineIndex);
+  const { parentPath, textPath } = splitTextPath(path);
+  const parent =
+    parentPath === "" ? packagePath : `${packagePath}!${parentPath}`;
+  const startPath =
+    parentPath === "" ? `!${textPath}:${start}` : `${textPath}:${start}`;
+  const endPath =
+    parentPath === "" ? `!${textPath}:${end}` : `${textPath}:${end}`;
 
   return {
-    cfi: `epubcfi(${prefix}${path}:${start},${path}:${end})`,
+    cfi: `epubcfi(${parent},${startPath},${endPath})`,
+  };
+}
+
+function splitTextPath(path: string): {
+  readonly parentPath: string;
+  readonly textPath: string;
+} {
+  const separator = path.lastIndexOf("/");
+  if (separator < 0 || separator === path.length - 1) {
+    throw new Error(`EPUB text mapping has an invalid CFI path: ${path}`);
+  }
+
+  return {
+    parentPath: path.slice(0, separator),
+    textPath: path.slice(separator),
   };
 }
 
@@ -703,7 +795,11 @@ function createPointLocator(
 }
 
 function createCfiPrefix(spineIndex: number): string {
-  return `/6/${(spineIndex + 1) * 2}!`;
+  return `${createCfiPackagePath(spineIndex)}!`;
+}
+
+function createCfiPackagePath(spineIndex: number): string {
+  return `/6/${(spineIndex + 1) * 2}`;
 }
 
 function escapeCfiAssertion(value: string): string {

--- a/packages/core/src/text/source/epub/document.ts
+++ b/packages/core/src/text/source/epub/document.ts
@@ -265,7 +265,7 @@ function groupTargetsByPath(
 ): ReadonlyMap<string, readonly EpubSectionTarget[]> {
   const targetsByPath = new Map<string, EpubSectionTarget[]>();
   const spineIndexesByPath = new Map(
-    packageData.spine.map((item, index) => [item.path, index]),
+    packageData.spine.map((item) => [item.path, item.spineIndex]),
   );
 
   for (const section of flattenSections(sections)) {

--- a/packages/core/src/text/source/epub/package.ts
+++ b/packages/core/src/text/source/epub/package.ts
@@ -31,6 +31,8 @@ export interface EpubSpineItem {
   readonly idref: string;
   readonly path: string;
   readonly mediaType: string;
+  /** The itemref's zero-based position in the OPF spine element. */
+  readonly spineIndex: number;
 }
 
 export interface EpubPackageData {
@@ -206,9 +208,12 @@ function buildSpine(
   }
 
   return findChildren(spineElement, "itemref")
-    .map((itemref) => getAttribute(itemref, "idref"))
-    .filter((idref): idref is string => idref !== undefined)
-    .map((idref) => {
+    .map((itemref, spineIndex) => {
+      const idref = getAttribute(itemref, "idref");
+      if (idref === undefined) {
+        return undefined;
+      }
+
       const item = manifest.get(idref);
 
       if (
@@ -223,6 +228,7 @@ function buildSpine(
         idref,
         path: item.path,
         mediaType: item.mediaType,
+        spineIndex,
       } satisfies EpubSpineItem;
     })
     .filter((item): item is EpubSpineItem => item !== undefined);

--- a/test/core/text/source/epub-source-adapter.test.ts
+++ b/test/core/text/source/epub-source-adapter.test.ts
@@ -10,6 +10,7 @@ import {
   EpubContentLoader,
 } from "../../../../packages/core/src/text/source/epub/content.js";
 import { EpubArchive } from "../../../../packages/core/src/text/source/epub/archive.js";
+import { readEpubPackage } from "../../../../packages/core/src/text/source/epub/package.js";
 import { EPUB_SOURCE_ADAPTER } from "../../../../packages/core/src/text/source/index.js";
 import {
   collectSectionTitles,
@@ -124,6 +125,18 @@ describe("source/epub", () => {
       expect(
         resolveCfiText(xhtml, mappings[0]!.locator.cfi as string),
       ).toContain("Joan Robinson");
+      for (const mapping of mappings) {
+        const cfi = mapping.locator.cfi;
+        expect(typeof cfi).toBe("string");
+        const components = splitCfiComponents(
+          (cfi as string).slice("epubcfi(".length, -1),
+        );
+        expect(components.length === 1 || components.length === 3).toBe(true);
+        if (components.length === 3) {
+          expect(components[1]).toMatch(/:\d+$/u);
+          expect(components[2]).toMatch(/:\d+$/u);
+        }
+      }
       expect(() =>
         parseSourceTextJsonl(
           [
@@ -193,9 +206,50 @@ describe("source/epub", () => {
 
     expect(firstText).toBe("A😀B");
     expect(secondText).toBe("Second");
-    expect(firstCfi).toContain("/4/2[first]/2/1:1");
-    expect(firstCfi).toContain("/4/2[first]/2/1:5)");
-    expect(secondCfi).toContain("/4/4[second]/2/1:0");
+    expect(firstCfi).toContain("epubcfi(/6/2!/4/2[first]/2,/1:1,/1:5)");
+    expect(secondCfi).toContain("epubcfi(/6/2!/4/4[second]/2,/1:0,/1:6)");
+  });
+
+  it("keeps the original OPF spine position when unsupported items precede XHTML", async () => {
+    const files = new Map([
+      [
+        "META-INF/container.xml",
+        '<container><rootfiles><rootfile full-path="package.opf"/></rootfiles></container>',
+      ],
+      [
+        "package.opf",
+        [
+          '<package version="3.0">',
+          '<metadata><dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">Test</dc:title></metadata>',
+          "<manifest>",
+          '<item id="cover" href="cover.svg" media-type="image/svg+xml"/>',
+          '<item id="chapter" href="chapter.xhtml" media-type="application/xhtml+xml"/>',
+          "</manifest>",
+          "<spine>",
+          '<itemref idref="cover"/>',
+          '<itemref idref="chapter"/>',
+          "</spine>",
+          "</package>",
+        ].join(""),
+      ],
+    ]);
+    const packageData = await readEpubPackage({
+      readText: (path: string) => {
+        const content = files.get(path);
+        if (content === undefined) {
+          return Promise.reject(new Error(`missing test EPUB entry: ${path}`));
+        }
+        return Promise.resolve(content);
+      },
+      resolveRelativePath: (_basePath: string, href: string) => href,
+    } as never);
+
+    expect(packageData.spine).toHaveLength(1);
+    expect(packageData.spine[0]).toMatchObject({
+      idref: "chapter",
+      path: "chapter.xhtml",
+      spineIndex: 1,
+    });
   });
 
   it("reopens the underlying xhtml entry for repeated section reads", async () => {
@@ -290,17 +344,23 @@ describe("source/epub", () => {
 
 function resolveCfiText(html: string, cfi: string): string {
   const body = cfi.slice("epubcfi(".length, -1);
-  const indirection = body.indexOf("!");
-  const localPath = indirection < 0 ? body : body.slice(indirection + 1);
-  const [startPath, endPath] = localPath.split(",", 3);
-  if (startPath === undefined || endPath === undefined) {
+  const components = splitCfiComponents(body);
+  if (components.length !== 3) {
     throw new Error("Test CFI does not contain a range.");
   }
-  const steps = [...startPath.matchAll(/\/(\d+)(?:\[[^\]]*\])?/gu)].map(
+  const [parentPath, relativeStartPath, relativeEndPath] = components;
+  const startPath = joinCfiPath(parentPath!, relativeStartPath!);
+  const endPath = joinCfiPath(parentPath!, relativeEndPath!);
+  const indirection = startPath.indexOf("!");
+  const localPath =
+    indirection < 0 ? startPath : startPath.slice(indirection + 1);
+  const localEndPath =
+    indirection < 0 ? endPath : endPath.slice(indirection + 1);
+  const steps = [...localPath.matchAll(/\/(\d+)(?:\[[^\]]*\])?/gu)].map(
     (match) => Number(match[1]),
   );
-  const offset = Number(startPath.match(/:(\d+)$/u)?.[1] ?? 0);
-  const endOffset = Number(endPath.match(/:(\d+)$/u)?.[1] ?? 0);
+  const offset = Number(localPath.match(/:(\d+)$/u)?.[1] ?? 0);
+  const endOffset = Number(localEndPath.match(/:(\d+)$/u)?.[1] ?? 0);
   const root = parseDocument(html) as unknown as TestHtmlNode;
   const rootElement = (root.children ?? []).find(isTestElement);
   if (rootElement === undefined) {
@@ -321,6 +381,44 @@ function resolveCfiText(html: string, cfi: string): string {
   }
 
   return node.data ?? "";
+}
+
+function joinCfiPath(parentPath: string, relativePath: string): string {
+  return `${parentPath}${relativePath}`;
+}
+
+function splitCfiComponents(value: string): string[] {
+  const components: string[] = [];
+  let componentStart = 0;
+  let assertionDepth = 0;
+  let escaped = false;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "^") {
+      escaped = true;
+      continue;
+    }
+    if (character === "[") {
+      assertionDepth += 1;
+      continue;
+    }
+    if (character === "]") {
+      assertionDepth -= 1;
+      continue;
+    }
+    if (character === "," && assertionDepth === 0) {
+      components.push(value.slice(componentStart, index));
+      componentStart = index + 1;
+    }
+  }
+
+  components.push(value.slice(componentStart));
+  return components;
 }
 
 interface TestHtmlNode {


### PR DESCRIPTION
## 摘要

- 将 EPUB 文本范围 locator 改为标准的 `epubcfi(P,S,E)` 三元组格式。
- 保留 UTF-16 偏移和文本规范化映射，并处理根节点直接文本。
- 按 OPF 原始 spine itemref 顺序计算 CFI spine step，避免非 XHTML itemref 导致偏移。
- 增加 Cambridge fixture 和前置非 XHTML spine 的回归测试。

## 验证

- `pnpm verify`
- `pnpm test:run`（146 个测试文件、961 个测试）
- 真实 CLI 导入 Cambridge EPUB