### PR TITLE
feat: add v3 to v4 archive schema migration

### DIFF
--- a/docs/en/wikg-standard.md
+++ b/docs/en/wikg-standard.md
@@ -88,7 +88,8 @@ archive, including:
   projections, and evidence references;
 - object metadata, including archive-level book metadata;
 - generation parameter hashes and readiness state;
-- chapter index artifacts.
+- chapter index artifacts;
+- source provenance artifacts, locators, and text maps.
 
 Book metadata is not stored as a top-level `meta.json` file. It is stored in
 `database.db` as archive-level object metadata.

--- a/docs/schema-upgrade.md
+++ b/docs/schema-upgrade.md
@@ -52,6 +52,12 @@ old `archive_index_settings` table, and deletes embedded `index.db` / legacy
 `fts.db` caches. It does not create embedding artifacts, because older schemas
 never stored them as important data.
 
+The v3 -> v4 archive upgrader adds the source provenance schema to
+`database.db`: `source_artifacts`, `source_locators`, `source_text_maps`, and
+their indexes. It preserves existing source/summary text and structured archive
+data; provenance tables are initialized in the extracted upgrade workspace and
+the resulting database is written back only by the explicit archive upgrader.
+
 Archive upgraders must refuse active coordinator state for the target archive
 and non-search-index overlays, because those can represent uncommitted important
 data.

--- a/docs/zh-CN/wikg-standard.md
+++ b/docs/zh-CN/wikg-standard.md
@@ -71,7 +71,8 @@ Reader 必须拒绝缺少 `manifest.json` 的归档、`manifest.json` 中包含�
 - Knowledge Graph mentions、mention links、entity projections、triple projections 和 evidence references；
 - object metadata，包括 archive-level book metadata；
 - generation parameter hashes 和 readiness state；
-- chapter index artifacts。
+- chapter index artifacts；
+- source provenance artifacts、locators 和 text maps。
 
 Book metadata 不存为顶层 `meta.json` 文件。它作为 archive-level object metadata 存在 `database.db` 中。
 

--- a/packages/core/src/storage/schema-upgrade/index.ts
+++ b/packages/core/src/storage/schema-upgrade/index.ts
@@ -36,7 +36,7 @@ export {
   readWikiGraphHomeSchemaVersion,
 } from "../../document/home-schema-upgrade.js";
 
-export const CURRENT_ARCHIVE_SCHEMA_VERSION = 3;
+export const CURRENT_ARCHIVE_SCHEMA_VERSION = 4;
 const LOCK_STALE_TIMEOUT_MS = 5 * 60 * 1000;
 
 export interface WikiGraphArchiveSchemaUpgradeResult {
@@ -109,7 +109,10 @@ export async function upgradeWikiGraphArchiveSchema(
     const archiveDatabaseUpgrade = await createArchiveDatabaseUpgradeOverlay(
       resolvedArchivePath,
       temporaryDirectories,
-      { refreshArtifacts: schemaChanged },
+      {
+        persistDatabase: schemaChanged,
+        refreshArtifacts: schemaVersion < 3,
+      },
     );
 
     if (
@@ -240,7 +243,10 @@ async function createChapterTocUpgradeOverlay(
 async function createArchiveDatabaseUpgradeOverlay(
   archivePath: string,
   temporaryDirectories: string[],
-  options: { readonly refreshArtifacts: boolean },
+  options: {
+    readonly persistDatabase: boolean;
+    readonly refreshArtifacts: boolean;
+  },
 ): Promise<{
   readonly overlay:
     | {
@@ -273,7 +279,7 @@ async function createArchiveDatabaseUpgradeOverlay(
   if (!(await pathExists(databasePath))) {
     return { overlay: undefined, repairedTextWords };
   }
-  if (!options.refreshArtifacts && !repairedTextWords) {
+  if (!options.persistDatabase && !repairedTextWords) {
     return { overlay: undefined, repairedTextWords: false };
   }
 

--- a/packages/core/src/storage/wikg/archive/manifest.ts
+++ b/packages/core/src/storage/wikg/archive/manifest.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { WIKG_MANIFEST_PATH, WIKG_MUTATION_TOKEN_PATH } from "./constants.js";
 
 export const WIKG_FORMAT_VERSION = 1;
-export const WIKG_SCHEMA_VERSION = 3;
+export const WIKG_SCHEMA_VERSION = 4;
 export const WIKG_MANIFEST_CONTENT = `${JSON.stringify({
   formatVersion: WIKG_FORMAT_VERSION,
   schemaVersion: WIKG_SCHEMA_VERSION,

--- a/test/core/storage/schema-upgrade/index.test.ts
+++ b/test/core/storage/schema-upgrade/index.test.ts
@@ -33,6 +33,7 @@ import {
   WIKG_MUTATION_TOKEN_PATH,
   SEARCH_INDEX_DATABASE_PATH,
 } from "../../../../packages/core/src/storage/wikg/archive/constants.js";
+import { DATABASE_ENTRY_PATH } from "../../../../packages/core/src/storage/wikg/wikg-coordinator/constants.js";
 import { createWikgMutationTokenContent } from "../../../../packages/core/src/storage/wikg/archive/manifest.js";
 import {
   extractWikgArchive,
@@ -79,7 +80,7 @@ describe("schema-upgrade", () => {
       );
       await expect(
         readWikiGraphArchiveSchemaVersion(archivePath),
-      ).resolves.toBe(3);
+      ).resolves.toBe(4);
       await expect(
         readWikgArchiveEntry(archivePath, SEARCH_INDEX_DATABASE_PATH),
       ).resolves.toBeUndefined();
@@ -92,7 +93,7 @@ describe("schema-upgrade", () => {
     });
   });
 
-  it("upgrades v2 source indexes into v3 FTS artifacts", async () => {
+  it("upgrades v2 source indexes into current FTS artifacts", async () => {
     await withTempDir("wikigraph-schema-upgrade-v2-artifact-", async (root) => {
       setWikiGraphStateDirectoryPathForTesting(join(root, "home"));
       const archivePath = join(root, "book.wikg");
@@ -111,7 +112,7 @@ describe("schema-upgrade", () => {
       ).resolves.toEqual(mutationTokenBefore);
       await expect(
         readWikiGraphArchiveSchemaVersion(archivePath),
-      ).resolves.toBe(3);
+      ).resolves.toBe(4);
       await expect(
         readWikgArchiveEntry(archivePath, SEARCH_INDEX_DATABASE_PATH),
       ).resolves.toBeUndefined();
@@ -145,6 +146,154 @@ describe("schema-upgrade", () => {
         await document.release();
       }
     });
+  });
+
+  it("adds provenance tables when upgrading a real v3 database shape", async () => {
+    await withTempDir(
+      "wikigraph-schema-upgrade-v3-provenance-",
+      async (root) => {
+        setWikiGraphStateDirectoryPathForTesting(join(root, "home"));
+        const archivePath = join(root, "book.wikg");
+        const beforePath = join(root, "before");
+        const afterPath = join(root, "after");
+        const sourceText = "A v3 source archive without provenance tables.";
+
+        await writeV3ArchiveWithoutSourceProvenanceSchema(
+          archivePath,
+          sourceText,
+        );
+        const mutationTokenBefore = await readRawWikgArchiveEntry(
+          archivePath,
+          WIKG_MUTATION_TOKEN_PATH,
+        );
+        const sourceTextBefore = await readRawWikgArchiveEntry(
+          archivePath,
+          "texts/source/1.txt",
+        );
+        const tocBefore = await readRawWikgArchiveEntry(
+          archivePath,
+          "toc.json",
+        );
+
+        await extractWikgArchive(archivePath, beforePath);
+        const beforeDatabase = await Database.open(
+          join(beforePath, DATABASE_ENTRY_PATH),
+          "",
+          { readonly: true },
+        );
+        try {
+          await expect(
+            hasTable(beforeDatabase, "source_artifacts"),
+          ).resolves.toBe(false);
+          await expect(
+            hasTable(beforeDatabase, "source_locators"),
+          ).resolves.toBe(false);
+          await expect(
+            hasTable(beforeDatabase, "source_text_maps"),
+          ).resolves.toBe(false);
+          await expect(
+            beforeDatabase.queryOne(
+              "SELECT COUNT(*) AS count FROM serials",
+              undefined,
+              (row) => Number(row.count),
+            ),
+          ).resolves.toBe(1);
+        } finally {
+          await beforeDatabase.close();
+        }
+
+        await expect(
+          ensureWikiGraphArchiveSchemaCurrent(archivePath),
+        ).rejects.toThrow("wg maintenance upgrade");
+        await expect(
+          upgradeWikiGraphArchiveSchema(archivePath),
+        ).resolves.toEqual({
+          changed: true,
+          repairedToc: false,
+          repairedTextWords: false,
+          schemaChanged: true,
+        });
+
+        await expect(
+          readWikiGraphArchiveSchemaVersion(archivePath),
+        ).resolves.toBe(4);
+        await expect(
+          readRawWikgArchiveEntry(archivePath, WIKG_MUTATION_TOKEN_PATH),
+        ).resolves.toEqual(mutationTokenBefore);
+        await expect(
+          readWikgArchiveEntry(archivePath, "texts/source/1.txt"),
+        ).resolves.toEqual(sourceTextBefore);
+        await expect(
+          readWikgArchiveEntry(archivePath, "toc.json"),
+        ).resolves.toEqual(tocBefore);
+
+        await extractWikgArchive(archivePath, afterPath);
+        const afterDatabase = await Database.open(
+          join(afterPath, DATABASE_ENTRY_PATH),
+          "",
+          { readonly: true },
+        );
+        try {
+          await expect(
+            hasTable(afterDatabase, "source_artifacts"),
+          ).resolves.toBe(true);
+          await expect(
+            hasTable(afterDatabase, "source_locators"),
+          ).resolves.toBe(true);
+          await expect(
+            hasTable(afterDatabase, "source_text_maps"),
+          ).resolves.toBe(true);
+          await expect(
+            hasIndex(afterDatabase, "idx_source_locators_artifact"),
+          ).resolves.toBe(true);
+          await expect(
+            hasIndex(afterDatabase, "idx_source_text_maps_serial_range"),
+          ).resolves.toBe(true);
+          await expect(
+            hasIndex(afterDatabase, "idx_source_text_maps_locator"),
+          ).resolves.toBe(true);
+        } finally {
+          await afterDatabase.close();
+        }
+
+        const document = await DirectoryDocument.open(afterPath);
+        try {
+          await document.openSession(async (opened) => {
+            await opened.sourceProvenance.replace(1, 0, {
+              artifacts: [
+                {
+                  digest: "A".repeat(64),
+                  mediaType: "application/epub+zip",
+                  name: "book.epub",
+                },
+              ],
+              mappings: [
+                {
+                  artifactDigest: "A".repeat(64),
+                  locator: { cfi: "epubcfi(/6/2[body]!/4/2/1:0)" },
+                  sourceStart: 0,
+                  sourceEnd: sourceText.length,
+                },
+              ],
+            });
+            await expect(
+              opened.sourceProvenance.listMap(1),
+            ).resolves.toHaveLength(1);
+          });
+        } finally {
+          await document.release();
+        }
+
+        await expect(
+          upgradeWikiGraphArchiveSchema(archivePath),
+        ).resolves.toEqual({
+          changed: false,
+          repairedToc: false,
+          repairedTextWords: false,
+          schemaChanged: false,
+        });
+      },
+    );
   });
 
   it("persists missing chapter keys while upgrading a legacy archive", async () => {
@@ -204,7 +353,7 @@ describe("schema-upgrade", () => {
       const archivePath = join(root, "book.wikg");
       await writeArchiveWithSchemaVersion(
         archivePath,
-        3,
+        4,
         `${JSON.stringify({
           version: 1,
           items: [
@@ -233,7 +382,7 @@ describe("schema-upgrade", () => {
       });
       await expect(
         readWikiGraphArchiveSchemaVersion(archivePath),
-      ).resolves.toBe(3);
+      ).resolves.toBe(4);
 
       const upgradedTocEntry = await readWikgArchiveEntry(
         archivePath,
@@ -273,7 +422,7 @@ describe("schema-upgrade", () => {
       const archivePath = join(root, "book.wikg");
       const sourceText = "朱元璋攻克应天。陈友谅进攻采石。";
 
-      await writeBadWordCountArchive(archivePath, 3, sourceText);
+      await writeBadWordCountArchive(archivePath, 4, sourceText);
 
       await expect(
         upgradeWikiGraphArchiveSchema(archivePath),
@@ -1094,6 +1243,51 @@ async function createCoordinatorStateTable(
 
 async function writeLegacyArchive(archivePath: string): Promise<void> {
   await writeArchiveWithSchemaVersion(archivePath, 1);
+}
+
+async function writeV3ArchiveWithoutSourceProvenanceSchema(
+  archivePath: string,
+  sourceText: string,
+): Promise<void> {
+  await withTempDir(
+    "wikigraph-schema-v3-provenance-archive-",
+    async (sourceDir) => {
+      const document = await DirectoryDocument.open(sourceDir);
+
+      try {
+        await document.openSession(async (openedDocument) => {
+          const serialId = await openedDocument.createSerial();
+          const draft = await openedDocument
+            .getSerialFragments(serialId)
+            .createDraft();
+
+          draft.addSentence(sourceText, 7);
+          await draft.commit();
+          await openedDocument.writeToc({
+            items: [
+              {
+                children: [],
+                key: "v3-source",
+                serialId,
+                title: "V3 source",
+              },
+            ],
+            version: 1,
+          });
+        });
+
+        await document.readDatabase(async (database) => {
+          await database.run("DROP TABLE source_text_maps");
+          await database.run("DROP TABLE source_locators");
+          await database.run("DROP TABLE source_artifacts");
+        });
+      } finally {
+        await document.release();
+      }
+
+      await writeArchiveDirectoryWithSchemaVersion(sourceDir, archivePath, 3);
+    },
+  );
 }
 
 async function writeSourcedArchiveWithSchemaVersion(

--- a/test/core/storage/wikg/archive.test.ts
+++ b/test/core/storage/wikg/archive.test.ts
@@ -51,7 +51,7 @@ describe("wikg/archive", () => {
       ).toMatch(/^wikg-mutation-token:v1\n[A-Za-z0-9_-]{43}\n$/u);
       expect(
         JSON.parse(await readFile(`${extractDir}/manifest.json`, "utf8")),
-      ).toEqual({ formatVersion: 1, schemaVersion: 3 });
+      ).toEqual({ formatVersion: 1, schemaVersion: 4 });
       expect(await readFile(`${extractDir}/database.db`, "utf8")).toBe(
         "sqlite",
       );
@@ -190,7 +190,7 @@ describe("wikg/archive", () => {
 
       expect(
         JSON.parse(await readFile(`${extractDir}/manifest.json`, "utf8")),
-      ).toEqual({ formatVersion: 1, schemaVersion: 3 });
+      ).toEqual({ formatVersion: 1, schemaVersion: 4 });
     });
   });
 


### PR DESCRIPTION
Summary: bump .wikg archive schema to v4; persist source provenance tables during controlled v3-to-v4 upgrade; update English/Chinese standards and schema docs; add a genuine v3 missing-table regression covering preservation, provenance read/write, and idempotency. Verification: pnpm verify; pnpm test:run (147 files, 965 tests); pnpm build; pnpm --filter wiki-graph dev --help. Note: the assigned real external V3 archive path remains a placeholder and must be supplied for Review's read-only copy-based regression.