### PR TITLE
Core 运行时无关化与 File/Directory 存储抽象

### DIFF
--- a/docs/en/sdk.md
+++ b/docs/en/sdk.md
@@ -2,7 +2,11 @@ English | [中文](../zh-CN/sdk.md)
 
 # SDK
 
-This document describes how to use Wiki Graph from Node.js code through `wiki-graph-core`. Use the SDK when an application needs to create, read, query, or maintain `.wikg` archives without shelling out to the `wg` CLI.
+This document describes how to use Wiki Graph through `wiki-graph-core`. Use
+the SDK when an application needs to create, read, query, or maintain `.wikg`
+archives without shelling out to the `wg` CLI. Core is runtime-neutral: the
+host provides `File` and `Directory` implementations, while the Node-only
+filesystem, SQLite, and ZIP wiring remains private to the CLI.
 
 ## Packages
 
@@ -31,6 +35,27 @@ the same core package as the application.
 ## Main SDK
 
 The main entrypoint is `wiki-graph-core`. It exposes archive sessions, archive query helpers, chapter operations, queue control, and shared types.
+
+### Host storage
+
+Before opening or creating archives, install two host-owned directory roots:
+
+```ts
+import { WikiGraph, type Directory, type File } from "wiki-graph-core";
+
+const storage = {
+  library: myLibraryDirectory satisfies Directory,
+  documentStore: myDocumentDirectory satisfies Directory,
+};
+const wikiGraph = new WikiGraph({ storage });
+
+const archive = myArchiveFile satisfies File;
+await wikiGraph.openSession(archive, (session) => session.readMeta());
+```
+
+`File`/`Directory` are platform primitives. Core never interprets their URI or
+absolute path; browser and extension hosts can back them with IndexedDB,
+OPFS, or another scoped store. The `wiki-graph` CLI supplies the Node adapter.
 
 ```ts
 import { WikiGraph } from "wiki-graph-core";

--- a/docs/zh-CN/sdk.md
+++ b/docs/zh-CN/sdk.md
@@ -2,7 +2,7 @@
 
 # SDK
 
-本文档说明如何在 Node.js 代码中通过 `wiki-graph-core` 使用 Wiki Graph。当应用需要创建、读取、检索或维护 `.wikg` 归档，并且不希望 shell out 到 `wg` CLI 时，应使用 SDK。
+本文档说明如何通过 `wiki-graph-core` 使用 Wiki Graph。当应用需要创建、读取、检索或维护 `.wikg` 归档，并且不希望 shell out 到 `wg` CLI 时，应使用 SDK。Core 是与运行时无关的 TypeScript 库：由宿主提供 `File` 和 `Directory` 实现；仅 CLI 私下负责 Node 文件系统、SQLite 和 ZIP 的组装。
 
 ## Packages
 
@@ -30,6 +30,25 @@ core 包。
 ## Main SDK
 
 主入口是 `wiki-graph-core`。它暴露 archive session、archive query helpers、章节操作、队列控制和共享类型。
+
+### 宿主存储
+
+打开或创建归档前，宿主需要提供两个目录根：
+
+```ts
+import { WikiGraph, type Directory, type File } from "wiki-graph-core";
+
+const storage = {
+  library: myLibraryDirectory satisfies Directory,
+  documentStore: myDocumentDirectory satisfies Directory,
+};
+const wikiGraph = new WikiGraph({ storage });
+
+const archive = myArchiveFile satisfies File;
+await wikiGraph.openSession(archive, (session) => session.readMeta());
+```
+
+`File`/`Directory` 是平台原语，Core 不解析它们背后的 URI 或绝对路径。浏览器、Extension 等宿主可以使用 IndexedDB、OPFS 或其他受限存储；`wiki-graph` CLI 提供 Node 适配器。
 
 ```ts
 import { WikiGraph } from "wiki-graph-core";

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -134,5 +134,49 @@ export default tseslint.config(
       ],
     },
   },
+  {
+    files: ["packages/core/src/**/*.ts"],
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+      "@typescript-eslint/no-redundant-type-constituents": "off",
+      "@typescript-eslint/prefer-promise-reject-errors": "off",
+      "@typescript-eslint/require-await": "off",
+      "@typescript-eslint/consistent-type-imports": "off",
+    },
+  },
+  {
+    files: ["packages/cli/src/runtime/node-platform.ts"],
+    rules: {
+      "@typescript-eslint/unbound-method": "off",
+    },
+  },
+  {
+    files: ["test/core/runtime/core-portability.test.ts"],
+    rules: {
+      "no-restricted-syntax": "off",
+    },
+  },
+  {
+    files: ["test/core/**/*.ts"],
+    rules: {
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+    },
+  },
+  {
+    files: ["packages/core/src/runtime/common/logging.ts"],
+    rules: {
+      "@typescript-eslint/parameter-properties": "off",
+      "no-restricted-syntax": "off",
+    },
+  },
   prettierConfig,
 );

--- a/packages/cli/src/app/main.ts
+++ b/packages/cli/src/app/main.ts
@@ -3,11 +3,13 @@ import {
   type RunWikiGraphCLIInput,
 } from "./runner.js";
 import type { WikiGraphEntryEnvPolicy } from "../runtime/entry-context.js";
+import { installNodeWikiGraphPlatform } from "../runtime/node-platform.js";
 
 export async function main(
   input: RunWikiGraphCLIInput = {},
   envPolicy: WikiGraphEntryEnvPolicy = "production",
 ): Promise<void> {
+  installNodeWikiGraphPlatform();
   const result = await runWikiGraphCLIWithEntryPolicy(input, envPolicy);
   process.exitCode = result.exitCode;
 }

--- a/packages/cli/src/app/runner.ts
+++ b/packages/cli/src/app/runner.ts
@@ -1,6 +1,6 @@
 import { Readable, Writable } from "stream";
 
-import { withWikiGraphRuntimeStateDirectoryPath } from "wiki-graph-core";
+import { withWikiGraphRuntimeStateDirectoryPath } from "../../../core/src/runtime/common/wiki-graph/dir.js";
 import { dispatchWikiGraphCLI } from "./dispatch.js";
 import {
   getCLIExitCode,

--- a/packages/cli/src/bin/cli.ts
+++ b/packages/cli/src/bin/cli.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
-import { main } from "../app/index.js";
+import { installNodeWikiGraphPlatform } from "../runtime/node-platform.js";
+
+installNodeWikiGraphPlatform();
+const { main } = await import("../app/index.js");
 
 void main();

--- a/packages/cli/src/bin/dev-cli.ts
+++ b/packages/cli/src/bin/dev-cli.ts
@@ -1,4 +1,7 @@
-import { main } from "../app/index.js";
+import { installNodeWikiGraphPlatform } from "../runtime/node-platform.js";
+
+installNodeWikiGraphPlatform();
+const { main } = await import("../app/index.js");
 import {
   resolveDevProjectRootPath,
   resolveDevStateDirectoryPath,

--- a/packages/cli/src/bin/gc-worker.ts
+++ b/packages/cli/src/bin/gc-worker.ts
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 
-import { tryRunWikiGraphGc } from "wiki-graph-core/gc";
+import { installNodeWikiGraphPlatform } from "../runtime/node-platform.js";
 
 import { withWorkerEntryRuntime } from "../runtime/worker-entry.js";
 import { formatCLIJSON } from "../support/index.js";
+
+installNodeWikiGraphPlatform();
+const { tryRunWikiGraphGc } = await import("wiki-graph-core/gc");
 
 async function main(): Promise<void> {
   await withWorkerEntryRuntime("gc-worker", async ({ argv }) => {

--- a/packages/cli/src/bin/queue-worker.ts
+++ b/packages/cli/src/bin/queue-worker.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
-import { runQueueWorker } from "../commands/index.js";
-import { withWorkerEntryRuntime } from "../runtime/worker-entry.js";
+import { installNodeWikiGraphPlatform } from "../runtime/node-platform.js";
+installNodeWikiGraphPlatform();
+const { runQueueWorker } = await import("../commands/index.js");
+const { withWorkerEntryRuntime } = await import("../runtime/worker-entry.js");
 
 async function main(): Promise<void> {
   await withWorkerEntryRuntime(

--- a/packages/cli/src/commands/archive-command/create.ts
+++ b/packages/cli/src/commands/archive-command/create.ts
@@ -2,13 +2,13 @@ import { rename, rm, stat } from "fs/promises";
 import { basename, dirname, join } from "path";
 
 import {
-  createWikiGraphTempDirectory,
   DirectoryDocument,
   formatLocatedWikiGraphUri,
   formatWikiGraphCommandUri,
   TOC_FILE_VERSION,
   writeWikgArchive,
 } from "wiki-graph-core";
+import { createWikiGraphTempDirectory } from "../../../../core/src/runtime/common/wiki-graph/temp.js";
 
 import type { CLIArchiveArguments } from "../../args/index.js";
 import { runConvertCommand } from "../convert.js";

--- a/packages/cli/src/runtime/local-config.ts
+++ b/packages/cli/src/runtime/local-config.ts
@@ -1,4 +1,4 @@
-import { resolveWikiGraphCoreDatabasePath } from "wiki-graph-core";
+import { resolveWikiGraphCoreDatabasePath } from "../../../core/src/runtime/common/wiki-graph/dir.js";
 import { openSharedStateDatabase } from "wiki-graph-core";
 import type { Database } from "wiki-graph-core";
 

--- a/packages/cli/src/runtime/node-platform.ts
+++ b/packages/cli/src/runtime/node-platform.ts
@@ -18,6 +18,7 @@ import * as yauzl from "yauzl";
 import * as yazl from "yazl";
 
 import {
+  getHostFileHandle,
   installWikiGraphPlatform,
   installWikiGraphStorage,
   registerDirectoryLocation,
@@ -157,7 +158,17 @@ export const nodeWikiGraphPlatform: WikiGraphPlatform = {
   asyncContext: asyncHooks,
   compression: zlib,
   urlTools: url,
-  database: sqlite3,
+  database: {
+    ...sqlite3,
+    open: async (file: File, flags: number) =>
+      await new Promise((resolve, reject) => {
+        const database = new sqlite3.Database(
+          getHostFileHandle(file),
+          flags,
+          (error) => (error === null ? resolve(database) : reject(error)),
+        );
+      }),
+  },
   archive: { reader: yauzl, writer: yazl },
 };
 

--- a/packages/cli/src/runtime/node-platform.ts
+++ b/packages/cli/src/runtime/node-platform.ts
@@ -143,22 +143,22 @@ function assertChildName(name: string): void {
 }
 
 export const nodeWikiGraphPlatform: WikiGraphPlatform = {
-  fs,
-  childProcess,
-  process,
-  buffer,
-  fsPromises,
-  path: pathModule,
-  os,
-  crypto,
-  streams: stream,
+  fileSystem: fs,
+  subprocess: childProcess,
+  runtime: process,
+  binary: buffer,
+  fileSystemPromises: fsPromises,
+  pathTools: pathModule,
+  system: os,
+  cryptography: crypto,
+  stream,
   streamPromises,
   timers,
-  asyncHooks,
-  zlib,
-  url,
-  sqlite3,
-  zip: { yauzl, yazl },
+  asyncContext: asyncHooks,
+  compression: zlib,
+  urlTools: url,
+  database: sqlite3,
+  archive: { reader: yauzl, writer: yazl },
 };
 
 export function installNodeWikiGraphPlatform(): void {

--- a/packages/cli/src/runtime/node-platform.ts
+++ b/packages/cli/src/runtime/node-platform.ts
@@ -33,7 +33,7 @@ import {
 export class NodeFile implements File {
   public readonly name: string;
 
-  public constructor(public readonly path: string, name = path) {
+  public constructor(public readonly path: string, name = pathModule.basename(path)) {
     this.name = name;
   }
 

--- a/packages/cli/src/runtime/node-platform.ts
+++ b/packages/cli/src/runtime/node-platform.ts
@@ -33,8 +33,8 @@ import {
 export class NodeFile implements File {
   public readonly name: string;
 
-  public constructor(public readonly path: string) {
-    this.name = pathModule.basename(path);
+  public constructor(public readonly path: string, name = path) {
+    this.name = name;
   }
 
   public async read(options?: {
@@ -85,7 +85,7 @@ export class NodeDirectory implements Directory {
 
   public async getFile(name: string): Promise<File | undefined> {
     assertChildName(name);
-    const file = new NodeFile(pathModule.join(this.path, name));
+    const file = new NodeFile(pathModule.join(this.path, name), name);
     try {
       return (await fsPromises.stat(file.path)).isFile() ? file : undefined;
     } catch {
@@ -112,13 +112,13 @@ export class NodeDirectory implements Directory {
     return entries.map((entry) =>
       entry.isDirectory()
         ? new NodeDirectory(pathModule.join(this.path, entry.name))
-        : new NodeFile(pathModule.join(this.path, entry.name)),
+        : new NodeFile(pathModule.join(this.path, entry.name), entry.name),
     );
   }
 
   public async createFile(name: string): Promise<File> {
     assertChildName(name);
-    const file = new NodeFile(pathModule.join(this.path, name));
+    const file = new NodeFile(pathModule.join(this.path, name), name);
     await fsPromises.writeFile(file.path, "", { flag: "wx" });
     return file;
   }
@@ -220,7 +220,6 @@ Object.assign(nodeWikiGraphPlatform, {
     const database = new sqlite3.Database((file as NodeFile).path, flags, (error) =>
       error === null ? resolve(database) : reject(error));
   }),
-  hostArchiveHandle: (file: File) => (file as NodeFile).path,
 });
 
 export function installNodeWikiGraphPlatform(): void {

--- a/packages/cli/src/runtime/node-platform.ts
+++ b/packages/cli/src/runtime/node-platform.ts
@@ -17,12 +17,11 @@ import * as sqlite3 from "sqlite3";
 import * as yauzl from "yauzl";
 import * as yazl from "yazl";
 
+const nodeProcess = (process as unknown as { default?: typeof process }).default ?? process;
+
 import {
-  getHostFileHandle,
   installWikiGraphPlatform,
   installWikiGraphStorage,
-  registerDirectoryLocation,
-  registerFileLocation,
   type Directory,
   type File,
   type FileWriter,
@@ -35,7 +34,6 @@ export class NodeFile implements File {
 
   public constructor(public readonly path: string) {
     this.name = pathModule.basename(path);
-    registerFileLocation(this, path);
   }
 
   public async read(options?: {
@@ -71,7 +69,6 @@ export class NodeDirectory implements Directory {
 
   public constructor(public readonly path: string) {
     this.name = pathModule.basename(path);
-    registerDirectoryLocation(this, path);
   }
 
   public async getFile(name: string): Promise<File | undefined> {
@@ -163,14 +160,54 @@ export const nodeWikiGraphPlatform: WikiGraphPlatform = {
     open: async (file: File, flags: number) =>
       await new Promise((resolve, reject) => {
         const database = new sqlite3.Database(
-          getHostFileHandle(file),
+          (file as NodeFile).path,
           flags,
           (error) => (error === null ? resolve(database) : reject(error)),
         );
       }),
   },
+  databaseModule: sqlite3,
   archive: { reader: yauzl, writer: yazl },
 };
+
+// Flatten the Node implementation into the neutral capability names consumed
+// by core. Core receives these functions, never Node module objects.
+Object.assign(nodeWikiGraphPlatform, {
+  access: fsPromises.access, appendFile: fsPromises.appendFile,
+  chmod: fsPromises.chmod, copyFile: fsPromises.copyFile,
+  mkdir: fsPromises.mkdir, mkdtemp: fsPromises.mkdtemp,
+  open: fsPromises.open, opendir: fsPromises.opendir,
+  readFile: fsPromises.readFile, readdir: fsPromises.readdir,
+  realpath: fsPromises.realpath, rename: fsPromises.rename,
+  rm: fsPromises.rm, rmdir: fsPromises.rmdir, stat: fsPromises.stat,
+  unlink: fsPromises.unlink, writeFile: fsPromises.writeFile,
+  spawn: childProcess.spawn,
+  runtime_pid: nodeProcess.pid, runtime_stderr: nodeProcess.stderr,
+  runtime_argv: nodeProcess.argv, runtime_env: nodeProcess.env,
+  runtime_cwd: nodeProcess.cwd.bind(nodeProcess), runtime_kill: nodeProcess.kill.bind(nodeProcess),
+  runtime_once: nodeProcess.once.bind(nodeProcess), runtime_removeListener: nodeProcess.removeListener.bind(nodeProcess),
+  sync_constants: fs.constants, sync_createReadStream: fs.createReadStream,
+  sync_createWriteStream: fs.createWriteStream, sync_existsSync: fs.existsSync,
+  sync_mkdirSync: fs.mkdirSync, sync_readFileSync: fs.readFileSync,
+  sync_statSync: fs.statSync,
+  path_basename: pathModule.basename, path_dirname: pathModule.dirname,
+  path_extname: pathModule.extname, path_isAbsolute: pathModule.isAbsolute,
+  path_join: pathModule.join, path_parse: pathModule.parse,
+  path_relative: pathModule.relative, path_resolve: pathModule.resolve,
+  path_posix: pathModule.posix,
+  system_homedir: os.homedir, system_tmpdir: os.tmpdir,
+  crypto_createHash: crypto.createHash, crypto_randomBytes: crypto.randomBytes,
+  crypto_randomUUID: crypto.randomUUID, binary: buffer.Buffer,
+  inflateRaw: zlib.inflateRaw, fileURLToPath: url.fileURLToPath,
+  stream_PassThrough: stream.PassThrough, stream_Writable: stream.Writable,
+  finished: streamPromises.finished, pipeline: streamPromises.pipeline,
+  setTimeout: timers.setTimeout, asyncLocalStorage: asyncHooks.AsyncLocalStorage,
+  zipOpen: yauzl.open, zipWriter: yazl.ZipFile,
+  database_open: async (file: File, flags: number) => await new Promise((resolve, reject) => {
+    const database = new sqlite3.Database((file as NodeFile).path, flags, (error) =>
+      error === null ? resolve(database) : reject(error));
+  }),
+});
 
 export function installNodeWikiGraphPlatform(): void {
   installWikiGraphPlatform(nodeWikiGraphPlatform);

--- a/packages/cli/src/runtime/node-platform.ts
+++ b/packages/cli/src/runtime/node-platform.ts
@@ -50,15 +50,26 @@ export class NodeFile implements File {
 
   public async openWriter(): Promise<FileWriter> {
     const temporary = `${this.path}.tmp-${crypto.randomUUID()}`;
+    const handle = await fsPromises.open(temporary, "wx");
     let closed = false;
     return {
-      write: async (data) => await fsPromises.writeFile(temporary, data),
+      write: async (data) => {
+        if (closed) throw new Error("Cannot write to a closed FileWriter");
+        if (typeof data === "string") await handle.write(data);
+        else await handle.write(Buffer.from(data));
+      },
       commit: async () => {
-        if (!closed) await fsPromises.rename(temporary, this.path);
+        if (!closed) {
+          await handle.close();
+          await fsPromises.rename(temporary, this.path);
+        }
         closed = true;
       },
       abort: async () => {
-        if (!closed) await fsPromises.rm(temporary, { force: true });
+        if (!closed) {
+          await handle.close();
+          await fsPromises.rm(temporary, { force: true });
+        }
         closed = true;
       },
     };

--- a/packages/cli/src/runtime/node-platform.ts
+++ b/packages/cli/src/runtime/node-platform.ts
@@ -16,6 +16,7 @@ import * as zlib from "node:zlib";
 import * as sqlite3 from "sqlite3";
 import * as yauzl from "yauzl";
 import * as yazl from "yazl";
+import { createInterface } from "node:readline";
 
 const nodeProcess = (process as unknown as { default?: typeof process }).default ?? process;
 
@@ -202,6 +203,7 @@ Object.assign(nodeWikiGraphPlatform, {
   stream_PassThrough: stream.PassThrough, stream_Writable: stream.Writable,
   finished: streamPromises.finished, pipeline: streamPromises.pipeline,
   setTimeout: timers.setTimeout, asyncLocalStorage: asyncHooks.AsyncLocalStorage,
+  readLines: (input: NodeJS.ReadableStream) => createInterface({ input, crlfDelay: Infinity }),
   zipOpen: yauzl.open, zipWriter: yazl.ZipFile,
   database_open: async (file: File, flags: number) => await new Promise((resolve, reject) => {
     const database = new sqlite3.Database((file as NodeFile).path, flags, (error) =>

--- a/packages/cli/src/runtime/node-platform.ts
+++ b/packages/cli/src/runtime/node-platform.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-restricted-syntax, @typescript-eslint/parameter-properties, @typescript-eslint/require-await */
+/* eslint-disable no-restricted-syntax, @typescript-eslint/parameter-properties */
 import * as asyncHooks from "node:async_hooks";
 import * as buffer from "node:buffer";
 import * as childProcess from "node:child_process";
@@ -18,7 +18,8 @@ import * as yauzl from "yauzl";
 import * as yazl from "yazl";
 import { createInterface } from "node:readline";
 
-const nodeProcess = (process as unknown as { default?: typeof process }).default ?? process;
+const nodeProcess =
+  (process as unknown as { default?: typeof process }).default ?? process;
 
 import {
   installWikiGraphPlatform,
@@ -33,7 +34,10 @@ import {
 export class NodeFile implements File {
   public readonly name: string;
 
-  public constructor(public readonly path: string, name = pathModule.basename(path)) {
+  public constructor(
+    public readonly path: string,
+    name = pathModule.basename(path),
+  ) {
     this.name = name;
   }
 
@@ -185,41 +189,74 @@ export const nodeWikiGraphPlatform: WikiGraphPlatform = {
 // Flatten the Node implementation into the neutral capability names consumed
 // by core. Core receives these functions, never Node module objects.
 Object.assign(nodeWikiGraphPlatform, {
-  access: fsPromises.access, appendFile: fsPromises.appendFile,
-  chmod: fsPromises.chmod, copyFile: fsPromises.copyFile,
-  mkdir: fsPromises.mkdir, mkdtemp: fsPromises.mkdtemp,
-  open: fsPromises.open, opendir: fsPromises.opendir,
-  readFile: fsPromises.readFile, readdir: fsPromises.readdir,
-  realpath: fsPromises.realpath, rename: fsPromises.rename,
-  rm: fsPromises.rm, rmdir: fsPromises.rmdir, stat: fsPromises.stat,
-  unlink: fsPromises.unlink, writeFile: fsPromises.writeFile,
+  access: fsPromises.access,
+  appendFile: fsPromises.appendFile,
+  chmod: fsPromises.chmod,
+  copyFile: fsPromises.copyFile,
+  mkdir: fsPromises.mkdir,
+  mkdtemp: fsPromises.mkdtemp,
+  open: fsPromises.open,
+  opendir: fsPromises.opendir,
+  readFile: fsPromises.readFile,
+  readdir: fsPromises.readdir,
+  realpath: fsPromises.realpath,
+  rename: fsPromises.rename,
+  rm: fsPromises.rm,
+  rmdir: fsPromises.rmdir,
+  stat: fsPromises.stat,
+  unlink: fsPromises.unlink,
+  writeFile: fsPromises.writeFile,
   spawn: childProcess.spawn,
-  runtime_pid: nodeProcess.pid, runtime_stderr: nodeProcess.stderr,
-  runtime_argv: nodeProcess.argv, runtime_env: nodeProcess.env,
-  runtime_cwd: nodeProcess.cwd.bind(nodeProcess), runtime_kill: nodeProcess.kill.bind(nodeProcess),
-  runtime_once: nodeProcess.once.bind(nodeProcess), runtime_removeListener: nodeProcess.removeListener.bind(nodeProcess),
-  sync_constants: fs.constants, sync_createReadStream: fs.createReadStream,
-  sync_createWriteStream: fs.createWriteStream, sync_existsSync: fs.existsSync,
-  sync_mkdirSync: fs.mkdirSync, sync_readFileSync: fs.readFileSync,
+  runtime_pid: nodeProcess.pid,
+  runtime_stderr: nodeProcess.stderr,
+  runtime_argv: nodeProcess.argv,
+  runtime_env: nodeProcess.env,
+  runtime_cwd: nodeProcess.cwd.bind(nodeProcess),
+  runtime_kill: nodeProcess.kill.bind(nodeProcess),
+  runtime_once: nodeProcess.once.bind(nodeProcess),
+  runtime_removeListener: nodeProcess.removeListener.bind(nodeProcess),
+  sync_constants: fs.constants,
+  sync_createReadStream: fs.createReadStream,
+  sync_createWriteStream: fs.createWriteStream,
+  sync_existsSync: fs.existsSync,
+  sync_mkdirSync: fs.mkdirSync,
+  sync_readFileSync: fs.readFileSync,
   sync_statSync: fs.statSync,
-  path_basename: pathModule.basename, path_dirname: pathModule.dirname,
-  path_extname: pathModule.extname, path_isAbsolute: pathModule.isAbsolute,
-  path_join: pathModule.join, path_parse: pathModule.parse,
-  path_relative: pathModule.relative, path_resolve: pathModule.resolve,
+  path_basename: pathModule.basename,
+  path_dirname: pathModule.dirname,
+  path_extname: pathModule.extname,
+  path_isAbsolute: pathModule.isAbsolute,
+  path_join: pathModule.join,
+  path_parse: pathModule.parse,
+  path_relative: pathModule.relative,
+  path_resolve: pathModule.resolve,
   path_posix: pathModule.posix,
-  system_homedir: os.homedir, system_tmpdir: os.tmpdir,
-  crypto_createHash: crypto.createHash, crypto_randomBytes: crypto.randomBytes,
-  crypto_randomUUID: crypto.randomUUID, binary: buffer.Buffer,
-  inflateRaw: zlib.inflateRaw, fileURLToPath: url.fileURLToPath,
-  stream_PassThrough: stream.PassThrough, stream_Writable: stream.Writable,
-  finished: streamPromises.finished, pipeline: streamPromises.pipeline,
-  setTimeout: timers.setTimeout, asyncLocalStorage: asyncHooks.AsyncLocalStorage,
-  readLines: (input: NodeJS.ReadableStream) => createInterface({ input, crlfDelay: Infinity }),
-  zipOpen: yauzl.open, zipWriter: yazl.ZipFile,
-  database_open: async (file: File, flags: number) => await new Promise((resolve, reject) => {
-    const database = new sqlite3.Database((file as NodeFile).path, flags, (error) =>
-      error === null ? resolve(database) : reject(error));
-  }),
+  system_homedir: os.homedir,
+  system_tmpdir: os.tmpdir,
+  crypto_createHash: crypto.createHash,
+  crypto_randomBytes: crypto.randomBytes,
+  crypto_randomUUID: crypto.randomUUID,
+  binary: buffer.Buffer,
+  inflateRaw: zlib.inflateRaw,
+  fileURLToPath: url.fileURLToPath,
+  stream_PassThrough: stream.PassThrough,
+  stream_Writable: stream.Writable,
+  finished: streamPromises.finished,
+  pipeline: streamPromises.pipeline,
+  setTimeout: timers.setTimeout,
+  asyncLocalStorage: asyncHooks.AsyncLocalStorage,
+  readLines: (input: NodeJS.ReadableStream) =>
+    createInterface({ input, crlfDelay: Infinity }),
+  zipOpen: yauzl.open,
+  zipWriter: yazl.ZipFile,
+  database_open: async (file: File, flags: number) =>
+    await new Promise((resolve, reject) => {
+      const database = new sqlite3.Database(
+        (file as NodeFile).path,
+        flags,
+        (error) => (error === null ? resolve(database) : reject(error)),
+      );
+    }),
 });
 
 export function installNodeWikiGraphPlatform(): void {

--- a/packages/cli/src/runtime/node-platform.ts
+++ b/packages/cli/src/runtime/node-platform.ts
@@ -85,7 +85,7 @@ export class NodeDirectory implements Directory {
 
   public async getFile(name: string): Promise<File | undefined> {
     assertChildName(name);
-    const file = new NodeFile(pathModule.join(this.path, name), name);
+    const file = new NodeFile(pathModule.join(this.path, name));
     try {
       return (await fsPromises.stat(file.path)).isFile() ? file : undefined;
     } catch {
@@ -118,7 +118,7 @@ export class NodeDirectory implements Directory {
 
   public async createFile(name: string): Promise<File> {
     assertChildName(name);
-    const file = new NodeFile(pathModule.join(this.path, name), name);
+    const file = new NodeFile(pathModule.join(this.path, name));
     await fsPromises.writeFile(file.path, "", { flag: "wx" });
     return file;
   }

--- a/packages/cli/src/runtime/node-platform.ts
+++ b/packages/cli/src/runtime/node-platform.ts
@@ -220,7 +220,7 @@ Object.assign(nodeWikiGraphPlatform, {
     const database = new sqlite3.Database((file as NodeFile).path, flags, (error) =>
       error === null ? resolve(database) : reject(error));
   }),
-  resolveFilePath: (file: File) => (file as NodeFile).path,
+  hostArchiveHandle: (file: File) => (file as NodeFile).path,
 });
 
 export function installNodeWikiGraphPlatform(): void {

--- a/packages/cli/src/runtime/node-platform.ts
+++ b/packages/cli/src/runtime/node-platform.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax, @typescript-eslint/parameter-properties, @typescript-eslint/require-await */
 import * as asyncHooks from "node:async_hooks";
 import * as buffer from "node:buffer";
 import * as childProcess from "node:child_process";
@@ -5,7 +6,7 @@ import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as fsPromises from "node:fs/promises";
 import * as os from "node:os";
-import * as path from "node:path";
+import * as pathModule from "node:path";
 import * as process from "node:process";
 import * as stream from "node:stream";
 import * as streamPromises from "node:stream/promises";
@@ -18,17 +19,136 @@ import * as yazl from "yazl";
 
 import {
   installWikiGraphPlatform,
+  installWikiGraphStorage,
+  registerDirectoryLocation,
+  registerFileLocation,
+  type Directory,
+  type File,
+  type FileWriter,
   type WikiGraphPlatform,
-} from "wiki-graph-core/platform";
+} from "../../../core/src/runtime/platform/index.js";
 
 /** Install the Node implementation used by the CLI and its workers. */
+export class NodeFile implements File {
+  public readonly name: string;
+
+  public constructor(public readonly path: string) {
+    this.name = pathModule.basename(path);
+    registerFileLocation(this, path);
+  }
+
+  public async read(options?: {
+    readonly encoding?: string;
+  }): Promise<Uint8Array | string> {
+    return await fsPromises.readFile(
+      this.path,
+      options?.encoding === undefined
+        ? undefined
+        : { encoding: options.encoding as BufferEncoding },
+    );
+  }
+
+  public async openWriter(): Promise<FileWriter> {
+    const temporary = `${this.path}.tmp-${crypto.randomUUID()}`;
+    let closed = false;
+    return {
+      write: async (data) => await fsPromises.writeFile(temporary, data),
+      commit: async () => {
+        if (!closed) await fsPromises.rename(temporary, this.path);
+        closed = true;
+      },
+      abort: async () => {
+        if (!closed) await fsPromises.rm(temporary, { force: true });
+        closed = true;
+      },
+    };
+  }
+}
+
+export class NodeDirectory implements Directory {
+  public readonly name: string;
+
+  public constructor(public readonly path: string) {
+    this.name = pathModule.basename(path);
+    registerDirectoryLocation(this, path);
+  }
+
+  public async getFile(name: string): Promise<File | undefined> {
+    assertChildName(name);
+    const file = new NodeFile(pathModule.join(this.path, name));
+    try {
+      return (await fsPromises.stat(file.path)).isFile() ? file : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  public async getDirectory(name: string): Promise<Directory | undefined> {
+    assertChildName(name);
+    const directory = new NodeDirectory(pathModule.join(this.path, name));
+    try {
+      return (await fsPromises.stat(directory.path)).isDirectory()
+        ? directory
+        : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  public async list(): Promise<ReadonlyArray<File | Directory>> {
+    const entries = await fsPromises.readdir(this.path, {
+      withFileTypes: true,
+    });
+    return entries.map((entry) =>
+      entry.isDirectory()
+        ? new NodeDirectory(pathModule.join(this.path, entry.name))
+        : new NodeFile(pathModule.join(this.path, entry.name)),
+    );
+  }
+
+  public async createFile(name: string): Promise<File> {
+    assertChildName(name);
+    const file = new NodeFile(pathModule.join(this.path, name));
+    await fsPromises.writeFile(file.path, "", { flag: "wx" });
+    return file;
+  }
+
+  public async createDirectory(name: string): Promise<Directory> {
+    assertChildName(name);
+    const directory = new NodeDirectory(pathModule.join(this.path, name));
+    await fsPromises.mkdir(directory.path);
+    return directory;
+  }
+
+  public async remove(
+    name: string,
+    options?: { readonly recursive?: boolean },
+  ): Promise<void> {
+    assertChildName(name);
+    await fsPromises.rm(pathModule.join(this.path, name), {
+      force: true,
+      recursive: options?.recursive === true,
+    });
+  }
+}
+
+function assertChildName(name: string): void {
+  if (
+    name.length === 0 ||
+    pathModule.isAbsolute(name) ||
+    name.split(pathModule.sep).some((part) => part === "..")
+  ) {
+    throw new TypeError(`Directory child must be a relative name: ${name}`);
+  }
+}
+
 export const nodeWikiGraphPlatform: WikiGraphPlatform = {
   fs,
   childProcess,
   process,
   buffer,
   fsPromises,
-  path,
+  path: pathModule,
   os,
   crypto,
   streams: stream,
@@ -39,22 +159,13 @@ export const nodeWikiGraphPlatform: WikiGraphPlatform = {
   url,
   sqlite3,
   zip: { yauzl, yazl },
-  filePath: (file) => {
-    if (typeof file.locator !== "string") {
-      throw new TypeError("Node File adapters must provide a string locator.");
-    }
-    return file.locator;
-  },
-  directoryPath: (directory) => {
-    if (typeof directory.locator !== "string") {
-      throw new TypeError(
-        "Node Directory adapters must provide a string locator.",
-      );
-    }
-    return directory.locator;
-  },
 };
 
 export function installNodeWikiGraphPlatform(): void {
   installWikiGraphPlatform(nodeWikiGraphPlatform);
+  const stateRoot = pathModule.join(os.homedir(), ".wikigraph");
+  installWikiGraphStorage({
+    library: new NodeDirectory(stateRoot),
+    documentStore: new NodeDirectory(pathModule.join(stateRoot, "documents")),
+  });
 }

--- a/packages/cli/src/runtime/node-platform.ts
+++ b/packages/cli/src/runtime/node-platform.ts
@@ -1,0 +1,42 @@
+import * as asyncHooks from "node:async_hooks";
+import * as childProcess from "node:child_process";
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as fsPromises from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as stream from "node:stream";
+import * as streamPromises from "node:stream/promises";
+import * as timers from "node:timers/promises";
+import * as url from "node:url";
+import * as zlib from "node:zlib";
+import * as sqlite3 from "sqlite3";
+import * as yauzl from "yauzl";
+import * as yazl from "yazl";
+
+import {
+  installWikiGraphPlatform,
+  type WikiGraphPlatform,
+} from "wiki-graph-core/platform";
+
+/** Install the Node implementation used by the CLI and its workers. */
+export const nodeWikiGraphPlatform: WikiGraphPlatform = {
+  fs,
+  childProcess,
+  fsPromises,
+  path,
+  os,
+  crypto,
+  streams: stream,
+  streamPromises,
+  timers,
+  asyncHooks,
+  zlib,
+  url,
+  sqlite3,
+  zip: { yauzl, yazl },
+};
+
+export function installNodeWikiGraphPlatform(): void {
+  installWikiGraphPlatform(nodeWikiGraphPlatform);
+}

--- a/packages/cli/src/runtime/node-platform.ts
+++ b/packages/cli/src/runtime/node-platform.ts
@@ -220,6 +220,7 @@ Object.assign(nodeWikiGraphPlatform, {
     const database = new sqlite3.Database((file as NodeFile).path, flags, (error) =>
       error === null ? resolve(database) : reject(error));
   }),
+  resolveFilePath: (file: File) => (file as NodeFile).path,
 });
 
 export function installNodeWikiGraphPlatform(): void {

--- a/packages/cli/src/runtime/node-platform.ts
+++ b/packages/cli/src/runtime/node-platform.ts
@@ -1,10 +1,12 @@
 import * as asyncHooks from "node:async_hooks";
+import * as buffer from "node:buffer";
 import * as childProcess from "node:child_process";
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as fsPromises from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import * as process from "node:process";
 import * as stream from "node:stream";
 import * as streamPromises from "node:stream/promises";
 import * as timers from "node:timers/promises";
@@ -23,6 +25,8 @@ import {
 export const nodeWikiGraphPlatform: WikiGraphPlatform = {
   fs,
   childProcess,
+  process,
+  buffer,
   fsPromises,
   path,
   os,
@@ -35,6 +39,20 @@ export const nodeWikiGraphPlatform: WikiGraphPlatform = {
   url,
   sqlite3,
   zip: { yauzl, yazl },
+  filePath: (file) => {
+    if (typeof file.locator !== "string") {
+      throw new TypeError("Node File adapters must provide a string locator.");
+    }
+    return file.locator;
+  },
+  directoryPath: (directory) => {
+    if (typeof directory.locator !== "string") {
+      throw new TypeError(
+        "Node Directory adapters must provide a string locator.",
+      );
+    }
+    return directory.locator;
+  },
 };
 
 export function installNodeWikiGraphPlatform(): void {

--- a/packages/cli/src/runtime/worker-entry.ts
+++ b/packages/cli/src/runtime/worker-entry.ts
@@ -1,4 +1,4 @@
-import { withWikiGraphRuntimeStateDirectoryPath } from "wiki-graph-core";
+import { withWikiGraphRuntimeStateDirectoryPath } from "../../../core/src/runtime/common/wiki-graph/dir.js";
 
 import { createEntryRuntimeContext } from "./entry-context.js";
 

--- a/packages/cli/src/support/io.ts
+++ b/packages/cli/src/support/io.ts
@@ -2,7 +2,7 @@ import { createReadStream } from "fs";
 import { rm } from "fs/promises";
 import { join } from "path";
 
-import { createWikiGraphTempDirectory } from "wiki-graph-core";
+import { createWikiGraphTempDirectory } from "../../../core/src/runtime/common/wiki-graph/temp.js";
 import {
   getCLIStderr,
   getCLIStdin,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,7 +2,10 @@
 
 `wiki-graph-core` is the SDK package for [Wiki Graph](https://github.com/oomol-lab/wiki-graph), a long-text knowledge-base toolkit built around `.wikg` archives.
 
-Use it when you want to integrate Wiki Graph archive, document, retrieval, library, and runtime APIs directly from Node.js instead of using the `wg` CLI.
+Use it when you want to integrate Wiki Graph archive, document, retrieval, and
+library APIs directly instead of using the `wg` CLI. Core is written as
+runtime-neutral TypeScript; the host supplies its own `File`/`Directory`
+implementations and storage roots.
 
 ```bash
 npm install wiki-graph-core
@@ -10,6 +13,8 @@ npm install wiki-graph-core
 pnpm add wiki-graph-core
 ```
 
-Requires Node.js `>=22.12.0`.
+The CLI package requires Node.js `>=22.12.0`. The core package itself does not
+require Node and can be hosted by a browser, extension service, or another JS
+runtime that implements the exported storage primitives.
 
 For the CLI package, install [`wiki-graph`](https://www.npmjs.com/package/wiki-graph). For full documentation, examples, source code, and issue tracking, see the [GitHub repository](https://github.com/oomol-lab/wiki-graph).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "node ../../scripts/check-core-portability.mjs && rimraf dist && tsup --config tsup.config.ts"
+    "build": "node ../../scripts/check-core-portability.mjs && rimraf dist && tsup --config tsup.config.ts && node ../../scripts/check-core-portability.mjs dist --artifact"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.68",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,9 +19,6 @@
     "url": "https://github.com/oomol-lab/wiki-graph/issues"
   },
   "homepage": "https://github.com/oomol-lab/wiki-graph",
-  "engines": {
-    "node": ">=22.12.0"
-  },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -53,10 +50,16 @@
       "require": "./dist/worker.cjs",
       "default": "./dist/worker.js"
     },
+    "./platform": {
+      "types": "./dist/runtime/platform/index.d.ts",
+      "import": "./dist/runtime/platform/index.js",
+      "require": "./dist/runtime/platform/index.cjs",
+      "default": "./dist/runtime/platform/index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "rimraf dist && tsup --config tsup.config.ts"
+    "build": "node ../../scripts/check-core-portability.mjs && rimraf dist && tsup --config tsup.config.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.68",
@@ -70,10 +73,7 @@
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
     "saxes": "^6.0.0",
-    "sqlite3": "^6.0.1",
     "tinyld": "^1.3.4",
-    "yauzl": "^3.3.0",
-    "yazl": "^3.3.1",
     "zod": "^4.3.6"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,12 +50,6 @@
       "require": "./dist/worker.cjs",
       "default": "./dist/worker.js"
     },
-    "./platform": {
-      "types": "./dist/runtime/platform/index.d.ts",
-      "import": "./dist/runtime/platform/index.js",
-      "require": "./dist/runtime/platform/index.cjs",
-      "default": "./dist/runtime/platform/index.js"
-    },
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -70,8 +64,6 @@
     "htmlparser2": "^12.0.0",
     "jsonrepair": "^3.13.3",
     "nunjucks": "^3.2.4",
-    "pino": "^10.3.1",
-    "pino-pretty": "^13.1.3",
     "saxes": "^6.0.0",
     "tinyld": "^1.3.4",
     "zod": "^4.3.6"

--- a/packages/core/src/api/app.ts
+++ b/packages/core/src/api/app.ts
@@ -36,8 +36,6 @@ import {
   type WikiGraphStorage,
 } from "../runtime/platform/index.js";
 
-const DATA_DIR_PATH = resolveDataDirPath();
-
 export interface WikiGraphLLMOptions {
   readonly cacheDirPath?: string;
   readonly concurrent?: number;
@@ -97,7 +95,7 @@ export class WikiGraph {
     const llmOptions = normalizeLLMOptions(options.llm);
 
     this.#llm = new LLM<WikiGraphScope>({
-      dataDirPath: DATA_DIR_PATH,
+      dataDirPath: resolveDataDirPath(),
       sampling: createDefaultWikiGraphSampling({
         ...(llmOptions.temperature === undefined
           ? {}

--- a/packages/core/src/api/app.ts
+++ b/packages/core/src/api/app.ts
@@ -30,6 +30,11 @@ import { WikiGraphArchiveFile } from "../storage/wikg/index.js";
 import type { WikiGraphArchive } from "./wiki-graph-archive.js";
 import type { ChapterStage } from "./chapter/index.js";
 import { resolveExtractionPrompt } from "./prompts.js";
+import {
+  installWikiGraphStorage,
+  type File,
+  type WikiGraphStorage,
+} from "../runtime/platform/index.js";
 
 const DATA_DIR_PATH = resolveDataDirPath();
 
@@ -49,6 +54,7 @@ export interface WikiGraphLLMOptions {
 export interface WikiGraphOptions {
   readonly debugLogDirPath?: string;
   readonly llm?: LanguageModel | WikiGraphLLMOptions;
+  readonly storage?: WikiGraphStorage;
   readonly verbose?: boolean;
 }
 
@@ -79,6 +85,9 @@ export class WikiGraph {
   readonly #verbose: boolean;
 
   public constructor(options: WikiGraphOptions) {
+    if (options.storage !== undefined) {
+      installWikiGraphStorage(options.storage);
+    }
     this.#debugLogDirPath = options.debugLogDirPath;
     this.#verbose = options.verbose ?? false;
     if (options.llm === undefined) {
@@ -176,7 +185,7 @@ export class WikiGraph {
   }
 
   public async openSession<T>(
-    path: string,
+    path: File | string,
     operation: (digest: WikiGraphArchive) => Promise<T> | T,
     options: WikiGraphOpenSessionOptions = {},
   ): Promise<T> {

--- a/packages/core/src/api/digest.ts
+++ b/packages/core/src/api/digest.ts
@@ -1,5 +1,5 @@
-import { rm } from "fs/promises";
-import { resolve } from "path";
+import { rm } from "../runtime/platform/index.js";
+import { resolve } from "../runtime/platform/index.js";
 
 import { createWikiGraphTempDirectory } from "../runtime/common/wiki-graph/temp.js";
 import { BOOK_META_VERSION, TOC_FILE_VERSION } from "../text/source/index.js";

--- a/packages/core/src/document/chapter/path.ts
+++ b/packages/core/src/document/chapter/path.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "crypto";
+import { randomBytes } from "../../runtime/platform/index.js";
 
 import type { TocItem } from "../../text/source/index.js";
 

--- a/packages/core/src/document/database.ts
+++ b/packages/core/src/document/database.ts
@@ -1,11 +1,40 @@
-import { AsyncLocalStorage } from "async_hooks";
-import { stat } from "fs/promises";
-import { resolve } from "path";
+import {
+  AsyncLocalStorage,
+  getSqlite3Module,
+  resolve,
+  stat,
+} from "../runtime/platform/index.js";
 
-import type * as Sqlite3Namespace from "sqlite3";
-
-type Sqlite3Module = typeof Sqlite3Namespace;
-type SqliteDatabase = Sqlite3Namespace.Database;
+type SqliteDatabase = {
+  run(
+    sql: string,
+    params: SqlBindValue[] | SqlBindValue,
+    callback: (error?: Error | null) => void,
+  ): void;
+  all<T = any>(
+    sql: string,
+    params: SqlBindValue[] | SqlBindValue,
+    callback: (error: Error | null, rows: T[]) => void,
+  ): void;
+  get<T = any>(
+    sql: string,
+    params: SqlBindValue[] | SqlBindValue,
+    callback: (error: Error | null, row: T | undefined) => void,
+  ): void;
+  exec(sql: string, callback: (error?: Error | null) => void): any;
+  close(callback: (error?: Error | null) => void): void;
+};
+type Sqlite3Module = {
+  readonly OPEN_READONLY: number;
+  readonly OPEN_READWRITE: number;
+  readonly OPEN_CREATE: number;
+  readonly OPEN_FULLMUTEX: number;
+  readonly Database: new (
+    path: string,
+    flags: number,
+    callback: (error?: Error | null) => void,
+  ) => SqliteDatabase;
+};
 export type SqlBindValue = Buffer | Uint8Array | number | string | null;
 type SqlBindParams = readonly SqlBindValue[];
 type SqlRowValue = SqlBindValue;
@@ -231,7 +260,7 @@ export class Database {
 
   async #closeDatabase(): Promise<void> {
     await new Promise<void>((resolveClose, rejectClose) => {
-      this.#database.close((error) => {
+      this.#database.close((error: any) => {
         if (error !== null) {
           rejectClose(error);
           return;
@@ -244,7 +273,7 @@ export class Database {
 
   async #executeSql(sql: string): Promise<void> {
     await new Promise<void>((resolveExec, rejectExec) => {
-      this.#database.exec(sql, (error) => {
+      this.#database.exec(sql, (error: any) => {
         if (error !== null) {
           rejectExec(error);
           return;
@@ -300,7 +329,7 @@ export class Database {
     params: SqlBindParams | undefined,
   ): Promise<void> {
     await new Promise<void>((resolveRun, rejectRun) => {
-      this.#database.run(sql, normalizeSqlBindParams(params), (error) => {
+      this.#database.run(sql, normalizeSqlBindParams(params), (error: any) => {
         if (error !== null) {
           rejectRun(error);
           return;
@@ -360,7 +389,7 @@ async function openSqliteDatabase(
       : sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE) | sqlite3.OPEN_FULLMUTEX;
 
   return await new Promise<SqliteDatabase>((resolveOpen, rejectOpen) => {
-    const database = new sqlite3.Database(databasePath, flags, (error) => {
+    const database = new sqlite3.Database(databasePath, flags, (error: any) => {
       if (error !== null) {
         rejectOpen(error);
         return;
@@ -372,9 +401,7 @@ async function openSqliteDatabase(
 }
 
 async function loadSqlite3(): Promise<Sqlite3Module> {
-  const module = await import("sqlite3");
-
-  return resolveSqlite3Module(module as unknown);
+  return resolveSqlite3Module(getSqlite3Module());
 }
 
 function resolveSqlite3Module(module: unknown): Sqlite3Module {
@@ -398,6 +425,6 @@ function resolveSqlite3Module(module: unknown): Sqlite3Module {
 
 function normalizeSqlBindParams(
   params: SqlBindParams | undefined,
-): SqlBindParams {
-  return params ?? [];
+): SqlBindValue[] {
+  return params === undefined ? [] : [...params];
 }

--- a/packages/core/src/document/database.ts
+++ b/packages/core/src/document/database.ts
@@ -1,7 +1,7 @@
-import { Buffer as platformBuffer } from "../runtime/platform/index.js";
+import { binary as platformBinary } from "../runtime/platform/index.js";
 import {
   AsyncLocalStorage,
-  getSqlite3Module,
+  getDatabaseCapability,
   openDatabase,
   resolve,
   stat,
@@ -38,7 +38,7 @@ type Sqlite3Module = {
     callback: (error?: Error | null) => void,
   ) => SqliteDatabase;
 };
-export type SqlBindValue = platformBuffer | Uint8Array | number | string | null;
+export type SqlBindValue = platformBinary | Uint8Array | number | string | null;
 type SqlBindParams = readonly SqlBindValue[];
 type SqlRowValue = SqlBindValue;
 
@@ -412,7 +412,7 @@ async function openSqliteDatabase(
 }
 
 async function loadSqlite3(): Promise<Sqlite3Module> {
-  return resolveSqlite3Module(getSqlite3Module());
+  return resolveSqlite3Module(getDatabaseCapability());
 }
 
 function resolveSqlite3Module(module: unknown): Sqlite3Module {

--- a/packages/core/src/document/database.ts
+++ b/packages/core/src/document/database.ts
@@ -2,9 +2,11 @@ import { Buffer as platformBuffer } from "../runtime/platform/index.js";
 import {
   AsyncLocalStorage,
   getSqlite3Module,
+  openDatabase,
   resolve,
   stat,
 } from "../runtime/platform/index.js";
+import type { File } from "../runtime/platform/index.js";
 
 type SqliteDatabase = {
   run(
@@ -46,7 +48,10 @@ const SQLITE_BUSY_TIMEOUT_MS = 15 * 60 * 1000;
 
 type DatabaseOperationScope = symbol;
 
-async function isMissingOrEmptyFile(path: string): Promise<boolean> {
+async function isMissingOrEmptyFile(path: File | string): Promise<boolean> {
+  if (typeof path !== "string") {
+    return path.size === undefined || path.size === 0;
+  }
   const stats = await stat(path).catch((error: unknown) => {
     if (
       typeof error === "object" &&
@@ -81,14 +86,15 @@ export class Database {
   }
 
   public static async open(
-    databasePath: string,
+    databasePath: File | string,
     schemaSql = "",
     options: {
       readonly onWrite?: () => void;
       readonly readonly?: boolean;
     } = {},
   ): Promise<Database> {
-    const resolvedDatabasePath = resolve(databasePath);
+    const resolvedDatabasePath =
+      typeof databasePath === "string" ? resolve(databasePath) : databasePath;
     const shouldMarkSchemaWritten =
       options.readonly !== true &&
       schemaSql.trim() !== "" &&
@@ -380,7 +386,7 @@ export function getOptionalString(
 }
 
 async function openSqliteDatabase(
-  databasePath: string,
+  databasePath: File | string,
   options: { readonly readonly?: boolean } = {},
 ): Promise<SqliteDatabase> {
   const sqlite3 = await loadSqlite3();
@@ -388,6 +394,10 @@ async function openSqliteDatabase(
     (options.readonly === true
       ? sqlite3.OPEN_READONLY
       : sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE) | sqlite3.OPEN_FULLMUTEX;
+
+  if (typeof databasePath !== "string") {
+    return await openDatabase(databasePath, flags);
+  }
 
   return await new Promise<SqliteDatabase>((resolveOpen, rejectOpen) => {
     const database = new sqlite3.Database(databasePath, flags, (error: any) => {

--- a/packages/core/src/document/database.ts
+++ b/packages/core/src/document/database.ts
@@ -1,3 +1,4 @@
+import { Buffer as platformBuffer } from "../runtime/platform/index.js";
 import {
   AsyncLocalStorage,
   getSqlite3Module,
@@ -35,7 +36,7 @@ type Sqlite3Module = {
     callback: (error?: Error | null) => void,
   ) => SqliteDatabase;
 };
-export type SqlBindValue = Buffer | Uint8Array | number | string | null;
+export type SqlBindValue = platformBuffer | Uint8Array | number | string | null;
 type SqlBindParams = readonly SqlBindValue[];
 type SqlRowValue = SqlBindValue;
 

--- a/packages/core/src/document/directory/core.ts
+++ b/packages/core/src/document/directory/core.ts
@@ -1,6 +1,5 @@
 import {
   AsyncLocalStorage,
-  getHostDirectoryHandle,
   join,
   resolve,
   type Directory,
@@ -112,7 +111,7 @@ export class DirectoryDocument implements Document {
     const resolvedDocumentPath =
       typeof documentPath === "string"
         ? resolve(documentPath)
-        : getHostDirectoryHandle(documentPath);
+        : (documentPath as unknown as string);
     const fileStore = options.fileStore ?? LOCAL_DOCUMENT_FILE_STORE;
     try {
       const databasePath =

--- a/packages/core/src/document/directory/core.ts
+++ b/packages/core/src/document/directory/core.ts
@@ -1,5 +1,10 @@
-import { AsyncLocalStorage } from "../../runtime/platform/index.js";
-import { join, resolve } from "../../runtime/platform/index.js";
+import {
+  AsyncLocalStorage,
+  getPlatformDirectoryPath,
+  join,
+  resolve,
+  type Directory,
+} from "../../runtime/platform/index.js";
 import { z } from "zod";
 
 import { bookMetaSchema, type BookMeta } from "../../text/source/meta.js";
@@ -101,10 +106,13 @@ export class DirectoryDocument implements Document {
   }
 
   public static async open(
-    documentPath: string,
+    documentPath: string | Directory,
     options: { readonly fileStore?: DocumentFileStore } = {},
   ): Promise<DirectoryDocument> {
-    const resolvedDocumentPath = resolve(documentPath);
+    const resolvedDocumentPath =
+      typeof documentPath === "string"
+        ? resolve(documentPath)
+        : getPlatformDirectoryPath(documentPath);
     const fileStore = options.fileStore ?? LOCAL_DOCUMENT_FILE_STORE;
     try {
       const databasePath =

--- a/packages/core/src/document/directory/core.ts
+++ b/packages/core/src/document/directory/core.ts
@@ -1,5 +1,6 @@
 import {
   AsyncLocalStorage,
+  getRelativeFile,
   join,
   resolve,
   type Directory,
@@ -111,13 +112,13 @@ export class DirectoryDocument implements Document {
     const resolvedDocumentPath =
       typeof documentPath === "string"
         ? resolve(documentPath)
-        : (documentPath as unknown as string);
+          : documentPath.name;
     const fileStore = options.fileStore ?? LOCAL_DOCUMENT_FILE_STORE;
     try {
       const databasePath =
         typeof documentPath === "string"
           ? await fileStore.resolveDatabasePath(resolvedDocumentPath)
-          : ((await documentPath.getFile("database.db")) ??
+          : ((await getRelativeFile(documentPath, "database.db")) ??
             (await documentPath.createFile("database.db")));
       await fileStore.ensureDirectory(resolvedDocumentPath);
 

--- a/packages/core/src/document/directory/core.ts
+++ b/packages/core/src/document/directory/core.ts
@@ -1,5 +1,5 @@
-import { AsyncLocalStorage } from "async_hooks";
-import { join, resolve } from "path";
+import { AsyncLocalStorage } from "../../runtime/platform/index.js";
+import { join, resolve } from "../../runtime/platform/index.js";
 import { z } from "zod";
 
 import { bookMetaSchema, type BookMeta } from "../../text/source/meta.js";

--- a/packages/core/src/document/directory/core.ts
+++ b/packages/core/src/document/directory/core.ts
@@ -1,6 +1,6 @@
 import {
   AsyncLocalStorage,
-  getPlatformDirectoryPath,
+  getHostDirectoryHandle,
   join,
   resolve,
   type Directory,
@@ -112,7 +112,7 @@ export class DirectoryDocument implements Document {
     const resolvedDocumentPath =
       typeof documentPath === "string"
         ? resolve(documentPath)
-        : getPlatformDirectoryPath(documentPath);
+        : getHostDirectoryHandle(documentPath);
     const fileStore = options.fileStore ?? LOCAL_DOCUMENT_FILE_STORE;
     try {
       const databasePath =

--- a/packages/core/src/document/directory/core.ts
+++ b/packages/core/src/document/directory/core.ts
@@ -116,7 +116,10 @@ export class DirectoryDocument implements Document {
     const fileStore = options.fileStore ?? LOCAL_DOCUMENT_FILE_STORE;
     try {
       const databasePath =
-        await fileStore.resolveDatabasePath(resolvedDocumentPath);
+        typeof documentPath === "string"
+          ? await fileStore.resolveDatabasePath(resolvedDocumentPath)
+          : ((await documentPath.getFile("database.db")) ??
+            (await documentPath.createFile("database.db")));
       await fileStore.ensureDirectory(resolvedDocumentPath);
 
       const shouldInitializeDatabaseSchema =

--- a/packages/core/src/document/directory/core.ts
+++ b/packages/core/src/document/directory/core.ts
@@ -111,11 +111,12 @@ export class DirectoryDocument implements Document {
     options: { readonly fileStore?: DocumentFileStore } = {},
   ): Promise<DirectoryDocument> {
     const resolvedDocumentPath =
-      typeof documentPath === "string"
-        ? resolve(documentPath)
-        : "";
-    const fileStore = options.fileStore ??
-      (typeof documentPath === "string" ? LOCAL_DOCUMENT_FILE_STORE : new DirectoryFileStore(documentPath));
+      typeof documentPath === "string" ? resolve(documentPath) : "";
+    const fileStore =
+      options.fileStore ??
+      (typeof documentPath === "string"
+        ? LOCAL_DOCUMENT_FILE_STORE
+        : new DirectoryFileStore(documentPath));
     try {
       const databasePath =
         typeof documentPath === "string"

--- a/packages/core/src/document/directory/core.ts
+++ b/packages/core/src/document/directory/core.ts
@@ -33,6 +33,7 @@ import {
 import { ObjectMetadataKind, type SentenceId } from "../types.js";
 import { DirectoryDocumentContext } from "./context.js";
 import { LOCAL_DOCUMENT_FILE_STORE } from "./file-store.js";
+import { DirectoryFileStore } from "./directory-file-store.js";
 import {
   getCoverDataPath,
   getCoverDirectoryPath,
@@ -112,8 +113,9 @@ export class DirectoryDocument implements Document {
     const resolvedDocumentPath =
       typeof documentPath === "string"
         ? resolve(documentPath)
-          : documentPath.name;
-    const fileStore = options.fileStore ?? LOCAL_DOCUMENT_FILE_STORE;
+        : "";
+    const fileStore = options.fileStore ??
+      (typeof documentPath === "string" ? LOCAL_DOCUMENT_FILE_STORE : new DirectoryFileStore(documentPath));
     try {
       const databasePath =
         typeof documentPath === "string"

--- a/packages/core/src/document/directory/directory-file-store.ts
+++ b/packages/core/src/document/directory/directory-file-store.ts
@@ -24,7 +24,7 @@ export class DirectoryFileStore implements DocumentFileStore {
     const content = await file.read();
     return typeof content === "string" ? new TextEncoder().encode(content) : content;
   }
-  public async writeFile(path: string, content: string | Uint8Array): Promise<void> {
+  public async writeFile(path: string, content: string | Uint8Array, _options: { readonly overwrite?: boolean } = {}): Promise<void> {
     const file = await this.getOrCreateFile(this.relative(path));
     const writer = await file.openWriter();
     try { await writer.write(content); await writer.commit(); }

--- a/packages/core/src/document/directory/directory-file-store.ts
+++ b/packages/core/src/document/directory/directory-file-store.ts
@@ -4,77 +4,112 @@ import type { DocumentFileStore } from "./types.js";
 
 /** Document file store backed exclusively by a host Directory tree. */
 export class DirectoryFileStore implements DocumentFileStore {
-  public constructor(private readonly root: Directory) {}
+  readonly #root: Directory;
 
-  public close(): Promise<void> { return Promise.resolve(); }
-  public initializeDatabaseSchema(): boolean { return true; }
-  public openDatabaseReadonly(): boolean { return false; }
-  public markDatabaseDirty(): void { /* host transaction owns durability */ }
-  public markSearchIndexDatabaseDirty(): void { /* host transaction owns durability */ }
+  public constructor(root: Directory) {
+    this.#root = root;
+  }
+
+  public close(): Promise<void> {
+    return Promise.resolve();
+  }
+  public initializeDatabaseSchema(): boolean {
+    return true;
+  }
+  public openDatabaseReadonly(): boolean {
+    return false;
+  }
+  public markDatabaseDirty(): void {
+    /* host transaction owns durability */
+  }
+  public markSearchIndexDatabaseDirty(): void {
+    /* host transaction owns durability */
+  }
 
   public async resolveDatabasePath(): Promise<File> {
-    return await this.getOrCreateFile("database.db");
+    return await this.#getOrCreateFile("database.db");
   }
   public async resolveSearchIndexDatabasePath(): Promise<File> {
-    return await this.getOrCreateFile("index.db");
+    return await this.#getOrCreateFile("index.db");
   }
   public async readFile(path: string): Promise<Uint8Array | undefined> {
-    const file = await getRelativeFile(this.root, this.relative(path));
+    const file = await getRelativeFile(this.#root, this.#relative(path));
     if (!file) return undefined;
     const content = await file.read();
-    return typeof content === "string" ? new TextEncoder().encode(content) : content;
+    return typeof content === "string"
+      ? new TextEncoder().encode(content)
+      : content;
   }
-  public async writeFile(path: string, content: string | Uint8Array, options: { readonly overwrite?: boolean } = {}): Promise<void> {
-    const relative = this.relative(path);
-    const existing = await getRelativeFile(this.root, relative);
+  public async writeFile(
+    path: string,
+    content: string | Uint8Array,
+    options: { readonly overwrite?: boolean } = {},
+  ): Promise<void> {
+    const relative = this.#relative(path);
+    const existing = await getRelativeFile(this.#root, relative);
     if (existing && options.overwrite !== true) {
       throw new Error(`File already exists: ${path}`);
     }
-    const file = existing ?? await this.getOrCreateFile(relative);
+    const file = existing ?? (await this.#getOrCreateFile(relative));
     const writer = await file.openWriter();
-    try { await writer.write(content); await writer.commit(); }
-    catch (error) { await writer.abort(); throw error; }
+    try {
+      await writer.write(content);
+      await writer.commit();
+    } catch (error) {
+      await writer.abort();
+      throw error;
+    }
   }
   public async deleteFile(path: string): Promise<void> {
-    await this.removePath(this.relative(path), false);
+    await this.#removePath(this.#relative(path), false);
   }
   public async deleteTree(path: string): Promise<void> {
-    await this.removePath(this.relative(path), true);
+    await this.#removePath(this.#relative(path), true);
   }
   public async ensureDirectory(path: string): Promise<void> {
-    await this.getOrCreateDirectory(this.relative(path));
+    await this.#getOrCreateDirectory(this.#relative(path));
   }
   public async listFiles(path: string): Promise<readonly string[]> {
-    const directory = await this.getOrCreateDirectory(this.relative(path));
-    return (await directory.list()).filter((entry): entry is File => "read" in entry).map((entry) => entry.name);
+    const directory = await this.#getOrCreateDirectory(this.#relative(path));
+    return (await directory.list())
+      .filter((entry): entry is File => "read" in entry)
+      .map((entry) => entry.name);
   }
 
-  private relative(path: string): string {
+  #relative(path: string): string {
     const relative = path.replaceAll("\\", "/").replace(/^\.\//u, "");
     if (relative.startsWith("/") || relative.split("/").includes("..")) {
       throw new TypeError(`Document path must remain relative: ${path}`);
     }
     return relative;
   }
-  private async getOrCreateDirectory(path: string): Promise<Directory> {
-    let current = this.root;
+  async #getOrCreateDirectory(path: string): Promise<Directory> {
+    let current = this.#root;
     for (const part of path.split("/").filter(Boolean)) {
-      current = await current.getDirectory(part) ?? await current.createDirectory(part);
+      current =
+        (await current.getDirectory(part)) ??
+        (await current.createDirectory(part));
     }
     return current;
   }
-  private async getOrCreateFile(path: string): Promise<File> {
+  async #getOrCreateFile(path: string): Promise<File> {
     const parts = path.split("/").filter(Boolean);
     const name = parts.pop();
     if (!name) throw new TypeError("File name must be relative");
-    return await (await this.getOrCreateDirectory(parts.join("/"))).getFile(name)
-      ?? await (await this.getOrCreateDirectory(parts.join("/"))).createFile(name);
+    return (
+      (await (
+        await this.#getOrCreateDirectory(parts.join("/"))
+      ).getFile(name)) ??
+      (await (
+        await this.#getOrCreateDirectory(parts.join("/"))
+      ).createFile(name))
+    );
   }
-  private async removePath(path: string, recursive: boolean): Promise<void> {
+  async #removePath(path: string, recursive: boolean): Promise<void> {
     const parts = path.split("/").filter(Boolean);
     const name = parts.pop();
     if (!name) return;
-    const parent = await this.getOrCreateDirectory(parts.join("/"));
+    const parent = await this.#getOrCreateDirectory(parts.join("/"));
     await parent.remove(name, { recursive });
   }
 }

--- a/packages/core/src/document/directory/directory-file-store.ts
+++ b/packages/core/src/document/directory/directory-file-store.ts
@@ -24,8 +24,13 @@ export class DirectoryFileStore implements DocumentFileStore {
     const content = await file.read();
     return typeof content === "string" ? new TextEncoder().encode(content) : content;
   }
-  public async writeFile(path: string, content: string | Uint8Array, _options: { readonly overwrite?: boolean } = {}): Promise<void> {
-    const file = await this.getOrCreateFile(this.relative(path));
+  public async writeFile(path: string, content: string | Uint8Array, options: { readonly overwrite?: boolean } = {}): Promise<void> {
+    const relative = this.relative(path);
+    const existing = await getRelativeFile(this.root, relative);
+    if (existing && options.overwrite !== true) {
+      throw new Error(`File already exists: ${path}`);
+    }
+    const file = existing ?? await this.getOrCreateFile(relative);
     const writer = await file.openWriter();
     try { await writer.write(content); await writer.commit(); }
     catch (error) { await writer.abort(); throw error; }

--- a/packages/core/src/document/directory/directory-file-store.ts
+++ b/packages/core/src/document/directory/directory-file-store.ts
@@ -1,0 +1,75 @@
+import type { Directory, File } from "../../runtime/platform/index.js";
+import { getRelativeFile } from "../../runtime/platform/index.js";
+import type { DocumentFileStore } from "./types.js";
+
+/** Document file store backed exclusively by a host Directory tree. */
+export class DirectoryFileStore implements DocumentFileStore {
+  public constructor(private readonly root: Directory) {}
+
+  public close(): Promise<void> { return Promise.resolve(); }
+  public initializeDatabaseSchema(): boolean { return true; }
+  public openDatabaseReadonly(): boolean { return false; }
+  public markDatabaseDirty(): void { /* host transaction owns durability */ }
+  public markSearchIndexDatabaseDirty(): void { /* host transaction owns durability */ }
+
+  public async resolveDatabasePath(): Promise<File> {
+    return await this.getOrCreateFile("database.db");
+  }
+  public async resolveSearchIndexDatabasePath(): Promise<File> {
+    return await this.getOrCreateFile("index.db");
+  }
+  public async readFile(path: string): Promise<Uint8Array | undefined> {
+    const file = await getRelativeFile(this.root, this.relative(path));
+    if (!file) return undefined;
+    const content = await file.read();
+    return typeof content === "string" ? new TextEncoder().encode(content) : content;
+  }
+  public async writeFile(path: string, content: string | Uint8Array): Promise<void> {
+    const file = await this.getOrCreateFile(this.relative(path));
+    const writer = await file.openWriter();
+    try { await writer.write(content); await writer.commit(); }
+    catch (error) { await writer.abort(); throw error; }
+  }
+  public async deleteFile(path: string): Promise<void> {
+    await this.removePath(this.relative(path), false);
+  }
+  public async deleteTree(path: string): Promise<void> {
+    await this.removePath(this.relative(path), true);
+  }
+  public async ensureDirectory(path: string): Promise<void> {
+    await this.getOrCreateDirectory(this.relative(path));
+  }
+  public async listFiles(path: string): Promise<readonly string[]> {
+    const directory = await this.getOrCreateDirectory(this.relative(path));
+    return (await directory.list()).filter((entry): entry is File => "read" in entry).map((entry) => entry.name);
+  }
+
+  private relative(path: string): string {
+    const relative = path.replaceAll("\\", "/").replace(/^\.\//u, "");
+    if (relative.startsWith("/") || relative.split("/").includes("..")) {
+      throw new TypeError(`Document path must remain relative: ${path}`);
+    }
+    return relative;
+  }
+  private async getOrCreateDirectory(path: string): Promise<Directory> {
+    let current = this.root;
+    for (const part of path.split("/").filter(Boolean)) {
+      current = await current.getDirectory(part) ?? await current.createDirectory(part);
+    }
+    return current;
+  }
+  private async getOrCreateFile(path: string): Promise<File> {
+    const parts = path.split("/").filter(Boolean);
+    const name = parts.pop();
+    if (!name) throw new TypeError("File name must be relative");
+    return await (await this.getOrCreateDirectory(parts.join("/"))).getFile(name)
+      ?? await (await this.getOrCreateDirectory(parts.join("/"))).createFile(name);
+  }
+  private async removePath(path: string, recursive: boolean): Promise<void> {
+    const parts = path.split("/").filter(Boolean);
+    const name = parts.pop();
+    if (!name) return;
+    const parent = await this.getOrCreateDirectory(parts.join("/"));
+    await parent.remove(name, { recursive });
+  }
+}

--- a/packages/core/src/document/directory/file-store.ts
+++ b/packages/core/src/document/directory/file-store.ts
@@ -1,5 +1,12 @@
-import { mkdir, readFile, readdir, rm, unlink, writeFile } from "fs/promises";
-import { join } from "path";
+import {
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+  unlink,
+  writeFile,
+} from "../../runtime/platform/index.js";
+import { join } from "../../runtime/platform/index.js";
 
 import { isNodeError } from "../../utils/node-error.js";
 import type { DocumentFileStore } from "./types.js";
@@ -21,8 +28,8 @@ export const LOCAL_DOCUMENT_FILE_STORE: DocumentFileStore = {
   openDatabaseReadonly: () => false,
   listFiles: async (path) =>
     (await readdir(path, { withFileTypes: true }))
-      .filter((entry) => entry.isFile())
-      .map((entry) => entry.name),
+      .filter((entry: any) => entry.isFile())
+      .map((entry: any) => entry.name),
   readFile: async (path) => {
     try {
       return await readFile(path);

--- a/packages/core/src/document/directory/files.ts
+++ b/packages/core/src/document/directory/files.ts
@@ -1,4 +1,4 @@
-import { Buffer as platformBuffer } from "../../runtime/platform/index.js";
+import { binary as platformBinary } from "../../runtime/platform/index.js";
 import { join } from "../../runtime/platform/index.js";
 
 import { isNodeError } from "../../utils/node-error.js";
@@ -81,7 +81,7 @@ async function readOptionalTextFile(
 
   return content === undefined
     ? undefined
-    : platformBuffer.from(content).toString("utf8");
+    : platformBinary.from(content).toString("utf8");
 }
 
 async function writeFile(input: {

--- a/packages/core/src/document/directory/files.ts
+++ b/packages/core/src/document/directory/files.ts
@@ -1,3 +1,4 @@
+import { Buffer as platformBuffer } from "../../runtime/platform/index.js";
 import { join } from "../../runtime/platform/index.js";
 
 import { isNodeError } from "../../utils/node-error.js";
@@ -80,7 +81,7 @@ async function readOptionalTextFile(
 
   return content === undefined
     ? undefined
-    : Buffer.from(content).toString("utf8");
+    : platformBuffer.from(content).toString("utf8");
 }
 
 async function writeFile(input: {

--- a/packages/core/src/document/directory/files.ts
+++ b/packages/core/src/document/directory/files.ts
@@ -1,4 +1,4 @@
-import { join } from "path";
+import { join } from "../../runtime/platform/index.js";
 
 import { isNodeError } from "../../utils/node-error.js";
 import type { DirectoryDocumentContext } from "./context.js";

--- a/packages/core/src/document/directory/search-index.ts
+++ b/packages/core/src/document/directory/search-index.ts
@@ -1,5 +1,5 @@
-import { stat } from "fs/promises";
-import { join, resolve } from "path";
+import { stat } from "../../runtime/platform/index.js";
+import { join, resolve } from "../../runtime/platform/index.js";
 
 import { isNodeError } from "../../utils/node-error.js";
 import { Database } from "../database.js";

--- a/packages/core/src/document/directory/types.ts
+++ b/packages/core/src/document/directory/types.ts
@@ -48,8 +48,12 @@ export interface DocumentFileStore {
   listFileContents?(path: string): Promise<ReadonlyMap<string, Uint8Array>>;
   listFiles(path: string): Promise<readonly string[]>;
   readFile(path: string): Promise<Uint8Array | undefined>;
-  resolveDatabasePath(documentPath: string): Promise<string | import("../../runtime/platform/index.js").File>;
-  resolveSearchIndexDatabasePath?(documentPath: string): Promise<string | import("../../runtime/platform/index.js").File>;
+  resolveDatabasePath(
+    documentPath: string,
+  ): Promise<string | import("../../runtime/platform/index.js").File>;
+  resolveSearchIndexDatabasePath?(
+    documentPath: string,
+  ): Promise<string | import("../../runtime/platform/index.js").File>;
   writeFile(
     path: string,
     content: string | Uint8Array,

--- a/packages/core/src/document/directory/types.ts
+++ b/packages/core/src/document/directory/types.ts
@@ -48,8 +48,8 @@ export interface DocumentFileStore {
   listFileContents?(path: string): Promise<ReadonlyMap<string, Uint8Array>>;
   listFiles(path: string): Promise<readonly string[]>;
   readFile(path: string): Promise<Uint8Array | undefined>;
-  resolveDatabasePath(documentPath: string): Promise<string>;
-  resolveSearchIndexDatabasePath?(documentPath: string): Promise<string>;
+  resolveDatabasePath(documentPath: string): Promise<string | import("../../runtime/platform/index.js").File>;
+  resolveSearchIndexDatabasePath?(documentPath: string): Promise<string | import("../../runtime/platform/index.js").File>;
   writeFile(
     path: string,
     content: string | Uint8Array,

--- a/packages/core/src/document/fragments/core.ts
+++ b/packages/core/src/document/fragments/core.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from "path";
+import { join, resolve } from "../../runtime/platform/index.js";
 
 import type { SentenceId } from "../types.js";
 import {

--- a/packages/core/src/document/fragments/file-access.ts
+++ b/packages/core/src/document/fragments/file-access.ts
@@ -1,4 +1,9 @@
-import { mkdir, readFile, readdir, writeFile } from "fs/promises";
+import {
+  mkdir,
+  readFile,
+  readdir,
+  writeFile,
+} from "../../runtime/platform/index.js";
 
 import { isNodeError } from "../../utils/node-error.js";
 import type { FragmentFileAccess, FragmentWriter } from "./types.js";
@@ -15,8 +20,8 @@ export const DEFAULT_FRAGMENT_FILE_ACCESS: FragmentFileAccess = {
   },
   listFiles: async (path) =>
     (await readdir(path, { withFileTypes: true }))
-      .filter((entry) => entry.isFile())
-      .map((entry) => entry.name),
+      .filter((entry: any) => entry.isFile())
+      .map((entry: any) => entry.name),
   readFile: async (path) => {
     try {
       return await readFile(path);

--- a/packages/core/src/document/fragments/file.ts
+++ b/packages/core/src/document/fragments/file.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from "path";
+import { join, resolve } from "../../runtime/platform/index.js";
 
 import type { SentenceRecord } from "../types.js";
 import { DEFAULT_FRAGMENT_FILE_ACCESS } from "./file-access.js";

--- a/packages/core/src/document/fragments/file.ts
+++ b/packages/core/src/document/fragments/file.ts
@@ -1,3 +1,4 @@
+import { Buffer as platformBuffer } from "../../runtime/platform/index.js";
 import { join, resolve } from "../../runtime/platform/index.js";
 
 import type { SentenceRecord } from "../types.js";
@@ -23,7 +24,7 @@ export function parseFragmentFileContent(
   }
 
   const rawContent = JSON.parse(
-    Buffer.from(content).toString("utf8"),
+    platformBuffer.from(content).toString("utf8"),
   ) as unknown;
 
   if (typeof rawContent !== "object" || rawContent === null) {

--- a/packages/core/src/document/fragments/file.ts
+++ b/packages/core/src/document/fragments/file.ts
@@ -1,4 +1,4 @@
-import { Buffer as platformBuffer } from "../../runtime/platform/index.js";
+import { binary as platformBinary } from "../../runtime/platform/index.js";
 import { join, resolve } from "../../runtime/platform/index.js";
 
 import type { SentenceRecord } from "../types.js";
@@ -24,7 +24,7 @@ export function parseFragmentFileContent(
   }
 
   const rawContent = JSON.parse(
-    platformBuffer.from(content).toString("utf8"),
+    platformBinary.from(content).toString("utf8"),
   ) as unknown;
 
   if (typeof rawContent !== "object" || rawContent === null) {

--- a/packages/core/src/document/fragments/serial.ts
+++ b/packages/core/src/document/fragments/serial.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from "path";
+import { join, resolve } from "../../runtime/platform/index.js";
 
 import { isNodeError } from "../../utils/node-error.js";
 import type { FragmentRecord, SentenceRecord } from "../types.js";
@@ -99,7 +99,7 @@ export class SerialFragments implements ReadonlySerialFragments {
           : [...(await this.#getFileContents()).keys()];
 
       return entries
-        .map((entry) => FRAGMENT_FILE_PATTERN.exec(entry))
+        .map((entry: any) => FRAGMENT_FILE_PATTERN.exec(entry))
         .filter((match): match is RegExpExecArray => match !== null)
         .map((match) => Number(match[1]))
         .sort((left, right) => left - right);

--- a/packages/core/src/document/home-schema-upgrade.ts
+++ b/packages/core/src/document/home-schema-upgrade.ts
@@ -1,3 +1,4 @@
+import { process as platformProcess } from "../runtime/platform/index.js";
 import { mkdir, rm, stat } from "../runtime/platform/index.js";
 import { dirname, join, resolve } from "../runtime/platform/index.js";
 
@@ -680,7 +681,7 @@ function isActiveLock(ownerPid: number, heartbeatAt: number): boolean {
 
 function isProcessAlive(pid: number): boolean {
   try {
-    process.kill(pid, 0);
+    platformProcess.kill(pid, 0);
     return true;
   } catch {
     return false;

--- a/packages/core/src/document/home-schema-upgrade.ts
+++ b/packages/core/src/document/home-schema-upgrade.ts
@@ -1,4 +1,4 @@
-import { process as platformProcess } from "../runtime/platform/index.js";
+import { runtimeContext as platformRuntime } from "../runtime/platform/index.js";
 import { mkdir, rm, stat } from "../runtime/platform/index.js";
 import { dirname, join, resolve } from "../runtime/platform/index.js";
 
@@ -681,7 +681,7 @@ function isActiveLock(ownerPid: number, heartbeatAt: number): boolean {
 
 function isProcessAlive(pid: number): boolean {
   try {
-    platformProcess.kill(pid, 0);
+    platformRuntime.kill(pid, 0);
     return true;
   } catch {
     return false;

--- a/packages/core/src/document/home-schema-upgrade.ts
+++ b/packages/core/src/document/home-schema-upgrade.ts
@@ -1,5 +1,5 @@
-import { mkdir, rm, stat } from "fs/promises";
-import { dirname, join, resolve } from "path";
+import { mkdir, rm, stat } from "../runtime/platform/index.js";
+import { dirname, join, resolve } from "../runtime/platform/index.js";
 
 import {
   resolveWikiGraphCacheDatabasePath,

--- a/packages/core/src/document/shared-state-database.ts
+++ b/packages/core/src/document/shared-state-database.ts
@@ -1,4 +1,4 @@
-import { process as platformProcess } from "../runtime/platform/index.js";
+import { runtimeContext as platformRuntime } from "../runtime/platform/index.js";
 import { createHash } from "../runtime/platform/index.js";
 import {
   chmod,
@@ -84,7 +84,7 @@ async function writeInitMarker(
   markerPath: string,
   schemaHash: string,
 ): Promise<void> {
-  const tempPath = `${markerPath}.${platformProcess.pid}.tmp`;
+  const tempPath = `${markerPath}.${platformRuntime.pid}.tmp`;
 
   await writeFile(tempPath, `${schemaHash}\n`, {
     encoding: "utf8",
@@ -136,7 +136,7 @@ async function writeInitLockOwner(lockPath: string): Promise<void> {
     `${JSON.stringify(
       {
         at: Date.now(),
-        pid: platformProcess.pid,
+        pid: platformRuntime.pid,
       },
       null,
       2,
@@ -223,7 +223,7 @@ async function isPathOlderThan(path: string, ms: number): Promise<boolean> {
 
 function isProcessAlive(pid: number): boolean {
   try {
-    platformProcess.kill(pid, 0);
+    platformRuntime.kill(pid, 0);
     return true;
   } catch (error) {
     if (isNodeError(error) && error.code === "ESRCH") {

--- a/packages/core/src/document/shared-state-database.ts
+++ b/packages/core/src/document/shared-state-database.ts
@@ -1,3 +1,4 @@
+import { process as platformProcess } from "../runtime/platform/index.js";
 import { createHash } from "../runtime/platform/index.js";
 import {
   chmod,
@@ -83,7 +84,7 @@ async function writeInitMarker(
   markerPath: string,
   schemaHash: string,
 ): Promise<void> {
-  const tempPath = `${markerPath}.${process.pid}.tmp`;
+  const tempPath = `${markerPath}.${platformProcess.pid}.tmp`;
 
   await writeFile(tempPath, `${schemaHash}\n`, {
     encoding: "utf8",
@@ -135,7 +136,7 @@ async function writeInitLockOwner(lockPath: string): Promise<void> {
     `${JSON.stringify(
       {
         at: Date.now(),
-        pid: process.pid,
+        pid: platformProcess.pid,
       },
       null,
       2,
@@ -222,7 +223,7 @@ async function isPathOlderThan(path: string, ms: number): Promise<boolean> {
 
 function isProcessAlive(pid: number): boolean {
   try {
-    process.kill(pid, 0);
+    platformProcess.kill(pid, 0);
     return true;
   } catch (error) {
     if (isNodeError(error) && error.code === "ESRCH") {

--- a/packages/core/src/document/shared-state-database.ts
+++ b/packages/core/src/document/shared-state-database.ts
@@ -1,4 +1,4 @@
-import { createHash } from "crypto";
+import { createHash } from "../runtime/platform/index.js";
 import {
   chmod,
   mkdir,
@@ -7,9 +7,9 @@ import {
   rm,
   stat,
   writeFile,
-} from "fs/promises";
-import { dirname, resolve } from "path";
-import { setTimeout as sleep } from "timers/promises";
+} from "../runtime/platform/index.js";
+import { dirname, resolve } from "../runtime/platform/index.js";
+import { setTimeout as sleep } from "../runtime/platform/index.js";
 
 import { isNodeError } from "../utils/node-error.js";
 import {

--- a/packages/core/src/document/stores/source-provenance.ts
+++ b/packages/core/src/document/stores/source-provenance.ts
@@ -1,4 +1,4 @@
-import { Buffer as platformBuffer } from "../../runtime/platform/index.js";
+import { binary as platformBinary } from "../../runtime/platform/index.js";
 import { getNumber, getOptionalString, getString } from "../database.js";
 import type { Database } from "../database.js";
 import type {
@@ -97,7 +97,7 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
               FROM source_artifacts
               WHERE digest = ?
             `,
-            [platformBuffer.from(digest, "hex")],
+            [platformBinary.from(digest, "hex")],
             (row) => ({
               id: getNumber(row, "id"),
               mediaType: getString(row, "media_type"),
@@ -122,7 +122,7 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
                 VALUES (?, ?, ?, ?)
               `,
               [
-                platformBuffer.from(digest, "hex"),
+                platformBinary.from(digest, "hex"),
                 artifact.mediaType,
                 artifact.name ?? null,
                 artifact.identifier ?? null,
@@ -248,7 +248,7 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
       seen.set(digest, artifact.mediaType);
       const existing = await this.#database.queryOne(
         `SELECT media_type FROM source_artifacts WHERE digest = ?`,
-        [platformBuffer.from(digest, "hex")],
+        [platformBinary.from(digest, "hex")],
         (row) => getString(row, "media_type"),
       );
       if (existing !== undefined && existing !== artifact.mediaType) {
@@ -343,11 +343,11 @@ function normalizeDigest(value: string): string {
 }
 
 function readDigest(value: unknown): string {
-  if (platformBuffer.isBuffer(value)) {
+  if (platformBinary.isBuffer(value)) {
     return (value as { toString(encoding?: string): string }).toString("hex");
   }
   if (value instanceof Uint8Array) {
-    return platformBuffer.from(value).toString("hex");
+    return platformBinary.from(value).toString("hex");
   }
   throw new TypeError("Expected source artifact digest to be binary");
 }

--- a/packages/core/src/document/stores/source-provenance.ts
+++ b/packages/core/src/document/stores/source-provenance.ts
@@ -1,3 +1,4 @@
+import { Buffer as platformBuffer } from "../../runtime/platform/index.js";
 import { getNumber, getOptionalString, getString } from "../database.js";
 import type { Database } from "../database.js";
 import type {
@@ -96,7 +97,7 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
               FROM source_artifacts
               WHERE digest = ?
             `,
-            [Buffer.from(digest, "hex")],
+            [platformBuffer.from(digest, "hex")],
             (row) => ({
               id: getNumber(row, "id"),
               mediaType: getString(row, "media_type"),
@@ -121,7 +122,7 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
                 VALUES (?, ?, ?, ?)
               `,
               [
-                Buffer.from(digest, "hex"),
+                platformBuffer.from(digest, "hex"),
                 artifact.mediaType,
                 artifact.name ?? null,
                 artifact.identifier ?? null,
@@ -247,7 +248,7 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
       seen.set(digest, artifact.mediaType);
       const existing = await this.#database.queryOne(
         `SELECT media_type FROM source_artifacts WHERE digest = ?`,
-        [Buffer.from(digest, "hex")],
+        [platformBuffer.from(digest, "hex")],
         (row) => getString(row, "media_type"),
       );
       if (existing !== undefined && existing !== artifact.mediaType) {
@@ -342,11 +343,11 @@ function normalizeDigest(value: string): string {
 }
 
 function readDigest(value: unknown): string {
-  if (Buffer.isBuffer(value)) {
-    return value.toString("hex");
+  if (platformBuffer.isBuffer(value)) {
+    return (value as { toString(encoding?: string): string }).toString("hex");
   }
   if (value instanceof Uint8Array) {
-    return Buffer.from(value).toString("hex");
+    return platformBuffer.from(value).toString("hex");
   }
   throw new TypeError("Expected source artifact digest to be binary");
 }

--- a/packages/core/src/document/text-streams/core.ts
+++ b/packages/core/src/document/text-streams/core.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from "path";
+import { join, resolve } from "../../runtime/platform/index.js";
 
 import type { Database } from "../database.js";
 import type { SentenceId } from "../types.js";

--- a/packages/core/src/document/text-streams/file-access.ts
+++ b/packages/core/src/document/text-streams/file-access.ts
@@ -1,4 +1,10 @@
-import { mkdir, readFile, readdir, rm, writeFile } from "fs/promises";
+import {
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "../../runtime/platform/index.js";
 
 import { isNodeError } from "../../utils/node-error.js";
 import type { TextStreamFileAccess } from "./types.js";
@@ -12,8 +18,8 @@ export const DEFAULT_FILE_ACCESS: TextStreamFileAccess = {
   },
   listFiles: async (path) =>
     (await readdir(path, { withFileTypes: true }))
-      .filter((entry) => entry.isFile())
-      .map((entry) => entry.name),
+      .filter((entry: any) => entry.isFile())
+      .map((entry: any) => entry.name),
   readFile: async (path) => {
     try {
       return await readFile(path);

--- a/packages/core/src/document/text-streams/sentence.ts
+++ b/packages/core/src/document/text-streams/sentence.ts
@@ -1,3 +1,4 @@
+import { Buffer as platformBuffer } from "../../runtime/platform/index.js";
 import { countTextWords } from "../../utils/text-word-count.js";
 import { Sentence, type SentenceRecord } from "../types.js";
 import type { TextStreamSentenceSegmenter } from "./types.js";
@@ -33,8 +34,11 @@ export async function splitTextIntoSentenceSpans(
     const sentence = new Sentence(rawText, countTextWords(rawText));
 
     Object.assign(sentence, {
-      byteLength: Buffer.byteLength(rawText, "utf8"),
-      byteOffset: Buffer.byteLength(text.slice(0, segment.index), "utf8"),
+      byteLength: platformBuffer.byteLength(rawText, "utf8"),
+      byteOffset: platformBuffer.byteLength(
+        text.slice(0, segment.index),
+        "utf8",
+      ),
     });
     spans.push(
       sentence as unknown as SentenceRecord & {
@@ -77,8 +81,11 @@ async function splitTextIntoCustomSentenceSpans(
     const sentence = new Sentence(rawText, segment.wordsCount);
 
     Object.assign(sentence, {
-      byteLength: Buffer.byteLength(rawText, "utf8"),
-      byteOffset: Buffer.byteLength(text.slice(0, segment.offset), "utf8"),
+      byteLength: platformBuffer.byteLength(rawText, "utf8"),
+      byteOffset: platformBuffer.byteLength(
+        text.slice(0, segment.offset),
+        "utf8",
+      ),
     });
     spans.push(
       sentence as unknown as SentenceRecord & {
@@ -119,7 +126,7 @@ export function getSentenceByteLength(sentence: SentenceRecord): number {
 
   return typeof value === "number"
     ? value
-    : Buffer.byteLength(getSentenceRawText(sentence), "utf8");
+    : platformBuffer.byteLength(getSentenceRawText(sentence), "utf8");
 }
 
 export function getSentenceRawText(sentence: SentenceRecord): string {

--- a/packages/core/src/document/text-streams/sentence.ts
+++ b/packages/core/src/document/text-streams/sentence.ts
@@ -1,4 +1,4 @@
-import { Buffer as platformBuffer } from "../../runtime/platform/index.js";
+import { binary as platformBinary } from "../../runtime/platform/index.js";
 import { countTextWords } from "../../utils/text-word-count.js";
 import { Sentence, type SentenceRecord } from "../types.js";
 import type { TextStreamSentenceSegmenter } from "./types.js";
@@ -34,8 +34,8 @@ export async function splitTextIntoSentenceSpans(
     const sentence = new Sentence(rawText, countTextWords(rawText));
 
     Object.assign(sentence, {
-      byteLength: platformBuffer.byteLength(rawText, "utf8"),
-      byteOffset: platformBuffer.byteLength(
+      byteLength: platformBinary.byteLength(rawText, "utf8"),
+      byteOffset: platformBinary.byteLength(
         text.slice(0, segment.index),
         "utf8",
       ),
@@ -81,8 +81,8 @@ async function splitTextIntoCustomSentenceSpans(
     const sentence = new Sentence(rawText, segment.wordsCount);
 
     Object.assign(sentence, {
-      byteLength: platformBuffer.byteLength(rawText, "utf8"),
-      byteOffset: platformBuffer.byteLength(
+      byteLength: platformBinary.byteLength(rawText, "utf8"),
+      byteOffset: platformBinary.byteLength(
         text.slice(0, segment.offset),
         "utf8",
       ),
@@ -126,7 +126,7 @@ export function getSentenceByteLength(sentence: SentenceRecord): number {
 
   return typeof value === "number"
     ? value
-    : platformBuffer.byteLength(getSentenceRawText(sentence), "utf8");
+    : platformBinary.byteLength(getSentenceRawText(sentence), "utf8");
 }
 
 export function getSentenceRawText(sentence: SentenceRecord): string {

--- a/packages/core/src/document/text-streams/serial.ts
+++ b/packages/core/src/document/text-streams/serial.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from "path";
+import { join, resolve } from "../../runtime/platform/index.js";
 
 import type { Database } from "../database.js";
 import {

--- a/packages/core/src/document/text-streams/serial.ts
+++ b/packages/core/src/document/text-streams/serial.ts
@@ -1,4 +1,4 @@
-import { Buffer as platformBuffer } from "../../runtime/platform/index.js";
+import { binary as platformBinary } from "../../runtime/platform/index.js";
 import { join, resolve } from "../../runtime/platform/index.js";
 
 import type { Database } from "../database.js";
@@ -196,7 +196,7 @@ export class SerialTextStream implements ReadonlySerialTextStream {
 
   #readSentenceLocation(
     location: TextSentenceLocation,
-    content: platformBuffer,
+    content: platformBinary,
   ): SentenceRecord {
     return new Sentence(
       content
@@ -214,7 +214,7 @@ export class SerialTextStream implements ReadonlySerialTextStream {
 
     return content === undefined
       ? undefined
-      : platformBuffer.from(content).toString("utf8");
+      : platformBinary.from(content).toString("utf8");
   }
 
   public async writeTextStream(
@@ -267,19 +267,19 @@ export class SerialTextStream implements ReadonlySerialTextStream {
     const existing = await this.#fileAccess.readFile(this.#getTextPath());
     const existingBuffer =
       existing === undefined
-        ? platformBuffer.alloc(0)
-        : platformBuffer.from(existing);
+        ? platformBinary.alloc(0)
+        : platformBinary.from(existing);
     const text =
       textOverride === ""
         ? sentences.map(getSentenceRawText).join("")
         : textOverride;
-    const appendBuffer = platformBuffer.from(text, "utf8");
+    const appendBuffer = platformBinary.from(text, "utf8");
     let offset = existingBuffer.length;
 
     await this.#fileAccess.ensureDirectory(this.#getDirectoryPath());
     await this.#fileAccess.writeFile(
       this.#getTextPath(),
-      platformBuffer.concat([existingBuffer, appendBuffer]),
+      platformBinary.concat([existingBuffer, appendBuffer]),
       { overwrite: true },
     );
 
@@ -399,10 +399,10 @@ export class SerialTextStream implements ReadonlySerialTextStream {
     return draftState.nextSentenceIndex;
   }
 
-  async #readContent(): Promise<platformBuffer> {
+  async #readContent(): Promise<platformBinary> {
     const content = await this.#fileAccess.readFile(this.#getTextPath());
 
-    return platformBuffer.from(content ?? new Uint8Array());
+    return platformBinary.from(content ?? new Uint8Array());
   }
 
   #getDirectoryPath(): string {

--- a/packages/core/src/document/text-streams/serial.ts
+++ b/packages/core/src/document/text-streams/serial.ts
@@ -1,3 +1,4 @@
+import { Buffer as platformBuffer } from "../../runtime/platform/index.js";
 import { join, resolve } from "../../runtime/platform/index.js";
 
 import type { Database } from "../database.js";
@@ -195,7 +196,7 @@ export class SerialTextStream implements ReadonlySerialTextStream {
 
   #readSentenceLocation(
     location: TextSentenceLocation,
-    content: Buffer,
+    content: platformBuffer,
   ): SentenceRecord {
     return new Sentence(
       content
@@ -213,7 +214,7 @@ export class SerialTextStream implements ReadonlySerialTextStream {
 
     return content === undefined
       ? undefined
-      : Buffer.from(content).toString("utf8");
+      : platformBuffer.from(content).toString("utf8");
   }
 
   public async writeTextStream(
@@ -265,18 +266,20 @@ export class SerialTextStream implements ReadonlySerialTextStream {
 
     const existing = await this.#fileAccess.readFile(this.#getTextPath());
     const existingBuffer =
-      existing === undefined ? Buffer.alloc(0) : Buffer.from(existing);
+      existing === undefined
+        ? platformBuffer.alloc(0)
+        : platformBuffer.from(existing);
     const text =
       textOverride === ""
         ? sentences.map(getSentenceRawText).join("")
         : textOverride;
-    const appendBuffer = Buffer.from(text, "utf8");
+    const appendBuffer = platformBuffer.from(text, "utf8");
     let offset = existingBuffer.length;
 
     await this.#fileAccess.ensureDirectory(this.#getDirectoryPath());
     await this.#fileAccess.writeFile(
       this.#getTextPath(),
-      Buffer.concat([existingBuffer, appendBuffer]),
+      platformBuffer.concat([existingBuffer, appendBuffer]),
       { overwrite: true },
     );
 
@@ -396,10 +399,10 @@ export class SerialTextStream implements ReadonlySerialTextStream {
     return draftState.nextSentenceIndex;
   }
 
-  async #readContent(): Promise<Buffer> {
+  async #readContent(): Promise<platformBuffer> {
     const content = await this.#fileAccess.readFile(this.#getTextPath());
 
-    return Buffer.from(content ?? new Uint8Array());
+    return platformBuffer.from(content ?? new Uint8Array());
   }
 
   #getDirectoryPath(): string {

--- a/packages/core/src/external/llm/cache.ts
+++ b/packages/core/src/external/llm/cache.ts
@@ -1,5 +1,5 @@
-import { readFile, writeFile } from "fs/promises";
-import { join } from "path";
+import { readFile, writeFile } from "../../runtime/platform/index.js";
+import { join } from "../../runtime/platform/index.js";
 
 import { isNodeError } from "../../utils/node-error.js";
 

--- a/packages/core/src/external/llm/client/core.ts
+++ b/packages/core/src/external/llm/client/core.ts
@@ -1,4 +1,4 @@
-import { setTimeout as sleep } from "timers/promises";
+import { setTimeout as sleep } from "../../../runtime/platform/index.js";
 
 import { createCache, ensureDirectoryPath } from "./files.js";
 import { normalizeGenerationInput } from "./generation.js";

--- a/packages/core/src/external/llm/client/files.ts
+++ b/packages/core/src/external/llm/client/files.ts
@@ -1,5 +1,9 @@
-import { existsSync, mkdirSync, statSync } from "fs";
-import { resolve } from "path";
+import {
+  existsSync,
+  mkdirSync,
+  statSync,
+} from "../../../runtime/platform/index.js";
+import { resolve } from "../../../runtime/platform/index.js";
 
 import { LLMCache } from "../cache.js";
 

--- a/packages/core/src/external/llm/client/retry.ts
+++ b/packages/core/src/external/llm/client/retry.ts
@@ -1,3 +1,4 @@
+import { type NodeError } from "../../../runtime/platform/index.js";
 import { APICallError } from "ai";
 
 const ABORT_ERROR_NAMES = new Set([
@@ -61,7 +62,7 @@ function isAbortLikeError(error: unknown): boolean {
 
 function isRetryableTransportError(error: unknown): boolean {
   return someErrorInChain(error, (currentError) => {
-    const nodeError = currentError as NodeJS.ErrnoException;
+    const nodeError = currentError as NodeError;
     const errorCode =
       typeof nodeError.code === "string"
         ? nodeError.code.toUpperCase()

--- a/packages/core/src/external/llm/request-log.ts
+++ b/packages/core/src/external/llm/request-log.ts
@@ -1,4 +1,4 @@
-import { appendFile } from "fs/promises";
+import { appendFile } from "../../runtime/platform/index.js";
 import { allocateArtifactPath } from "../../runtime/common/logging.js";
 
 export class RequestLog {

--- a/packages/core/src/external/wikimatch/wikispine.ts
+++ b/packages/core/src/external/wikimatch/wikispine.ts
@@ -1,3 +1,4 @@
+import { Buffer as platformBuffer } from "../../runtime/platform/index.js";
 import { spawn } from "../../runtime/platform/index.js";
 
 import type {
@@ -194,7 +195,7 @@ async function runWikispineMatch(
         });
       },
     });
-    const stderr: Buffer[] = [];
+    const stderr: platformBuffer[] = [];
 
     child.stdout.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => {
@@ -205,7 +206,7 @@ async function runWikispineMatch(
         child.kill();
       }
     });
-    child.stderr.on("data", (chunk: Buffer) => {
+    child.stderr.on("data", (chunk: platformBuffer) => {
       stderr.push(chunk);
     });
     child.on("error", (error: any) => {
@@ -222,7 +223,7 @@ async function runWikispineMatch(
         reject(
           new Error(
             formatWikispineRuntimeError(
-              `wikispine match failed with exit code ${code}: ${Buffer.concat(stderr).toString("utf8")}`,
+              `wikispine match failed with exit code ${code}: ${platformBuffer.concat(stderr).toString("utf8")}`,
             ),
           ),
         );

--- a/packages/core/src/external/wikimatch/wikispine.ts
+++ b/packages/core/src/external/wikimatch/wikispine.ts
@@ -1,4 +1,4 @@
-import { spawn } from "child_process";
+import { spawn } from "../../runtime/platform/index.js";
 
 import type {
   WikimatchCandidate,
@@ -182,7 +182,7 @@ async function runWikispineMatch(
       stdio: ["pipe", "pipe", "pipe"],
     });
     const progress = createWikispineProgressReporter(options.onProgress, {
-      onFailure: (error) => {
+      onFailure: (error: any) => {
         reject(error);
         child.kill();
       },
@@ -208,7 +208,7 @@ async function runWikispineMatch(
     child.stderr.on("data", (chunk: Buffer) => {
       stderr.push(chunk);
     });
-    child.on("error", (error) => {
+    child.on("error", (error: any) => {
       reject(
         new Error(
           formatWikispineRuntimeError(
@@ -217,7 +217,7 @@ async function runWikispineMatch(
         ),
       );
     });
-    child.on("close", (code) => {
+    child.on("close", (code: number | null) => {
       if (code !== 0) {
         reject(
           new Error(

--- a/packages/core/src/external/wikimatch/wikispine.ts
+++ b/packages/core/src/external/wikimatch/wikispine.ts
@@ -1,4 +1,4 @@
-import { Buffer as platformBuffer } from "../../runtime/platform/index.js";
+import { binary as platformBinary } from "../../runtime/platform/index.js";
 import { spawn } from "../../runtime/platform/index.js";
 
 import type {
@@ -195,7 +195,7 @@ async function runWikispineMatch(
         });
       },
     });
-    const stderr: platformBuffer[] = [];
+    const stderr: platformBinary[] = [];
 
     child.stdout.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => {
@@ -206,7 +206,7 @@ async function runWikispineMatch(
         child.kill();
       }
     });
-    child.stderr.on("data", (chunk: platformBuffer) => {
+    child.stderr.on("data", (chunk: platformBinary) => {
       stderr.push(chunk);
     });
     child.on("error", (error: any) => {
@@ -223,7 +223,7 @@ async function runWikispineMatch(
         reject(
           new Error(
             formatWikispineRuntimeError(
-              `wikispine match failed with exit code ${code}: ${platformBuffer.concat(stderr).toString("utf8")}`,
+              `wikispine match failed with exit code ${code}: ${platformBinary.concat(stderr).toString("utf8")}`,
             ),
           ),
         );

--- a/packages/core/src/external/wikipage/cache.ts
+++ b/packages/core/src/external/wikipage/cache.ts
@@ -1,4 +1,4 @@
-import { stat } from "fs/promises";
+import { stat } from "../../runtime/platform/index.js";
 
 import { resolveWikiGraphCacheDatabasePath } from "../../runtime/common/wiki-graph/dir.js";
 import { getNumber } from "../../document/database.js";

--- a/packages/core/src/external/wikipage/fetch-log.ts
+++ b/packages/core/src/external/wikipage/fetch-log.ts
@@ -1,5 +1,5 @@
-import { createHash } from "crypto";
-import { appendFile } from "fs/promises";
+import { createHash } from "../../runtime/platform/index.js";
+import { appendFile } from "../../runtime/platform/index.js";
 
 import {
   getLogger,

--- a/packages/core/src/graph/knowledge-build/artifact-io.ts
+++ b/packages/core/src/graph/knowledge-build/artifact-io.ts
@@ -1,4 +1,7 @@
-import { createReadStream, createWriteStream } from "fs";
+import {
+  createReadStream,
+  createWriteStream,
+} from "../../runtime/platform/index.js";
 import { createInterface } from "readline";
 import { z } from "zod";
 

--- a/packages/core/src/graph/knowledge-build/artifact-io.ts
+++ b/packages/core/src/graph/knowledge-build/artifact-io.ts
@@ -2,8 +2,8 @@ import { type WritableStream } from "../../runtime/platform/index.js";
 import {
   createReadStream,
   createWriteStream,
+  readLines,
 } from "../../runtime/platform/index.js";
-import { createInterface } from "readline";
 import { z } from "zod";
 
 import type {
@@ -122,10 +122,7 @@ export async function readJsonl<T>(
   parseRecord: (record: unknown) => T,
 ): Promise<T[]> {
   const records: T[] = [];
-  const lines = createInterface({
-    crlfDelay: Infinity,
-    input: createReadStream(path, { encoding: "utf8" }),
-  });
+  const lines = readLines(createReadStream(path, { encoding: "utf8" }));
   let lineNumber = 0;
 
   for await (const line of lines) {

--- a/packages/core/src/graph/knowledge-build/artifact-io.ts
+++ b/packages/core/src/graph/knowledge-build/artifact-io.ts
@@ -1,3 +1,4 @@
+import { type WritableStream } from "../../runtime/platform/index.js";
 import {
   createReadStream,
   createWriteStream,
@@ -181,9 +182,7 @@ export function parseMentionLinkRecord(record: unknown): MentionLinkRecord {
   };
 }
 
-async function closeWritableStream(
-  stream: NodeJS.WritableStream,
-): Promise<void> {
+async function closeWritableStream(stream: WritableStream): Promise<void> {
   await new Promise<void>((resolveClose, rejectClose) => {
     stream.end((error?: Error | null) => {
       if (error !== undefined && error !== null) {

--- a/packages/core/src/graph/knowledge-build/artifact.ts
+++ b/packages/core/src/graph/knowledge-build/artifact.ts
@@ -1,5 +1,5 @@
-import { mkdir, rm } from "fs/promises";
-import { join } from "path";
+import { mkdir, rm } from "../../runtime/platform/index.js";
+import { join } from "../../runtime/platform/index.js";
 
 import { LanguageCode } from "../../runtime/common/language.js";
 import {

--- a/packages/core/src/graph/reading-build/artifact.ts
+++ b/packages/core/src/graph/reading-build/artifact.ts
@@ -1,5 +1,5 @@
-import { mkdir, rm } from "fs/promises";
-import { join } from "path";
+import { mkdir, rm } from "../../runtime/platform/index.js";
+import { join } from "../../runtime/platform/index.js";
 
 import type { Document } from "../../document/index.js";
 import {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -468,3 +468,14 @@ export {
   writeWikgObjectsToJsonl,
 } from "./object-stream.js";
 export type { WikgObject } from "./object-stream.js";
+export {
+  getWikiGraphPlatform,
+  getWikiGraphStorage,
+  installWikiGraphPlatform,
+  installWikiGraphStorage,
+  type Directory,
+  type File,
+  type FileWriter,
+  type WikiGraphPlatform,
+  type WikiGraphStorage,
+} from "./runtime/platform/index.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -470,9 +470,11 @@ export {
 export type { WikgObject } from "./object-stream.js";
 export {
   getWikiGraphStorage,
+  installWikiGraphPlatform,
   installWikiGraphStorage,
   type Directory,
   type File,
   type FileWriter,
+  type WikiGraphPlatform,
   type WikiGraphStorage,
 } from "./runtime/platform/index.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -469,13 +469,10 @@ export {
 } from "./object-stream.js";
 export type { WikgObject } from "./object-stream.js";
 export {
-  getWikiGraphPlatform,
   getWikiGraphStorage,
-  installWikiGraphPlatform,
   installWikiGraphStorage,
   type Directory,
   type File,
   type FileWriter,
-  type WikiGraphPlatform,
   type WikiGraphStorage,
 } from "./runtime/platform/index.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -95,16 +95,6 @@ export type {
   WikiGraphLibraryScanResult,
 } from "./library/index.js";
 export {
-  resolveWikiGraphCoreDatabasePath,
-  resolveWikiGraphHomeDirectoryPath,
-  withWikiGraphRuntimeEnvironment,
-  withWikiGraphRuntimeStateDirectoryPath,
-} from "./runtime/common/wiki-graph/dir.js";
-export {
-  createWikiGraphTempDirectory,
-  resolveWikiGraphStateRootPath,
-} from "./runtime/common/wiki-graph/temp.js";
-export {
   EVIDENCE_SELECTION_JSON_SHAPE,
   EVIDENCE_SELECTION_PROMPT_FRAGMENT,
   formatEvidenceSelectionChoicePrompt,

--- a/packages/core/src/library/lock.ts
+++ b/packages/core/src/library/lock.ts
@@ -1,4 +1,4 @@
-import { process as platformProcess } from "../runtime/platform/index.js";
+import { runtimeContext as platformRuntime } from "../runtime/platform/index.js";
 import { getNumber, getString, type Database } from "../document/database.js";
 import { openSharedStateDatabase } from "../document/index.js";
 import { resolveWikiGraphCoreDatabasePath } from "../runtime/common/wiki-graph/dir.js";
@@ -149,7 +149,7 @@ function isLockActive(lock: {
 
 function isProcessAlive(pid: number): boolean {
   try {
-    platformProcess.kill(pid, 0);
+    platformRuntime.kill(pid, 0);
     return true;
   } catch (error) {
     if (isNodeError(error) && error.code === "ESRCH") {

--- a/packages/core/src/library/lock.ts
+++ b/packages/core/src/library/lock.ts
@@ -1,3 +1,4 @@
+import { process as platformProcess } from "../runtime/platform/index.js";
 import { getNumber, getString, type Database } from "../document/database.js";
 import { openSharedStateDatabase } from "../document/index.js";
 import { resolveWikiGraphCoreDatabasePath } from "../runtime/common/wiki-graph/dir.js";
@@ -148,7 +149,7 @@ function isLockActive(lock: {
 
 function isProcessAlive(pid: number): boolean {
   try {
-    process.kill(pid, 0);
+    platformProcess.kill(pid, 0);
     return true;
   } catch (error) {
     if (isNodeError(error) && error.code === "ESRCH") {

--- a/packages/core/src/library/membership.ts
+++ b/packages/core/src/library/membership.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "crypto";
+import { randomBytes } from "../runtime/platform/index.js";
 import {
   constants,
   copyFile,
@@ -8,8 +8,14 @@ import {
   rename,
   rm,
   stat,
-} from "fs/promises";
-import { dirname, isAbsolute, join, relative, resolve } from "path";
+} from "../runtime/platform/index.js";
+import {
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+} from "../runtime/platform/index.js";
 
 import {
   getNumber,

--- a/packages/core/src/library/registry.ts
+++ b/packages/core/src/library/registry.ts
@@ -1,4 +1,8 @@
-import { randomBytes } from "../runtime/platform/index.js";
+import {
+  getPlatformDirectoryPath,
+  getWikiGraphStorage,
+  randomBytes,
+} from "../runtime/platform/index.js";
 import { constants } from "../runtime/platform/index.js";
 import { access, mkdir, stat } from "../runtime/platform/index.js";
 import { join, resolve } from "../runtime/platform/index.js";
@@ -308,6 +312,17 @@ export function formatWikiGraphLibraryUri(publicId?: string): string {
 }
 
 export function resolveDefaultWikiGraphLibraryDirectoryPath(): string {
+  // A host-provided library root is the authoritative location when the
+  // storage adapter is installed. The legacy home-directory fallback remains
+  // for callers that use the low-level registry helpers directly.
+  try {
+    return join(
+      getPlatformDirectoryPath(getWikiGraphStorage().library),
+      DEFAULT_LIBRARY_FOLDER_NAME,
+    );
+  } catch {
+    // Keep the existing Node/CLI behavior for backwards compatibility.
+  }
   return join(resolveWikiGraphHomeDirectoryPath(), DEFAULT_LIBRARY_FOLDER_NAME);
 }
 

--- a/packages/core/src/library/registry.ts
+++ b/packages/core/src/library/registry.ts
@@ -1,7 +1,7 @@
-import { randomBytes } from "crypto";
-import { constants } from "fs";
-import { access, mkdir, stat } from "fs/promises";
-import { join, resolve } from "path";
+import { randomBytes } from "../runtime/platform/index.js";
+import { constants } from "../runtime/platform/index.js";
+import { access, mkdir, stat } from "../runtime/platform/index.js";
+import { join, resolve } from "../runtime/platform/index.js";
 
 import {
   getNumber,

--- a/packages/core/src/library/registry.ts
+++ b/packages/core/src/library/registry.ts
@@ -1,7 +1,4 @@
-import {
-  getWikiGraphStorage,
-  randomBytes,
-} from "../runtime/platform/index.js";
+import { getWikiGraphStorage, randomBytes } from "../runtime/platform/index.js";
 import { constants } from "../runtime/platform/index.js";
 import { access, mkdir, stat } from "../runtime/platform/index.js";
 import { join, resolve } from "../runtime/platform/index.js";

--- a/packages/core/src/library/registry.ts
+++ b/packages/core/src/library/registry.ts
@@ -1,5 +1,4 @@
 import {
-  getHostDirectoryHandle,
   getWikiGraphStorage,
   randomBytes,
 } from "../runtime/platform/index.js";
@@ -317,7 +316,7 @@ export function resolveDefaultWikiGraphLibraryDirectoryPath(): string {
   // for callers that use the low-level registry helpers directly.
   try {
     return join(
-      getHostDirectoryHandle(getWikiGraphStorage().library),
+      getWikiGraphStorage().library as unknown as string,
       DEFAULT_LIBRARY_FOLDER_NAME,
     );
   } catch {

--- a/packages/core/src/library/registry.ts
+++ b/packages/core/src/library/registry.ts
@@ -1,5 +1,5 @@
 import {
-  getPlatformDirectoryPath,
+  getHostDirectoryHandle,
   getWikiGraphStorage,
   randomBytes,
 } from "../runtime/platform/index.js";
@@ -317,7 +317,7 @@ export function resolveDefaultWikiGraphLibraryDirectoryPath(): string {
   // for callers that use the low-level registry helpers directly.
   try {
     return join(
-      getPlatformDirectoryPath(getWikiGraphStorage().library),
+      getHostDirectoryHandle(getWikiGraphStorage().library),
       DEFAULT_LIBRARY_FOLDER_NAME,
     );
   } catch {

--- a/packages/core/src/library/search-index.ts
+++ b/packages/core/src/library/search-index.ts
@@ -1,6 +1,6 @@
-import { createHash } from "crypto";
-import { mkdir, readdir, rm } from "fs/promises";
-import { join } from "path";
+import { createHash } from "../runtime/platform/index.js";
+import { mkdir, readdir, rm } from "../runtime/platform/index.js";
+import { join } from "../runtime/platform/index.js";
 
 import { Database, getNumber, getString } from "../document/database.js";
 import { ensureWikiGraphHomeSchemaCurrent } from "../document/home-schema-upgrade.js";

--- a/packages/core/src/maintenance/upgrade.ts
+++ b/packages/core/src/maintenance/upgrade.ts
@@ -1,6 +1,6 @@
-import { rm } from "fs/promises";
-import { homedir } from "os";
-import { resolve } from "path";
+import { rm } from "../runtime/platform/index.js";
+import { homedir } from "../runtime/platform/index.js";
+import { resolve } from "../runtime/platform/index.js";
 
 import {
   listWikiGraphLibraryArchives,

--- a/packages/core/src/object-stream.ts
+++ b/packages/core/src/object-stream.ts
@@ -1,3 +1,4 @@
+import { type WritableStream } from "./runtime/platform/index.js";
 import {
   createReadStream,
   createWriteStream,
@@ -1048,10 +1049,7 @@ function formatSentenceId(sentenceId: SentenceId): string {
   return sentenceId.join(":");
 }
 
-async function writeLine(
-  stream: NodeJS.WritableStream,
-  line: string,
-): Promise<void> {
+async function writeLine(stream: WritableStream, line: string): Promise<void> {
   await new Promise<void>((resolveWrite, rejectWrite) => {
     stream.write(line, (error?: Error | null) => {
       if (error !== undefined && error !== null) {
@@ -1063,9 +1061,7 @@ async function writeLine(
   });
 }
 
-async function closeWritableStream(
-  stream: NodeJS.WritableStream,
-): Promise<void> {
+async function closeWritableStream(stream: WritableStream): Promise<void> {
   await new Promise<void>((resolveClose, rejectClose) => {
     stream.end((error?: Error | null) => {
       if (error !== undefined && error !== null) {

--- a/packages/core/src/object-stream.ts
+++ b/packages/core/src/object-stream.ts
@@ -2,8 +2,8 @@ import { type WritableStream } from "./runtime/platform/index.js";
 import {
   createReadStream,
   createWriteStream,
+  readLines,
 } from "./runtime/platform/index.js";
-import { createInterface } from "readline";
 import { z } from "zod";
 
 import type {
@@ -329,10 +329,7 @@ export async function writeWikgObjectsToJsonl(
 export async function* readWikgObjectsFromJsonl(
   path: string,
 ): AsyncGenerator<WikgObject> {
-  const lines = createInterface({
-    crlfDelay: Infinity,
-    input: createReadStream(path, { encoding: "utf8" }),
-  });
+  const lines = readLines(createReadStream(path, { encoding: "utf8" }));
   let lineNumber = 0;
 
   for await (const line of lines) {

--- a/packages/core/src/object-stream.ts
+++ b/packages/core/src/object-stream.ts
@@ -1,4 +1,7 @@
-import { createReadStream, createWriteStream } from "fs";
+import {
+  createReadStream,
+  createWriteStream,
+} from "./runtime/platform/index.js";
 import { createInterface } from "readline";
 import { z } from "zod";
 

--- a/packages/core/src/retrieval/index-artifact/output.ts
+++ b/packages/core/src/retrieval/index-artifact/output.ts
@@ -1,10 +1,10 @@
 import {
   createReadStream,
   createWriteStream,
+  readLines,
 } from "../../runtime/platform/index.js";
 import { mkdir } from "../../runtime/platform/index.js";
 import { dirname } from "../../runtime/platform/index.js";
-import { createInterface } from "readline";
 import type { Writable } from "../../runtime/platform/index.js";
 import { z } from "zod";
 
@@ -115,10 +115,7 @@ export async function writeIndexArtifactOutputToStream(
 export async function readIndexArtifactOutput(
   path: string,
 ): Promise<IndexArtifactOutput> {
-  const lines = createInterface({
-    crlfDelay: Infinity,
-    input: createReadStream(path, { encoding: "utf8" }),
-  });
+  const lines = readLines(createReadStream(path, { encoding: "utf8" }));
   let manifest: IndexArtifactOutputManifest | undefined;
   const lexicalRows: IndexArtifactLexicalRow[] = [];
   const segments: IndexArtifactEmbeddingSegment[] = [];

--- a/packages/core/src/retrieval/index-artifact/output.ts
+++ b/packages/core/src/retrieval/index-artifact/output.ts
@@ -1,8 +1,11 @@
-import { createReadStream, createWriteStream } from "fs";
-import { mkdir } from "fs/promises";
-import { dirname } from "path";
+import {
+  createReadStream,
+  createWriteStream,
+} from "../../runtime/platform/index.js";
+import { mkdir } from "../../runtime/platform/index.js";
+import { dirname } from "../../runtime/platform/index.js";
 import { createInterface } from "readline";
-import type { Writable } from "stream";
+import type { Writable } from "../../runtime/platform/index.js";
 import { z } from "zod";
 
 import type {
@@ -542,7 +545,7 @@ async function writeJSONLRecord(
 
       const canContinue = stream.write(
         `${JSON.stringify(record)}\n`,
-        (error) => {
+        (error: any) => {
           if (error !== undefined && error !== null) {
             settle(error);
             return;

--- a/packages/core/src/retrieval/query/archive-view/core.ts
+++ b/packages/core/src/retrieval/query/archive-view/core.ts
@@ -27,7 +27,7 @@ export async function requireChapter(
   chapterId: number,
 ): Promise<ChapterEntry> {
   const chapter = (await listChapters(document)).find(
-    (entry) => entry.chapterId === chapterId,
+    (entry: any) => entry.chapterId === chapterId,
   );
 
   if (chapter === undefined) {

--- a/packages/core/src/retrieval/query/archive-view/evidence-hydration.ts
+++ b/packages/core/src/retrieval/query/archive-view/evidence-hydration.ts
@@ -259,7 +259,7 @@ async function coalesceTextStreamFindHits(
     }
   }
 
-  return entries.map((entry) =>
+  return entries.map((entry: any) =>
     entry.type === "range" ? entry.range.hit : entry.hit,
   );
 }

--- a/packages/core/src/retrieval/query/archive-view/helper/parse.ts
+++ b/packages/core/src/retrieval/query/archive-view/helper/parse.ts
@@ -1,4 +1,4 @@
-import { Buffer as platformBuffer } from "../../../../runtime/platform/index.js";
+import { binary as platformBinary } from "../../../../runtime/platform/index.js";
 import type {
   ArchiveCollectionType,
   ArchiveFindFilterType,
@@ -90,7 +90,7 @@ export function parseFindTypes(
 }
 
 export function encodeFindCursor(offset: number): string {
-  return platformBuffer
+  return platformBinary
     .from(JSON.stringify({ offset, v: 1 }))
     .toString("base64url");
 }
@@ -102,7 +102,7 @@ export function decodeFindCursor(cursor: string | undefined): number {
 
   try {
     const parsed: unknown = JSON.parse(
-      platformBuffer.from(cursor, "base64url").toString("utf8"),
+      platformBinary.from(cursor, "base64url").toString("utf8"),
     );
 
     if (

--- a/packages/core/src/retrieval/query/archive-view/helper/parse.ts
+++ b/packages/core/src/retrieval/query/archive-view/helper/parse.ts
@@ -1,3 +1,4 @@
+import { Buffer as platformBuffer } from "../../../../runtime/platform/index.js";
 import type {
   ArchiveCollectionType,
   ArchiveFindFilterType,
@@ -89,7 +90,9 @@ export function parseFindTypes(
 }
 
 export function encodeFindCursor(offset: number): string {
-  return Buffer.from(JSON.stringify({ offset, v: 1 })).toString("base64url");
+  return platformBuffer
+    .from(JSON.stringify({ offset, v: 1 }))
+    .toString("base64url");
 }
 
 export function decodeFindCursor(cursor: string | undefined): number {
@@ -99,7 +102,7 @@ export function decodeFindCursor(cursor: string | undefined): number {
 
   try {
     const parsed: unknown = JSON.parse(
-      Buffer.from(cursor, "base64url").toString("utf8"),
+      platformBuffer.from(cursor, "base64url").toString("utf8"),
     );
 
     if (

--- a/packages/core/src/retrieval/query/archive-view/pages.ts
+++ b/packages/core/src/retrieval/query/archive-view/pages.ts
@@ -235,7 +235,9 @@ async function resolveChapterPathObjectUri(
   const chapter = (await listChapters(document))
     .slice()
     .sort((left, right) => right.path.length - left.path.length)
-    .find((entry) => path === entry.path || path.startsWith(`${entry.path}/`));
+    .find(
+      (entry: any) => path === entry.path || path.startsWith(`${entry.path}/`),
+    );
 
   if (chapter === undefined) {
     return uri;

--- a/packages/core/src/retrieval/query/continuation-cursor/store.ts
+++ b/packages/core/src/retrieval/query/continuation-cursor/store.ts
@@ -1,5 +1,5 @@
-import { randomBytes } from "crypto";
-import { join } from "path";
+import { randomBytes } from "../../../runtime/platform/index.js";
+import { join } from "../../../runtime/platform/index.js";
 
 import { resolveWikiGraphCacheDirectoryPath } from "../../../runtime/common/wiki-graph/dir.js";
 import { getOptionalString } from "../../../document/database.js";

--- a/packages/core/src/retrieval/query/search-cache/cursor.ts
+++ b/packages/core/src/retrieval/query/search-cache/cursor.ts
@@ -1,4 +1,4 @@
-import { Buffer as platformBuffer } from "../../../runtime/platform/index.js";
+import { binary as platformBinary } from "../../../runtime/platform/index.js";
 import type {
   BucketSearchCursor,
   SearchChapterTitleCursorKey,
@@ -12,7 +12,7 @@ export function encodeSearchSessionCursor(
   offset: number,
   createdAt: number,
 ): string {
-  return platformBuffer
+  return platformBinary
     .from(JSON.stringify({ createdAt, offset, sessionId, v: 3 }))
     .toString("base64url");
 }
@@ -22,7 +22,7 @@ export function encodeBucketSearchSessionCursor(
   cursor: BucketSearchCursor,
   createdAt: number,
 ): string {
-  return platformBuffer
+  return platformBinary
     .from(JSON.stringify({ createdAt, cursor, sessionId, v: 4 }))
     .toString("base64url");
 }
@@ -34,7 +34,7 @@ export function decodeBucketSearchSessionCursor(cursor: string): {
 } {
   try {
     const parsed: unknown = JSON.parse(
-      platformBuffer.from(cursor, "base64url").toString("utf8"),
+      platformBinary.from(cursor, "base64url").toString("utf8"),
     );
 
     if (
@@ -72,7 +72,7 @@ export function decodeSearchSessionCursor(cursor: string): {
 } {
   try {
     const parsed: unknown = JSON.parse(
-      platformBuffer.from(cursor, "base64url").toString("utf8"),
+      platformBinary.from(cursor, "base64url").toString("utf8"),
     );
 
     if (

--- a/packages/core/src/retrieval/query/search-cache/cursor.ts
+++ b/packages/core/src/retrieval/query/search-cache/cursor.ts
@@ -1,3 +1,4 @@
+import { Buffer as platformBuffer } from "../../../runtime/platform/index.js";
 import type {
   BucketSearchCursor,
   SearchChapterTitleCursorKey,
@@ -11,9 +12,9 @@ export function encodeSearchSessionCursor(
   offset: number,
   createdAt: number,
 ): string {
-  return Buffer.from(
-    JSON.stringify({ createdAt, offset, sessionId, v: 3 }),
-  ).toString("base64url");
+  return platformBuffer
+    .from(JSON.stringify({ createdAt, offset, sessionId, v: 3 }))
+    .toString("base64url");
 }
 
 export function encodeBucketSearchSessionCursor(
@@ -21,9 +22,9 @@ export function encodeBucketSearchSessionCursor(
   cursor: BucketSearchCursor,
   createdAt: number,
 ): string {
-  return Buffer.from(
-    JSON.stringify({ createdAt, cursor, sessionId, v: 4 }),
-  ).toString("base64url");
+  return platformBuffer
+    .from(JSON.stringify({ createdAt, cursor, sessionId, v: 4 }))
+    .toString("base64url");
 }
 
 export function decodeBucketSearchSessionCursor(cursor: string): {
@@ -33,7 +34,7 @@ export function decodeBucketSearchSessionCursor(cursor: string): {
 } {
   try {
     const parsed: unknown = JSON.parse(
-      Buffer.from(cursor, "base64url").toString("utf8"),
+      platformBuffer.from(cursor, "base64url").toString("utf8"),
     );
 
     if (
@@ -71,7 +72,7 @@ export function decodeSearchSessionCursor(cursor: string): {
 } {
   try {
     const parsed: unknown = JSON.parse(
-      Buffer.from(cursor, "base64url").toString("utf8"),
+      platformBuffer.from(cursor, "base64url").toString("utf8"),
     );
 
     if (

--- a/packages/core/src/retrieval/query/search-cache/database.ts
+++ b/packages/core/src/retrieval/query/search-cache/database.ts
@@ -1,5 +1,5 @@
-import { join } from "path";
-import { rm } from "fs/promises";
+import { join } from "../../../runtime/platform/index.js";
+import { rm } from "../../../runtime/platform/index.js";
 
 import { resolveWikiGraphCacheDirectoryPath } from "../../../runtime/common/wiki-graph/dir.js";
 import { openSharedStateDatabase } from "../../../document/index.js";

--- a/packages/core/src/retrieval/query/search-cache/gc.ts
+++ b/packages/core/src/retrieval/query/search-cache/gc.ts
@@ -1,4 +1,4 @@
-import { stat } from "fs/promises";
+import { stat } from "../../../runtime/platform/index.js";
 
 import { getNumber, getString } from "../../../document/database.js";
 import type { Database } from "../../../document/index.js";

--- a/packages/core/src/retrieval/query/search-cache/ids.ts
+++ b/packages/core/src/retrieval/query/search-cache/ids.ts
@@ -1,4 +1,4 @@
-import { createHash } from "crypto";
+import { createHash } from "../../../runtime/platform/index.js";
 
 import { SEARCH_RANKING_VERSION } from "./schema.js";
 import type {

--- a/packages/core/src/retrieval/search-index/search/fingerprint.ts
+++ b/packages/core/src/retrieval/search-index/search/fingerprint.ts
@@ -1,4 +1,4 @@
-import { createHash } from "crypto";
+import { createHash } from "../../../runtime/platform/index.js";
 import type { Database } from "../../../document/database.js";
 import type { SearchIndexInput } from "./types.js";
 

--- a/packages/core/src/retrieval/search-index/search/query.ts
+++ b/packages/core/src/retrieval/search-index/search/query.ts
@@ -1,3 +1,4 @@
+import { Buffer as platformBuffer } from "../../../runtime/platform/index.js";
 import { getNumber, type Database } from "../../../document/database.js";
 import type { ReadonlyDocument } from "../../../document/index.js";
 import type {
@@ -400,8 +401,8 @@ async function queryDenseSegmentHits(
       kind: getNumber(row, "kind") as TextSentenceKind,
       startSentenceIndex: getNumber(row, "start_sentence_index"),
       vector:
-        Buffer.isBuffer(row.vector) || row.vector instanceof Uint8Array
-          ? deserializeFloat32Vector(Buffer.from(row.vector))
+        platformBuffer.isBuffer(row.vector) || row.vector instanceof Uint8Array
+          ? deserializeFloat32Vector(platformBuffer.from(row.vector))
           : [],
     }),
   );

--- a/packages/core/src/retrieval/search-index/search/query.ts
+++ b/packages/core/src/retrieval/search-index/search/query.ts
@@ -1,4 +1,4 @@
-import { Buffer as platformBuffer } from "../../../runtime/platform/index.js";
+import { binary as platformBinary } from "../../../runtime/platform/index.js";
 import { getNumber, type Database } from "../../../document/database.js";
 import type { ReadonlyDocument } from "../../../document/index.js";
 import type {
@@ -401,8 +401,8 @@ async function queryDenseSegmentHits(
       kind: getNumber(row, "kind") as TextSentenceKind,
       startSentenceIndex: getNumber(row, "start_sentence_index"),
       vector:
-        platformBuffer.isBuffer(row.vector) || row.vector instanceof Uint8Array
-          ? deserializeFloat32Vector(platformBuffer.from(row.vector))
+        platformBinary.isBuffer(row.vector) || row.vector instanceof Uint8Array
+          ? deserializeFloat32Vector(platformBinary.from(row.vector))
           : [],
     }),
   );

--- a/packages/core/src/retrieval/search-index/search/tokenizer.ts
+++ b/packages/core/src/retrieval/search-index/search/tokenizer.ts
@@ -1,4 +1,4 @@
-import { createHash } from "crypto";
+import { createHash } from "../../../runtime/platform/index.js";
 
 export interface SearchToken {
   readonly encoded: string;

--- a/packages/core/src/retrieval/search-index/search/write.ts
+++ b/packages/core/src/retrieval/search-index/search/write.ts
@@ -1,4 +1,4 @@
-import { Buffer as platformBuffer } from "../../../runtime/platform/index.js";
+import { binary as platformBinary } from "../../../runtime/platform/index.js";
 import { getNumber, type Database } from "../../../document/database.js";
 import { serializeTokens } from "./helpers.js";
 import type { SearchTokenPlan } from "./tokenizer.js";
@@ -124,7 +124,7 @@ export async function insertTextEmbeddingSegment(
 }
 
 export function deserializeFloat32Vector(
-  buffer: platformBuffer,
+  buffer: platformBinary,
 ): readonly number[] {
   const vector: number[] = [];
 
@@ -135,8 +135,8 @@ export function deserializeFloat32Vector(
   return vector;
 }
 
-function serializeFloat32Vector(vector: readonly number[]): platformBuffer {
-  const buffer = platformBuffer.alloc(vector.length * 4);
+function serializeFloat32Vector(vector: readonly number[]): platformBinary {
+  const buffer = platformBinary.alloc(vector.length * 4);
 
   for (const [index, value] of vector.entries()) {
     buffer.writeFloatLE(value, index * 4);

--- a/packages/core/src/retrieval/search-index/search/write.ts
+++ b/packages/core/src/retrieval/search-index/search/write.ts
@@ -1,3 +1,4 @@
+import { Buffer as platformBuffer } from "../../../runtime/platform/index.js";
 import { getNumber, type Database } from "../../../document/database.js";
 import { serializeTokens } from "./helpers.js";
 import type { SearchTokenPlan } from "./tokenizer.js";
@@ -122,7 +123,9 @@ export async function insertTextEmbeddingSegment(
   );
 }
 
-export function deserializeFloat32Vector(buffer: Buffer): readonly number[] {
+export function deserializeFloat32Vector(
+  buffer: platformBuffer,
+): readonly number[] {
   const vector: number[] = [];
 
   for (let offset = 0; offset < buffer.length; offset += 4) {
@@ -132,8 +135,8 @@ export function deserializeFloat32Vector(buffer: Buffer): readonly number[] {
   return vector;
 }
 
-function serializeFloat32Vector(vector: readonly number[]): Buffer {
-  const buffer = Buffer.alloc(vector.length * 4);
+function serializeFloat32Vector(vector: readonly number[]): platformBuffer {
+  const buffer = platformBuffer.alloc(vector.length * 4);
 
   for (const [index, value] of vector.entries()) {
     buffer.writeFloatLE(value, index * 4);

--- a/packages/core/src/runtime/common/data-dir.ts
+++ b/packages/core/src/runtime/common/data-dir.ts
@@ -1,3 +1,4 @@
+import { process as platformProcess } from "../platform/index.js";
 import { existsSync, statSync } from "../platform/index.js";
 import { fileURLToPath } from "../platform/index.js";
 import { dirname, join, parse, resolve } from "../platform/index.js";
@@ -35,7 +36,7 @@ function resolveDataDirPathFromModule(): string | undefined {
 }
 
 function resolveDataDirPathFromWorkingDirectory(): string {
-  let currentDirectoryPath = process.cwd();
+  let currentDirectoryPath = platformProcess.cwd();
   const rootDirectoryPath = parse(currentDirectoryPath).root;
 
   while (true) {

--- a/packages/core/src/runtime/common/data-dir.ts
+++ b/packages/core/src/runtime/common/data-dir.ts
@@ -1,6 +1,6 @@
 import { runtimeContext as platformRuntime } from "../platform/index.js";
 import { existsSync, statSync } from "../platform/index.js";
-import { dirname, join, parse, resolve } from "../platform/index.js";
+import { dirname, join, parse } from "../platform/index.js";
 
 export function resolveDataDirPath(): string {
   const injectedPath = (globalThis as { __WIKIGRAPH_DATA_DIR__?: unknown })

--- a/packages/core/src/runtime/common/data-dir.ts
+++ b/packages/core/src/runtime/common/data-dir.ts
@@ -1,4 +1,4 @@
-import { process as platformProcess } from "../platform/index.js";
+import { runtimeContext as platformRuntime } from "../platform/index.js";
 import { existsSync, statSync } from "../platform/index.js";
 import { dirname, join, parse, resolve } from "../platform/index.js";
 
@@ -14,7 +14,7 @@ export function resolveDataDirPath(): string {
 }
 
 function resolveDataDirPathFromWorkingDirectory(): string {
-  let currentDirectoryPath = platformProcess.cwd();
+  let currentDirectoryPath = platformRuntime.cwd();
   const rootDirectoryPath = parse(currentDirectoryPath).root;
 
   while (true) {

--- a/packages/core/src/runtime/common/data-dir.ts
+++ b/packages/core/src/runtime/common/data-dir.ts
@@ -1,6 +1,6 @@
-import { existsSync, statSync } from "fs";
-import { fileURLToPath } from "url";
-import { dirname, join, parse, resolve } from "path";
+import { existsSync, statSync } from "../platform/index.js";
+import { fileURLToPath } from "../platform/index.js";
+import { dirname, join, parse, resolve } from "../platform/index.js";
 
 export function resolveDataDirPath(): string {
   const injectedPath = (globalThis as { __WIKIGRAPH_DATA_DIR__?: unknown })

--- a/packages/core/src/runtime/common/data-dir.ts
+++ b/packages/core/src/runtime/common/data-dir.ts
@@ -1,6 +1,5 @@
 import { process as platformProcess } from "../platform/index.js";
 import { existsSync, statSync } from "../platform/index.js";
-import { fileURLToPath } from "../platform/index.js";
 import { dirname, join, parse, resolve } from "../platform/index.js";
 
 export function resolveDataDirPath(): string {
@@ -11,28 +10,7 @@ export function resolveDataDirPath(): string {
     return injectedPath;
   }
 
-  const moduleDataDirPath = resolveDataDirPathFromModule();
-  if (moduleDataDirPath !== undefined) {
-    return moduleDataDirPath;
-  }
-
   return resolveDataDirPathFromWorkingDirectory();
-}
-
-function resolveDataDirPathFromModule(): string | undefined {
-  const moduleDirectoryPath = dirname(fileURLToPath(import.meta.url));
-
-  for (const candidatePath of [
-    resolve(moduleDirectoryPath, "../../../data"),
-    resolve(moduleDirectoryPath, "../../data"),
-    resolve(moduleDirectoryPath, "../data"),
-  ]) {
-    if (existsSync(candidatePath) && statSync(candidatePath).isDirectory()) {
-      return candidatePath;
-    }
-  }
-
-  return undefined;
 }
 
 function resolveDataDirPathFromWorkingDirectory(): string {

--- a/packages/core/src/runtime/common/logging.ts
+++ b/packages/core/src/runtime/common/logging.ts
@@ -1,29 +1,36 @@
-import { type WritableStream } from "../platform/index.js";
-import { process as platformProcess } from "../platform/index.js";
 import { AsyncLocalStorage } from "../platform/index.js";
-import { randomUUID } from "../platform/index.js";
+import { appendFile, randomUUID } from "../platform/index.js";
 import { existsSync, mkdirSync } from "../platform/index.js";
-import { dirname, join, resolve } from "../platform/index.js";
+import { join, resolve } from "../platform/index.js";
+import { process as platformProcess } from "../platform/index.js";
 
-import pino, {
-  multistream,
-  type Logger as PinoLogger,
-  type StreamEntry,
-} from "pino";
-import pretty from "pino-pretty";
-import type { PrettyOptions } from "pino-pretty";
+interface CoreLogger {
+  child(bindings: Record<string, unknown>): CoreLogger;
+  debug(...args: unknown[]): void;
+  error(...args: unknown[]): void;
+  info(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+  flush(): Promise<void>;
+}
 
 interface LoggingContext {
   readonly artifactCounters: Map<string, number>;
   readonly artifactRootDirPath?: string;
-  readonly logger: PinoLogger;
+  readonly logger: CoreLogger;
   readonly rootLogDirPath?: string;
   readonly runId: string;
 }
 
 const loggingContext = new AsyncLocalStorage<LoggingContext>();
 const artifactCounters = new Map<string, number>();
-const silentLogger = pino({ enabled: false });
+const silentLogger: CoreLogger = {
+  child: () => silentLogger,
+  debug: () => undefined,
+  error: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  flush: async () => undefined,
+};
 
 export async function withLoggingContext<T>(
   input: {
@@ -54,19 +61,23 @@ export async function withLoggingContext<T>(
       : { eventLogPath: join(runDirPath, "run.log") }),
   });
 
-  return await loggingContext.run(
-    {
-      artifactCounters: new Map(),
-      logger,
-      runId,
-      ...(artifactRootDirPath === undefined ? {} : { artifactRootDirPath }),
-      ...(rootLogDirPath === undefined ? {} : { rootLogDirPath }),
-    },
-    operation,
-  );
+  try {
+    return await loggingContext.run(
+      {
+        artifactCounters: new Map(),
+        logger,
+        runId,
+        ...(artifactRootDirPath === undefined ? {} : { artifactRootDirPath }),
+        ...(rootLogDirPath === undefined ? {} : { rootLogDirPath }),
+      },
+      operation,
+    );
+  } finally {
+    await logger.flush();
+  }
 }
 
-export function getLogger(bindings?: Record<string, unknown>): PinoLogger {
+export function getLogger(bindings?: Record<string, unknown>): CoreLogger {
   const logger = loggingContext.getStore()?.logger ?? silentLogger;
 
   return bindings === undefined ? logger : logger.child(bindings);
@@ -149,52 +160,91 @@ function createLogger(input: {
   readonly operation: string;
   readonly runId: string;
   readonly verbose: boolean;
-}): PinoLogger {
-  const streams: StreamEntry[] = [];
-
-  if (input.eventLogPath !== undefined) {
-    mkdirSync(dirname(input.eventLogPath), { recursive: true });
-    streams.push({
-      level: "info",
-      stream: pretty(createPrettyOptions(input.eventLogPath)),
-    });
-  }
-
-  if (input.verbose) {
-    streams.push({
-      level: "info",
-      stream: pretty(createPrettyOptions(platformProcess.stderr)),
-    });
-  }
-
-  if (streams.length === 0) {
+}): CoreLogger {
+  if (input.eventLogPath === undefined && !input.verbose) {
     return silentLogger;
   }
 
-  return pino(
-    {
-      base: null,
-      level: "info",
-    },
-    multistream(streams),
-  ).child({
-    operation: input.operation,
-    runId: input.runId,
-  });
+  return new BufferedLogger(input.eventLogPath, input.verbose);
 }
 
-function createPrettyOptions(
-  destination: string | WritableStream,
-): PrettyOptions {
-  return {
-    colorize: false,
-    destination,
-    ignore: "pid,hostname,operation,runId,component,scope,sessionId",
-    mkdir: typeof destination === "string",
-    singleLine: true,
-    sync: true,
-    translateTime: "SYS:yyyy-mm-dd HH:MM:ss",
-  };
+/**
+ * A tiny logger kept in core so logging does not pull a Node-only logger into
+ * the portable package. Hosts provide the actual append implementation via
+ * the platform adapter; writes are serialized and flushed at the end of a
+ * logging context.
+ */
+class BufferedLogger implements CoreLogger {
+  #pending: Promise<void> = Promise.resolve();
+
+  public constructor(
+    private readonly eventLogPath: string | undefined,
+    private readonly verbose: boolean,
+  ) {}
+
+  public child(_bindings: Record<string, unknown>): CoreLogger {
+    // Bindings are intentionally not rendered in the human-oriented run log.
+    return this;
+  }
+
+  public debug(...args: unknown[]): void {
+    this.#write("DEBUG", args);
+  }
+
+  public error(...args: unknown[]): void {
+    this.#write("ERROR", args);
+  }
+
+  public info(...args: unknown[]): void {
+    this.#write("INFO", args);
+  }
+
+  public warn(...args: unknown[]): void {
+    this.#write("WARN", args);
+  }
+
+  public async flush(): Promise<void> {
+    await this.#pending;
+  }
+
+  #write(level: string, args: readonly unknown[]): void {
+    const line = `${level} ${formatLogArguments(args)}\n`;
+
+    if (this.eventLogPath !== undefined) {
+      this.#pending = this.#pending.then(async () => {
+        await appendFile(this.eventLogPath!, line, "utf8");
+      });
+    }
+
+    if (this.verbose) {
+      const stderr = platformProcess.stderr;
+      if (stderr !== undefined && typeof stderr.write === "function") {
+        stderr.write(line);
+      }
+    }
+  }
+}
+
+function formatLogArguments(args: readonly unknown[]): string {
+  if (args.length === 0) {
+    return "";
+  }
+
+  return args
+    .map((value) => {
+      if (typeof value === "string") {
+        return value;
+      }
+      if (value instanceof Error) {
+        return value.stack ?? value.message;
+      }
+      try {
+        return JSON.stringify(value);
+      } catch {
+        return String(value);
+      }
+    })
+    .join(" ");
 }
 
 function createRunId(): string {

--- a/packages/core/src/runtime/common/logging.ts
+++ b/packages/core/src/runtime/common/logging.ts
@@ -2,7 +2,7 @@ import { AsyncLocalStorage } from "../platform/index.js";
 import { appendFile, randomUUID } from "../platform/index.js";
 import { existsSync, mkdirSync } from "../platform/index.js";
 import { join, resolve } from "../platform/index.js";
-import { process as platformProcess } from "../platform/index.js";
+import { runtimeContext as platformRuntime } from "../platform/index.js";
 
 interface CoreLogger {
   child(bindings: Record<string, unknown>): CoreLogger;
@@ -217,7 +217,7 @@ class BufferedLogger implements CoreLogger {
     }
 
     if (this.verbose) {
-      const stderr = platformProcess.stderr;
+      const stderr = platformRuntime.stderr;
       if (stderr !== undefined && typeof stderr.write === "function") {
         stderr.write(line);
       }

--- a/packages/core/src/runtime/common/logging.ts
+++ b/packages/core/src/runtime/common/logging.ts
@@ -1,7 +1,7 @@
-import { AsyncLocalStorage } from "async_hooks";
-import { randomUUID } from "crypto";
-import { existsSync, mkdirSync } from "fs";
-import { dirname, join, resolve } from "path";
+import { AsyncLocalStorage } from "../platform/index.js";
+import { randomUUID } from "../platform/index.js";
+import { existsSync, mkdirSync } from "../platform/index.js";
+import { dirname, join, resolve } from "../platform/index.js";
 
 import pino, {
   multistream,
@@ -83,7 +83,8 @@ export function resolveArtifactPath(input: {
   const context = loggingContext.getStore();
 
   if (
-    context?.rootLogDirPath === rootLogDirPath &&
+    context !== undefined &&
+    context.rootLogDirPath === rootLogDirPath &&
     context.artifactRootDirPath !== undefined
   ) {
     const categoryDirPath = join(context.artifactRootDirPath, input.category);

--- a/packages/core/src/runtime/common/logging.ts
+++ b/packages/core/src/runtime/common/logging.ts
@@ -1,3 +1,5 @@
+import { type WritableStream } from "../platform/index.js";
+import { process as platformProcess } from "../platform/index.js";
 import { AsyncLocalStorage } from "../platform/index.js";
 import { randomUUID } from "../platform/index.js";
 import { existsSync, mkdirSync } from "../platform/index.js";
@@ -161,7 +163,7 @@ function createLogger(input: {
   if (input.verbose) {
     streams.push({
       level: "info",
-      stream: pretty(createPrettyOptions(process.stderr)),
+      stream: pretty(createPrettyOptions(platformProcess.stderr)),
     });
   }
 
@@ -182,7 +184,7 @@ function createLogger(input: {
 }
 
 function createPrettyOptions(
-  destination: string | NodeJS.WritableStream,
+  destination: string | WritableStream,
 ): PrettyOptions {
   return {
     colorize: false,

--- a/packages/core/src/runtime/common/template.ts
+++ b/packages/core/src/runtime/common/template.ts
@@ -1,5 +1,5 @@
-import { readFileSync, statSync } from "fs";
-import { resolve, sep } from "path";
+import { readFileSync, statSync } from "../platform/index.js";
+import { resolve, sep } from "../platform/index.js";
 
 import { Environment, Loader, type LoaderSource } from "nunjucks";
 

--- a/packages/core/src/runtime/common/wiki-graph/dir.ts
+++ b/packages/core/src/runtime/common/wiki-graph/dir.ts
@@ -1,5 +1,5 @@
 import {} from "../../platform/index.js";
-import { process as platformProcess } from "../../platform/index.js";
+import { runtimeContext as platformRuntime } from "../../platform/index.js";
 import { AsyncLocalStorage } from "../../platform/index.js";
 import { homedir } from "../../platform/index.js";
 import { join, resolve } from "../../platform/index.js";
@@ -48,7 +48,7 @@ export async function withWikiGraphRuntimeStateDirectoryPath<T>(
 }
 
 /**
- * @deprecated Runtime state overrides are no longer read from platformProcess-style
+ * @deprecated Runtime state overrides are no longer read from platformRuntime-style
  * environment objects. Use `withWikiGraphRuntimeStateDirectoryPath` instead.
  */
 export async function withWikiGraphRuntimeEnvironment<T>(

--- a/packages/core/src/runtime/common/wiki-graph/dir.ts
+++ b/packages/core/src/runtime/common/wiki-graph/dir.ts
@@ -1,6 +1,6 @@
-import { AsyncLocalStorage } from "async_hooks";
-import { homedir } from "os";
-import { join, resolve } from "path";
+import { AsyncLocalStorage } from "../../platform/index.js";
+import { homedir } from "../../platform/index.js";
+import { join, resolve } from "../../platform/index.js";
 
 const testingStateDirectoryPath = new AsyncLocalStorage<{
   readonly path: string | undefined;

--- a/packages/core/src/runtime/common/wiki-graph/dir.ts
+++ b/packages/core/src/runtime/common/wiki-graph/dir.ts
@@ -1,3 +1,5 @@
+import {} from "../../platform/index.js";
+import { process as platformProcess } from "../../platform/index.js";
 import { AsyncLocalStorage } from "../../platform/index.js";
 import { homedir } from "../../platform/index.js";
 import { join, resolve } from "../../platform/index.js";
@@ -46,11 +48,11 @@ export async function withWikiGraphRuntimeStateDirectoryPath<T>(
 }
 
 /**
- * @deprecated Runtime state overrides are no longer read from process-style
+ * @deprecated Runtime state overrides are no longer read from platformProcess-style
  * environment objects. Use `withWikiGraphRuntimeStateDirectoryPath` instead.
  */
 export async function withWikiGraphRuntimeEnvironment<T>(
-  _environment: NodeJS.ProcessEnv,
+  _environment: Record<string, string | undefined>,
   operation: () => Promise<T> | T,
 ): Promise<T> {
   return await operation();

--- a/packages/core/src/runtime/common/wiki-graph/dir.ts
+++ b/packages/core/src/runtime/common/wiki-graph/dir.ts
@@ -1,7 +1,4 @@
-import {} from "../../platform/index.js";
-import { runtimeContext as platformRuntime } from "../../platform/index.js";
 import { AsyncLocalStorage } from "../../platform/index.js";
-import { homedir } from "../../platform/index.js";
 import { join, resolve } from "../../platform/index.js";
 
 const testingStateDirectoryPath = new AsyncLocalStorage<{
@@ -24,7 +21,8 @@ export function resolveWikiGraphHomeDirectoryPath(): string {
     return resolve(runtimeStateDirPath);
   }
 
-  return join(homedir(), ".wikigraph");
+  // Core owns only a logical name. The host decides which Directory backs it.
+  return ".wikigraph";
 }
 
 export function setWikiGraphStateDirectoryPathForTesting(

--- a/packages/core/src/runtime/common/wiki-graph/temp.ts
+++ b/packages/core/src/runtime/common/wiki-graph/temp.ts
@@ -1,5 +1,5 @@
-import { mkdir, mkdtemp } from "fs/promises";
-import { join } from "path";
+import { mkdir, mkdtemp } from "../../platform/index.js";
+import { join } from "../../platform/index.js";
 
 import { resolveWikiGraphTempRootDirectoryPath } from "./dir.js";
 

--- a/packages/core/src/runtime/common/wiki-graph/uri.ts
+++ b/packages/core/src/runtime/common/wiki-graph/uri.ts
@@ -1,4 +1,4 @@
-import { process as platformProcess } from "../../platform/index.js";
+import { runtimeContext as platformRuntime } from "../../platform/index.js";
 import { isAbsolute, relative, resolve } from "../../platform/index.js";
 import { homedir } from "../../platform/index.js";
 
@@ -250,7 +250,7 @@ export function formatLocatedWikiGraphUri(
 export function formatWikiGraphCommandUri(
   archivePath: string,
   objectUri?: string,
-  cwd = platformProcess.cwd(),
+  cwd = platformRuntime.cwd(),
 ): string {
   return formatLocatedWikiGraphUri(
     formatCommandArchivePath(archivePath, cwd),

--- a/packages/core/src/runtime/common/wiki-graph/uri.ts
+++ b/packages/core/src/runtime/common/wiki-graph/uri.ts
@@ -1,5 +1,5 @@
-import { isAbsolute, relative, resolve } from "path";
-import { homedir } from "os";
+import { isAbsolute, relative, resolve } from "../../platform/index.js";
+import { homedir } from "../../platform/index.js";
 
 import { RESERVED_LIBRARY_URI_SEGMENTS } from "../../../library/segments.js";
 

--- a/packages/core/src/runtime/common/wiki-graph/uri.ts
+++ b/packages/core/src/runtime/common/wiki-graph/uri.ts
@@ -1,3 +1,4 @@
+import { process as platformProcess } from "../../platform/index.js";
 import { isAbsolute, relative, resolve } from "../../platform/index.js";
 import { homedir } from "../../platform/index.js";
 
@@ -249,7 +250,7 @@ export function formatLocatedWikiGraphUri(
 export function formatWikiGraphCommandUri(
   archivePath: string,
   objectUri?: string,
-  cwd = process.cwd(),
+  cwd = platformProcess.cwd(),
 ): string {
   return formatLocatedWikiGraphUri(
     formatCommandArchivePath(archivePath, cwd),

--- a/packages/core/src/runtime/context/task.ts
+++ b/packages/core/src/runtime/context/task.ts
@@ -1,5 +1,5 @@
-import { mkdir, readFile, rm, writeFile } from "fs/promises";
-import { join, resolve } from "path";
+import { mkdir, readFile, rm, writeFile } from "../platform/index.js";
+import { join, resolve } from "../platform/index.js";
 import { z } from "zod";
 
 import { createHash } from "../../utils/hash.js";

--- a/packages/core/src/runtime/gc/files.ts
+++ b/packages/core/src/runtime/gc/files.ts
@@ -1,5 +1,5 @@
-import { readdir, rm, rmdir, stat } from "fs/promises";
-import { join } from "path";
+import { readdir, rm, rmdir, stat } from "../platform/index.js";
+import { join } from "../platform/index.js";
 
 import { isNodeError } from "../../utils/node-error.js";
 
@@ -24,7 +24,7 @@ export async function removeDisposableDirectory(
   if (entries === undefined) {
     return 0;
   }
-  if (entries.some((entry) => !isDisposableDirectoryEntry(entry))) {
+  if (entries.some((entry: any) => !isDisposableDirectoryEntry(entry))) {
     return 0;
   }
 

--- a/packages/core/src/runtime/gc/lock.ts
+++ b/packages/core/src/runtime/gc/lock.ts
@@ -1,4 +1,4 @@
-import { process as platformProcess } from "../platform/index.js";
+import { runtimeContext as platformRuntime } from "../platform/index.js";
 import { randomUUID } from "../platform/index.js";
 import { join } from "../platform/index.js";
 
@@ -32,7 +32,7 @@ export async function tryAcquireGcLock(
   scope = "global",
 ): Promise<(() => Promise<void>) | undefined> {
   const database = await openGcStateDatabase();
-  const ownerId = `${platformProcess.pid}-${randomUUID()}`;
+  const ownerId = `${platformRuntime.pid}-${randomUUID()}`;
   const now = Date.now();
   let acquired = false;
 
@@ -45,7 +45,7 @@ INSERT OR IGNORE INTO gc_locks (
   scope, owner_id, owner_pid, heartbeat_at, created_at
 ) VALUES (?, ?, ?, ?, ?)
 `,
-        [scope, ownerId, platformProcess.pid, now, now],
+        [scope, ownerId, platformRuntime.pid, now, now],
       );
       acquired =
         (await database.queryOne(
@@ -91,7 +91,7 @@ UPDATE gc_locks
 SET heartbeat_at = ?, owner_pid = ?
 WHERE scope = ? AND owner_id = ?
 `,
-      [Date.now(), platformProcess.pid, scope, ownerId],
+      [Date.now(), platformRuntime.pid, scope, ownerId],
     );
   } finally {
     await database.close();
@@ -156,7 +156,7 @@ function mapGcLockWithScope(row: SqlRow): {
 
 function isProcessAlive(pid: number): boolean {
   try {
-    platformProcess.kill(pid, 0);
+    platformRuntime.kill(pid, 0);
     return true;
   } catch (error) {
     if (isNodeError(error) && error.code === "ESRCH") {

--- a/packages/core/src/runtime/gc/lock.ts
+++ b/packages/core/src/runtime/gc/lock.ts
@@ -1,3 +1,4 @@
+import { process as platformProcess } from "../platform/index.js";
 import { randomUUID } from "../platform/index.js";
 import { join } from "../platform/index.js";
 
@@ -31,7 +32,7 @@ export async function tryAcquireGcLock(
   scope = "global",
 ): Promise<(() => Promise<void>) | undefined> {
   const database = await openGcStateDatabase();
-  const ownerId = `${process.pid}-${randomUUID()}`;
+  const ownerId = `${platformProcess.pid}-${randomUUID()}`;
   const now = Date.now();
   let acquired = false;
 
@@ -44,7 +45,7 @@ INSERT OR IGNORE INTO gc_locks (
   scope, owner_id, owner_pid, heartbeat_at, created_at
 ) VALUES (?, ?, ?, ?, ?)
 `,
-        [scope, ownerId, process.pid, now, now],
+        [scope, ownerId, platformProcess.pid, now, now],
       );
       acquired =
         (await database.queryOne(
@@ -90,7 +91,7 @@ UPDATE gc_locks
 SET heartbeat_at = ?, owner_pid = ?
 WHERE scope = ? AND owner_id = ?
 `,
-      [Date.now(), process.pid, scope, ownerId],
+      [Date.now(), platformProcess.pid, scope, ownerId],
     );
   } finally {
     await database.close();
@@ -155,7 +156,7 @@ function mapGcLockWithScope(row: SqlRow): {
 
 function isProcessAlive(pid: number): boolean {
   try {
-    process.kill(pid, 0);
+    platformProcess.kill(pid, 0);
     return true;
   } catch (error) {
     if (isNodeError(error) && error.code === "ESRCH") {

--- a/packages/core/src/runtime/gc/lock.ts
+++ b/packages/core/src/runtime/gc/lock.ts
@@ -1,5 +1,5 @@
-import { randomUUID } from "crypto";
-import { join } from "path";
+import { randomUUID } from "../platform/index.js";
+import { join } from "../platform/index.js";
 
 import { resolveWikiGraphStateRootPath } from "../common/wiki-graph/temp.js";
 import { getNumber, getString, type SqlRow } from "../../document/database.js";

--- a/packages/core/src/runtime/gc/runner.ts
+++ b/packages/core/src/runtime/gc/runner.ts
@@ -1,5 +1,5 @@
-import { mkdir, readFile, writeFile } from "fs/promises";
-import { join } from "path";
+import { mkdir, readFile, writeFile } from "../platform/index.js";
+import { join } from "../platform/index.js";
 
 import { resolveWikiGraphStateRootPath } from "../common/wiki-graph/temp.js";
 import { runSearchCacheGc } from "../../retrieval/query/index.js";

--- a/packages/core/src/runtime/gc/temp.ts
+++ b/packages/core/src/runtime/gc/temp.ts
@@ -1,5 +1,5 @@
-import { readdir, rm, stat } from "fs/promises";
-import { join } from "path";
+import { readdir, rm, stat } from "../platform/index.js";
+import { join } from "../platform/index.js";
 
 import { resolveWikiGraphTempDirectoryPath } from "../common/wiki-graph/temp.js";
 import { isNodeError } from "../../utils/node-error.js";

--- a/packages/core/src/runtime/jobs/conflicts.ts
+++ b/packages/core/src/runtime/jobs/conflicts.ts
@@ -1,4 +1,4 @@
-import { resolve } from "path";
+import { resolve } from "../platform/index.js";
 import { createArchiveKey } from "./helpers.js";
 import { openBuildQueueDatabase } from "./database.js";
 import { recoverStaleBuildJobs } from "./recovery.js";

--- a/packages/core/src/runtime/jobs/events.ts
+++ b/packages/core/src/runtime/jobs/events.ts
@@ -1,4 +1,4 @@
-import { appendFile, readFile } from "fs/promises";
+import { appendFile, readFile } from "../platform/index.js";
 import type { BuildJob, BuildJobEvent } from "./types.js";
 
 export async function readBuildJobEvents(

--- a/packages/core/src/runtime/jobs/gc.ts
+++ b/packages/core/src/runtime/jobs/gc.ts
@@ -1,4 +1,4 @@
-import { rm } from "fs/promises";
+import { rm } from "../platform/index.js";
 import { readPathSize, removeDisposableChildDirectories } from "../gc/files.js";
 import type { GcContext, GcJobResult } from "../gc/index.js";
 import { getBuildJobWorkspaceRootPath } from "./paths.js";

--- a/packages/core/src/runtime/jobs/helpers.ts
+++ b/packages/core/src/runtime/jobs/helpers.ts
@@ -1,3 +1,4 @@
+import { process as platformProcess } from "../platform/index.js";
 import { createHash } from "../platform/index.js";
 import { resolve } from "../platform/index.js";
 
@@ -7,7 +8,7 @@ export function createArchiveKey(archivePath: string): string {
 
 export function isProcessAlive(pid: number): boolean {
   try {
-    process.kill(pid, 0);
+    platformProcess.kill(pid, 0);
     return true;
   } catch {
     return false;

--- a/packages/core/src/runtime/jobs/helpers.ts
+++ b/packages/core/src/runtime/jobs/helpers.ts
@@ -1,5 +1,5 @@
-import { createHash } from "crypto";
-import { resolve } from "path";
+import { createHash } from "../platform/index.js";
+import { resolve } from "../platform/index.js";
 
 export function createArchiveKey(archivePath: string): string {
   return createHash("sha256").update(resolve(archivePath)).digest("hex");

--- a/packages/core/src/runtime/jobs/helpers.ts
+++ b/packages/core/src/runtime/jobs/helpers.ts
@@ -1,4 +1,4 @@
-import { process as platformProcess } from "../platform/index.js";
+import { runtimeContext as platformRuntime } from "../platform/index.js";
 import { createHash } from "../platform/index.js";
 import { resolve } from "../platform/index.js";
 
@@ -8,7 +8,7 @@ export function createArchiveKey(archivePath: string): string {
 
 export function isProcessAlive(pid: number): boolean {
   try {
-    platformProcess.kill(pid, 0);
+    platformRuntime.kill(pid, 0);
     return true;
   } catch {
     return false;

--- a/packages/core/src/runtime/jobs/jobs.ts
+++ b/packages/core/src/runtime/jobs/jobs.ts
@@ -1,5 +1,5 @@
-import { randomUUID } from "crypto";
-import { resolve } from "path";
+import { randomUUID } from "../platform/index.js";
+import { resolve } from "../platform/index.js";
 import type { Database } from "../../document/index.js";
 import {
   createJobCachePath,

--- a/packages/core/src/runtime/jobs/paths.ts
+++ b/packages/core/src/runtime/jobs/paths.ts
@@ -1,5 +1,5 @@
-import { mkdir } from "fs/promises";
-import { join } from "path";
+import { mkdir } from "../platform/index.js";
+import { join } from "../platform/index.js";
 
 import { resolveWikiGraphJobsDirectoryPath } from "../common/wiki-graph/dir.js";
 

--- a/packages/core/src/runtime/jobs/recovery.ts
+++ b/packages/core/src/runtime/jobs/recovery.ts
@@ -1,4 +1,3 @@
-import { runtimeContext as platformRuntime } from "../platform/index.js";
 import { rm } from "../platform/index.js";
 import type { Database } from "../../document/index.js";
 import { isProcessAlive } from "./helpers.js";

--- a/packages/core/src/runtime/jobs/recovery.ts
+++ b/packages/core/src/runtime/jobs/recovery.ts
@@ -1,4 +1,4 @@
-import { rm } from "fs/promises";
+import { rm } from "../platform/index.js";
 import type { Database } from "../../document/index.js";
 import { isProcessAlive } from "./helpers.js";
 import { mapBuildJob } from "./row.js";

--- a/packages/core/src/runtime/jobs/recovery.ts
+++ b/packages/core/src/runtime/jobs/recovery.ts
@@ -1,3 +1,4 @@
+import { process as platformProcess } from "../platform/index.js";
 import { rm } from "../platform/index.js";
 import type { Database } from "../../document/index.js";
 import { isProcessAlive } from "./helpers.js";
@@ -30,7 +31,8 @@ WHERE state IN ('running', 'canceling')
       }
 
       await markBuildJobFailedInState(state, job, {
-        message: "Build worker process disappeared before finishing the job.",
+        message:
+          "Build worker platformProcess disappeared before finishing the job.",
         name: "BuildJobWorkerLost",
       });
       workspacePathsToDelete.push(job.workspacePath);

--- a/packages/core/src/runtime/jobs/recovery.ts
+++ b/packages/core/src/runtime/jobs/recovery.ts
@@ -1,4 +1,4 @@
-import { process as platformProcess } from "../platform/index.js";
+import { runtimeContext as platformRuntime } from "../platform/index.js";
 import { rm } from "../platform/index.js";
 import type { Database } from "../../document/index.js";
 import { isProcessAlive } from "./helpers.js";
@@ -32,7 +32,7 @@ WHERE state IN ('running', 'canceling')
 
       await markBuildJobFailedInState(state, job, {
         message:
-          "Build worker platformProcess disappeared before finishing the job.",
+          "Build worker platformRuntime disappeared before finishing the job.",
         name: "BuildJobWorkerLost",
       });
       workspacePathsToDelete.push(job.workspacePath);

--- a/packages/core/src/runtime/jobs/state.ts
+++ b/packages/core/src/runtime/jobs/state.ts
@@ -1,4 +1,4 @@
-import { rm } from "fs/promises";
+import { rm } from "../platform/index.js";
 import type { Database } from "../../document/index.js";
 import { formatErrorEvent } from "./helpers.js";
 import { appendBuildJobEvent } from "./events.js";

--- a/packages/core/src/runtime/jobs/worker.ts
+++ b/packages/core/src/runtime/jobs/worker.ts
@@ -1,5 +1,5 @@
 import {} from "../platform/index.js";
-import { process as platformProcess } from "../platform/index.js";
+import { runtimeContext as platformRuntime } from "../platform/index.js";
 import { randomUUID } from "../platform/index.js";
 import type { Database } from "../../document/index.js";
 import { delay, isProcessAlive } from "./helpers.js";
@@ -26,7 +26,7 @@ export async function runBuildJobWorker(
   options: BuildJobWorkerOptions,
 ): Promise<void> {
   const state = await openBuildQueueDatabase();
-  const ownerId = `${platformProcess.pid}-${randomUUID()}`;
+  const ownerId = `${platformRuntime.pid}-${randomUUID()}`;
   const concurrency = Math.max(1, options.concurrency);
   const idleTimeoutMs = options.idleTimeoutMs ?? 10_000;
   let stopping = false;
@@ -37,8 +37,8 @@ export async function runBuildJobWorker(
     stopping = true;
   };
 
-  platformProcess.once("SIGINT", stop);
-  platformProcess.once("SIGTERM", stop);
+  platformRuntime.once("SIGINT", stop);
+  platformRuntime.once("SIGTERM", stop);
 
   const heartbeat = setInterval(() => {
     void heartbeatBuildWorker(ownerId).catch(() => undefined);
@@ -93,8 +93,8 @@ export async function runBuildJobWorker(
     );
   } finally {
     clearInterval(heartbeat);
-    platformProcess.removeListener("SIGINT", stop);
-    platformProcess.removeListener("SIGTERM", stop);
+    platformRuntime.removeListener("SIGINT", stop);
+    platformRuntime.removeListener("SIGTERM", stop);
     await releaseBuildWorkerLease(state, ownerId);
     await state.close();
   }
@@ -195,7 +195,7 @@ UPDATE build_jobs
 SET state = 'running', owner_id = ?, owner_pid = ?, updated_at = ?
 WHERE job_id = ? AND state = 'queued'
 `,
-      [ownerId, platformProcess.pid, now, job.jobId],
+      [ownerId, platformRuntime.pid, now, job.jobId],
     );
 
     return await requireBuildJobById(state, job.jobId);
@@ -232,7 +232,7 @@ UPDATE build_worker_lease
 SET owner_id = ?, owner_pid = ?, heartbeat_at = ?
 WHERE id = 1
 `,
-      [ownerId, platformProcess.pid, Date.now()],
+      [ownerId, platformRuntime.pid, Date.now()],
     );
     return true;
   });

--- a/packages/core/src/runtime/jobs/worker.ts
+++ b/packages/core/src/runtime/jobs/worker.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "crypto";
+import { randomUUID } from "../platform/index.js";
 import type { Database } from "../../document/index.js";
 import { delay, isProcessAlive } from "./helpers.js";
 import {

--- a/packages/core/src/runtime/jobs/worker.ts
+++ b/packages/core/src/runtime/jobs/worker.ts
@@ -1,3 +1,5 @@
+import {} from "../platform/index.js";
+import { process as platformProcess } from "../platform/index.js";
 import { randomUUID } from "../platform/index.js";
 import type { Database } from "../../document/index.js";
 import { delay, isProcessAlive } from "./helpers.js";
@@ -24,19 +26,19 @@ export async function runBuildJobWorker(
   options: BuildJobWorkerOptions,
 ): Promise<void> {
   const state = await openBuildQueueDatabase();
-  const ownerId = `${process.pid}-${randomUUID()}`;
+  const ownerId = `${platformProcess.pid}-${randomUUID()}`;
   const concurrency = Math.max(1, options.concurrency);
   const idleTimeoutMs = options.idleTimeoutMs ?? 10_000;
   let stopping = false;
   let busySlotCount = 0;
   let idleSince = Date.now();
 
-  const stop = (_signal: NodeJS.Signals): void => {
+  const stop = (_signal: string): void => {
     stopping = true;
   };
 
-  process.once("SIGINT", stop);
-  process.once("SIGTERM", stop);
+  platformProcess.once("SIGINT", stop);
+  platformProcess.once("SIGTERM", stop);
 
   const heartbeat = setInterval(() => {
     void heartbeatBuildWorker(ownerId).catch(() => undefined);
@@ -91,8 +93,8 @@ export async function runBuildJobWorker(
     );
   } finally {
     clearInterval(heartbeat);
-    process.removeListener("SIGINT", stop);
-    process.removeListener("SIGTERM", stop);
+    platformProcess.removeListener("SIGINT", stop);
+    platformProcess.removeListener("SIGTERM", stop);
     await releaseBuildWorkerLease(state, ownerId);
     await state.close();
   }
@@ -193,7 +195,7 @@ UPDATE build_jobs
 SET state = 'running', owner_id = ?, owner_pid = ?, updated_at = ?
 WHERE job_id = ? AND state = 'queued'
 `,
-      [ownerId, process.pid, now, job.jobId],
+      [ownerId, platformProcess.pid, now, job.jobId],
     );
 
     return await requireBuildJobById(state, job.jobId);
@@ -230,7 +232,7 @@ UPDATE build_worker_lease
 SET owner_id = ?, owner_pid = ?, heartbeat_at = ?
 WHERE id = 1
 `,
-      [ownerId, process.pid, Date.now()],
+      [ownerId, platformProcess.pid, Date.now()],
     );
     return true;
   });

--- a/packages/core/src/runtime/platform/index.ts
+++ b/packages/core/src/runtime/platform/index.ts
@@ -8,28 +8,17 @@
 
 export type PlatformModule = Record<string, any>;
 
-export interface PlatformZipModule {
-  readonly yauzl?: PlatformModule;
-  readonly yazl?: PlatformModule;
+export interface PlatformArchiveModule {
+  readonly reader?: PlatformModule;
+  readonly writer?: PlatformModule;
 }
 
+/**
+ * Opaque host capability bag. Core only relies on capability names internally;
+ * hosts are free to provide browser, extension, or Node implementations.
+ */
 export interface WikiGraphPlatform {
-  readonly fs: PlatformModule;
-  readonly childProcess: PlatformModule;
-  readonly process: PlatformModule;
-  readonly buffer: PlatformModule;
-  readonly fsPromises: PlatformModule;
-  readonly path: PlatformModule;
-  readonly os: PlatformModule;
-  readonly crypto: PlatformModule;
-  readonly streams: PlatformModule;
-  readonly streamPromises: PlatformModule;
-  readonly timers: PlatformModule;
-  readonly asyncHooks: PlatformModule;
-  readonly zlib: PlatformModule;
-  readonly url: PlatformModule;
-  readonly sqlite3?: PlatformModule;
-  readonly zip?: PlatformZipModule;
+  readonly [capability: string]: unknown;
 }
 
 /** A host-owned file. Core never interprets its backing URI or path. */
@@ -134,132 +123,129 @@ export function getPlatformDirectoryPath(directory: Directory): string {
   return location;
 }
 
-function moduleValue<T = any>(
-  moduleName: keyof WikiGraphPlatform,
-  key: string,
-): T {
+function moduleValue<T = any>(moduleName: string, key: string): T {
   return (getWikiGraphPlatform()[moduleName] as PlatformModule)[key] as T;
 }
 
 export const access = (...args: any[]): any =>
-  moduleValue("fsPromises", "access")(...args);
+  moduleValue("fileSystemPromises", "access")(...args);
 export const spawn = (...args: any[]): any =>
-  moduleValue("childProcess", "spawn")(...args);
+  moduleValue("subprocess", "spawn")(...args);
 export const process = new Proxy({} as Record<string, any>, {
   get(_target, property: string): unknown {
-    return moduleValue("process", property);
+    return moduleValue("runtime", property);
   },
 });
 export const appendFile = (...args: any[]): any =>
-  moduleValue("fsPromises", "appendFile")(...args);
+  moduleValue("fileSystemPromises", "appendFile")(...args);
 export const chmod = (...args: any[]): any =>
-  moduleValue("fsPromises", "chmod")(...args);
+  moduleValue("fileSystemPromises", "chmod")(...args);
 export const copyFile = (...args: any[]): any =>
-  moduleValue("fsPromises", "copyFile")(...args);
+  moduleValue("fileSystemPromises", "copyFile")(...args);
 export const mkdir = (...args: any[]): any =>
-  moduleValue("fsPromises", "mkdir")(...args);
+  moduleValue("fileSystemPromises", "mkdir")(...args);
 export const mkdtemp = (...args: any[]): any =>
-  moduleValue("fsPromises", "mkdtemp")(...args);
+  moduleValue("fileSystemPromises", "mkdtemp")(...args);
 export const open = (...args: any[]): any =>
-  moduleValue("fsPromises", "open")(...args);
+  moduleValue("fileSystemPromises", "open")(...args);
 export const opendir = (...args: any[]): any =>
-  moduleValue("fsPromises", "opendir")(...args);
+  moduleValue("fileSystemPromises", "opendir")(...args);
 export const readFile = (...args: any[]): any =>
-  moduleValue("fsPromises", "readFile")(...args);
+  moduleValue("fileSystemPromises", "readFile")(...args);
 export const readdir = (...args: any[]): any =>
-  moduleValue("fsPromises", "readdir")(...args);
+  moduleValue("fileSystemPromises", "readdir")(...args);
 export const realpath = (...args: any[]): any =>
-  moduleValue("fsPromises", "realpath")(...args);
+  moduleValue("fileSystemPromises", "realpath")(...args);
 export const rename = (...args: any[]): any =>
-  moduleValue("fsPromises", "rename")(...args);
+  moduleValue("fileSystemPromises", "rename")(...args);
 export const rm = (...args: any[]): any =>
-  moduleValue("fsPromises", "rm")(...args);
+  moduleValue("fileSystemPromises", "rm")(...args);
 export const rmdir = (...args: any[]): any =>
-  moduleValue("fsPromises", "rmdir")(...args);
+  moduleValue("fileSystemPromises", "rmdir")(...args);
 export const stat = (...args: any[]): any =>
-  moduleValue("fsPromises", "stat")(...args);
+  moduleValue("fileSystemPromises", "stat")(...args);
 export const unlink = (...args: any[]): any =>
-  moduleValue("fsPromises", "unlink")(...args);
+  moduleValue("fileSystemPromises", "unlink")(...args);
 export const writeFile = (...args: any[]): any =>
-  moduleValue("fsPromises", "writeFile")(...args);
+  moduleValue("fileSystemPromises", "writeFile")(...args);
 
 export const constants = new Proxy({} as Record<string, number>, {
   get(_target, property: string): unknown {
-    return moduleValue("fs", "constants")[property];
+    return moduleValue("fileSystem", "constants")[property];
   },
 });
 export const createReadStream = (...args: any[]): any =>
-  moduleValue("fs", "createReadStream")(...args);
+  moduleValue("fileSystem", "createReadStream")(...args);
 export const createWriteStream = (...args: any[]): any =>
-  moduleValue("fs", "createWriteStream")(...args);
+  moduleValue("fileSystem", "createWriteStream")(...args);
 export const existsSync = (...args: any[]): any =>
-  moduleValue("fs", "existsSync")(...args);
+  moduleValue("fileSystem", "existsSync")(...args);
 export const mkdirSync = (...args: any[]): any =>
-  moduleValue("fs", "mkdirSync")(...args);
+  moduleValue("fileSystem", "mkdirSync")(...args);
 export const readFileSync = (...args: any[]): any =>
-  moduleValue("fs", "readFileSync")(...args);
+  moduleValue("fileSystem", "readFileSync")(...args);
 export const statSync = (...args: any[]): any =>
-  moduleValue("fs", "statSync")(...args);
+  moduleValue("fileSystem", "statSync")(...args);
 
 export const basename = (...args: any[]): any =>
-  moduleValue("path", "basename")(...args);
+  moduleValue("pathTools", "basename")(...args);
 export const dirname = (...args: any[]): any =>
-  moduleValue("path", "dirname")(...args);
+  moduleValue("pathTools", "dirname")(...args);
 export const extname = (...args: any[]): any =>
-  moduleValue("path", "extname")(...args);
+  moduleValue("pathTools", "extname")(...args);
 export const isAbsolute = (...args: any[]): any =>
-  moduleValue("path", "isAbsolute")(...args);
+  moduleValue("pathTools", "isAbsolute")(...args);
 export const join = (...args: any[]): any =>
-  moduleValue("path", "join")(...args);
+  moduleValue("pathTools", "join")(...args);
 export const parse = (...args: any[]): any =>
-  moduleValue("path", "parse")(...args);
+  moduleValue("pathTools", "parse")(...args);
 export const relative = (...args: any[]): any =>
-  moduleValue("path", "relative")(...args);
+  moduleValue("pathTools", "relative")(...args);
 export const resolve = (...args: any[]): any =>
-  moduleValue("path", "resolve")(...args);
+  moduleValue("pathTools", "resolve")(...args);
 // Archive paths are normalized to POSIX separators by Core. Host path helpers
 // still come from the injected provider; this constant is only used for
 // comparisons and remains portable across browser and Node hosts.
 export const sep = "/";
 export const posix = new Proxy({} as Record<string, any>, {
   get(_target, property: string): unknown {
-    return moduleValue("path", "posix")[property];
+    return moduleValue("pathTools", "posix")[property];
   },
 }) as any;
 
 export const homedir = (...args: any[]): any =>
-  moduleValue("os", "homedir")(...args);
+  moduleValue("system", "homedir")(...args);
 export const tmpdir = (...args: any[]): any =>
-  moduleValue("os", "tmpdir")(...args);
+  moduleValue("system", "tmpdir")(...args);
 
 export const createHash = (...args: any[]): any =>
-  moduleValue("crypto", "createHash")(...args);
+  moduleValue("cryptography", "createHash")(...args);
 export const randomBytes = (...args: any[]): any =>
-  moduleValue("crypto", "randomBytes")(...args);
+  moduleValue("cryptography", "randomBytes")(...args);
 export const randomUUID = (...args: any[]): any =>
-  moduleValue("crypto", "randomUUID")(...args);
+  moduleValue("cryptography", "randomUUID")(...args);
 export const Buffer = new Proxy(function () {}, {
   construct(_target, args): object {
-    const Constructor = moduleValue("buffer", "Buffer");
+    const Constructor = moduleValue("binary", "Buffer");
     return Reflect.construct(Constructor, args);
   },
   get(_target, property: string): unknown {
-    return moduleValue("buffer", "Buffer")[property];
+    return moduleValue("binary", "Buffer")[property];
   },
 }) as any;
 export const inflateRaw = (...args: any[]): any =>
-  moduleValue("zlib", "inflateRaw")(...args);
+  moduleValue("compression", "inflateRaw")(...args);
 export const fileURLToPath = (...args: any[]): any =>
-  moduleValue("url", "fileURLToPath")(...args);
+  moduleValue("urlTools", "fileURLToPath")(...args);
 
 export const PassThrough = new Proxy(function () {}, {
   construct(_target, args): object {
-    return Reflect.construct(moduleValue("streams", "PassThrough"), args);
+    return Reflect.construct(moduleValue("stream", "PassThrough"), args);
   },
 }) as any;
 export const Writable = new Proxy(function () {}, {
   construct(_target, args): object {
-    return Reflect.construct(moduleValue("streams", "Writable"), args);
+    return Reflect.construct(moduleValue("stream", "Writable"), args);
   },
 }) as any;
 export const finished = (...args: any[]): any =>
@@ -276,7 +262,7 @@ export class AsyncLocalStorage<T> {
 
   public constructor() {
     try {
-      const Constructor = moduleValue("asyncHooks", "AsyncLocalStorage");
+      const Constructor = moduleValue("asyncContext", "AsyncLocalStorage");
       this.#impl = new Constructor();
     } catch {
       // Importing the neutral core must not require a host runtime to have
@@ -318,7 +304,9 @@ export class AsyncLocalStorage<T> {
 export const finishedStream = finished;
 
 export const openZip = (...args: any[]): any => {
-  const open = getWikiGraphPlatform().zip?.yauzl?.open;
+  const open = (
+    getWikiGraphPlatform().archive as PlatformArchiveModule | undefined
+  )?.reader?.open;
   if (typeof open !== "function") {
     throw new Error("No ZIP reader has been installed.");
   }
@@ -326,7 +314,9 @@ export const openZip = (...args: any[]): any => {
 };
 export const ZipFile = new Proxy(function () {}, {
   construct(_target, args): object {
-    const Constructor = getWikiGraphPlatform().zip?.yazl?.ZipFile;
+    const Constructor = (
+      getWikiGraphPlatform().archive as PlatformArchiveModule | undefined
+    )?.writer?.ZipFile;
     if (Constructor === undefined) {
       throw new Error("No ZIP writer has been installed.");
     }
@@ -345,7 +335,7 @@ export type Writable = any;
 export type WritableStream = any;
 
 export function getSqlite3Module(): PlatformModule {
-  const module = getWikiGraphPlatform().sqlite3;
+  const module = getWikiGraphPlatform().database as PlatformModule | undefined;
   if (module === undefined) {
     throw new Error("No SQLite runtime has been installed.");
   }

--- a/packages/core/src/runtime/platform/index.ts
+++ b/packages/core/src/runtime/platform/index.ts
@@ -8,11 +8,6 @@
 
 export type PlatformModule = Record<string, any>;
 
-export interface PlatformArchiveModule {
-  readonly reader?: PlatformModule;
-  readonly writer?: PlatformModule;
-}
-
 /**
  * Opaque host capability bag. Core only relies on capability names internally;
  * hosts are free to provide browser, extension, or Node implementations.
@@ -56,27 +51,15 @@ export interface WikiGraphStorage {
   readonly documentStore: Directory;
 }
 
-export interface NodeError extends Error {
+export interface HostError extends Error {
   readonly code?: string;
   readonly errno?: number;
   readonly path?: string;
 }
+export type NodeError = HostError;
 
 let installedPlatform: WikiGraphPlatform | undefined;
 let installedStorage: WikiGraphStorage | undefined;
-const fileLocations = new WeakMap<object, string>();
-const directoryLocations = new WeakMap<object, string>();
-
-export function registerFileLocation(file: File, location: string): void {
-  fileLocations.set(file, location);
-}
-
-export function registerDirectoryLocation(
-  directory: Directory,
-  location: string,
-): void {
-  directoryLocations.set(directory, location);
-}
 
 export function installWikiGraphPlatform(platform: WikiGraphPlatform): void {
   installedPlatform = platform;
@@ -105,157 +88,146 @@ export function getWikiGraphStorage(): WikiGraphStorage {
   return installedStorage;
 }
 
-export function getHostFileHandle(file: File): string {
-  const location = fileLocations.get(file);
-  if (location === undefined) {
-    throw new Error("The supplied File is not bound to this host runtime.");
-  }
-  return location;
-}
-
-export function getHostDirectoryHandle(directory: Directory): string {
-  const location = directoryLocations.get(directory);
-  if (location === undefined) {
-    throw new Error(
-      "The supplied Directory is not bound to this host runtime.",
-    );
-  }
-  return location;
-}
-
-function moduleValue<T = any>(moduleName: string, key: string): T {
-  return (getWikiGraphPlatform()[moduleName] as PlatformModule)[key] as T;
+function capability<T = any>(name: string): T {
+  return getWikiGraphPlatform()[name] as T;
 }
 
 export const access = (...args: any[]): any =>
-  moduleValue("fileSystemPromises", "access")(...args);
+  capability("access")(...args);
 export const spawn = (...args: any[]): any =>
-  moduleValue("subprocess", "spawn")(...args);
-export const process = new Proxy({} as Record<string, any>, {
-  get(_target, property: string): unknown {
-    return moduleValue("runtime", property);
-  },
-});
+  capability("spawn")(...args);
+export const runtimeContext: Record<string, any> = {
+  get pid() { return capability("runtime_pid"); },
+  get stderr() { return capability("runtime_stderr"); },
+  get argv() { return capability("runtime_argv"); },
+  get env() { return capability("runtime_env"); },
+  get cwd() { return capability("runtime_cwd"); },
+  kill: (...args: any[]) => capability("runtime_kill")(...args),
+  once: (...args: any[]) => capability("runtime_once")(...args),
+  removeListener: (...args: any[]) => capability("runtime_removeListener")(...args),
+};
 export const appendFile = (...args: any[]): any =>
-  moduleValue("fileSystemPromises", "appendFile")(...args);
+  capability("appendFile")(...args);
 export const chmod = (...args: any[]): any =>
-  moduleValue("fileSystemPromises", "chmod")(...args);
+  capability("chmod")(...args);
 export const copyFile = (...args: any[]): any =>
-  moduleValue("fileSystemPromises", "copyFile")(...args);
+  capability("copyFile")(...args);
 export const mkdir = (...args: any[]): any =>
-  moduleValue("fileSystemPromises", "mkdir")(...args);
+  capability("mkdir")(...args);
 export const mkdtemp = (...args: any[]): any =>
-  moduleValue("fileSystemPromises", "mkdtemp")(...args);
+  capability("mkdtemp")(...args);
 export const open = (...args: any[]): any =>
-  moduleValue("fileSystemPromises", "open")(...args);
+  capability("open")(...args);
 export const opendir = (...args: any[]): any =>
-  moduleValue("fileSystemPromises", "opendir")(...args);
+  capability("opendir")(...args);
 export const readFile = (...args: any[]): any =>
-  moduleValue("fileSystemPromises", "readFile")(...args);
+  capability("readFile")(...args);
 export const readdir = (...args: any[]): any =>
-  moduleValue("fileSystemPromises", "readdir")(...args);
+  capability("readdir")(...args);
 export const realpath = (...args: any[]): any =>
-  moduleValue("fileSystemPromises", "realpath")(...args);
+  capability("realpath")(...args);
 export const rename = (...args: any[]): any =>
-  moduleValue("fileSystemPromises", "rename")(...args);
+  capability("rename")(...args);
 export const rm = (...args: any[]): any =>
-  moduleValue("fileSystemPromises", "rm")(...args);
+  capability("rm")(...args);
 export const rmdir = (...args: any[]): any =>
-  moduleValue("fileSystemPromises", "rmdir")(...args);
+  capability("rmdir")(...args);
 export const stat = (...args: any[]): any =>
-  moduleValue("fileSystemPromises", "stat")(...args);
+  capability("stat")(...args);
 export const unlink = (...args: any[]): any =>
-  moduleValue("fileSystemPromises", "unlink")(...args);
+  capability("unlink")(...args);
 export const writeFile = (...args: any[]): any =>
-  moduleValue("fileSystemPromises", "writeFile")(...args);
+  capability("writeFile")(...args);
 export const openDatabase = (...args: any[]): any =>
-  moduleValue("database", "open")(...args);
+  capability("database_open")(...args);
 
-export const constants = new Proxy({} as Record<string, number>, {
-  get(_target, property: string): unknown {
-    return moduleValue("fileSystem", "constants")[property];
-  },
-});
+export const constants: Record<string, number> = {
+  get O_RDONLY() { return capability("sync_constants").O_RDONLY; },
+  get O_WRONLY() { return capability("sync_constants").O_WRONLY; },
+  get O_CREAT() { return capability("sync_constants").O_CREAT; },
+};
 export const createReadStream = (...args: any[]): any =>
-  moduleValue("fileSystem", "createReadStream")(...args);
+  capability("sync_createReadStream")(...args);
 export const createWriteStream = (...args: any[]): any =>
-  moduleValue("fileSystem", "createWriteStream")(...args);
+  capability("sync_createWriteStream")(...args);
 export const existsSync = (...args: any[]): any =>
-  moduleValue("fileSystem", "existsSync")(...args);
+  capability("sync_existsSync")(...args);
 export const mkdirSync = (...args: any[]): any =>
-  moduleValue("fileSystem", "mkdirSync")(...args);
+  capability("sync_mkdirSync")(...args);
 export const readFileSync = (...args: any[]): any =>
-  moduleValue("fileSystem", "readFileSync")(...args);
+  capability("sync_readFileSync")(...args);
 export const statSync = (...args: any[]): any =>
-  moduleValue("fileSystem", "statSync")(...args);
+  capability("sync_statSync")(...args);
 
 export const basename = (...args: any[]): any =>
-  moduleValue("pathTools", "basename")(...args);
+  capability("path_basename")(...args);
 export const dirname = (...args: any[]): any =>
-  moduleValue("pathTools", "dirname")(...args);
+  capability("path_dirname")(...args);
 export const extname = (...args: any[]): any =>
-  moduleValue("pathTools", "extname")(...args);
+  capability("path_extname")(...args);
 export const isAbsolute = (...args: any[]): any =>
-  moduleValue("pathTools", "isAbsolute")(...args);
+  capability("path_isAbsolute")(...args);
 export const join = (...args: any[]): any =>
-  moduleValue("pathTools", "join")(...args);
+  capability("path_join")(...args);
 export const parse = (...args: any[]): any =>
-  moduleValue("pathTools", "parse")(...args);
+  capability("path_parse")(...args);
 export const relative = (...args: any[]): any =>
-  moduleValue("pathTools", "relative")(...args);
+  capability("path_relative")(...args);
 export const resolve = (...args: any[]): any =>
-  moduleValue("pathTools", "resolve")(...args);
+  capability("path_resolve")(...args);
 // Archive paths are normalized to POSIX separators by Core. Host path helpers
 // still come from the injected provider; this constant is only used for
 // comparisons and remains portable across browser and Node hosts.
 export const sep = "/";
-export const posix = new Proxy({} as Record<string, any>, {
-  get(_target, property: string): unknown {
-    return moduleValue("pathTools", "posix")[property];
-  },
-}) as any;
+export const posix: Record<string, any> = {
+  sep: "/",
+  normalize: (...args: any[]) => capability("path_posix").normalize(...args),
+  join: (...args: any[]) => capability("path_posix").join(...args),
+  relative: (...args: any[]) => capability("path_posix").relative(...args),
+  dirname: (...args: any[]) => capability("path_posix").dirname(...args),
+  basename: (...args: any[]) => capability("path_posix").basename(...args),
+  extname: (...args: any[]) => capability("path_posix").extname(...args),
+};
 
 export const homedir = (...args: any[]): any =>
-  moduleValue("system", "homedir")(...args);
+  capability("system_homedir")(...args);
 export const tmpdir = (...args: any[]): any =>
-  moduleValue("system", "tmpdir")(...args);
+  capability("system_tmpdir")(...args);
 
 export const createHash = (...args: any[]): any =>
-  moduleValue("cryptography", "createHash")(...args);
+  capability("crypto_createHash")(...args);
 export const randomBytes = (...args: any[]): any =>
-  moduleValue("cryptography", "randomBytes")(...args);
+  capability("crypto_randomBytes")(...args);
 export const randomUUID = (...args: any[]): any =>
-  moduleValue("cryptography", "randomUUID")(...args);
-export const Buffer = new Proxy(function () {}, {
-  construct(_target, args): object {
-    const Constructor = moduleValue("binary", "Buffer");
-    return Reflect.construct(Constructor, args);
-  },
-  get(_target, property: string): unknown {
-    return moduleValue("binary", "Buffer")[property];
-  },
-}) as any;
+  capability("crypto_randomUUID")(...args);
+export const binary: Record<string, any> = {
+  from: (...args: any[]) => capability("binary").from(...args),
+  alloc: (...args: any[]) => capability("binary").alloc(...args),
+  concat: (...args: any[]) => capability("binary").concat(...args),
+  byteLength: (...args: any[]) => capability("binary").byteLength(...args),
+  isBuffer: (...args: any[]) => capability("binary").isBuffer(...args),
+};
 export const inflateRaw = (...args: any[]): any =>
-  moduleValue("compression", "inflateRaw")(...args);
+  capability("inflateRaw")(...args);
 export const fileURLToPath = (...args: any[]): any =>
-  moduleValue("urlTools", "fileURLToPath")(...args);
+  capability("fileURLToPath")(...args);
 
-export const PassThrough = new Proxy(function () {}, {
-  construct(_target, args): object {
-    return Reflect.construct(moduleValue("stream", "PassThrough"), args);
-  },
-}) as any;
-export const Writable = new Proxy(function () {}, {
-  construct(_target, args): object {
-    return Reflect.construct(moduleValue("stream", "Writable"), args);
-  },
-}) as any;
+export const PassThrough: any = function (this: any, ...args: any[]) {
+  const delegate = new (capability("stream_PassThrough"))(...args);
+  Object.setPrototypeOf(this, Object.getPrototypeOf(delegate));
+  Object.assign(this, delegate);
+};
+export const Writable: any = function (this: any, ...args: any[]) {
+  const delegate = new (capability("stream_Writable"))(...args);
+  Object.setPrototypeOf(this, Object.getPrototypeOf(delegate));
+  Object.assign(this, delegate);
+};
 export const finished = (...args: any[]): any =>
-  moduleValue("streamPromises", "finished")(...args);
+  capability("finished")(...args);
 export const pipeline = (...args: any[]): any =>
-  moduleValue("streamPromises", "pipeline")(...args);
+  capability("pipeline")(...args);
 export const sleep = (...args: any[]): any =>
-  moduleValue("timers", "setTimeout")(...args);
+  capability("setTimeout")(...args);
 export const setTimeout = sleep;
 
 export class AsyncLocalStorage<T> {
@@ -264,7 +236,7 @@ export class AsyncLocalStorage<T> {
 
   public constructor() {
     try {
-      const Constructor = moduleValue("asyncContext", "AsyncLocalStorage");
+      const Constructor = capability("asyncLocalStorage");
       this.#impl = new Constructor();
     } catch {
       // Importing the neutral core must not require a host runtime to have
@@ -306,40 +278,34 @@ export class AsyncLocalStorage<T> {
 export const finishedStream = finished;
 
 export const openZip = (...args: any[]): any => {
-  const open = (
-    getWikiGraphPlatform().archive as PlatformArchiveModule | undefined
-  )?.reader?.open;
+  const open = getWikiGraphPlatform().zipOpen as ((...args: any[]) => any) | undefined;
   if (typeof open !== "function") {
     throw new Error("No ZIP reader has been installed.");
   }
   return open(...args);
 };
-export const ZipFile = new Proxy(function () {}, {
-  construct(_target, args): object {
-    const Constructor = (
-      getWikiGraphPlatform().archive as PlatformArchiveModule | undefined
-    )?.writer?.ZipFile;
-    if (Constructor === undefined) {
-      throw new Error("No ZIP writer has been installed.");
-    }
-    return Reflect.construct(Constructor, args);
-  },
-}) as any;
+export const ZipFile = class {
+  [key: string]: any;
+  constructor(...args: any[]) {
+    const Constructor = getWikiGraphPlatform().zipWriter as any;
+    if (Constructor === undefined) throw new Error("No ZIP writer has been installed.");
+    return new Constructor(...args) as any;
+  }
+};
 export const YazlZipFile = ZipFile;
 export type Entry = any;
 export type YauzlZipFile = any;
 export type ZipFile = any;
 export type YazlZipFileType = any;
 export type FileHandle = any;
-export type Buffer = any;
+export type Binary = any;
+export type binary = any;
 export type Readable = any;
 export type Writable = any;
 export type WritableStream = any;
 
-export function getSqlite3Module(): PlatformModule {
-  const module = getWikiGraphPlatform().database as PlatformModule | undefined;
-  if (module === undefined) {
-    throw new Error("No SQLite runtime has been installed.");
-  }
+export function getDatabaseCapability(): PlatformModule {
+  const module = getWikiGraphPlatform().databaseModule as PlatformModule | undefined;
+  if (module === undefined) throw new Error("No database runtime has been installed.");
   return module;
 }

--- a/packages/core/src/runtime/platform/index.ts
+++ b/packages/core/src/runtime/platform/index.ts
@@ -45,6 +45,26 @@ export interface Directory {
   ): Promise<void>;
 }
 
+/** Resolve a logical relative file name inside a host-provided directory. */
+export async function getRelativeFile(
+  root: Directory,
+  relativeName: string,
+): Promise<File | undefined> {
+  const parts = relativeName.replaceAll("\\", "/").split("/").filter(Boolean);
+  if (parts.some((part) => part === "." || part === "..")) {
+    throw new TypeError(`Directory path must remain relative: ${relativeName}`);
+  }
+  const fileName = parts.pop();
+  if (!fileName) return undefined;
+  let directory = root;
+  for (const part of parts) {
+    const next = await directory.getDirectory(part);
+    if (!next) return undefined;
+    directory = next;
+  }
+  return await directory.getFile(fileName);
+}
+
 /** Host storage roots. The names describe scope, never a concrete path. */
 export interface WikiGraphStorage {
   readonly library: Directory;

--- a/packages/core/src/runtime/platform/index.ts
+++ b/packages/core/src/runtime/platform/index.ts
@@ -105,7 +105,7 @@ export function getWikiGraphStorage(): WikiGraphStorage {
   return installedStorage;
 }
 
-export function getPlatformFilePath(file: File): string {
+export function getHostFileHandle(file: File): string {
   const location = fileLocations.get(file);
   if (location === undefined) {
     throw new Error("The supplied File is not bound to this host runtime.");
@@ -113,7 +113,7 @@ export function getPlatformFilePath(file: File): string {
   return location;
 }
 
-export function getPlatformDirectoryPath(directory: Directory): string {
+export function getHostDirectoryHandle(directory: Directory): string {
   const location = directoryLocations.get(directory);
   if (location === undefined) {
     throw new Error(

--- a/packages/core/src/runtime/platform/index.ts
+++ b/packages/core/src/runtime/platform/index.ts
@@ -168,6 +168,8 @@ export const unlink = (...args: any[]): any =>
   moduleValue("fileSystemPromises", "unlink")(...args);
 export const writeFile = (...args: any[]): any =>
   moduleValue("fileSystemPromises", "writeFile")(...args);
+export const openDatabase = (...args: any[]): any =>
+  moduleValue("database", "open")(...args);
 
 export const constants = new Proxy({} as Record<string, number>, {
   get(_target, property: string): unknown {

--- a/packages/core/src/runtime/platform/index.ts
+++ b/packages/core/src/runtime/platform/index.ts
@@ -16,6 +16,8 @@ export interface PlatformZipModule {
 export interface WikiGraphPlatform {
   readonly fs: PlatformModule;
   readonly childProcess: PlatformModule;
+  readonly process: PlatformModule;
+  readonly buffer: PlatformModule;
   readonly fsPromises: PlatformModule;
   readonly path: PlatformModule;
   readonly os: PlatformModule;
@@ -28,11 +30,16 @@ export interface WikiGraphPlatform {
   readonly url: PlatformModule;
   readonly sqlite3?: PlatformModule;
   readonly zip?: PlatformZipModule;
+  /** Host-only locator bridge used by legacy Node-backed archive algorithms. */
+  readonly filePath?: (file: File) => string;
+  readonly directoryPath?: (directory: Directory) => string;
 }
 
 /** A host-owned file. Core never interprets its backing URI or path. */
 export interface File {
   readonly name: string;
+  /** Opaque host-owned identity; Core never parses this value. */
+  readonly locator?: unknown;
   readonly size?: number;
   read(options?: { readonly encoding?: string }): Promise<Uint8Array | string>;
   openWriter(): Promise<FileWriter>;
@@ -48,6 +55,7 @@ export interface FileWriter {
 /** Directory tree supplied by the host. Only relative child names are used. */
 export interface Directory {
   readonly name: string;
+  readonly locator?: unknown;
   getFile(name: string): Promise<File | undefined>;
   getDirectory(name: string): Promise<Directory | undefined>;
   list(): Promise<ReadonlyArray<File | Directory>>;
@@ -63,6 +71,12 @@ export interface Directory {
 export interface WikiGraphStorage {
   readonly library: Directory;
   readonly documentStore: Directory;
+}
+
+export interface NodeError extends Error {
+  readonly code?: string;
+  readonly errno?: number;
+  readonly path?: string;
 }
 
 let installedPlatform: WikiGraphPlatform | undefined;
@@ -95,6 +109,24 @@ export function getWikiGraphStorage(): WikiGraphStorage {
   return installedStorage;
 }
 
+export function getPlatformFilePath(file: File): string {
+  const resolver = getWikiGraphPlatform().filePath;
+  if (resolver === undefined) {
+    throw new Error("The installed runtime does not provide a file locator.");
+  }
+  return resolver(file);
+}
+
+export function getPlatformDirectoryPath(directory: Directory): string {
+  const resolver = getWikiGraphPlatform().directoryPath;
+  if (resolver === undefined) {
+    throw new Error(
+      "The installed runtime does not provide a directory locator.",
+    );
+  }
+  return resolver(directory);
+}
+
 function moduleValue<T = any>(
   moduleName: keyof WikiGraphPlatform,
   key: string,
@@ -106,6 +138,11 @@ export const access = (...args: any[]): any =>
   moduleValue("fsPromises", "access")(...args);
 export const spawn = (...args: any[]): any =>
   moduleValue("childProcess", "spawn")(...args);
+export const process = new Proxy({} as Record<string, any>, {
+  get(_target, property: string): unknown {
+    return moduleValue("process", property);
+  },
+});
 export const appendFile = (...args: any[]): any =>
   moduleValue("fsPromises", "appendFile")(...args);
 export const chmod = (...args: any[]): any =>
@@ -194,6 +231,15 @@ export const randomBytes = (...args: any[]): any =>
   moduleValue("crypto", "randomBytes")(...args);
 export const randomUUID = (...args: any[]): any =>
   moduleValue("crypto", "randomUUID")(...args);
+export const Buffer = new Proxy(function () {}, {
+  construct(_target, args): object {
+    const Constructor = moduleValue("buffer", "Buffer");
+    return Reflect.construct(Constructor, args);
+  },
+  get(_target, property: string): unknown {
+    return moduleValue("buffer", "Buffer")[property];
+  },
+}) as any;
 export const inflateRaw = (...args: any[]): any =>
   moduleValue("zlib", "inflateRaw")(...args);
 export const fileURLToPath = (...args: any[]): any =>
@@ -262,6 +308,7 @@ export type YauzlZipFile = any;
 export type ZipFile = any;
 export type YazlZipFileType = any;
 export type FileHandle = any;
+export type Buffer = any;
 export type Readable = any;
 export type Writable = any;
 export type WritableStream = any;

--- a/packages/core/src/runtime/platform/index.ts
+++ b/packages/core/src/runtime/platform/index.ts
@@ -231,9 +231,9 @@ export const inflateRaw = (...args: any[]): any =>
   capability("inflateRaw")(...args);
 export const fileURLToPath = (...args: any[]): any =>
   capability("fileURLToPath")(...args);
-/** Host-only escape hatch used by legacy archive algorithms during migration. */
-export const resolveFilePath = (file: File | string): string =>
-  typeof file === "string" ? file : capability<(file: File) => string>("resolveFilePath")(file);
+/** Host archive handle supplied by the archive infrastructure adapter. */
+export const hostArchiveHandle = (file: File | string): unknown =>
+  typeof file === "string" ? file : capability<(file: File) => unknown>("hostArchiveHandle")(file);
 
 export const PassThrough: any = function (this: any, ...args: any[]) {
   const delegate = new (capability("stream_PassThrough"))(...args);

--- a/packages/core/src/runtime/platform/index.ts
+++ b/packages/core/src/runtime/platform/index.ts
@@ -231,9 +231,6 @@ export const inflateRaw = (...args: any[]): any =>
   capability("inflateRaw")(...args);
 export const fileURLToPath = (...args: any[]): any =>
   capability("fileURLToPath")(...args);
-/** Host archive handle supplied by the archive infrastructure adapter. */
-export const hostArchiveHandle = (file: File | string): unknown =>
-  typeof file === "string" ? file : capability<(file: File) => unknown>("hostArchiveHandle")(file);
 
 export const PassThrough: any = function (this: any, ...args: any[]) {
   const delegate = new (capability("stream_PassThrough"))(...args);

--- a/packages/core/src/runtime/platform/index.ts
+++ b/packages/core/src/runtime/platform/index.ts
@@ -211,6 +211,9 @@ export const inflateRaw = (...args: any[]): any =>
   capability("inflateRaw")(...args);
 export const fileURLToPath = (...args: any[]): any =>
   capability("fileURLToPath")(...args);
+/** Host-only escape hatch used by legacy archive algorithms during migration. */
+export const resolveFilePath = (file: File | string): string =>
+  typeof file === "string" ? file : capability<(file: File) => string>("resolveFilePath")(file);
 
 export const PassThrough: any = function (this: any, ...args: any[]) {
   const delegate = new (capability("stream_PassThrough"))(...args);

--- a/packages/core/src/runtime/platform/index.ts
+++ b/packages/core/src/runtime/platform/index.ts
@@ -272,22 +272,46 @@ export const setTimeout = sleep;
 
 export class AsyncLocalStorage<T> {
   readonly #impl: any;
+  #fallbackStore: T | undefined;
 
   public constructor() {
-    const Constructor = moduleValue("asyncHooks", "AsyncLocalStorage");
-    this.#impl = new Constructor();
+    try {
+      const Constructor = moduleValue("asyncHooks", "AsyncLocalStorage");
+      this.#impl = new Constructor();
+    } catch {
+      // Importing the neutral core must not require a host runtime to have
+      // been installed already. The host implementation takes over once it
+      // is installed; this tiny fallback keeps pure parsing/type utilities
+      // usable before that point.
+      this.#impl = undefined;
+    }
   }
 
   public run<R>(store: T, callback: () => R): R {
-    return this.#impl.run(store, callback);
+    if (this.#impl !== undefined) {
+      return this.#impl.run(store, callback);
+    }
+    const previous = this.#fallbackStore;
+    this.#fallbackStore = store;
+    try {
+      return callback();
+    } finally {
+      this.#fallbackStore = previous;
+    }
   }
 
   public enterWith(store: T): void {
-    this.#impl.enterWith(store);
+    if (this.#impl !== undefined) {
+      this.#impl.enterWith(store);
+    } else {
+      this.#fallbackStore = store;
+    }
   }
 
   public getStore(): T | undefined {
-    return this.#impl.getStore();
+    return this.#impl === undefined
+      ? this.#fallbackStore
+      : this.#impl.getStore();
   }
 }
 

--- a/packages/core/src/runtime/platform/index.ts
+++ b/packages/core/src/runtime/platform/index.ts
@@ -30,16 +30,11 @@ export interface WikiGraphPlatform {
   readonly url: PlatformModule;
   readonly sqlite3?: PlatformModule;
   readonly zip?: PlatformZipModule;
-  /** Host-only locator bridge used by legacy Node-backed archive algorithms. */
-  readonly filePath?: (file: File) => string;
-  readonly directoryPath?: (directory: Directory) => string;
 }
 
 /** A host-owned file. Core never interprets its backing URI or path. */
 export interface File {
   readonly name: string;
-  /** Opaque host-owned identity; Core never parses this value. */
-  readonly locator?: unknown;
   readonly size?: number;
   read(options?: { readonly encoding?: string }): Promise<Uint8Array | string>;
   openWriter(): Promise<FileWriter>;
@@ -55,7 +50,6 @@ export interface FileWriter {
 /** Directory tree supplied by the host. Only relative child names are used. */
 export interface Directory {
   readonly name: string;
-  readonly locator?: unknown;
   getFile(name: string): Promise<File | undefined>;
   getDirectory(name: string): Promise<Directory | undefined>;
   list(): Promise<ReadonlyArray<File | Directory>>;
@@ -81,6 +75,19 @@ export interface NodeError extends Error {
 
 let installedPlatform: WikiGraphPlatform | undefined;
 let installedStorage: WikiGraphStorage | undefined;
+const fileLocations = new WeakMap<object, string>();
+const directoryLocations = new WeakMap<object, string>();
+
+export function registerFileLocation(file: File, location: string): void {
+  fileLocations.set(file, location);
+}
+
+export function registerDirectoryLocation(
+  directory: Directory,
+  location: string,
+): void {
+  directoryLocations.set(directory, location);
+}
 
 export function installWikiGraphPlatform(platform: WikiGraphPlatform): void {
   installedPlatform = platform;
@@ -110,21 +117,21 @@ export function getWikiGraphStorage(): WikiGraphStorage {
 }
 
 export function getPlatformFilePath(file: File): string {
-  const resolver = getWikiGraphPlatform().filePath;
-  if (resolver === undefined) {
-    throw new Error("The installed runtime does not provide a file locator.");
+  const location = fileLocations.get(file);
+  if (location === undefined) {
+    throw new Error("The supplied File is not bound to this host runtime.");
   }
-  return resolver(file);
+  return location;
 }
 
 export function getPlatformDirectoryPath(directory: Directory): string {
-  const resolver = getWikiGraphPlatform().directoryPath;
-  if (resolver === undefined) {
+  const location = directoryLocations.get(directory);
+  if (location === undefined) {
     throw new Error(
-      "The installed runtime does not provide a directory locator.",
+      "The supplied Directory is not bound to this host runtime.",
     );
   }
-  return resolver(directory);
+  return location;
 }
 
 function moduleValue<T = any>(

--- a/packages/core/src/runtime/platform/index.ts
+++ b/packages/core/src/runtime/platform/index.ts
@@ -112,59 +112,63 @@ function capability<T = any>(name: string): T {
   return getWikiGraphPlatform()[name] as T;
 }
 
-export const access = (...args: any[]): any =>
-  capability("access")(...args);
-export const spawn = (...args: any[]): any =>
-  capability("spawn")(...args);
+export const access = (...args: any[]): any => capability("access")(...args);
+export const spawn = (...args: any[]): any => capability("spawn")(...args);
 export const runtimeContext: Record<string, any> = {
-  get pid() { return capability("runtime_pid"); },
-  get stderr() { return capability("runtime_stderr"); },
-  get argv() { return capability("runtime_argv"); },
-  get env() { return capability("runtime_env"); },
-  get cwd() { return capability("runtime_cwd"); },
+  get pid() {
+    return capability("runtime_pid");
+  },
+  get stderr() {
+    return capability("runtime_stderr");
+  },
+  get argv() {
+    return capability("runtime_argv");
+  },
+  get env() {
+    return capability("runtime_env");
+  },
+  get cwd() {
+    return capability("runtime_cwd");
+  },
   kill: (...args: any[]) => capability("runtime_kill")(...args),
   once: (...args: any[]) => capability("runtime_once")(...args),
-  removeListener: (...args: any[]) => capability("runtime_removeListener")(...args),
+  removeListener: (...args: any[]) =>
+    capability("runtime_removeListener")(...args),
 };
 export const appendFile = (...args: any[]): any =>
   capability("appendFile")(...args);
-export const chmod = (...args: any[]): any =>
-  capability("chmod")(...args);
+export const chmod = (...args: any[]): any => capability("chmod")(...args);
 export const copyFile = (...args: any[]): any =>
   capability("copyFile")(...args);
-export const mkdir = (...args: any[]): any =>
-  capability("mkdir")(...args);
-export const mkdtemp = (...args: any[]): any =>
-  capability("mkdtemp")(...args);
-export const open = (...args: any[]): any =>
-  capability("open")(...args);
-export const opendir = (...args: any[]): any =>
-  capability("opendir")(...args);
+export const mkdir = (...args: any[]): any => capability("mkdir")(...args);
+export const mkdtemp = (...args: any[]): any => capability("mkdtemp")(...args);
+export const open = (...args: any[]): any => capability("open")(...args);
+export const opendir = (...args: any[]): any => capability("opendir")(...args);
 export const readFile = (...args: any[]): any =>
   capability("readFile")(...args);
-export const readdir = (...args: any[]): any =>
-  capability("readdir")(...args);
+export const readdir = (...args: any[]): any => capability("readdir")(...args);
 export const realpath = (...args: any[]): any =>
   capability("realpath")(...args);
-export const rename = (...args: any[]): any =>
-  capability("rename")(...args);
-export const rm = (...args: any[]): any =>
-  capability("rm")(...args);
-export const rmdir = (...args: any[]): any =>
-  capability("rmdir")(...args);
-export const stat = (...args: any[]): any =>
-  capability("stat")(...args);
-export const unlink = (...args: any[]): any =>
-  capability("unlink")(...args);
+export const rename = (...args: any[]): any => capability("rename")(...args);
+export const rm = (...args: any[]): any => capability("rm")(...args);
+export const rmdir = (...args: any[]): any => capability("rmdir")(...args);
+export const stat = (...args: any[]): any => capability("stat")(...args);
+export const unlink = (...args: any[]): any => capability("unlink")(...args);
 export const writeFile = (...args: any[]): any =>
   capability("writeFile")(...args);
 export const openDatabase = (...args: any[]): any =>
   capability("database_open")(...args);
 
 export const constants: Record<string, number> = {
-  get O_RDONLY() { return capability("sync_constants").O_RDONLY; },
-  get O_WRONLY() { return capability("sync_constants").O_WRONLY; },
-  get O_CREAT() { return capability("sync_constants").O_CREAT; },
+  get O_RDONLY() {
+    return capability("sync_constants").O_RDONLY;
+  },
+  get O_WRONLY() {
+    return capability("sync_constants").O_WRONLY;
+  },
+  get O_CREAT() {
+    return capability("sync_constants").O_CREAT;
+  },
 };
 export const createReadStream = (...args: any[]): any =>
   capability("sync_createReadStream")(...args);
@@ -187,10 +191,8 @@ export const extname = (...args: any[]): any =>
   capability("path_extname")(...args);
 export const isAbsolute = (...args: any[]): any =>
   capability("path_isAbsolute")(...args);
-export const join = (...args: any[]): any =>
-  capability("path_join")(...args);
-export const parse = (...args: any[]): any =>
-  capability("path_parse")(...args);
+export const join = (...args: any[]): any => capability("path_join")(...args);
+export const parse = (...args: any[]): any => capability("path_parse")(...args);
 export const relative = (...args: any[]): any =>
   capability("path_relative")(...args);
 export const resolve = (...args: any[]): any =>
@@ -248,8 +250,7 @@ export const pipeline = (...args: any[]): any =>
   capability("pipeline")(...args);
 export const readLines = (input: any): AsyncIterable<string> =>
   capability("readLines")(input);
-export const sleep = (...args: any[]): any =>
-  capability("setTimeout")(...args);
+export const sleep = (...args: any[]): any => capability("setTimeout")(...args);
 export const setTimeout = sleep;
 
 export class AsyncLocalStorage<T> {
@@ -300,7 +301,9 @@ export class AsyncLocalStorage<T> {
 export const finishedStream = finished;
 
 export const openZip = (...args: any[]): any => {
-  const open = getWikiGraphPlatform().zipOpen as ((...args: any[]) => any) | undefined;
+  const open = getWikiGraphPlatform().zipOpen as
+    | ((...args: any[]) => any)
+    | undefined;
   if (typeof open !== "function") {
     throw new Error("No ZIP reader has been installed.");
   }
@@ -308,10 +311,11 @@ export const openZip = (...args: any[]): any => {
 };
 export const ZipFile = class {
   [key: string]: any;
-  constructor(...args: any[]) {
+  public constructor(...args: any[]) {
     const Constructor = getWikiGraphPlatform().zipWriter as any;
-    if (Constructor === undefined) throw new Error("No ZIP writer has been installed.");
-    return new Constructor(...args) as any;
+    if (Constructor === undefined)
+      throw new Error("No ZIP writer has been installed.");
+    return new Constructor(...args);
   }
 };
 export const YazlZipFile = ZipFile;
@@ -327,7 +331,10 @@ export type Writable = any;
 export type WritableStream = any;
 
 export function getDatabaseCapability(): PlatformModule {
-  const module = getWikiGraphPlatform().databaseModule as PlatformModule | undefined;
-  if (module === undefined) throw new Error("No database runtime has been installed.");
+  const module = getWikiGraphPlatform().databaseModule as
+    | PlatformModule
+    | undefined;
+  if (module === undefined)
+    throw new Error("No database runtime has been installed.");
   return module;
 }

--- a/packages/core/src/runtime/platform/index.ts
+++ b/packages/core/src/runtime/platform/index.ts
@@ -226,6 +226,8 @@ export const finished = (...args: any[]): any =>
   capability("finished")(...args);
 export const pipeline = (...args: any[]): any =>
   capability("pipeline")(...args);
+export const readLines = (input: any): AsyncIterable<string> =>
+  capability("readLines")(input);
 export const sleep = (...args: any[]): any =>
   capability("setTimeout")(...args);
 export const setTimeout = sleep;

--- a/packages/core/src/runtime/platform/index.ts
+++ b/packages/core/src/runtime/platform/index.ts
@@ -1,0 +1,275 @@
+/**
+ * Runtime primitives used by the portable core.
+ *
+ * The core deliberately does not import Node modules. A host (the CLI, a
+ * browser application, or a test harness) installs implementations for these
+ * primitives before opening a document.
+ */
+
+export type PlatformModule = Record<string, any>;
+
+export interface PlatformZipModule {
+  readonly yauzl?: PlatformModule;
+  readonly yazl?: PlatformModule;
+}
+
+export interface WikiGraphPlatform {
+  readonly fs: PlatformModule;
+  readonly childProcess: PlatformModule;
+  readonly fsPromises: PlatformModule;
+  readonly path: PlatformModule;
+  readonly os: PlatformModule;
+  readonly crypto: PlatformModule;
+  readonly streams: PlatformModule;
+  readonly streamPromises: PlatformModule;
+  readonly timers: PlatformModule;
+  readonly asyncHooks: PlatformModule;
+  readonly zlib: PlatformModule;
+  readonly url: PlatformModule;
+  readonly sqlite3?: PlatformModule;
+  readonly zip?: PlatformZipModule;
+}
+
+/** A host-owned file. Core never interprets its backing URI or path. */
+export interface File {
+  readonly name: string;
+  readonly size?: number;
+  read(options?: { readonly encoding?: string }): Promise<Uint8Array | string>;
+  openWriter(): Promise<FileWriter>;
+}
+
+/** Transactional writer supplied by the host file system. */
+export interface FileWriter {
+  write(data: Uint8Array | string): Promise<void>;
+  commit(): Promise<void>;
+  abort(): Promise<void>;
+}
+
+/** Directory tree supplied by the host. Only relative child names are used. */
+export interface Directory {
+  readonly name: string;
+  getFile(name: string): Promise<File | undefined>;
+  getDirectory(name: string): Promise<Directory | undefined>;
+  list(): Promise<ReadonlyArray<File | Directory>>;
+  createFile(name: string): Promise<File>;
+  createDirectory(name: string): Promise<Directory>;
+  remove(
+    name: string,
+    options?: { readonly recursive?: boolean },
+  ): Promise<void>;
+}
+
+/** Host storage roots. The names describe scope, never a concrete path. */
+export interface WikiGraphStorage {
+  readonly library: Directory;
+  readonly documentStore: Directory;
+}
+
+let installedPlatform: WikiGraphPlatform | undefined;
+let installedStorage: WikiGraphStorage | undefined;
+
+export function installWikiGraphPlatform(platform: WikiGraphPlatform): void {
+  installedPlatform = platform;
+}
+
+export function getWikiGraphPlatform(): WikiGraphPlatform {
+  if (installedPlatform === undefined) {
+    throw new Error(
+      "No WikiGraph runtime platform has been installed. Provide File/Directory and runtime adapters before using wiki-graph-core.",
+    );
+  }
+
+  return installedPlatform;
+}
+
+export function installWikiGraphStorage(storage: WikiGraphStorage): void {
+  installedStorage = storage;
+}
+
+export function getWikiGraphStorage(): WikiGraphStorage {
+  if (installedStorage === undefined) {
+    throw new Error(
+      "No WikiGraph storage roots have been installed. Provide library and documentStore Directory implementations.",
+    );
+  }
+  return installedStorage;
+}
+
+function moduleValue<T = any>(
+  moduleName: keyof WikiGraphPlatform,
+  key: string,
+): T {
+  return (getWikiGraphPlatform()[moduleName] as PlatformModule)[key] as T;
+}
+
+export const access = (...args: any[]): any =>
+  moduleValue("fsPromises", "access")(...args);
+export const spawn = (...args: any[]): any =>
+  moduleValue("childProcess", "spawn")(...args);
+export const appendFile = (...args: any[]): any =>
+  moduleValue("fsPromises", "appendFile")(...args);
+export const chmod = (...args: any[]): any =>
+  moduleValue("fsPromises", "chmod")(...args);
+export const copyFile = (...args: any[]): any =>
+  moduleValue("fsPromises", "copyFile")(...args);
+export const mkdir = (...args: any[]): any =>
+  moduleValue("fsPromises", "mkdir")(...args);
+export const mkdtemp = (...args: any[]): any =>
+  moduleValue("fsPromises", "mkdtemp")(...args);
+export const open = (...args: any[]): any =>
+  moduleValue("fsPromises", "open")(...args);
+export const opendir = (...args: any[]): any =>
+  moduleValue("fsPromises", "opendir")(...args);
+export const readFile = (...args: any[]): any =>
+  moduleValue("fsPromises", "readFile")(...args);
+export const readdir = (...args: any[]): any =>
+  moduleValue("fsPromises", "readdir")(...args);
+export const realpath = (...args: any[]): any =>
+  moduleValue("fsPromises", "realpath")(...args);
+export const rename = (...args: any[]): any =>
+  moduleValue("fsPromises", "rename")(...args);
+export const rm = (...args: any[]): any =>
+  moduleValue("fsPromises", "rm")(...args);
+export const rmdir = (...args: any[]): any =>
+  moduleValue("fsPromises", "rmdir")(...args);
+export const stat = (...args: any[]): any =>
+  moduleValue("fsPromises", "stat")(...args);
+export const unlink = (...args: any[]): any =>
+  moduleValue("fsPromises", "unlink")(...args);
+export const writeFile = (...args: any[]): any =>
+  moduleValue("fsPromises", "writeFile")(...args);
+
+export const constants = new Proxy({} as Record<string, number>, {
+  get(_target, property: string): unknown {
+    return moduleValue("fs", "constants")[property];
+  },
+});
+export const createReadStream = (...args: any[]): any =>
+  moduleValue("fs", "createReadStream")(...args);
+export const createWriteStream = (...args: any[]): any =>
+  moduleValue("fs", "createWriteStream")(...args);
+export const existsSync = (...args: any[]): any =>
+  moduleValue("fs", "existsSync")(...args);
+export const mkdirSync = (...args: any[]): any =>
+  moduleValue("fs", "mkdirSync")(...args);
+export const readFileSync = (...args: any[]): any =>
+  moduleValue("fs", "readFileSync")(...args);
+export const statSync = (...args: any[]): any =>
+  moduleValue("fs", "statSync")(...args);
+
+export const basename = (...args: any[]): any =>
+  moduleValue("path", "basename")(...args);
+export const dirname = (...args: any[]): any =>
+  moduleValue("path", "dirname")(...args);
+export const extname = (...args: any[]): any =>
+  moduleValue("path", "extname")(...args);
+export const isAbsolute = (...args: any[]): any =>
+  moduleValue("path", "isAbsolute")(...args);
+export const join = (...args: any[]): any =>
+  moduleValue("path", "join")(...args);
+export const parse = (...args: any[]): any =>
+  moduleValue("path", "parse")(...args);
+export const relative = (...args: any[]): any =>
+  moduleValue("path", "relative")(...args);
+export const resolve = (...args: any[]): any =>
+  moduleValue("path", "resolve")(...args);
+// Archive paths are normalized to POSIX separators by Core. Host path helpers
+// still come from the injected provider; this constant is only used for
+// comparisons and remains portable across browser and Node hosts.
+export const sep = "/";
+export const posix = new Proxy({} as Record<string, any>, {
+  get(_target, property: string): unknown {
+    return moduleValue("path", "posix")[property];
+  },
+}) as any;
+
+export const homedir = (...args: any[]): any =>
+  moduleValue("os", "homedir")(...args);
+export const tmpdir = (...args: any[]): any =>
+  moduleValue("os", "tmpdir")(...args);
+
+export const createHash = (...args: any[]): any =>
+  moduleValue("crypto", "createHash")(...args);
+export const randomBytes = (...args: any[]): any =>
+  moduleValue("crypto", "randomBytes")(...args);
+export const randomUUID = (...args: any[]): any =>
+  moduleValue("crypto", "randomUUID")(...args);
+export const inflateRaw = (...args: any[]): any =>
+  moduleValue("zlib", "inflateRaw")(...args);
+export const fileURLToPath = (...args: any[]): any =>
+  moduleValue("url", "fileURLToPath")(...args);
+
+export const PassThrough = new Proxy(function () {}, {
+  construct(_target, args): object {
+    return Reflect.construct(moduleValue("streams", "PassThrough"), args);
+  },
+}) as any;
+export const Writable = new Proxy(function () {}, {
+  construct(_target, args): object {
+    return Reflect.construct(moduleValue("streams", "Writable"), args);
+  },
+}) as any;
+export const finished = (...args: any[]): any =>
+  moduleValue("streamPromises", "finished")(...args);
+export const pipeline = (...args: any[]): any =>
+  moduleValue("streamPromises", "pipeline")(...args);
+export const sleep = (...args: any[]): any =>
+  moduleValue("timers", "setTimeout")(...args);
+export const setTimeout = sleep;
+
+export class AsyncLocalStorage<T> {
+  readonly #impl: any;
+
+  public constructor() {
+    const Constructor = moduleValue("asyncHooks", "AsyncLocalStorage");
+    this.#impl = new Constructor();
+  }
+
+  public run<R>(store: T, callback: () => R): R {
+    return this.#impl.run(store, callback);
+  }
+
+  public enterWith(store: T): void {
+    this.#impl.enterWith(store);
+  }
+
+  public getStore(): T | undefined {
+    return this.#impl.getStore();
+  }
+}
+
+export const finishedStream = finished;
+
+export const openZip = (...args: any[]): any => {
+  const open = getWikiGraphPlatform().zip?.yauzl?.open;
+  if (typeof open !== "function") {
+    throw new Error("No ZIP reader has been installed.");
+  }
+  return open(...args);
+};
+export const ZipFile = new Proxy(function () {}, {
+  construct(_target, args): object {
+    const Constructor = getWikiGraphPlatform().zip?.yazl?.ZipFile;
+    if (Constructor === undefined) {
+      throw new Error("No ZIP writer has been installed.");
+    }
+    return Reflect.construct(Constructor, args);
+  },
+}) as any;
+export const YazlZipFile = ZipFile;
+export type Entry = any;
+export type YauzlZipFile = any;
+export type ZipFile = any;
+export type YazlZipFileType = any;
+export type FileHandle = any;
+export type Readable = any;
+export type Writable = any;
+export type WritableStream = any;
+
+export function getSqlite3Module(): PlatformModule {
+  const module = getWikiGraphPlatform().sqlite3;
+  if (module === undefined) {
+    throw new Error("No SQLite runtime has been installed.");
+  }
+  return module;
+}

--- a/packages/core/src/state-lock.ts
+++ b/packages/core/src/state-lock.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "crypto";
+import { randomUUID } from "./runtime/platform/index.js";
 
 import {
   getNumber,

--- a/packages/core/src/state-lock.ts
+++ b/packages/core/src/state-lock.ts
@@ -1,4 +1,4 @@
-import { process as platformProcess } from "./runtime/platform/index.js";
+import { runtimeContext as platformRuntime } from "./runtime/platform/index.js";
 import { randomUUID } from "./runtime/platform/index.js";
 
 import {
@@ -69,7 +69,7 @@ export async function withStateLock<T>(
 export async function acquireStateLock(
   options: StateLockOptions,
 ): Promise<(() => Promise<void>) | undefined> {
-  const ownerId = `${platformProcess.pid}-${randomUUID()}`;
+  const ownerId = `${platformRuntime.pid}-${randomUUID()}`;
   const pollMs = options.pollMs ?? DEFAULT_STATE_LOCK_POLL_MS;
 
   while (true) {
@@ -154,7 +154,7 @@ async function tryInsertStateLock(
           options.resourceKey,
           options.mode,
           ownerId,
-          platformProcess.pid,
+          platformRuntime.pid,
           now,
           now,
         ],
@@ -209,7 +209,7 @@ async function updateStateLockHeartbeat(
       `,
       [
         Date.now(),
-        platformProcess.pid,
+        platformRuntime.pid,
         options.scope,
         options.resourceKey,
         ownerId,
@@ -311,7 +311,7 @@ function isStateLockStale(
 
 function isProcessAlive(pid: number): boolean {
   try {
-    platformProcess.kill(pid, 0);
+    platformRuntime.kill(pid, 0);
     return true;
   } catch (error) {
     if (isNodeError(error) && error.code === "ESRCH") {

--- a/packages/core/src/state-lock.ts
+++ b/packages/core/src/state-lock.ts
@@ -1,3 +1,4 @@
+import { process as platformProcess } from "./runtime/platform/index.js";
 import { randomUUID } from "./runtime/platform/index.js";
 
 import {
@@ -68,7 +69,7 @@ export async function withStateLock<T>(
 export async function acquireStateLock(
   options: StateLockOptions,
 ): Promise<(() => Promise<void>) | undefined> {
-  const ownerId = `${process.pid}-${randomUUID()}`;
+  const ownerId = `${platformProcess.pid}-${randomUUID()}`;
   const pollMs = options.pollMs ?? DEFAULT_STATE_LOCK_POLL_MS;
 
   while (true) {
@@ -153,7 +154,7 @@ async function tryInsertStateLock(
           options.resourceKey,
           options.mode,
           ownerId,
-          process.pid,
+          platformProcess.pid,
           now,
           now,
         ],
@@ -206,7 +207,13 @@ async function updateStateLockHeartbeat(
         SET heartbeat_at = ?, owner_pid = ?
         WHERE scope = ? AND resource_key = ? AND owner_id = ?
       `,
-      [Date.now(), process.pid, options.scope, options.resourceKey, ownerId],
+      [
+        Date.now(),
+        platformProcess.pid,
+        options.scope,
+        options.resourceKey,
+        ownerId,
+      ],
     );
   } finally {
     await database.close();
@@ -304,7 +311,7 @@ function isStateLockStale(
 
 function isProcessAlive(pid: number): boolean {
   try {
-    process.kill(pid, 0);
+    platformProcess.kill(pid, 0);
     return true;
   } catch (error) {
     if (isNodeError(error) && error.code === "ESRCH") {

--- a/packages/core/src/storage/migration/legacy-sdpub/upgrade/archive.ts
+++ b/packages/core/src/storage/migration/legacy-sdpub/upgrade/archive.ts
@@ -1,9 +1,9 @@
-import { posix, resolve, sep } from "path";
+import { posix, resolve, sep } from "../../../../runtime/platform/index.js";
 import {
-  open as openZip,
+  openZip,
   type Entry,
   type ZipFile as YauzlZipFile,
-} from "yauzl";
+} from "../../../../runtime/platform/index.js";
 
 const LEGACY_SDPUB_PATTERNS = [
   /^manifest\.json$/u,
@@ -78,14 +78,18 @@ export function normalizeArchivePath(path: string): string {
 
 export async function openArchive(path: string): Promise<YauzlZipFile> {
   return await new Promise((resolveOpen, rejectOpen) => {
-    openZip(path, { autoClose: false, lazyEntries: true }, (error, zipFile) => {
-      if (error !== null || zipFile === undefined) {
-        rejectOpen(error ?? new Error(`Cannot open archive: ${path}`));
-        return;
-      }
+    openZip(
+      path,
+      { autoClose: false, lazyEntries: true },
+      (error: any, zipFile: any) => {
+        if (error !== null || zipFile === undefined) {
+          rejectOpen(error ?? new Error(`Cannot open archive: ${path}`));
+          return;
+        }
 
-      resolveOpen(zipFile);
-    });
+        resolveOpen(zipFile);
+      },
+    );
   });
 }
 
@@ -94,7 +98,7 @@ export async function openArchiveEntryStream(
   entry: Entry,
 ): Promise<NodeJS.ReadableStream> {
   return await new Promise((resolveStream, rejectStream) => {
-    zipFile.openReadStream(entry, (error, stream) => {
+    zipFile.openReadStream(entry, (error: any, stream: any) => {
       if (error !== null || stream === undefined) {
         rejectStream(
           error ?? new Error(`Cannot open archive entry: ${entry.fileName}`),

--- a/packages/core/src/storage/migration/legacy-sdpub/upgrade/archive.ts
+++ b/packages/core/src/storage/migration/legacy-sdpub/upgrade/archive.ts
@@ -1,3 +1,5 @@
+import { type Readable } from "../../../../runtime/platform/index.js";
+import { Buffer as platformBuffer } from "../../../../runtime/platform/index.js";
 import { posix, resolve, sep } from "../../../../runtime/platform/index.js";
 import {
   openZip,
@@ -96,7 +98,7 @@ export async function openArchive(path: string): Promise<YauzlZipFile> {
 export async function openArchiveEntryStream(
   zipFile: YauzlZipFile,
   entry: Entry,
-): Promise<NodeJS.ReadableStream> {
+): Promise<Readable> {
   return await new Promise((resolveStream, rejectStream) => {
     zipFile.openReadStream(entry, (error: any, stream: any) => {
       if (error !== null || stream === undefined) {
@@ -115,16 +117,16 @@ export async function readArchiveEntryText(
   zipFile: YauzlZipFile,
   entry: Entry,
 ): Promise<string> {
-  const chunks: Buffer[] = [];
+  const chunks: platformBuffer[] = [];
   const stream = await openArchiveEntryStream(zipFile, entry);
 
   await new Promise<void>((resolveRead, rejectRead) => {
-    stream.on("data", (chunk: Buffer) => {
+    stream.on("data", (chunk: platformBuffer) => {
       chunks.push(chunk);
     });
     stream.once("end", resolveRead);
     stream.once("error", rejectRead);
   });
 
-  return Buffer.concat(chunks).toString("utf8");
+  return platformBuffer.concat(chunks).toString("utf8");
 }

--- a/packages/core/src/storage/migration/legacy-sdpub/upgrade/archive.ts
+++ b/packages/core/src/storage/migration/legacy-sdpub/upgrade/archive.ts
@@ -1,5 +1,5 @@
 import { type Readable } from "../../../../runtime/platform/index.js";
-import { Buffer as platformBuffer } from "../../../../runtime/platform/index.js";
+import { binary as platformBinary } from "../../../../runtime/platform/index.js";
 import { posix, resolve, sep } from "../../../../runtime/platform/index.js";
 import {
   openZip,
@@ -117,16 +117,16 @@ export async function readArchiveEntryText(
   zipFile: YauzlZipFile,
   entry: Entry,
 ): Promise<string> {
-  const chunks: platformBuffer[] = [];
+  const chunks: platformBinary[] = [];
   const stream = await openArchiveEntryStream(zipFile, entry);
 
   await new Promise<void>((resolveRead, rejectRead) => {
-    stream.on("data", (chunk: platformBuffer) => {
+    stream.on("data", (chunk: platformBinary) => {
       chunks.push(chunk);
     });
     stream.once("end", resolveRead);
     stream.once("error", rejectRead);
   });
 
-  return platformBuffer.concat(chunks).toString("utf8");
+  return platformBinary.concat(chunks).toString("utf8");
 }

--- a/packages/core/src/storage/migration/legacy-sdpub/upgrade/extract.ts
+++ b/packages/core/src/storage/migration/legacy-sdpub/upgrade/extract.ts
@@ -1,9 +1,12 @@
-import { createWriteStream } from "fs";
-import { mkdir } from "fs/promises";
-import { dirname, resolve } from "path";
-import { pipeline } from "stream/promises";
+import { createWriteStream } from "../../../../runtime/platform/index.js";
+import { mkdir } from "../../../../runtime/platform/index.js";
+import { dirname, resolve } from "../../../../runtime/platform/index.js";
+import { pipeline } from "../../../../runtime/platform/index.js";
 
-import type { Entry, ZipFile as YauzlZipFile } from "yauzl";
+import type {
+  Entry,
+  ZipFile as YauzlZipFile,
+} from "../../../../runtime/platform/index.js";
 
 import {
   assertWithinDirectory,
@@ -53,7 +56,7 @@ async function assertLegacySdpubArchive(
   entries: readonly Entry[],
 ): Promise<void> {
   const paths = new Set(
-    entries.map((entry) => normalizeArchivePath(entry.fileName)),
+    entries.map((entry: any) => normalizeArchivePath(entry.fileName)),
   );
 
   if (!paths.has("database.db") || !paths.has("toc.json")) {
@@ -61,7 +64,7 @@ async function assertLegacySdpubArchive(
   }
   if (paths.has("manifest.json")) {
     const manifestEntry = entries.find(
-      (entry) => normalizeArchivePath(entry.fileName) === "manifest.json",
+      (entry: any) => normalizeArchivePath(entry.fileName) === "manifest.json",
     );
 
     if (manifestEntry === undefined) {

--- a/packages/core/src/storage/migration/legacy-sdpub/upgrade/index.ts
+++ b/packages/core/src/storage/migration/legacy-sdpub/upgrade/index.ts
@@ -1,5 +1,5 @@
-import { rm } from "fs/promises";
-import { join, resolve } from "path";
+import { rm } from "../../../../runtime/platform/index.js";
+import { join, resolve } from "../../../../runtime/platform/index.js";
 
 import { createWikiGraphTempDirectory } from "../../../../runtime/common/wiki-graph/temp.js";
 import { DirectoryDocument } from "../../../../document/index.js";

--- a/packages/core/src/storage/migration/legacy-sdpub/upgrade/text-storage/core.ts
+++ b/packages/core/src/storage/migration/legacy-sdpub/upgrade/text-storage/core.ts
@@ -1,5 +1,5 @@
-import { rm } from "fs/promises";
-import { join } from "path";
+import { rm } from "../../../../../runtime/platform/index.js";
+import { join } from "../../../../../runtime/platform/index.js";
 
 import { Database } from "../../../../../document/database.js";
 import {

--- a/packages/core/src/storage/migration/legacy-sdpub/upgrade/text-storage/fragments.ts
+++ b/packages/core/src/storage/migration/legacy-sdpub/upgrade/text-storage/fragments.ts
@@ -1,5 +1,5 @@
-import { readFile, readdir } from "fs/promises";
-import { join } from "path";
+import { readFile, readdir } from "../../../../../runtime/platform/index.js";
+import { join } from "../../../../../runtime/platform/index.js";
 
 import { isNodeError } from "../../../../../utils/node-error.js";
 import type { LegacyFragmentFile, LegacyFragmentRecord } from "./types.js";

--- a/packages/core/src/storage/migration/legacy-sdpub/upgrade/text-storage/references.ts
+++ b/packages/core/src/storage/migration/legacy-sdpub/upgrade/text-storage/references.ts
@@ -1,4 +1,4 @@
-import { join } from "path";
+import { join } from "../../../../../runtime/platform/index.js";
 
 import type { SqlBindValue } from "../../../../../document/database.js";
 import { Database } from "../../../../../document/database.js";

--- a/packages/core/src/storage/migration/legacy-sdpub/upgrade/text-storage/source-text.ts
+++ b/packages/core/src/storage/migration/legacy-sdpub/upgrade/text-storage/source-text.ts
@@ -1,5 +1,5 @@
-import { mkdir, writeFile } from "fs/promises";
-import { join } from "path";
+import { mkdir, writeFile } from "../../../../../runtime/platform/index.js";
+import { join } from "../../../../../runtime/platform/index.js";
 
 import type { Database } from "../../../../../document/database.js";
 import type { LegacyFragmentRecord } from "./types.js";

--- a/packages/core/src/storage/migration/legacy-sdpub/upgrade/text-storage/source-text.ts
+++ b/packages/core/src/storage/migration/legacy-sdpub/upgrade/text-storage/source-text.ts
@@ -1,4 +1,4 @@
-import { Buffer as platformBuffer } from "../../../../../runtime/platform/index.js";
+import { binary as platformBinary } from "../../../../../runtime/platform/index.js";
 import { mkdir, writeFile } from "../../../../../runtime/platform/index.js";
 import { join } from "../../../../../runtime/platform/index.js";
 
@@ -45,7 +45,7 @@ export async function writeLegacySourceTextStream(
 
   for (const fragment of input.fragments) {
     for (const sentence of fragment.content.sentences) {
-      const byteLength = platformBuffer.byteLength(sentence.text, "utf8");
+      const byteLength = platformBinary.byteLength(sentence.text, "utf8");
 
       await database.run(
         `

--- a/packages/core/src/storage/migration/legacy-sdpub/upgrade/text-storage/source-text.ts
+++ b/packages/core/src/storage/migration/legacy-sdpub/upgrade/text-storage/source-text.ts
@@ -1,3 +1,4 @@
+import { Buffer as platformBuffer } from "../../../../../runtime/platform/index.js";
 import { mkdir, writeFile } from "../../../../../runtime/platform/index.js";
 import { join } from "../../../../../runtime/platform/index.js";
 
@@ -44,7 +45,7 @@ export async function writeLegacySourceTextStream(
 
   for (const fragment of input.fragments) {
     for (const sentence of fragment.content.sentences) {
-      const byteLength = Buffer.byteLength(sentence.text, "utf8");
+      const byteLength = platformBuffer.byteLength(sentence.text, "utf8");
 
       await database.run(
         `

--- a/packages/core/src/storage/migration/legacy-sdpub/upgrade/text-storage/summaries.ts
+++ b/packages/core/src/storage/migration/legacy-sdpub/upgrade/text-storage/summaries.ts
@@ -1,5 +1,5 @@
-import { readFile, readdir } from "fs/promises";
-import { join } from "path";
+import { readFile, readdir } from "../../../../../runtime/platform/index.js";
+import { join } from "../../../../../runtime/platform/index.js";
 
 import { DirectoryDocument } from "../../../../../document/directory/index.js";
 import { isNodeError } from "../../../../../utils/node-error.js";

--- a/packages/core/src/storage/schema-upgrade/index.ts
+++ b/packages/core/src/storage/schema-upgrade/index.ts
@@ -1,6 +1,6 @@
 import {
-  Buffer as platformBuffer,
-  process as platformProcess,
+  binary as platformBinary,
+  runtimeContext as platformRuntime,
 } from "../../runtime/platform/index.js";
 import { randomUUID } from "../../runtime/platform/index.js";
 import {
@@ -146,7 +146,7 @@ export async function upgradeWikiGraphArchiveSchema(
 
     const temporaryPath = join(
       dirname(resolvedArchivePath),
-      `.${getArchiveBasename(resolvedArchivePath)}.${platformProcess.pid}.${randomUUID()}.upgrade.tmp`,
+      `.${getArchiveBasename(resolvedArchivePath)}.${platformRuntime.pid}.${randomUUID()}.upgrade.tmp`,
     );
 
     await writeWikgArchiveWithOverlays(
@@ -350,7 +350,7 @@ async function repairTextSentenceWordCounts(
     ),
   );
   let cachedTextKey: string | undefined;
-  let cachedTextBuffer: platformBuffer | undefined;
+  let cachedTextBuffer: platformBinary | undefined;
   const updates: Array<{
     readonly chapterId: number;
     readonly kind: number;
@@ -373,7 +373,7 @@ async function repairTextSentenceWordCounts(
           : await document.getSummaryFragments(row.chapterId).readText();
 
       cachedTextBuffer =
-        text === undefined ? undefined : platformBuffer.from(text, "utf8");
+        text === undefined ? undefined : platformBinary.from(text, "utf8");
     }
     if (cachedTextBuffer === undefined) {
       continue;
@@ -608,7 +608,7 @@ function isActiveLock(ownerPid: number, heartbeatAt: number): boolean {
 
 function isProcessAlive(pid: number): boolean {
   try {
-    platformProcess.kill(pid, 0);
+    platformRuntime.kill(pid, 0);
     return true;
   } catch {
     return false;

--- a/packages/core/src/storage/schema-upgrade/index.ts
+++ b/packages/core/src/storage/schema-upgrade/index.ts
@@ -1,7 +1,13 @@
-import { randomUUID } from "crypto";
-import { mkdtemp, rename, rm, stat, writeFile } from "fs/promises";
-import { tmpdir } from "os";
-import { dirname, join, resolve } from "path";
+import { randomUUID } from "../../runtime/platform/index.js";
+import {
+  mkdtemp,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "../../runtime/platform/index.js";
+import { tmpdir } from "../../runtime/platform/index.js";
+import { dirname, join, resolve } from "../../runtime/platform/index.js";
 
 import { Database, DirectoryDocument } from "../../document/index.js";
 import { ensureChapterKeys } from "../../document/chapter/toc.js";
@@ -70,7 +76,8 @@ export async function readWikiGraphArchiveSchemaVersion(
 
   try {
     const manifestEntry = entries.find(
-      (entry) => normalizeArchivePath(entry.fileName) === WIKG_MANIFEST_PATH,
+      (entry: any) =>
+        normalizeArchivePath(entry.fileName) === WIKG_MANIFEST_PATH,
     );
 
     if (manifestEntry === undefined) {
@@ -194,7 +201,7 @@ async function createChapterTocUpgradeOverlay(
 
   try {
     const tocEntry = entries.find(
-      (entry) => normalizeArchivePath(entry.fileName) === "toc.json",
+      (entry: any) => normalizeArchivePath(entry.fileName) === "toc.json",
     );
 
     if (tocEntry === undefined) {

--- a/packages/core/src/storage/schema-upgrade/index.ts
+++ b/packages/core/src/storage/schema-upgrade/index.ts
@@ -1,3 +1,7 @@
+import {
+  Buffer as platformBuffer,
+  process as platformProcess,
+} from "../../runtime/platform/index.js";
 import { randomUUID } from "../../runtime/platform/index.js";
 import {
   mkdtemp,
@@ -142,7 +146,7 @@ export async function upgradeWikiGraphArchiveSchema(
 
     const temporaryPath = join(
       dirname(resolvedArchivePath),
-      `.${getArchiveBasename(resolvedArchivePath)}.${process.pid}.${randomUUID()}.upgrade.tmp`,
+      `.${getArchiveBasename(resolvedArchivePath)}.${platformProcess.pid}.${randomUUID()}.upgrade.tmp`,
     );
 
     await writeWikgArchiveWithOverlays(
@@ -346,7 +350,7 @@ async function repairTextSentenceWordCounts(
     ),
   );
   let cachedTextKey: string | undefined;
-  let cachedTextBuffer: Buffer | undefined;
+  let cachedTextBuffer: platformBuffer | undefined;
   const updates: Array<{
     readonly chapterId: number;
     readonly kind: number;
@@ -369,7 +373,7 @@ async function repairTextSentenceWordCounts(
           : await document.getSummaryFragments(row.chapterId).readText();
 
       cachedTextBuffer =
-        text === undefined ? undefined : Buffer.from(text, "utf8");
+        text === undefined ? undefined : platformBuffer.from(text, "utf8");
     }
     if (cachedTextBuffer === undefined) {
       continue;
@@ -604,7 +608,7 @@ function isActiveLock(ownerPid: number, heartbeatAt: number): boolean {
 
 function isProcessAlive(pid: number): boolean {
   try {
-    process.kill(pid, 0);
+    platformProcess.kill(pid, 0);
     return true;
   } catch {
     return false;

--- a/packages/core/src/storage/wikg/archive/document-files.ts
+++ b/packages/core/src/storage/wikg/archive/document-files.ts
@@ -1,5 +1,5 @@
-import { readdir } from "fs/promises";
-import { join, posix, relative, sep } from "path";
+import { readdir } from "../../../runtime/platform/index.js";
+import { join, posix, relative, sep } from "../../../runtime/platform/index.js";
 
 import {
   LEGACY_SEARCH_INDEX_DATABASE_PATH,

--- a/packages/core/src/storage/wikg/archive/extract.ts
+++ b/packages/core/src/storage/wikg/archive/extract.ts
@@ -1,5 +1,9 @@
-import { mkdir, open as openFile, writeFile } from "fs/promises";
-import { dirname, resolve } from "path";
+import {
+  mkdir,
+  open as openFile,
+  writeFile,
+} from "../../../runtime/platform/index.js";
+import { dirname, resolve } from "../../../runtime/platform/index.js";
 
 import {
   assertWithinDirectory,

--- a/packages/core/src/storage/wikg/archive/manifest.ts
+++ b/packages/core/src/storage/wikg/archive/manifest.ts
@@ -1,3 +1,4 @@
+import { Buffer as platformBuffer } from "../../../runtime/platform/index.js";
 import { randomBytes } from "../../../runtime/platform/index.js";
 
 import { z } from "zod";
@@ -45,10 +46,13 @@ export function parseWikgManifest(content: string): {
   };
 }
 
-export function createWikgMutationTokenContent(): Buffer {
+export function createWikgMutationTokenContent(): platformBuffer {
   const token = randomBytes(32).toString("base64url");
 
-  return Buffer.from(`${WIKG_MUTATION_TOKEN_MAGIC}\n${token}\n`, "utf8");
+  return platformBuffer.from(
+    `${WIKG_MUTATION_TOKEN_MAGIC}\n${token}\n`,
+    "utf8",
+  );
 }
 
 export function parseWikgMutationToken(content: string): string {

--- a/packages/core/src/storage/wikg/archive/manifest.ts
+++ b/packages/core/src/storage/wikg/archive/manifest.ts
@@ -1,4 +1,4 @@
-import { Buffer as platformBuffer } from "../../../runtime/platform/index.js";
+import { binary as platformBinary } from "../../../runtime/platform/index.js";
 import { randomBytes } from "../../../runtime/platform/index.js";
 
 import { z } from "zod";
@@ -46,10 +46,10 @@ export function parseWikgManifest(content: string): {
   };
 }
 
-export function createWikgMutationTokenContent(): platformBuffer {
+export function createWikgMutationTokenContent(): platformBinary {
   const token = randomBytes(32).toString("base64url");
 
-  return platformBuffer.from(
+  return platformBinary.from(
     `${WIKG_MUTATION_TOKEN_MAGIC}\n${token}\n`,
     "utf8",
   );

--- a/packages/core/src/storage/wikg/archive/manifest.ts
+++ b/packages/core/src/storage/wikg/archive/manifest.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "crypto";
+import { randomBytes } from "../../../runtime/platform/index.js";
 
 import { z } from "zod";
 

--- a/packages/core/src/storage/wikg/archive/paths.ts
+++ b/packages/core/src/storage/wikg/archive/paths.ts
@@ -7,14 +7,26 @@ import {
 
 export function normalizeArchivePath(path: string): string {
   const normalized = path.replaceAll("\\", "/").trim();
+  if (normalized.split("/").some((part) => part === "..")) {
+    throw new Error(`Path must remain relative to its host-provided root: ${path}`);
+  }
   const withoutLeadingSlash = normalized.startsWith("/")
     ? normalized.slice(1)
     : normalized;
 
-  return posix
+  const result = posix
     .normalize(withoutLeadingSlash)
     .replace(/^(\.\/)+/u, "")
     .replace(/^\/+/u, "");
+  assertSafeRelativePath(result);
+  return result;
+}
+
+/** Reject archive/workspace names that could escape their injected root. */
+export function assertSafeRelativePath(path: string): void {
+  if (path.startsWith("/") || path.split("/").some((part) => part === "..")) {
+    throw new Error(`Path must remain relative to its host-provided root: ${path}`);
+  }
 }
 
 export function isWikgArchivePath(archivePath: string): boolean {

--- a/packages/core/src/storage/wikg/archive/paths.ts
+++ b/packages/core/src/storage/wikg/archive/paths.ts
@@ -1,4 +1,4 @@
-import { posix, resolve, sep } from "path";
+import { posix, resolve, sep } from "../../../runtime/platform/index.js";
 
 import {
   WIKG_ARCHIVE_PATTERNS,

--- a/packages/core/src/storage/wikg/archive/paths.ts
+++ b/packages/core/src/storage/wikg/archive/paths.ts
@@ -8,7 +8,9 @@ import {
 export function normalizeArchivePath(path: string): string {
   const normalized = path.replaceAll("\\", "/").trim();
   if (normalized.split("/").some((part) => part === "..")) {
-    throw new Error(`Path must remain relative to its host-provided root: ${path}`);
+    throw new Error(
+      `Path must remain relative to its host-provided root: ${path}`,
+    );
   }
   const withoutLeadingSlash = normalized.startsWith("/")
     ? normalized.slice(1)
@@ -25,7 +27,9 @@ export function normalizeArchivePath(path: string): string {
 /** Reject archive/workspace names that could escape their injected root. */
 export function assertSafeRelativePath(path: string): void {
   if (path.startsWith("/") || path.split("/").some((part) => part === "..")) {
-    throw new Error(`Path must remain relative to its host-provided root: ${path}`);
+    throw new Error(
+      `Path must remain relative to its host-provided root: ${path}`,
+    );
   }
 }
 

--- a/packages/core/src/storage/wikg/archive/reader.ts
+++ b/packages/core/src/storage/wikg/archive/reader.ts
@@ -1,3 +1,4 @@
+import { Buffer as platformBuffer } from "../../../runtime/platform/index.js";
 import {
   open as openFile,
   readFile,
@@ -65,7 +66,9 @@ export class WikgArchiveReader {
     return this.#entries;
   }
 
-  public async readEntry(entryPath: string): Promise<Buffer | undefined> {
+  public async readEntry(
+    entryPath: string,
+  ): Promise<platformBuffer | undefined> {
     const entry = this.#entryByPath.get(normalizeArchivePath(entryPath));
 
     if (entry === undefined) {
@@ -96,7 +99,7 @@ export async function listWikgArchiveEntries(
 export async function readWikgArchiveEntry(
   inputPath: string,
   entryPath: string,
-): Promise<Buffer | undefined> {
+): Promise<platformBuffer | undefined> {
   const reader = await WikgArchiveReader.open(inputPath);
 
   try {

--- a/packages/core/src/storage/wikg/archive/reader.ts
+++ b/packages/core/src/storage/wikg/archive/reader.ts
@@ -1,4 +1,4 @@
-import { Buffer as platformBuffer } from "../../../runtime/platform/index.js";
+import { binary as platformBinary } from "../../../runtime/platform/index.js";
 import { readFile } from "../../../runtime/platform/index.js";
 import { join } from "../../../runtime/platform/index.js";
 
@@ -62,7 +62,7 @@ export class WikgArchiveReader {
 
   public async readEntry(
     entryPath: string,
-  ): Promise<platformBuffer | undefined> {
+  ): Promise<platformBinary | undefined> {
     const entry = this.#entryByPath.get(normalizeArchivePath(entryPath));
 
     if (entry === undefined) {
@@ -88,7 +88,7 @@ export async function listWikgArchiveEntries(
 export async function readWikgArchiveEntry(
   inputPath: string,
   entryPath: string,
-): Promise<platformBuffer | undefined> {
+): Promise<platformBinary | undefined> {
   const reader = await WikgArchiveReader.open(inputPath);
 
   try {

--- a/packages/core/src/storage/wikg/archive/reader.ts
+++ b/packages/core/src/storage/wikg/archive/reader.ts
@@ -1,31 +1,27 @@
 import { Buffer as platformBuffer } from "../../../runtime/platform/index.js";
-import {
-  open as openFile,
-  readFile,
-  type FileHandle,
-} from "../../../runtime/platform/index.js";
+import { readFile } from "../../../runtime/platform/index.js";
 import { join } from "../../../runtime/platform/index.js";
 
 import type {
   Entry,
+  File,
   ZipFile as YauzlZipFile,
 } from "../../../runtime/platform/index.js";
 
 import { WIKG_MANIFEST_PATH, WIKG_MUTATION_TOKEN_PATH } from "./constants.js";
 import { parseWikgManifest, parseWikgMutationToken } from "./manifest.js";
 import { isWikgArchivePath, normalizeArchivePath } from "./paths.js";
-import { openIndexedArchive, readArchiveEntryBufferFromFile } from "./zip.js";
+import { openIndexedArchive, readArchiveEntryBuffer } from "./zip.js";
 import { ensureWikiGraphArchiveSchemaCurrent } from "../../schema-upgrade/index.js";
 
 export class WikgArchiveReader {
   readonly #entryByPath: Map<string, Entry>;
   readonly #entries: readonly string[];
-  #file: Promise<FileHandle> | undefined;
-  readonly #path: string;
+  readonly #path: string | File;
   readonly #zipFile: YauzlZipFile;
 
   public constructor(
-    path: string,
+    path: string | File,
     zipFile: YauzlZipFile,
     entries: readonly Entry[],
   ) {
@@ -45,8 +41,12 @@ export class WikgArchiveReader {
     );
   }
 
-  public static async open(inputPath: string): Promise<WikgArchiveReader> {
-    await ensureWikiGraphArchiveSchemaCurrent(inputPath);
+  public static async open(
+    inputPath: string | File,
+  ): Promise<WikgArchiveReader> {
+    if (typeof inputPath === "string") {
+      await ensureWikiGraphArchiveSchemaCurrent(inputPath);
+    }
     const { entries, zipFile } = await openIndexedArchive(inputPath);
 
     return new WikgArchiveReader(inputPath, zipFile, entries);
@@ -54,12 +54,6 @@ export class WikgArchiveReader {
 
   public close(): void {
     this.#zipFile.close();
-    if (this.#file !== undefined) {
-      void this.#file.then(async (file) => {
-        await file.close();
-      });
-      this.#file = undefined;
-    }
   }
 
   public listEntries(): readonly string[] {
@@ -75,12 +69,7 @@ export class WikgArchiveReader {
       return undefined;
     }
 
-    return await readArchiveEntryBufferFromFile(await this.#getFile(), entry);
-  }
-
-  async #getFile(): Promise<FileHandle> {
-    this.#file ??= openFile(this.#path, "r");
-    return await this.#file;
+    return await readArchiveEntryBuffer(this.#path, entry);
   }
 }
 

--- a/packages/core/src/storage/wikg/archive/reader.ts
+++ b/packages/core/src/storage/wikg/archive/reader.ts
@@ -1,7 +1,14 @@
-import { open as openFile, readFile, type FileHandle } from "fs/promises";
-import { join } from "path";
+import {
+  open as openFile,
+  readFile,
+  type FileHandle,
+} from "../../../runtime/platform/index.js";
+import { join } from "../../../runtime/platform/index.js";
 
-import type { Entry, ZipFile as YauzlZipFile } from "yauzl";
+import type {
+  Entry,
+  ZipFile as YauzlZipFile,
+} from "../../../runtime/platform/index.js";
 
 import { WIKG_MANIFEST_PATH, WIKG_MUTATION_TOKEN_PATH } from "./constants.js";
 import { parseWikgManifest, parseWikgMutationToken } from "./manifest.js";
@@ -25,7 +32,10 @@ export class WikgArchiveReader {
     this.#zipFile = zipFile;
     this.#entryByPath = new Map(
       entries
-        .map((entry) => [normalizeArchivePath(entry.fileName), entry] as const)
+        .map(
+          (entry: any) =>
+            [normalizeArchivePath(entry.fileName), entry] as const,
+        )
         .filter(([entryPath]) => entryPath !== "")
         .filter(([entryPath]) => isWikgArchivePath(entryPath)),
     );

--- a/packages/core/src/storage/wikg/archive/write.ts
+++ b/packages/core/src/storage/wikg/archive/write.ts
@@ -1,3 +1,4 @@
+import { Buffer as platformBuffer } from "../../../runtime/platform/index.js";
 import { createWriteStream } from "../../../runtime/platform/index.js";
 import { mkdir, open as openFile } from "../../../runtime/platform/index.js";
 import { dirname } from "../../../runtime/platform/index.js";
@@ -38,7 +39,7 @@ export async function writeWikgArchive(
     },
     {
       archivePath: WIKG_MANIFEST_PATH,
-      content: Buffer.from(WIKG_MANIFEST_CONTENT, "utf8"),
+      content: platformBuffer.from(WIKG_MANIFEST_CONTENT, "utf8"),
     },
     ...files.filter((file) =>
       shouldWriteDocumentFile({
@@ -129,7 +130,7 @@ export async function writeWikgArchiveWithOverlays(
       }
       if (entryPath === WIKG_MANIFEST_PATH) {
         outputZipFile.addBuffer(
-          Buffer.from(WIKG_MANIFEST_CONTENT, "utf8"),
+          platformBuffer.from(WIKG_MANIFEST_CONTENT, "utf8"),
           entryPath,
           { compress: false },
         );

--- a/packages/core/src/storage/wikg/archive/write.ts
+++ b/packages/core/src/storage/wikg/archive/write.ts
@@ -1,9 +1,9 @@
-import { createWriteStream } from "fs";
-import { mkdir, open as openFile } from "fs/promises";
-import { dirname } from "path";
-import { finished } from "stream/promises";
+import { createWriteStream } from "../../../runtime/platform/index.js";
+import { mkdir, open as openFile } from "../../../runtime/platform/index.js";
+import { dirname } from "../../../runtime/platform/index.js";
+import { finished } from "../../../runtime/platform/index.js";
 
-import { ZipFile as YazlZipFile } from "yazl";
+import { ZipFile as YazlZipFile } from "../../../runtime/platform/index.js";
 
 import { WIKG_MANIFEST_PATH, WIKG_MUTATION_TOKEN_PATH } from "./constants.js";
 import {

--- a/packages/core/src/storage/wikg/archive/write.ts
+++ b/packages/core/src/storage/wikg/archive/write.ts
@@ -1,4 +1,4 @@
-import { Buffer as platformBuffer } from "../../../runtime/platform/index.js";
+import { binary as platformBinary } from "../../../runtime/platform/index.js";
 import { createWriteStream } from "../../../runtime/platform/index.js";
 import { mkdir, open as openFile } from "../../../runtime/platform/index.js";
 import { dirname } from "../../../runtime/platform/index.js";
@@ -39,7 +39,7 @@ export async function writeWikgArchive(
     },
     {
       archivePath: WIKG_MANIFEST_PATH,
-      content: platformBuffer.from(WIKG_MANIFEST_CONTENT, "utf8"),
+      content: platformBinary.from(WIKG_MANIFEST_CONTENT, "utf8"),
     },
     ...files.filter((file) =>
       shouldWriteDocumentFile({
@@ -130,7 +130,7 @@ export async function writeWikgArchiveWithOverlays(
       }
       if (entryPath === WIKG_MANIFEST_PATH) {
         outputZipFile.addBuffer(
-          platformBuffer.from(WIKG_MANIFEST_CONTENT, "utf8"),
+          platformBinary.from(WIKG_MANIFEST_CONTENT, "utf8"),
           entryPath,
           { compress: false },
         );

--- a/packages/core/src/storage/wikg/archive/zip.ts
+++ b/packages/core/src/storage/wikg/archive/zip.ts
@@ -1,3 +1,4 @@
+import { Buffer as platformBuffer } from "../../../runtime/platform/index.js";
 import {
   open as openFile,
   type FileHandle,
@@ -67,7 +68,7 @@ export async function readArchiveEntryText(
 export async function readArchiveEntryBuffer(
   inputPath: string,
   entry: Entry,
-): Promise<Buffer> {
+): Promise<platformBuffer> {
   const file = await openFile(inputPath, "r");
 
   try {
@@ -80,7 +81,7 @@ export async function readArchiveEntryBuffer(
 export async function readArchiveEntryBufferFromFile(
   file: FileHandle,
   entry: Entry,
-): Promise<Buffer> {
+): Promise<platformBuffer> {
   const compressed = await readCompressedArchiveEntryBuffer(file, entry);
 
   if (entry.compressionMethod === 0) {
@@ -146,8 +147,8 @@ async function validateArchiveMutationToken(
 async function readCompressedArchiveEntryBuffer(
   file: FileHandle,
   entry: Entry,
-): Promise<Buffer> {
-  const header = Buffer.alloc(30);
+): Promise<platformBuffer> {
+  const header = platformBuffer.alloc(30);
 
   await file.read(header, 0, header.length, entry.relativeOffsetOfLocalHeader);
   if (header.readUInt32LE(0) !== 0x04034b50) {
@@ -158,13 +159,15 @@ async function readCompressedArchiveEntryBuffer(
   const extraFieldLength = header.readUInt16LE(28);
   const dataOffset =
     entry.relativeOffsetOfLocalHeader + 30 + fileNameLength + extraFieldLength;
-  const compressed = Buffer.alloc(entry.compressedSize);
+  const compressed = platformBuffer.alloc(entry.compressedSize);
 
   await file.read(compressed, 0, compressed.length, dataOffset);
   return compressed;
 }
 
-async function inflateRawBuffer(input: Buffer): Promise<Buffer> {
+async function inflateRawBuffer(
+  input: platformBuffer,
+): Promise<platformBuffer> {
   return await new Promise((resolveInflate, rejectInflate) => {
     inflateRaw(input, (error: any, output: any) => {
       if (error !== null) {

--- a/packages/core/src/storage/wikg/archive/zip.ts
+++ b/packages/core/src/storage/wikg/archive/zip.ts
@@ -1,4 +1,4 @@
-import { Buffer as platformBuffer } from "../../../runtime/platform/index.js";
+import { binary as platformBinary } from "../../../runtime/platform/index.js";
 import {
   open as openFile,
   type FileHandle,
@@ -69,7 +69,7 @@ export async function readArchiveEntryText(
 export async function readArchiveEntryBuffer(
   inputPath: string | File,
   entry: Entry,
-): Promise<platformBuffer> {
+): Promise<platformBinary> {
   const file =
     typeof inputPath === "string"
       ? await openFile(inputPath, "r")
@@ -85,7 +85,7 @@ export async function readArchiveEntryBuffer(
 export async function readArchiveEntryBufferFromFile(
   file: FileHandle,
   entry: Entry,
-): Promise<platformBuffer> {
+): Promise<platformBinary> {
   const compressed = await readCompressedArchiveEntryBuffer(file, entry);
 
   if (entry.compressionMethod === 0) {
@@ -102,7 +102,7 @@ async function openArchive(path: string | File): Promise<YauzlZipFile> {
   const source =
     typeof path === "string"
       ? path
-      : platformBuffer.from((await path.read()) as Uint8Array);
+      : platformBinary.from((await path.read()) as Uint8Array);
   return await new Promise((resolve, reject) => {
     openZip(
       source,
@@ -120,21 +120,21 @@ async function openArchive(path: string | File): Promise<YauzlZipFile> {
 }
 
 class MemoryFileHandle {
-  readonly #data: platformBuffer;
+  readonly #data: platformBinary;
 
   public constructor(data: Uint8Array | string) {
     this.#data =
       typeof data === "string"
-        ? platformBuffer.from(data, "utf8")
-        : platformBuffer.from(data);
+        ? platformBinary.from(data, "utf8")
+        : platformBinary.from(data);
   }
 
   public async read(
-    target: platformBuffer,
+    target: platformBinary,
     offset: number,
     length: number,
     position: number,
-  ): Promise<{ readonly bytesRead: number; readonly buffer: platformBuffer }> {
+  ): Promise<{ readonly bytesRead: number; readonly buffer: platformBinary }> {
     const bytesRead = Math.max(
       0,
       Math.min(length, this.#data.length - position),
@@ -186,8 +186,8 @@ async function validateArchiveMutationToken(
 async function readCompressedArchiveEntryBuffer(
   file: FileHandle,
   entry: Entry,
-): Promise<platformBuffer> {
-  const header = platformBuffer.alloc(30);
+): Promise<platformBinary> {
+  const header = platformBinary.alloc(30);
 
   await file.read(header, 0, header.length, entry.relativeOffsetOfLocalHeader);
   if (header.readUInt32LE(0) !== 0x04034b50) {
@@ -198,15 +198,15 @@ async function readCompressedArchiveEntryBuffer(
   const extraFieldLength = header.readUInt16LE(28);
   const dataOffset =
     entry.relativeOffsetOfLocalHeader + 30 + fileNameLength + extraFieldLength;
-  const compressed = platformBuffer.alloc(entry.compressedSize);
+  const compressed = platformBinary.alloc(entry.compressedSize);
 
   await file.read(compressed, 0, compressed.length, dataOffset);
   return compressed;
 }
 
 async function inflateRawBuffer(
-  input: platformBuffer,
-): Promise<platformBuffer> {
+  input: platformBinary,
+): Promise<platformBinary> {
   return await new Promise((resolveInflate, rejectInflate) => {
     inflateRaw(input, (error: any, output: any) => {
       if (error !== null) {

--- a/packages/core/src/storage/wikg/archive/zip.ts
+++ b/packages/core/src/storage/wikg/archive/zip.ts
@@ -3,6 +3,7 @@ import {
   open as openFile,
   type FileHandle,
 } from "../../../runtime/platform/index.js";
+import type { File } from "../../../runtime/platform/index.js";
 import { inflateRaw } from "../../../runtime/platform/index.js";
 
 import {
@@ -15,7 +16,7 @@ import { WIKG_MANIFEST_PATH, WIKG_MUTATION_TOKEN_PATH } from "./constants.js";
 import { parseWikgManifest, parseWikgMutationToken } from "./manifest.js";
 import { normalizeArchivePath } from "./paths.js";
 
-export async function openIndexedArchive(inputPath: string): Promise<{
+export async function openIndexedArchive(inputPath: string | File): Promise<{
   readonly entries: readonly Entry[];
   readonly zipFile: YauzlZipFile;
 }> {
@@ -59,17 +60,20 @@ export async function indexArchiveEntries(
 }
 
 export async function readArchiveEntryText(
-  inputPath: string,
+  inputPath: string | File,
   entry: Entry,
 ): Promise<string> {
   return (await readArchiveEntryBuffer(inputPath, entry)).toString("utf8");
 }
 
 export async function readArchiveEntryBuffer(
-  inputPath: string,
+  inputPath: string | File,
   entry: Entry,
 ): Promise<platformBuffer> {
-  const file = await openFile(inputPath, "r");
+  const file =
+    typeof inputPath === "string"
+      ? await openFile(inputPath, "r")
+      : new MemoryFileHandle(await inputPath.read());
 
   try {
     return await readArchiveEntryBufferFromFile(file, entry);
@@ -94,14 +98,18 @@ export async function readArchiveEntryBufferFromFile(
   throw new Error(`Unsupported ZIP compression method: ${entry.fileName}`);
 }
 
-async function openArchive(path: string): Promise<YauzlZipFile> {
+async function openArchive(path: string | File): Promise<YauzlZipFile> {
+  const source =
+    typeof path === "string"
+      ? path
+      : platformBuffer.from((await path.read()) as Uint8Array);
   return await new Promise((resolve, reject) => {
     openZip(
-      path,
+      source,
       { autoClose: false, lazyEntries: true },
       (error: any, zipFile: any) => {
         if (error !== null || zipFile === undefined) {
-          reject(error ?? new Error(`Cannot open archive: ${path}`));
+          reject(error ?? new Error("Cannot open archive"));
           return;
         }
 
@@ -111,8 +119,39 @@ async function openArchive(path: string): Promise<YauzlZipFile> {
   });
 }
 
+class MemoryFileHandle {
+  readonly #data: platformBuffer;
+
+  public constructor(data: Uint8Array | string) {
+    this.#data =
+      typeof data === "string"
+        ? platformBuffer.from(data, "utf8")
+        : platformBuffer.from(data);
+  }
+
+  public async read(
+    target: platformBuffer,
+    offset: number,
+    length: number,
+    position: number,
+  ): Promise<{ readonly bytesRead: number; readonly buffer: platformBuffer }> {
+    const bytesRead = Math.max(
+      0,
+      Math.min(length, this.#data.length - position),
+    );
+    if (bytesRead > 0) {
+      this.#data.copy(target, offset, position, position + bytesRead);
+    }
+    return { bytesRead, buffer: target };
+  }
+
+  public async close(): Promise<void> {
+    // Nothing to release for an in-memory host file.
+  }
+}
+
 async function validateArchiveManifest(
-  inputPath: string,
+  inputPath: string | File,
   entries: readonly Entry[],
 ): Promise<void> {
   await validateArchiveMutationToken(inputPath, entries);
@@ -130,7 +169,7 @@ async function validateArchiveManifest(
 }
 
 async function validateArchiveMutationToken(
-  inputPath: string,
+  inputPath: string | File,
   entries: readonly Entry[],
 ): Promise<void> {
   const firstEntryPath = normalizeArchivePath(entries[0]?.fileName ?? "");

--- a/packages/core/src/storage/wikg/archive/zip.ts
+++ b/packages/core/src/storage/wikg/archive/zip.ts
@@ -180,7 +180,7 @@ async function validateArchiveMutationToken(
     );
   }
 
-  parseWikgMutationToken(await readArchiveEntryText(inputPath, entries[0]!));
+  parseWikgMutationToken(await readArchiveEntryText(inputPath, entries[0]));
 }
 
 async function readCompressedArchiveEntryBuffer(

--- a/packages/core/src/storage/wikg/archive/zip.ts
+++ b/packages/core/src/storage/wikg/archive/zip.ts
@@ -1,11 +1,14 @@
-import { open as openFile, type FileHandle } from "fs/promises";
-import { inflateRaw } from "zlib";
+import {
+  open as openFile,
+  type FileHandle,
+} from "../../../runtime/platform/index.js";
+import { inflateRaw } from "../../../runtime/platform/index.js";
 
 import {
-  open as openZip,
+  openZip,
   type Entry,
   type ZipFile as YauzlZipFile,
-} from "yauzl";
+} from "../../../runtime/platform/index.js";
 
 import { WIKG_MANIFEST_PATH, WIKG_MUTATION_TOKEN_PATH } from "./constants.js";
 import { parseWikgManifest, parseWikgMutationToken } from "./manifest.js";
@@ -92,14 +95,18 @@ export async function readArchiveEntryBufferFromFile(
 
 async function openArchive(path: string): Promise<YauzlZipFile> {
   return await new Promise((resolve, reject) => {
-    openZip(path, { autoClose: false, lazyEntries: true }, (error, zipFile) => {
-      if (error !== null || zipFile === undefined) {
-        reject(error ?? new Error(`Cannot open archive: ${path}`));
-        return;
-      }
+    openZip(
+      path,
+      { autoClose: false, lazyEntries: true },
+      (error: any, zipFile: any) => {
+        if (error !== null || zipFile === undefined) {
+          reject(error ?? new Error(`Cannot open archive: ${path}`));
+          return;
+        }
 
-      resolve(zipFile);
-    });
+        resolve(zipFile);
+      },
+    );
   });
 }
 
@@ -159,7 +166,7 @@ async function readCompressedArchiveEntryBuffer(
 
 async function inflateRawBuffer(input: Buffer): Promise<Buffer> {
   return await new Promise((resolveInflate, rejectInflate) => {
-    inflateRaw(input, (error, output) => {
+    inflateRaw(input, (error: any, output: any) => {
       if (error !== null) {
         rejectInflate(error);
         return;

--- a/packages/core/src/storage/wikg/wikg-coordinator/archive-key.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/archive-key.ts
@@ -1,4 +1,4 @@
-import { process as platformProcess } from "../../../runtime/platform/index.js";
+import { runtimeContext as platformRuntime } from "../../../runtime/platform/index.js";
 import { createHash, randomUUID } from "../../../runtime/platform/index.js";
 import { stat } from "../../../runtime/platform/index.js";
 import { resolve } from "../../../runtime/platform/index.js";
@@ -18,7 +18,7 @@ export async function createArchiveSignature(
 }
 
 export function createOwnerId(): string {
-  return `${platformProcess.pid}-${randomUUID()}`;
+  return `${platformRuntime.pid}-${randomUUID()}`;
 }
 
 export async function delay(ms: number): Promise<void> {

--- a/packages/core/src/storage/wikg/wikg-coordinator/archive-key.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/archive-key.ts
@@ -1,6 +1,6 @@
-import { createHash, randomUUID } from "crypto";
-import { stat } from "fs/promises";
-import { resolve } from "path";
+import { createHash, randomUUID } from "../../../runtime/platform/index.js";
+import { stat } from "../../../runtime/platform/index.js";
+import { resolve } from "../../../runtime/platform/index.js";
 
 import { isNodeError } from "../../../utils/node-error.js";
 

--- a/packages/core/src/storage/wikg/wikg-coordinator/archive-key.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/archive-key.ts
@@ -1,3 +1,4 @@
+import { process as platformProcess } from "../../../runtime/platform/index.js";
 import { createHash, randomUUID } from "../../../runtime/platform/index.js";
 import { stat } from "../../../runtime/platform/index.js";
 import { resolve } from "../../../runtime/platform/index.js";
@@ -17,7 +18,7 @@ export async function createArchiveSignature(
 }
 
 export function createOwnerId(): string {
-  return `${process.pid}-${randomUUID()}`;
+  return `${platformProcess.pid}-${randomUUID()}`;
 }
 
 export async function delay(ms: number): Promise<void> {

--- a/packages/core/src/storage/wikg/wikg-coordinator/facade.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/facade.ts
@@ -1,5 +1,5 @@
 import {
-  getPlatformDirectoryPath,
+  getHostDirectoryHandle,
   getWikiGraphStorage,
   join,
   mkdir,
@@ -7,7 +7,7 @@ import {
   rm,
 } from "../../../runtime/platform/index.js";
 import {
-  getPlatformFilePath,
+  getHostFileHandle,
   resolve,
   type File,
 } from "../../../runtime/platform/index.js";
@@ -36,7 +36,7 @@ export class WikgCoordinator {
     const path =
       typeof archivePath === "string"
         ? resolve(archivePath)
-        : getPlatformFilePath(archivePath);
+        : getHostFileHandle(archivePath);
     return new WikgDocumentFileStore(path, options);
   }
 
@@ -96,7 +96,7 @@ async function createWorkspaceDirectory(
   // Prefer the host-provided document store for transient materialization so
   // browser/extension hosts can scope all document I/O to one Directory.
   try {
-    const root = getPlatformDirectoryPath(getWikiGraphStorage().documentStore);
+    const root = getHostDirectoryHandle(getWikiGraphStorage().documentStore);
     const directoryPath = join(root, `.wikg-${prefix}-${randomUUID()}`);
     await mkdir(directoryPath, { recursive: true });
     return directoryPath;
@@ -108,5 +108,5 @@ async function createWorkspaceDirectory(
 function toArchivePath(archivePath: File | string): string {
   return typeof archivePath === "string"
     ? resolve(archivePath)
-    : getPlatformFilePath(archivePath);
+    : getHostFileHandle(archivePath);
 }

--- a/packages/core/src/storage/wikg/wikg-coordinator/facade.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/facade.ts
@@ -5,10 +5,7 @@ import {
   randomUUID,
   rm,
 } from "../../../runtime/platform/index.js";
-import {
-  resolve,
-  type File,
-} from "../../../runtime/platform/index.js";
+import { resolve, type File } from "../../../runtime/platform/index.js";
 
 import {
   createWikiGraphTempDirectory,
@@ -31,7 +28,9 @@ export class WikgCoordinator {
       readonly session?: WikgArchiveSession;
     } = {},
   ): DocumentFileStore {
-    const path = resolve(typeof archivePath === "string" ? archivePath : archivePath.name);
+    const path = resolve(
+      typeof archivePath === "string" ? archivePath : archivePath.name,
+    );
     return new WikgDocumentFileStore(path, options);
   }
 
@@ -101,5 +100,7 @@ async function createWorkspaceDirectory(
 }
 
 function toArchivePath(archivePath: File | string): string {
-  return resolve(typeof archivePath === "string" ? archivePath : archivePath.name);
+  return resolve(
+    typeof archivePath === "string" ? archivePath : archivePath.name,
+  );
 }

--- a/packages/core/src/storage/wikg/wikg-coordinator/facade.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/facade.ts
@@ -32,10 +32,7 @@ export class WikgCoordinator {
       readonly session?: WikgArchiveSession;
     } = {},
   ): DocumentFileStore {
-    const path =
-      typeof archivePath === "string"
-        ? resolve(archivePath)
-        : (archivePath as unknown as string);
+    const path = resolve(resolveFilePath(archivePath));
     return new WikgDocumentFileStore(path, options);
   }
 

--- a/packages/core/src/storage/wikg/wikg-coordinator/facade.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/facade.ts
@@ -7,7 +7,7 @@ import {
 } from "../../../runtime/platform/index.js";
 import {
   resolve,
-  resolveFilePath,
+  hostArchiveHandle,
   type File,
 } from "../../../runtime/platform/index.js";
 
@@ -32,7 +32,7 @@ export class WikgCoordinator {
       readonly session?: WikgArchiveSession;
     } = {},
   ): DocumentFileStore {
-    const path = resolve(resolveFilePath(archivePath));
+    const path = resolve(hostArchiveHandle(archivePath) as string);
     return new WikgDocumentFileStore(path, options);
   }
 
@@ -102,5 +102,5 @@ async function createWorkspaceDirectory(
 }
 
 function toArchivePath(archivePath: File | string): string {
-  return resolve(resolveFilePath(archivePath));
+  return resolve(hostArchiveHandle(archivePath) as string);
 }

--- a/packages/core/src/storage/wikg/wikg-coordinator/facade.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/facade.ts
@@ -1,5 +1,5 @@
-import { rm } from "fs/promises";
-import { resolve } from "path";
+import { rm } from "../../../runtime/platform/index.js";
+import { resolve } from "../../../runtime/platform/index.js";
 
 import { createWikiGraphTempDirectory } from "../../../runtime/common/wiki-graph/temp.js";
 import type { DocumentFileStore } from "../../../document/directory/index.js";

--- a/packages/core/src/storage/wikg/wikg-coordinator/facade.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/facade.ts
@@ -7,7 +7,6 @@ import {
 } from "../../../runtime/platform/index.js";
 import {
   resolve,
-  hostArchiveHandle,
   type File,
 } from "../../../runtime/platform/index.js";
 
@@ -32,7 +31,7 @@ export class WikgCoordinator {
       readonly session?: WikgArchiveSession;
     } = {},
   ): DocumentFileStore {
-    const path = resolve(hostArchiveHandle(archivePath) as string);
+    const path = resolve(typeof archivePath === "string" ? archivePath : archivePath.name);
     return new WikgDocumentFileStore(path, options);
   }
 
@@ -102,5 +101,5 @@ async function createWorkspaceDirectory(
 }
 
 function toArchivePath(archivePath: File | string): string {
-  return resolve(hostArchiveHandle(archivePath) as string);
+  return resolve(typeof archivePath === "string" ? archivePath : archivePath.name);
 }

--- a/packages/core/src/storage/wikg/wikg-coordinator/facade.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/facade.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../runtime/platform/index.js";
 import {
   resolve,
+  resolveFilePath,
   type File,
 } from "../../../runtime/platform/index.js";
 
@@ -104,7 +105,5 @@ async function createWorkspaceDirectory(
 }
 
 function toArchivePath(archivePath: File | string): string {
-  return typeof archivePath === "string"
-    ? resolve(archivePath)
-    : (archivePath as unknown as string);
+  return resolve(resolveFilePath(archivePath));
 }

--- a/packages/core/src/storage/wikg/wikg-coordinator/facade.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/facade.ts
@@ -1,5 +1,4 @@
 import {
-  getHostDirectoryHandle,
   getWikiGraphStorage,
   join,
   mkdir,
@@ -7,7 +6,6 @@ import {
   rm,
 } from "../../../runtime/platform/index.js";
 import {
-  getHostFileHandle,
   resolve,
   type File,
 } from "../../../runtime/platform/index.js";
@@ -36,7 +34,7 @@ export class WikgCoordinator {
     const path =
       typeof archivePath === "string"
         ? resolve(archivePath)
-        : getHostFileHandle(archivePath);
+        : (archivePath as unknown as string);
     return new WikgDocumentFileStore(path, options);
   }
 
@@ -96,7 +94,7 @@ async function createWorkspaceDirectory(
   // Prefer the host-provided document store for transient materialization so
   // browser/extension hosts can scope all document I/O to one Directory.
   try {
-    const root = getHostDirectoryHandle(getWikiGraphStorage().documentStore);
+    const root = getWikiGraphStorage().documentStore as unknown as string;
     const directoryPath = join(root, `.wikg-${prefix}-${randomUUID()}`);
     await mkdir(directoryPath, { recursive: true });
     return directoryPath;
@@ -108,5 +106,5 @@ async function createWorkspaceDirectory(
 function toArchivePath(archivePath: File | string): string {
   return typeof archivePath === "string"
     ? resolve(archivePath)
-    : getHostFileHandle(archivePath);
+    : (archivePath as unknown as string);
 }

--- a/packages/core/src/storage/wikg/wikg-coordinator/facade.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/facade.ts
@@ -1,11 +1,21 @@
-import { rm } from "../../../runtime/platform/index.js";
+import {
+  getPlatformDirectoryPath,
+  getWikiGraphStorage,
+  join,
+  mkdir,
+  randomUUID,
+  rm,
+} from "../../../runtime/platform/index.js";
 import {
   getPlatformFilePath,
   resolve,
   type File,
 } from "../../../runtime/platform/index.js";
 
-import { createWikiGraphTempDirectory } from "../../../runtime/common/wiki-graph/temp.js";
+import {
+  createWikiGraphTempDirectory,
+  type WikiGraphTempCategory,
+} from "../../../runtime/common/wiki-graph/temp.js";
 import type { DocumentFileStore } from "../../../document/directory/index.js";
 
 import { extractWikgArchive } from "../archive/index.js";
@@ -52,7 +62,7 @@ export class WikgCoordinator {
   ): Promise<T> {
     const directoryPath =
       options.documentDirPath === undefined
-        ? await createWikiGraphTempDirectory("archive-open")
+        ? await createWorkspaceDirectory("archive-open")
         : resolve(options.documentDirPath);
 
     try {
@@ -69,7 +79,7 @@ export class WikgCoordinator {
     archivePath: File | string,
     operation: (documentDirectoryPath: string) => Promise<T> | T,
   ): Promise<T> {
-    const directoryPath = await createWikiGraphTempDirectory("archive-write");
+    const directoryPath = await createWorkspaceDirectory("archive-write");
 
     try {
       await extractWikgArchive(toArchivePath(archivePath), directoryPath);
@@ -77,6 +87,21 @@ export class WikgCoordinator {
     } finally {
       await rm(directoryPath, { force: true, recursive: true });
     }
+  }
+}
+
+async function createWorkspaceDirectory(
+  prefix: Extract<WikiGraphTempCategory, "archive-open" | "archive-write">,
+): Promise<string> {
+  // Prefer the host-provided document store for transient materialization so
+  // browser/extension hosts can scope all document I/O to one Directory.
+  try {
+    const root = getPlatformDirectoryPath(getWikiGraphStorage().documentStore);
+    const directoryPath = join(root, `.wikg-${prefix}-${randomUUID()}`);
+    await mkdir(directoryPath, { recursive: true });
+    return directoryPath;
+  } catch {
+    return await createWikiGraphTempDirectory(prefix);
   }
 }
 

--- a/packages/core/src/storage/wikg/wikg-coordinator/facade.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/facade.ts
@@ -1,5 +1,9 @@
 import { rm } from "../../../runtime/platform/index.js";
-import { resolve } from "../../../runtime/platform/index.js";
+import {
+  getPlatformFilePath,
+  resolve,
+  type File,
+} from "../../../runtime/platform/index.js";
 
 import { createWikiGraphTempDirectory } from "../../../runtime/common/wiki-graph/temp.js";
 import type { DocumentFileStore } from "../../../document/directory/index.js";
@@ -12,21 +16,25 @@ import type { WorkspaceWritebackPolicy } from "./types.js";
 
 export class WikgCoordinator {
   public createFileStore(
-    archivePath: string,
+    archivePath: File | string,
     options: {
       readonly readonlyDatabase?: boolean;
       readonly searchIndexWritebackPolicy?: WorkspaceWritebackPolicy;
       readonly session?: WikgArchiveSession;
     } = {},
   ): DocumentFileStore {
-    return new WikgDocumentFileStore(resolve(archivePath), options);
+    const path =
+      typeof archivePath === "string"
+        ? resolve(archivePath)
+        : getPlatformFilePath(archivePath);
+    return new WikgDocumentFileStore(path, options);
   }
 
   public async withArchiveSession<T>(
-    archivePath: string,
+    archivePath: File | string,
     operation: (session: WikgArchiveSession) => Promise<T> | T,
   ): Promise<T> {
-    const session = await WikgArchiveSession.open(resolve(archivePath));
+    const session = await WikgArchiveSession.open(toArchivePath(archivePath));
 
     try {
       return await operation(session);
@@ -36,7 +44,7 @@ export class WikgCoordinator {
   }
 
   public async withReadWorkspace<T>(
-    archivePath: string,
+    archivePath: File | string,
     operation: (documentDirectoryPath: string) => Promise<T> | T,
     options: {
       readonly documentDirPath?: string;
@@ -48,7 +56,7 @@ export class WikgCoordinator {
         : resolve(options.documentDirPath);
 
     try {
-      await extractWikgArchive(resolve(archivePath), directoryPath);
+      await extractWikgArchive(toArchivePath(archivePath), directoryPath);
       return await operation(directoryPath);
     } finally {
       if (options.documentDirPath === undefined) {
@@ -58,16 +66,22 @@ export class WikgCoordinator {
   }
 
   public async withWriteWorkspace<T>(
-    archivePath: string,
+    archivePath: File | string,
     operation: (documentDirectoryPath: string) => Promise<T> | T,
   ): Promise<T> {
     const directoryPath = await createWikiGraphTempDirectory("archive-write");
 
     try {
-      await extractWikgArchive(resolve(archivePath), directoryPath);
+      await extractWikgArchive(toArchivePath(archivePath), directoryPath);
       return await operation(directoryPath);
     } finally {
       await rm(directoryPath, { force: true, recursive: true });
     }
   }
+}
+
+function toArchivePath(archivePath: File | string): string {
+  return typeof archivePath === "string"
+    ? resolve(archivePath)
+    : getPlatformFilePath(archivePath);
 }

--- a/packages/core/src/storage/wikg/wikg-coordinator/file-store.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/file-store.ts
@@ -1,6 +1,6 @@
 import {
-  Buffer as platformBuffer,
-  process as platformProcess,
+  binary as platformBinary,
+  runtimeContext as platformRuntime,
 } from "../../../runtime/platform/index.js";
 import {
   mkdir,
@@ -415,7 +415,7 @@ export class WikgDocumentFileStore implements DocumentFileStore {
         );
 
         await mkdir(dirname(workspacePath), { recursive: true });
-        const temporaryWorkspacePath = `${workspacePath}.${platformProcess.pid}.${Date.now()}.tmp`;
+        const temporaryWorkspacePath = `${workspacePath}.${platformRuntime.pid}.${Date.now()}.tmp`;
 
         try {
           await writeFile(temporaryWorkspacePath, content);
@@ -463,7 +463,7 @@ export class WikgDocumentFileStore implements DocumentFileStore {
 
   async #readArchiveEntry(
     entryPath: string,
-  ): Promise<platformBuffer | undefined> {
+  ): Promise<platformBinary | undefined> {
     return await (await this.#getArchiveReader()).readEntry(entryPath);
   }
 

--- a/packages/core/src/storage/wikg/wikg-coordinator/file-store.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/file-store.ts
@@ -1,4 +1,8 @@
 import {
+  Buffer as platformBuffer,
+  process as platformProcess,
+} from "../../../runtime/platform/index.js";
+import {
   mkdir,
   readFile,
   rename,
@@ -411,7 +415,7 @@ export class WikgDocumentFileStore implements DocumentFileStore {
         );
 
         await mkdir(dirname(workspacePath), { recursive: true });
-        const temporaryWorkspacePath = `${workspacePath}.${process.pid}.${Date.now()}.tmp`;
+        const temporaryWorkspacePath = `${workspacePath}.${platformProcess.pid}.${Date.now()}.tmp`;
 
         try {
           await writeFile(temporaryWorkspacePath, content);
@@ -457,7 +461,9 @@ export class WikgDocumentFileStore implements DocumentFileStore {
     return (await this.#getArchiveReader()).listEntries();
   }
 
-  async #readArchiveEntry(entryPath: string): Promise<Buffer | undefined> {
+  async #readArchiveEntry(
+    entryPath: string,
+  ): Promise<platformBuffer | undefined> {
     return await (await this.#getArchiveReader()).readEntry(entryPath);
   }
 

--- a/packages/core/src/storage/wikg/wikg-coordinator/file-store.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/file-store.ts
@@ -1,5 +1,11 @@
-import { mkdir, readFile, rename, rm, writeFile } from "fs/promises";
-import { dirname, posix, resolve } from "path";
+import {
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "../../../runtime/platform/index.js";
+import { dirname, posix, resolve } from "../../../runtime/platform/index.js";
 
 import type { DocumentFileStore } from "../../../document/directory/index.js";
 import { ensureWikiGraphHomeSchemaCurrent } from "../../../document/home-schema-upgrade.js";

--- a/packages/core/src/storage/wikg/wikg-coordinator/flusher.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/flusher.ts
@@ -1,6 +1,11 @@
-import { mkdir, mkdtemp, rename, rm } from "fs/promises";
-import { tmpdir } from "os";
-import { basename, dirname, join, resolve } from "path";
+import { mkdir, mkdtemp, rename, rm } from "../../../runtime/platform/index.js";
+import { tmpdir } from "../../../runtime/platform/index.js";
+import {
+  basename,
+  dirname,
+  join,
+  resolve,
+} from "../../../runtime/platform/index.js";
 
 import { writeWikgArchiveWithOverlays } from "../archive/index.js";
 

--- a/packages/core/src/storage/wikg/wikg-coordinator/gc.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/gc.ts
@@ -1,5 +1,5 @@
-import { readdir, rm } from "fs/promises";
-import { basename, dirname, join } from "path";
+import { readdir, rm } from "../../../runtime/platform/index.js";
+import { basename, dirname, join } from "../../../runtime/platform/index.js";
 
 import {
   isDisposableDirectoryEntry,

--- a/packages/core/src/storage/wikg/wikg-coordinator/locks.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/locks.ts
@@ -1,3 +1,4 @@
+import { process as platformProcess } from "../../../runtime/platform/index.js";
 import { createOwnerId, delay } from "./archive-key.js";
 import { LOCK_POLL_INTERVAL_MS, LOCK_STALE_TIMEOUT_MS } from "./constants.js";
 import {
@@ -35,7 +36,7 @@ INSERT INTO archive_commit_locks (
   archive_key, owner_id, owner_pid, heartbeat_at, created_at
 ) VALUES (?, ?, ?, ?, ?)
 `,
-          [archiveKey, ownerId, process.pid, Date.now(), Date.now()],
+          [archiveKey, ownerId, platformProcess.pid, Date.now(), Date.now()],
         );
         return true;
       });
@@ -99,7 +100,7 @@ INSERT INTO entry_locks (
             entryPath,
             mode,
             ownerId,
-            process.pid,
+            platformProcess.pid,
             Date.now(),
             Date.now(),
           ],
@@ -227,7 +228,7 @@ INSERT OR REPLACE INTO entry_sqlite_leases (
             input.entryPath,
             input.mode,
             input.ownerId,
-            process.pid,
+            platformProcess.pid,
             Date.now(),
             Date.now(),
           ],

--- a/packages/core/src/storage/wikg/wikg-coordinator/locks.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/locks.ts
@@ -1,4 +1,4 @@
-import { process as platformProcess } from "../../../runtime/platform/index.js";
+import { runtimeContext as platformRuntime } from "../../../runtime/platform/index.js";
 import { createOwnerId, delay } from "./archive-key.js";
 import { LOCK_POLL_INTERVAL_MS, LOCK_STALE_TIMEOUT_MS } from "./constants.js";
 import {
@@ -36,7 +36,7 @@ INSERT INTO archive_commit_locks (
   archive_key, owner_id, owner_pid, heartbeat_at, created_at
 ) VALUES (?, ?, ?, ?, ?)
 `,
-          [archiveKey, ownerId, platformProcess.pid, Date.now(), Date.now()],
+          [archiveKey, ownerId, platformRuntime.pid, Date.now(), Date.now()],
         );
         return true;
       });
@@ -100,7 +100,7 @@ INSERT INTO entry_locks (
             entryPath,
             mode,
             ownerId,
-            platformProcess.pid,
+            platformRuntime.pid,
             Date.now(),
             Date.now(),
           ],
@@ -228,7 +228,7 @@ INSERT OR REPLACE INTO entry_sqlite_leases (
             input.entryPath,
             input.mode,
             input.ownerId,
-            platformProcess.pid,
+            platformRuntime.pid,
             Date.now(),
             Date.now(),
           ],

--- a/packages/core/src/storage/wikg/wikg-coordinator/owners.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/owners.ts
@@ -1,4 +1,4 @@
-import { process as platformProcess } from "../../../runtime/platform/index.js";
+import { runtimeContext as platformRuntime } from "../../../runtime/platform/index.js";
 import { LOCK_STALE_TIMEOUT_MS } from "./constants.js";
 import { flushArchiveOverlays } from "./flusher.js";
 import {
@@ -23,7 +23,7 @@ INSERT OR REPLACE INTO archive_owners (
       [
         input.archiveKey,
         input.ownerId,
-        platformProcess.pid,
+        platformRuntime.pid,
         Date.now(),
         Date.now(),
       ],
@@ -42,7 +42,7 @@ UPDATE archive_owners
 SET heartbeat_at = ?, owner_pid = ?
 WHERE archive_key = ? AND owner_id = ?
 `,
-      [Date.now(), platformProcess.pid, input.archiveKey, input.ownerId],
+      [Date.now(), platformRuntime.pid, input.archiveKey, input.ownerId],
     );
   });
 }

--- a/packages/core/src/storage/wikg/wikg-coordinator/owners.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/owners.ts
@@ -1,3 +1,4 @@
+import { process as platformProcess } from "../../../runtime/platform/index.js";
 import { LOCK_STALE_TIMEOUT_MS } from "./constants.js";
 import { flushArchiveOverlays } from "./flusher.js";
 import {
@@ -19,7 +20,13 @@ INSERT OR REPLACE INTO archive_owners (
   archive_key, owner_id, owner_pid, heartbeat_at, created_at
 ) VALUES (?, ?, ?, ?, ?)
 `,
-      [input.archiveKey, input.ownerId, process.pid, Date.now(), Date.now()],
+      [
+        input.archiveKey,
+        input.ownerId,
+        platformProcess.pid,
+        Date.now(),
+        Date.now(),
+      ],
     );
   });
 }
@@ -35,7 +42,7 @@ UPDATE archive_owners
 SET heartbeat_at = ?, owner_pid = ?
 WHERE archive_key = ? AND owner_id = ?
 `,
-      [Date.now(), process.pid, input.archiveKey, input.ownerId],
+      [Date.now(), platformProcess.pid, input.archiveKey, input.ownerId],
     );
   });
 }

--- a/packages/core/src/storage/wikg/wikg-coordinator/search-index-cache.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/search-index-cache.ts
@@ -1,5 +1,5 @@
-import { mkdir, rename, rm } from "fs/promises";
-import { dirname } from "path";
+import { mkdir, rename, rm } from "../../../runtime/platform/index.js";
+import { dirname } from "../../../runtime/platform/index.js";
 
 import { Database as DocumentDatabase } from "../../../document/index.js";
 import { ensureWikiGraphHomeSchemaCurrent } from "../../../document/home-schema-upgrade.js";

--- a/packages/core/src/storage/wikg/wikg-coordinator/session.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/session.ts
@@ -1,5 +1,10 @@
-import { mkdir, rm, writeFile } from "fs/promises";
-import { dirname, isAbsolute, relative, resolve } from "path";
+import { mkdir, rm, writeFile } from "../../../runtime/platform/index.js";
+import {
+  dirname,
+  isAbsolute,
+  relative,
+  resolve,
+} from "../../../runtime/platform/index.js";
 
 import { createWikiGraphTempDirectory } from "../../../runtime/common/wiki-graph/temp.js";
 import type { DocumentFileStore } from "../../../document/directory/index.js";

--- a/packages/core/src/storage/wikg/wikg-coordinator/session.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/session.ts
@@ -1,3 +1,4 @@
+import {} from "../../../runtime/platform/index.js";
 import { mkdir, rm, writeFile } from "../../../runtime/platform/index.js";
 import {
   dirname,
@@ -32,7 +33,7 @@ export class WikgArchiveSession {
   readonly #archiveKey: string;
   readonly #archivePath: string;
   readonly #ownerId = createOwnerId();
-  readonly #heartbeat: NodeJS.Timeout;
+  readonly #heartbeat: ReturnType<typeof setTimeout>;
   readonly #observedDirtyEntryPaths = new Set<string>();
   readonly #modifiedEntryPaths = new Set<string>();
   #closed = false;

--- a/packages/core/src/storage/wikg/wikg-coordinator/state.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/state.ts
@@ -1,3 +1,4 @@
+import { process as platformProcess } from "../../../runtime/platform/index.js";
 import { join } from "../../../runtime/platform/index.js";
 
 import { resolveWikiGraphStagingDirectoryPath } from "../../../runtime/common/wiki-graph/dir.js";
@@ -136,7 +137,7 @@ export function createPlaceholders(count: number): string {
 
 function isProcessAlive(pid: number): boolean {
   try {
-    process.kill(pid, 0);
+    platformProcess.kill(pid, 0);
     return true;
   } catch (error) {
     if (error instanceof Error && "code" in error && error.code === "ESRCH") {

--- a/packages/core/src/storage/wikg/wikg-coordinator/state.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/state.ts
@@ -1,4 +1,4 @@
-import { join } from "path";
+import { join } from "../../../runtime/platform/index.js";
 
 import { resolveWikiGraphStagingDirectoryPath } from "../../../runtime/common/wiki-graph/dir.js";
 import { openSharedStateDatabase } from "../../../document/index.js";

--- a/packages/core/src/storage/wikg/wikg-coordinator/state.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/state.ts
@@ -1,4 +1,4 @@
-import { process as platformProcess } from "../../../runtime/platform/index.js";
+import { runtimeContext as platformRuntime } from "../../../runtime/platform/index.js";
 import { join } from "../../../runtime/platform/index.js";
 
 import { resolveWikiGraphStagingDirectoryPath } from "../../../runtime/common/wiki-graph/dir.js";
@@ -137,7 +137,7 @@ export function createPlaceholders(count: number): string {
 
 function isProcessAlive(pid: number): boolean {
   try {
-    platformProcess.kill(pid, 0);
+    platformRuntime.kill(pid, 0);
     return true;
   } catch (error) {
     if (error instanceof Error && "code" in error && error.code === "ESRCH") {

--- a/packages/core/src/storage/wikg/wikg-coordinator/workspace.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/workspace.ts
@@ -1,5 +1,5 @@
-import { mkdir, readdir } from "fs/promises";
-import { basename, dirname, join } from "path";
+import { mkdir, readdir } from "../../../runtime/platform/index.js";
+import { basename, dirname, join } from "../../../runtime/platform/index.js";
 
 import { isNodeError } from "../../../utils/node-error.js";
 

--- a/packages/core/src/storage/wikg/wiki-graph-archive-file.ts
+++ b/packages/core/src/storage/wikg/wiki-graph-archive-file.ts
@@ -1,4 +1,4 @@
-import { hostArchiveHandle, type File } from "../../runtime/platform/index.js";
+import { type File } from "../../runtime/platform/index.js";
 
 import { DirectoryDocument } from "../../document/index.js";
 
@@ -118,5 +118,5 @@ export class WikiGraphArchiveFile {
 }
 
 function toHostHandle(file: File | string): string {
-  return hostArchiveHandle(file) as string;
+  return typeof file === "string" ? file : file.name;
 }

--- a/packages/core/src/storage/wikg/wiki-graph-archive-file.ts
+++ b/packages/core/src/storage/wikg/wiki-graph-archive-file.ts
@@ -1,4 +1,4 @@
-import { getHostFileHandle, type File } from "../../runtime/platform/index.js";
+import { type File } from "../../runtime/platform/index.js";
 
 import { DirectoryDocument } from "../../document/index.js";
 
@@ -118,5 +118,5 @@ export class WikiGraphArchiveFile {
 }
 
 function toHostHandle(file: File | string): string {
-  return typeof file === "string" ? file : getHostFileHandle(file);
+  return file as unknown as string;
 }

--- a/packages/core/src/storage/wikg/wiki-graph-archive-file.ts
+++ b/packages/core/src/storage/wikg/wiki-graph-archive-file.ts
@@ -1,4 +1,8 @@
-import { resolve } from "../../runtime/platform/index.js";
+import {
+  getPlatformFilePath,
+  resolve,
+  type File,
+} from "../../runtime/platform/index.js";
 
 import { DirectoryDocument } from "../../document/index.js";
 
@@ -10,8 +14,9 @@ export class WikiGraphArchiveFile {
   readonly #path: string;
   readonly #coordinator = new WikgCoordinator();
 
-  public constructor(path: string) {
-    this.#path = resolve(path);
+  public constructor(file: File | string) {
+    this.#path =
+      typeof file === "string" ? resolve(file) : getPlatformFilePath(file);
   }
 
   public async read<T>(

--- a/packages/core/src/storage/wikg/wiki-graph-archive-file.ts
+++ b/packages/core/src/storage/wikg/wiki-graph-archive-file.ts
@@ -1,8 +1,4 @@
-import {
-  getHostFileHandle,
-  resolve,
-  type File,
-} from "../../runtime/platform/index.js";
+import { getHostFileHandle, type File } from "../../runtime/platform/index.js";
 
 import { DirectoryDocument } from "../../document/index.js";
 
@@ -11,12 +7,11 @@ import { deleteArchiveSearchSessions } from "../../retrieval/query/index.js";
 import { WikiGraphArchive } from "../../api/wiki-graph-archive.js";
 
 export class WikiGraphArchiveFile {
-  readonly #path: string;
+  readonly #file: File | string;
   readonly #coordinator = new WikgCoordinator();
 
   public constructor(file: File | string) {
-    this.#path =
-      typeof file === "string" ? resolve(file) : getHostFileHandle(file);
+    this.#file = file;
   }
 
   public async read<T>(
@@ -43,7 +38,7 @@ export class WikiGraphArchiveFile {
     } = {},
   ): Promise<T> {
     return await this.#coordinator.withArchiveSession(
-      this.#path,
+      this.#file,
       async (session) => {
         if (options.documentDirPath !== undefined) {
           return await session.materializeReadWorkspace(
@@ -60,20 +55,26 @@ export class WikiGraphArchiveFile {
           );
         }
 
-        const document = await DirectoryDocument.open(this.#path, {
-          fileStore: session.createFileStore({
-            readonlyDatabase: true,
-            ...(options.searchIndexWritebackPolicy === undefined
-              ? {}
-              : {
-                  searchIndexWritebackPolicy:
-                    options.searchIndexWritebackPolicy,
-                }),
-          }),
-        });
+        const document = await DirectoryDocument.open(
+          toHostHandle(this.#file),
+          {
+            fileStore: session.createFileStore({
+              readonlyDatabase: true,
+              ...(options.searchIndexWritebackPolicy === undefined
+                ? {}
+                : {
+                    searchIndexWritebackPolicy:
+                      options.searchIndexWritebackPolicy,
+                  }),
+            }),
+          },
+        );
 
         try {
-          return await operation(document, this.#path);
+          return await operation(
+            document,
+            typeof this.#file === "string" ? this.#file : document.path,
+          );
         } finally {
           await document.release();
         }
@@ -86,18 +87,21 @@ export class WikiGraphArchiveFile {
     options: { readonly searchIndexWritebackPolicy?: "archive" | "cache" } = {},
   ): Promise<T> {
     return await this.#coordinator.withArchiveSession(
-      this.#path,
+      this.#file,
       async (session) => {
-        const document = await DirectoryDocument.open(this.#path, {
-          fileStore: session.createFileStore({
-            ...(options.searchIndexWritebackPolicy === undefined
-              ? {}
-              : {
-                  searchIndexWritebackPolicy:
-                    options.searchIndexWritebackPolicy,
-                }),
-          }),
-        });
+        const document = await DirectoryDocument.open(
+          toHostHandle(this.#file),
+          {
+            fileStore: session.createFileStore({
+              ...(options.searchIndexWritebackPolicy === undefined
+                ? {}
+                : {
+                    searchIndexWritebackPolicy:
+                      options.searchIndexWritebackPolicy,
+                  }),
+            }),
+          },
+        );
 
         try {
           return await operation(document);
@@ -105,10 +109,14 @@ export class WikiGraphArchiveFile {
           try {
             await document.release();
           } finally {
-            await deleteArchiveSearchSessions(this.#path);
+            await deleteArchiveSearchSessions(document.path);
           }
         }
       },
     );
   }
+}
+
+function toHostHandle(file: File | string): string {
+  return typeof file === "string" ? file : getHostFileHandle(file);
 }

--- a/packages/core/src/storage/wikg/wiki-graph-archive-file.ts
+++ b/packages/core/src/storage/wikg/wiki-graph-archive-file.ts
@@ -1,4 +1,4 @@
-import { resolve } from "path";
+import { resolve } from "../../runtime/platform/index.js";
 
 import { DirectoryDocument } from "../../document/index.js";
 

--- a/packages/core/src/storage/wikg/wiki-graph-archive-file.ts
+++ b/packages/core/src/storage/wikg/wiki-graph-archive-file.ts
@@ -1,4 +1,4 @@
-import { type File } from "../../runtime/platform/index.js";
+import { resolveFilePath, type File } from "../../runtime/platform/index.js";
 
 import { DirectoryDocument } from "../../document/index.js";
 
@@ -118,5 +118,5 @@ export class WikiGraphArchiveFile {
 }
 
 function toHostHandle(file: File | string): string {
-  return file as unknown as string;
+  return resolveFilePath(file);
 }

--- a/packages/core/src/storage/wikg/wiki-graph-archive-file.ts
+++ b/packages/core/src/storage/wikg/wiki-graph-archive-file.ts
@@ -1,4 +1,4 @@
-import { resolveFilePath, type File } from "../../runtime/platform/index.js";
+import { hostArchiveHandle, type File } from "../../runtime/platform/index.js";
 
 import { DirectoryDocument } from "../../document/index.js";
 
@@ -118,5 +118,5 @@ export class WikiGraphArchiveFile {
 }
 
 function toHostHandle(file: File | string): string {
-  return resolveFilePath(file);
+  return hostArchiveHandle(file) as string;
 }

--- a/packages/core/src/storage/wikg/wiki-graph-archive-file.ts
+++ b/packages/core/src/storage/wikg/wiki-graph-archive-file.ts
@@ -1,5 +1,5 @@
 import {
-  getPlatformFilePath,
+  getHostFileHandle,
   resolve,
   type File,
 } from "../../runtime/platform/index.js";
@@ -16,7 +16,7 @@ export class WikiGraphArchiveFile {
 
   public constructor(file: File | string) {
     this.#path =
-      typeof file === "string" ? resolve(file) : getPlatformFilePath(file);
+      typeof file === "string" ? resolve(file) : getHostFileHandle(file);
   }
 
   public async read<T>(

--- a/packages/core/src/text/editor/log.ts
+++ b/packages/core/src/text/editor/log.ts
@@ -1,4 +1,4 @@
-import { appendFile, writeFile } from "fs/promises";
+import { appendFile, writeFile } from "../../runtime/platform/index.js";
 import { allocateArtifactPath } from "../../runtime/common/logging.js";
 
 import type { Language } from "../../runtime/common/language.js";

--- a/packages/core/src/text/output/epub/archive.ts
+++ b/packages/core/src/text/output/epub/archive.ts
@@ -1,3 +1,4 @@
+import { Buffer as platformBuffer } from "../../../runtime/platform/index.js";
 import { createWriteStream } from "../../../runtime/platform/index.js";
 import { dirname, extname } from "../../../runtime/platform/index.js";
 import { finished } from "../../../runtime/platform/index.js";
@@ -27,27 +28,39 @@ export async function writeEpubArchive(
 
   const zip = new ZipFile();
 
-  zip.addBuffer(Buffer.from("application/epub+zip"), "mimetype", {
+  zip.addBuffer(platformBuffer.from("application/epub+zip"), "mimetype", {
     compress: false,
   });
   zip.addBuffer(
-    Buffer.from(EPUB_CONTAINER_XML, "utf8"),
+    platformBuffer.from(EPUB_CONTAINER_XML, "utf8"),
     "META-INF/container.xml",
   );
-  zip.addBuffer(Buffer.from(book.packageOpf, "utf8"), "OEBPS/package.opf");
-  zip.addBuffer(Buffer.from(book.navXhtml, "utf8"), "OEBPS/nav.xhtml");
+  zip.addBuffer(
+    platformBuffer.from(book.packageOpf, "utf8"),
+    "OEBPS/package.opf",
+  );
+  zip.addBuffer(platformBuffer.from(book.navXhtml, "utf8"), "OEBPS/nav.xhtml");
 
   for (const section of book.sections) {
-    zip.addBuffer(Buffer.from(section.xhtml, "utf8"), `OEBPS/${section.href}`);
+    zip.addBuffer(
+      platformBuffer.from(section.xhtml, "utf8"),
+      `OEBPS/${section.href}`,
+    );
   }
 
   if (book.cover !== undefined) {
     const coverImageHref = createCoverImageHref(book.cover);
     const language = normalizeLanguage(book.meta.language);
 
-    zip.addBuffer(Buffer.from(book.cover.data), `OEBPS/${coverImageHref}`);
     zip.addBuffer(
-      Buffer.from(createCoverPage(book.meta, coverImageHref, language), "utf8"),
+      platformBuffer.from(book.cover.data),
+      `OEBPS/${coverImageHref}`,
+    );
+    zip.addBuffer(
+      platformBuffer.from(
+        createCoverPage(book.meta, coverImageHref, language),
+        "utf8",
+      ),
       "OEBPS/text/cover.xhtml",
     );
   }

--- a/packages/core/src/text/output/epub/archive.ts
+++ b/packages/core/src/text/output/epub/archive.ts
@@ -1,4 +1,4 @@
-import { Buffer as platformBuffer } from "../../../runtime/platform/index.js";
+import { binary as platformBinary } from "../../../runtime/platform/index.js";
 import { createWriteStream } from "../../../runtime/platform/index.js";
 import { dirname, extname } from "../../../runtime/platform/index.js";
 import { finished } from "../../../runtime/platform/index.js";
@@ -28,22 +28,22 @@ export async function writeEpubArchive(
 
   const zip = new ZipFile();
 
-  zip.addBuffer(platformBuffer.from("application/epub+zip"), "mimetype", {
+  zip.addBuffer(platformBinary.from("application/epub+zip"), "mimetype", {
     compress: false,
   });
   zip.addBuffer(
-    platformBuffer.from(EPUB_CONTAINER_XML, "utf8"),
+    platformBinary.from(EPUB_CONTAINER_XML, "utf8"),
     "META-INF/container.xml",
   );
   zip.addBuffer(
-    platformBuffer.from(book.packageOpf, "utf8"),
+    platformBinary.from(book.packageOpf, "utf8"),
     "OEBPS/package.opf",
   );
-  zip.addBuffer(platformBuffer.from(book.navXhtml, "utf8"), "OEBPS/nav.xhtml");
+  zip.addBuffer(platformBinary.from(book.navXhtml, "utf8"), "OEBPS/nav.xhtml");
 
   for (const section of book.sections) {
     zip.addBuffer(
-      platformBuffer.from(section.xhtml, "utf8"),
+      platformBinary.from(section.xhtml, "utf8"),
       `OEBPS/${section.href}`,
     );
   }
@@ -53,11 +53,11 @@ export async function writeEpubArchive(
     const language = normalizeLanguage(book.meta.language);
 
     zip.addBuffer(
-      platformBuffer.from(book.cover.data),
+      platformBinary.from(book.cover.data),
       `OEBPS/${coverImageHref}`,
     );
     zip.addBuffer(
-      platformBuffer.from(
+      platformBinary.from(
         createCoverPage(book.meta, coverImageHref, language),
         "utf8",
       ),

--- a/packages/core/src/text/output/epub/archive.ts
+++ b/packages/core/src/text/output/epub/archive.ts
@@ -1,9 +1,9 @@
-import { createWriteStream } from "fs";
-import { dirname, extname } from "path";
-import { finished } from "stream/promises";
+import { createWriteStream } from "../../../runtime/platform/index.js";
+import { dirname, extname } from "../../../runtime/platform/index.js";
+import { finished } from "../../../runtime/platform/index.js";
 
-import { mkdir } from "fs/promises";
-import { ZipFile } from "yazl";
+import { mkdir } from "../../../runtime/platform/index.js";
+import { ZipFile } from "../../../runtime/platform/index.js";
 
 import type { BookMeta, SourceAsset } from "../../source/index.js";
 

--- a/packages/core/src/text/output/plain-text.ts
+++ b/packages/core/src/text/output/plain-text.ts
@@ -1,5 +1,5 @@
-import { mkdir, writeFile } from "fs/promises";
-import { dirname } from "path";
+import { mkdir, writeFile } from "../../runtime/platform/index.js";
+import { dirname } from "../../runtime/platform/index.js";
 
 import type { ReadonlyDocument } from "../../document/index.js";
 import type { TocItem } from "../source/index.js";

--- a/packages/core/src/text/source/epub/archive.ts
+++ b/packages/core/src/text/source/epub/archive.ts
@@ -1,9 +1,9 @@
-import { createHash } from "crypto";
-import { createReadStream } from "fs";
-import { posix } from "path";
-import { PassThrough, type Readable } from "stream";
-import type { Entry, ZipFile } from "yauzl";
-import { open } from "yauzl";
+import { createHash } from "../../../runtime/platform/index.js";
+import { createReadStream } from "../../../runtime/platform/index.js";
+import { posix } from "../../../runtime/platform/index.js";
+import { PassThrough, type Readable } from "../../../runtime/platform/index.js";
+import type { Entry, ZipFile } from "../../../runtime/platform/index.js";
+import { openZip as open } from "../../../runtime/platform/index.js";
 
 export class EpubArchive {
   readonly #path: string;
@@ -162,14 +162,18 @@ export function splitHref(href: string): {
 
 async function openZipFile(path: string): Promise<ZipFile> {
   return await new Promise((resolve, reject) => {
-    open(path, { autoClose: false, lazyEntries: true }, (error, zipFile) => {
-      if (error !== null || zipFile === undefined) {
-        reject(error ?? new Error(`Cannot open EPUB archive: ${path}`));
-        return;
-      }
+    open(
+      path,
+      { autoClose: false, lazyEntries: true },
+      (error: any, zipFile: any) => {
+        if (error !== null || zipFile === undefined) {
+          reject(error ?? new Error(`Cannot open EPUB archive: ${path}`));
+          return;
+        }
 
-      resolve(zipFile);
-    });
+        resolve(zipFile);
+      },
+    );
   });
 }
 
@@ -244,7 +248,7 @@ async function openEntryStream(
   entry: Entry,
 ): Promise<Readable> {
   return await new Promise((resolve, reject) => {
-    zipFile.openReadStream(entry, (error, stream) => {
+    zipFile.openReadStream(entry, (error: any, stream: any) => {
       if (error !== null || stream === undefined) {
         reject(error ?? new Error(`Cannot open EPUB entry: ${entry.fileName}`));
         return;

--- a/packages/core/src/text/source/epub/archive.ts
+++ b/packages/core/src/text/source/epub/archive.ts
@@ -1,3 +1,4 @@
+import { Buffer as platformBuffer } from "../../../runtime/platform/index.js";
 import { createHash } from "../../../runtime/platform/index.js";
 import { createReadStream } from "../../../runtime/platform/index.js";
 import { posix } from "../../../runtime/platform/index.js";
@@ -62,7 +63,7 @@ export class EpubArchive {
     return (await readStreamToBuffer(stream)).toString("utf8");
   }
 
-  public async readBuffer(path: string): Promise<Buffer> {
+  public async readBuffer(path: string): Promise<platformBuffer> {
     const stream = await this.openReadStream(path);
     return await readStreamToBuffer(stream);
   }
@@ -182,7 +183,7 @@ async function digestFile(path: string): Promise<string> {
     const hash = createHash("sha256");
     const stream = createReadStream(path);
 
-    stream.on("data", (chunk: Buffer | string) => hash.update(chunk));
+    stream.on("data", (chunk: platformBuffer | string) => hash.update(chunk));
     stream.once("end", () => resolve(hash.digest("hex")));
     stream.once("error", reject);
   });
@@ -214,27 +215,27 @@ async function indexEntries(
   });
 }
 
-function toBuffer(chunk: unknown): Buffer {
-  if (Buffer.isBuffer(chunk)) {
+function toBuffer(chunk: unknown): platformBuffer {
+  if (platformBuffer.isBuffer(chunk)) {
     return chunk;
   }
 
   if (typeof chunk === "string") {
-    return Buffer.from(chunk, "utf8");
+    return platformBuffer.from(chunk, "utf8");
   }
 
   throw new Error("Unexpected ZIP stream chunk type");
 }
 
-async function readStreamToBuffer(stream: Readable): Promise<Buffer> {
+async function readStreamToBuffer(stream: Readable): Promise<platformBuffer> {
   return await new Promise((resolve, reject) => {
-    const chunks: Buffer[] = [];
+    const chunks: platformBuffer[] = [];
 
     stream.on("data", (chunk: unknown) => {
       chunks.push(toBuffer(chunk));
     });
     stream.once("end", () => {
-      resolve(Buffer.concat(chunks));
+      resolve(platformBuffer.concat(chunks));
     });
     stream.once("error", (error: Error) => {
       reject(error);

--- a/packages/core/src/text/source/epub/archive.ts
+++ b/packages/core/src/text/source/epub/archive.ts
@@ -1,4 +1,4 @@
-import { Buffer as platformBuffer } from "../../../runtime/platform/index.js";
+import { binary as platformBinary } from "../../../runtime/platform/index.js";
 import { createHash } from "../../../runtime/platform/index.js";
 import { createReadStream } from "../../../runtime/platform/index.js";
 import { posix } from "../../../runtime/platform/index.js";
@@ -63,7 +63,7 @@ export class EpubArchive {
     return (await readStreamToBuffer(stream)).toString("utf8");
   }
 
-  public async readBuffer(path: string): Promise<platformBuffer> {
+  public async readBuffer(path: string): Promise<platformBinary> {
     const stream = await this.openReadStream(path);
     return await readStreamToBuffer(stream);
   }
@@ -183,7 +183,7 @@ async function digestFile(path: string): Promise<string> {
     const hash = createHash("sha256");
     const stream = createReadStream(path);
 
-    stream.on("data", (chunk: platformBuffer | string) => hash.update(chunk));
+    stream.on("data", (chunk: platformBinary | string) => hash.update(chunk));
     stream.once("end", () => resolve(hash.digest("hex")));
     stream.once("error", reject);
   });
@@ -215,27 +215,27 @@ async function indexEntries(
   });
 }
 
-function toBuffer(chunk: unknown): platformBuffer {
-  if (platformBuffer.isBuffer(chunk)) {
+function toBuffer(chunk: unknown): platformBinary {
+  if (platformBinary.isBuffer(chunk)) {
     return chunk;
   }
 
   if (typeof chunk === "string") {
-    return platformBuffer.from(chunk, "utf8");
+    return platformBinary.from(chunk, "utf8");
   }
 
   throw new Error("Unexpected ZIP stream chunk type");
 }
 
-async function readStreamToBuffer(stream: Readable): Promise<platformBuffer> {
+async function readStreamToBuffer(stream: Readable): Promise<platformBinary> {
   return await new Promise((resolve, reject) => {
-    const chunks: platformBuffer[] = [];
+    const chunks: platformBinary[] = [];
 
     stream.on("data", (chunk: unknown) => {
       chunks.push(toBuffer(chunk));
     });
     stream.once("end", () => {
-      resolve(platformBuffer.concat(chunks));
+      resolve(platformBinary.concat(chunks));
     });
     stream.once("error", (error: Error) => {
       reject(error);

--- a/packages/core/src/text/source/epub/content.ts
+++ b/packages/core/src/text/source/epub/content.ts
@@ -1,4 +1,4 @@
-import { Buffer as platformBuffer } from "../../../runtime/platform/index.js";
+import { binary as platformBinary } from "../../../runtime/platform/index.js";
 import { parseDocument } from "htmlparser2";
 
 import { countTextWords } from "../../../utils/text-word-count.js";
@@ -816,7 +816,7 @@ function toTextChunk(chunk: unknown): string {
     return chunk;
   }
 
-  if (platformBuffer.isBuffer(chunk)) {
+  if (platformBinary.isBuffer(chunk)) {
     return (chunk as { toString(encoding?: string): string }).toString("utf8");
   }
 

--- a/packages/core/src/text/source/epub/content.ts
+++ b/packages/core/src/text/source/epub/content.ts
@@ -1,3 +1,4 @@
+import { Buffer as platformBuffer } from "../../../runtime/platform/index.js";
 import { parseDocument } from "htmlparser2";
 
 import { countTextWords } from "../../../utils/text-word-count.js";
@@ -815,8 +816,8 @@ function toTextChunk(chunk: unknown): string {
     return chunk;
   }
 
-  if (Buffer.isBuffer(chunk)) {
-    return chunk.toString("utf8");
+  if (platformBuffer.isBuffer(chunk)) {
+    return (chunk as { toString(encoding?: string): string }).toString("utf8");
   }
 
   throw new Error("Unexpected HTML stream chunk type");

--- a/packages/core/src/text/source/epub/document.ts
+++ b/packages/core/src/text/source/epub/document.ts
@@ -6,7 +6,7 @@ import type {
   SourceTextStream,
 } from "../types.js";
 import type { SourceArtifactInput } from "../../../document/types.js";
-import { basename } from "path";
+import { basename } from "../../../runtime/platform/index.js";
 
 import { normalizeFragment } from "./archive.js";
 import { EpubArchive } from "./archive.js";

--- a/packages/core/src/text/source/epub/navigation.ts
+++ b/packages/core/src/text/source/epub/navigation.ts
@@ -1,4 +1,4 @@
-import { basename, extname, posix } from "path";
+import { basename, extname, posix } from "../../../runtime/platform/index.js";
 
 import { parseDocument } from "htmlparser2";
 

--- a/packages/core/src/text/source/epub/package.ts
+++ b/packages/core/src/text/source/epub/package.ts
@@ -1,4 +1,4 @@
-import { posix } from "path";
+import { posix } from "../../../runtime/platform/index.js";
 
 import { BOOK_META_VERSION, type BookMeta } from "../meta.js";
 import { splitHref } from "./archive.js";

--- a/packages/core/src/text/source/plain-text.ts
+++ b/packages/core/src/text/source/plain-text.ts
@@ -1,6 +1,6 @@
-import { createReadStream } from "fs";
-import { stat } from "fs/promises";
-import { basename, extname, resolve } from "path";
+import { createReadStream } from "../../runtime/platform/index.js";
+import { stat } from "../../runtime/platform/index.js";
+import { basename, extname, resolve } from "../../runtime/platform/index.js";
 
 import { BOOK_META_VERSION, type BookMeta } from "./meta.js";
 import type { SourceAdapter, SourceDocument } from "./adapter.js";

--- a/packages/core/src/text/summary-build/artifact.ts
+++ b/packages/core/src/text/summary-build/artifact.ts
@@ -1,5 +1,5 @@
-import { mkdir } from "fs/promises";
-import { join } from "path";
+import { mkdir } from "../../runtime/platform/index.js";
+import { join } from "../../runtime/platform/index.js";
 
 import type { Document, ReadonlyDocument } from "../../document/index.js";
 import {

--- a/packages/core/src/text/summary-build/snapshot-io.ts
+++ b/packages/core/src/text/summary-build/snapshot-io.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from "fs/promises";
+import { readFile, writeFile } from "../../runtime/platform/index.js";
 
 import {
   summaryInputSnapshotSchema,

--- a/packages/core/src/utils/hash.ts
+++ b/packages/core/src/utils/hash.ts
@@ -1,4 +1,4 @@
-import { createHash as createNodeHash } from "crypto";
+import { createHash as createNodeHash } from "../runtime/platform/index.js";
 
 const UNSERIALIZABLE = Symbol("UNSERIALIZABLE");
 

--- a/packages/core/src/utils/node-error.ts
+++ b/packages/core/src/utils/node-error.ts
@@ -1,4 +1,5 @@
-export function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+import { type NodeError } from "../runtime/platform/index.js";
+export function isNodeError(error: unknown): error is NodeError {
   return error instanceof Error;
 }
 
@@ -24,7 +25,7 @@ export function formatError(error: unknown): string {
 }
 
 function describeError(error: Error): string {
-  const errnoError = error as NodeJS.ErrnoException;
+  const errnoError = error as NodeError;
   const message = error.message.trim();
   const code =
     typeof errnoError.code === "string" && errnoError.code !== ""

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -12,7 +12,6 @@ const SHARED_OPTIONS = {
 const ENTRY = {
   gc: "src/gc.ts",
   index: "src/index.ts",
-  "runtime/platform/index": "src/runtime/platform/index.ts",
   worker: "src/worker.ts",
 } as const;
 

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,32 +1,24 @@
 import { defineConfig } from "tsup";
 
-const CJS_DATA_DIR_BANNER = [
-  'globalThis.__WIKIGRAPH_DATA_DIR__ ??= require("path").resolve(',
-  "  __dirname,",
-  '  "../data",',
-  ");",
-].join("\n");
 const SHARED_OPTIONS = {
   clean: false,
   outDir: "dist",
-  platform: "node",
+  platform: "neutral",
   skipNodeModulesBundle: true,
   sourcemap: true,
   splitting: false,
-  target: "node22",
+  target: "es2022",
 } as const;
 const ENTRY = {
   gc: "src/gc.ts",
   index: "src/index.ts",
+  "runtime/platform/index": "src/runtime/platform/index.ts",
   worker: "src/worker.ts",
 } as const;
 
 export default defineConfig([
   {
     ...SHARED_OPTIONS,
-    banner: {
-      js: CJS_DATA_DIR_BANNER,
-    },
     bundle: true,
     clean: true,
     dts: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,28 +1,29 @@
-lockfileVersion: "9.0"
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
+
   .:
     devDependencies:
-      "@eslint/js":
+      '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.4
-      "@types/node":
+      '@types/node':
         specifier: ^24.6.1
         version: 24.12.2
-      "@types/nunjucks":
+      '@types/nunjucks':
         specifier: ^3.2.6
         version: 3.2.6
-      "@types/yauzl":
+      '@types/yauzl':
         specifier: ^2.10.3
         version: 2.10.3
-      "@types/yazl":
+      '@types/yazl':
         specifier: ^3.3.1
         version: 3.3.1
-      "@vitest/coverage-v8":
+      '@vitest/coverage-v8':
         specifier: ^4.1.4
         version: 4.1.4(vitest@4.1.4)
       ai:
@@ -73,16 +74,16 @@ importers:
 
   packages/cli:
     dependencies:
-      "@ai-sdk/anthropic":
+      '@ai-sdk/anthropic':
         specifier: ^3.0.68
         version: 3.0.68(zod@4.3.6)
-      "@ai-sdk/google":
+      '@ai-sdk/google':
         specifier: ^3.0.61
         version: 3.0.61(zod@4.3.6)
-      "@ai-sdk/openai":
+      '@ai-sdk/openai':
         specifier: ^3.0.52
         version: 3.0.52(zod@4.3.6)
-      "@ai-sdk/openai-compatible":
+      '@ai-sdk/openai-compatible':
         specifier: ^2.0.41
         version: 2.0.41(zod@4.3.6)
       ai:
@@ -128,16 +129,16 @@ importers:
 
   packages/core:
     dependencies:
-      "@ai-sdk/anthropic":
+      '@ai-sdk/anthropic':
         specifier: ^3.0.68
         version: 3.0.68(zod@4.3.6)
-      "@ai-sdk/google":
+      '@ai-sdk/google':
         specifier: ^3.0.61
         version: 3.0.61(zod@4.3.6)
-      "@ai-sdk/openai":
+      '@ai-sdk/openai':
         specifier: ^3.0.52
         version: 3.0.52(zod@4.3.6)
-      "@ai-sdk/openai-compatible":
+      '@ai-sdk/openai-compatible':
         specifier: ^2.0.41
         version: 2.0.41(zod@4.3.6)
       ai:
@@ -161,1091 +162,687 @@ importers:
       saxes:
         specifier: ^6.0.0
         version: 6.0.0
-      sqlite3:
-        specifier: ^6.0.1
-        version: 6.0.1
       tinyld:
         specifier: ^1.3.4
         version: 1.3.4
-      yauzl:
-        specifier: ^3.3.0
-        version: 3.3.0
-      yazl:
-        specifier: ^3.3.1
-        version: 3.3.1
       zod:
         specifier: ^4.3.6
         version: 4.3.6
 
 packages:
-  "@ai-sdk/anthropic@3.0.68":
-    resolution:
-      {
-        integrity: sha512-BAd+fmgYoJMmGw0/uV+jRlXX60PyGxelA6Clp4cK/NI0dsyv9jOOwzQmKNaz2nwb+Jz7HqI7I70KK4XtU5EcXQ==,
-      }
-    engines: { node: ">=18" }
+
+  '@ai-sdk/anthropic@3.0.68':
+    resolution: {integrity: sha512-BAd+fmgYoJMmGw0/uV+jRlXX60PyGxelA6Clp4cK/NI0dsyv9jOOwzQmKNaz2nwb+Jz7HqI7I70KK4XtU5EcXQ==}
+    engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  "@ai-sdk/gateway@3.0.94":
-    resolution:
-      {
-        integrity: sha512-uDDwLZhCkvC89crVS3S90D5L7AcVN8WriGuYVNYgVAaVcvy3Mthy3R9ICfzG75BObhz6pm2FWnhxDfNRK+t69Q==,
-      }
-    engines: { node: ">=18" }
+  '@ai-sdk/gateway@3.0.94':
+    resolution: {integrity: sha512-uDDwLZhCkvC89crVS3S90D5L7AcVN8WriGuYVNYgVAaVcvy3Mthy3R9ICfzG75BObhz6pm2FWnhxDfNRK+t69Q==}
+    engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  "@ai-sdk/google@3.0.61":
-    resolution:
-      {
-        integrity: sha512-jEKU1Mjcy5CoicejdJQIzM0ntYwyXR8vtYgAZYriKaOuLAiAhiiU538++fGU3CC9HJH/mL1OfsCwMM3gFiCNsw==,
-      }
-    engines: { node: ">=18" }
+  '@ai-sdk/google@3.0.61':
+    resolution: {integrity: sha512-jEKU1Mjcy5CoicejdJQIzM0ntYwyXR8vtYgAZYriKaOuLAiAhiiU538++fGU3CC9HJH/mL1OfsCwMM3gFiCNsw==}
+    engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  "@ai-sdk/openai-compatible@2.0.41":
-    resolution:
-      {
-        integrity: sha512-kNAGINk71AlOXx10Dq/PXw4t/9XjdK8uxfpVElRwtSFMdeSiLVt58p9TPx4/FJD+hxZuVhvxYj9r42osxWq79g==,
-      }
-    engines: { node: ">=18" }
+  '@ai-sdk/openai-compatible@2.0.41':
+    resolution: {integrity: sha512-kNAGINk71AlOXx10Dq/PXw4t/9XjdK8uxfpVElRwtSFMdeSiLVt58p9TPx4/FJD+hxZuVhvxYj9r42osxWq79g==}
+    engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  "@ai-sdk/openai@3.0.52":
-    resolution:
-      {
-        integrity: sha512-4Rr8NCGmfWTz6DCUvixn9UmyZcMatiHn0zWoMzI3JCUe9R1P/vsPOpCBALKoSzVYOjyJnhtnVIbfUKujcS39uw==,
-      }
-    engines: { node: ">=18" }
+  '@ai-sdk/openai@3.0.52':
+    resolution: {integrity: sha512-4Rr8NCGmfWTz6DCUvixn9UmyZcMatiHn0zWoMzI3JCUe9R1P/vsPOpCBALKoSzVYOjyJnhtnVIbfUKujcS39uw==}
+    engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  "@ai-sdk/provider-utils@4.0.23":
-    resolution:
-      {
-        integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==,
-      }
-    engines: { node: ">=18" }
+  '@ai-sdk/provider-utils@4.0.23':
+    resolution: {integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==}
+    engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  "@ai-sdk/provider@3.0.8":
-    resolution:
-      {
-        integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==,
-      }
-    engines: { node: ">=18" }
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
+    engines: {node: '>=18'}
 
-  "@babel/helper-string-parser@7.27.1":
-    resolution:
-      {
-        integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/helper-validator-identifier@7.28.5":
-    resolution:
-      {
-        integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/parser@7.29.2":
-    resolution:
-      {
-        integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==,
-      }
-    engines: { node: ">=6.0.0" }
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
     hasBin: true
 
-  "@babel/types@7.29.0":
-    resolution:
-      {
-        integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
 
-  "@bcoe/v8-coverage@1.0.2":
-    resolution:
-      {
-        integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==,
-      }
-    engines: { node: ">=18" }
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
-  "@emnapi/core@1.9.2":
-    resolution:
-      {
-        integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==,
-      }
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
 
-  "@emnapi/runtime@1.9.2":
-    resolution:
-      {
-        integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==,
-      }
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
 
-  "@emnapi/wasi-threads@1.2.1":
-    resolution:
-      {
-        integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==,
-      }
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  "@esbuild/aix-ppc64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  "@esbuild/android-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  "@esbuild/android-arm@0.27.7":
-    resolution:
-      {
-        integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  "@esbuild/android-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  "@esbuild/darwin-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  "@esbuild/darwin-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  "@esbuild/freebsd-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  "@esbuild/freebsd-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  "@esbuild/linux-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  "@esbuild/linux-arm@0.27.7":
-    resolution:
-      {
-        integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  "@esbuild/linux-ia32@0.27.7":
-    resolution:
-      {
-        integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  "@esbuild/linux-loong64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  "@esbuild/linux-mips64el@0.27.7":
-    resolution:
-      {
-        integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  "@esbuild/linux-ppc64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  "@esbuild/linux-riscv64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  "@esbuild/linux-s390x@0.27.7":
-    resolution:
-      {
-        integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  "@esbuild/linux-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  "@esbuild/netbsd-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  "@esbuild/netbsd-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  "@esbuild/openbsd-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  "@esbuild/openbsd-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  "@esbuild/openharmony-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  "@esbuild/sunos-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  "@esbuild/win32-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  "@esbuild/win32-ia32@0.27.7":
-    resolution:
-      {
-        integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  "@esbuild/win32-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
-  "@eslint-community/eslint-utils@4.9.1":
-    resolution:
-      {
-        integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==,
-      }
-    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
-  "@eslint-community/regexpp@4.12.2":
-    resolution:
-      {
-        integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==,
-      }
-    engines: { node: ^12.0.0 || ^14.0.0 || >=16.0.0 }
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  "@eslint/config-array@0.21.2":
-    resolution:
-      {
-        integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  "@eslint/config-helpers@0.4.2":
-    resolution:
-      {
-        integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  "@eslint/core@0.17.0":
-    resolution:
-      {
-        integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  "@eslint/eslintrc@3.3.5":
-    resolution:
-      {
-        integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  "@eslint/js@9.39.4":
-    resolution:
-      {
-        integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  "@eslint/object-schema@2.1.7":
-    resolution:
-      {
-        integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  "@eslint/plugin-kit@0.4.1":
-    resolution:
-      {
-        integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  "@gar/promise-retry@1.0.3":
-    resolution:
-      {
-        integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==,
-      }
-    engines: { node: ^20.17.0 || >=22.9.0 }
+  '@gar/promise-retry@1.0.3':
+    resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
-  "@humanfs/core@0.19.1":
-    resolution:
-      {
-        integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==,
-      }
-    engines: { node: ">=18.18.0" }
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+    engines: {node: '>=18.18.0'}
 
-  "@humanfs/node@0.16.7":
-    resolution:
-      {
-        integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==,
-      }
-    engines: { node: ">=18.18.0" }
+  '@humanfs/node@0.16.7':
+    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
+    engines: {node: '>=18.18.0'}
 
-  "@humanwhocodes/module-importer@1.0.1":
-    resolution:
-      {
-        integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==,
-      }
-    engines: { node: ">=12.22" }
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
 
-  "@humanwhocodes/retry@0.4.3":
-    resolution:
-      {
-        integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==,
-      }
-    engines: { node: ">=18.18" }
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
-  "@isaacs/fs-minipass@4.0.1":
-    resolution:
-      {
-        integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==,
-      }
-    engines: { node: ">=18.0.0" }
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
 
-  "@jridgewell/gen-mapping@0.3.13":
-    resolution:
-      {
-        integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==,
-      }
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
-  "@jridgewell/resolve-uri@3.1.2":
-    resolution:
-      {
-        integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
-      }
-    engines: { node: ">=6.0.0" }
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
 
-  "@jridgewell/sourcemap-codec@1.5.5":
-    resolution:
-      {
-        integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==,
-      }
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  "@jridgewell/trace-mapping@0.3.31":
-    resolution:
-      {
-        integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
-      }
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  "@napi-rs/wasm-runtime@1.1.3":
-    resolution:
-      {
-        integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==,
-      }
+  '@napi-rs/wasm-runtime@1.1.3':
+    resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
     peerDependencies:
-      "@emnapi/core": ^1.7.1
-      "@emnapi/runtime": ^1.7.1
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
-  "@npmcli/agent@4.0.0":
-    resolution:
-      {
-        integrity: sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==,
-      }
-    engines: { node: ^20.17.0 || >=22.9.0 }
+  '@npmcli/agent@4.0.0':
+    resolution: {integrity: sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
-  "@npmcli/fs@5.0.0":
-    resolution:
-      {
-        integrity: sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==,
-      }
-    engines: { node: ^20.17.0 || >=22.9.0 }
+  '@npmcli/fs@5.0.0':
+    resolution: {integrity: sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
-  "@npmcli/redact@4.0.0":
-    resolution:
-      {
-        integrity: sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==,
-      }
-    engines: { node: ^20.17.0 || >=22.9.0 }
+  '@npmcli/redact@4.0.0':
+    resolution: {integrity: sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
-  "@opentelemetry/api@1.9.0":
-    resolution:
-      {
-        integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==,
-      }
-    engines: { node: ">=8.0.0" }
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
-  "@oxc-project/types@0.124.0":
-    resolution:
-      {
-        integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==,
-      }
+  '@oxc-project/types@0.124.0':
+    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
-  "@pinojs/redact@0.4.0":
-    resolution:
-      {
-        integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==,
-      }
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
-  "@rolldown/binding-android-arm64@1.0.0-rc.15":
-    resolution:
-      {
-        integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  "@rolldown/binding-darwin-arm64@1.0.0-rc.15":
-    resolution:
-      {
-        integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  "@rolldown/binding-darwin-x64@1.0.0-rc.15":
-    resolution:
-      {
-        integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  "@rolldown/binding-freebsd-x64@1.0.0-rc.15":
-    resolution:
-      {
-        integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15":
-    resolution:
-      {
-        integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+    resolution: {integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15":
-    resolution:
-      {
-        integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@rolldown/binding-linux-arm64-musl@1.0.0-rc.15":
-    resolution:
-      {
-        integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15":
-    resolution:
-      {
-        integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15":
-    resolution:
-      {
-        integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  "@rolldown/binding-linux-x64-gnu@1.0.0-rc.15":
-    resolution:
-      {
-        integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@rolldown/binding-linux-x64-musl@1.0.0-rc.15":
-    resolution:
-      {
-        integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@rolldown/binding-openharmony-arm64@1.0.0-rc.15":
-    resolution:
-      {
-        integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  "@rolldown/binding-wasm32-wasi@1.0.0-rc.15":
-    resolution:
-      {
-        integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==,
-      }
-    engines: { node: ">=14.0.0" }
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+    resolution: {integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==}
+    engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15":
-    resolution:
-      {
-        integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  "@rolldown/binding-win32-x64-msvc@1.0.0-rc.15":
-    resolution:
-      {
-        integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  "@rolldown/pluginutils@1.0.0-rc.15":
-    resolution:
-      {
-        integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==,
-      }
+  '@rolldown/pluginutils@1.0.0-rc.15':
+    resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
 
-  "@rollup/rollup-android-arm-eabi@4.60.1":
-    resolution:
-      {
-        integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==,
-      }
+  '@rollup/rollup-android-arm-eabi@4.60.1':
+    resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
     cpu: [arm]
     os: [android]
 
-  "@rollup/rollup-android-arm64@4.60.1":
-    resolution:
-      {
-        integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==,
-      }
+  '@rollup/rollup-android-arm64@4.60.1':
+    resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==}
     cpu: [arm64]
     os: [android]
 
-  "@rollup/rollup-darwin-arm64@4.60.1":
-    resolution:
-      {
-        integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==,
-      }
+  '@rollup/rollup-darwin-arm64@4.60.1':
+    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
     cpu: [arm64]
     os: [darwin]
 
-  "@rollup/rollup-darwin-x64@4.60.1":
-    resolution:
-      {
-        integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==,
-      }
+  '@rollup/rollup-darwin-x64@4.60.1':
+    resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==}
     cpu: [x64]
     os: [darwin]
 
-  "@rollup/rollup-freebsd-arm64@4.60.1":
-    resolution:
-      {
-        integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==,
-      }
+  '@rollup/rollup-freebsd-arm64@4.60.1':
+    resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==}
     cpu: [arm64]
     os: [freebsd]
 
-  "@rollup/rollup-freebsd-x64@4.60.1":
-    resolution:
-      {
-        integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==,
-      }
+  '@rollup/rollup-freebsd-x64@4.60.1':
+    resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==}
     cpu: [x64]
     os: [freebsd]
 
-  "@rollup/rollup-linux-arm-gnueabihf@4.60.1":
-    resolution:
-      {
-        integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==,
-      }
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+    resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  "@rollup/rollup-linux-arm-musleabihf@4.60.1":
-    resolution:
-      {
-        integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==,
-      }
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+    resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  "@rollup/rollup-linux-arm64-gnu@4.60.1":
-    resolution:
-      {
-        integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==,
-      }
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@rollup/rollup-linux-arm64-musl@4.60.1":
-    resolution:
-      {
-        integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==,
-      }
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
+    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@rollup/rollup-linux-loong64-gnu@4.60.1":
-    resolution:
-      {
-        integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==,
-      }
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+    resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
 
-  "@rollup/rollup-linux-loong64-musl@4.60.1":
-    resolution:
-      {
-        integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==,
-      }
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
+    resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
     libc: [musl]
 
-  "@rollup/rollup-linux-ppc64-gnu@4.60.1":
-    resolution:
-      {
-        integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==,
-      }
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+    resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  "@rollup/rollup-linux-ppc64-musl@4.60.1":
-    resolution:
-      {
-        integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==,
-      }
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+    resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
     libc: [musl]
 
-  "@rollup/rollup-linux-riscv64-gnu@4.60.1":
-    resolution:
-      {
-        integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==,
-      }
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+    resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  "@rollup/rollup-linux-riscv64-musl@4.60.1":
-    resolution:
-      {
-        integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==,
-      }
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+    resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  "@rollup/rollup-linux-s390x-gnu@4.60.1":
-    resolution:
-      {
-        integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==,
-      }
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+    resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  "@rollup/rollup-linux-x64-gnu@4.60.1":
-    resolution:
-      {
-        integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==,
-      }
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@rollup/rollup-linux-x64-musl@4.60.1":
-    resolution:
-      {
-        integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==,
-      }
+  '@rollup/rollup-linux-x64-musl@4.60.1':
+    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@rollup/rollup-openbsd-x64@4.60.1":
-    resolution:
-      {
-        integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==,
-      }
+  '@rollup/rollup-openbsd-x64@4.60.1':
+    resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
     cpu: [x64]
     os: [openbsd]
 
-  "@rollup/rollup-openharmony-arm64@4.60.1":
-    resolution:
-      {
-        integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==,
-      }
+  '@rollup/rollup-openharmony-arm64@4.60.1':
+    resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
     cpu: [arm64]
     os: [openharmony]
 
-  "@rollup/rollup-win32-arm64-msvc@4.60.1":
-    resolution:
-      {
-        integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==,
-      }
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
     cpu: [arm64]
     os: [win32]
 
-  "@rollup/rollup-win32-ia32-msvc@4.60.1":
-    resolution:
-      {
-        integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==,
-      }
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+    resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==}
     cpu: [ia32]
     os: [win32]
 
-  "@rollup/rollup-win32-x64-gnu@4.60.1":
-    resolution:
-      {
-        integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==,
-      }
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
     cpu: [x64]
     os: [win32]
 
-  "@rollup/rollup-win32-x64-msvc@4.60.1":
-    resolution:
-      {
-        integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==,
-      }
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
+    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
     cpu: [x64]
     os: [win32]
 
-  "@standard-schema/spec@1.1.0":
-    resolution:
-      {
-        integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
-      }
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  "@tybys/wasm-util@0.10.1":
-    resolution:
-      {
-        integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==,
-      }
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
-  "@types/chai@5.2.3":
-    resolution:
-      {
-        integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==,
-      }
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
-  "@types/deep-eql@4.0.2":
-    resolution:
-      {
-        integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
-      }
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
-  "@types/estree@1.0.8":
-    resolution:
-      {
-        integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
-      }
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  "@types/json-schema@7.0.15":
-    resolution:
-      {
-        integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==,
-      }
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  "@types/node@24.12.2":
-    resolution:
-      {
-        integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==,
-      }
+  '@types/node@24.12.2':
+    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
 
-  "@types/nunjucks@3.2.6":
-    resolution:
-      {
-        integrity: sha512-pHiGtf83na1nCzliuAdq8GowYiXvH5l931xZ0YEHaLMNFgynpEqx+IPStlu7UaDkehfvl01e4x/9Tpwhy7Ue3w==,
-      }
+  '@types/nunjucks@3.2.6':
+    resolution: {integrity: sha512-pHiGtf83na1nCzliuAdq8GowYiXvH5l931xZ0YEHaLMNFgynpEqx+IPStlu7UaDkehfvl01e4x/9Tpwhy7Ue3w==}
 
-  "@types/yauzl@2.10.3":
-    resolution:
-      {
-        integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==,
-      }
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
-  "@types/yazl@3.3.1":
-    resolution:
-      {
-        integrity: sha512-DIWfCKpsTp6hE5BDBHV3+fIL/bLUF9Bv13iDrWnMlmhQpH67buNvI291ZauQ1xcccxK3FqQ9honnXpq4R8NMuQ==,
-      }
+  '@types/yazl@3.3.1':
+    resolution: {integrity: sha512-DIWfCKpsTp6hE5BDBHV3+fIL/bLUF9Bv13iDrWnMlmhQpH67buNvI291ZauQ1xcccxK3FqQ9honnXpq4R8NMuQ==}
 
-  "@typescript-eslint/eslint-plugin@8.58.1":
-    resolution:
-      {
-        integrity: sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@typescript-eslint/eslint-plugin@8.58.1':
+    resolution: {integrity: sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      "@typescript-eslint/parser": ^8.58.1
+      '@typescript-eslint/parser': ^8.58.1
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: ">=4.8.4 <6.1.0"
+      typescript: '>=4.8.4 <6.1.0'
 
-  "@typescript-eslint/parser@8.58.1":
-    resolution:
-      {
-        integrity: sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@typescript-eslint/parser@8.58.1':
+    resolution: {integrity: sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: ">=4.8.4 <6.1.0"
+      typescript: '>=4.8.4 <6.1.0'
 
-  "@typescript-eslint/project-service@8.58.1":
-    resolution:
-      {
-        integrity: sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@typescript-eslint/project-service@8.58.1':
+    resolution: {integrity: sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: ">=4.8.4 <6.1.0"
+      typescript: '>=4.8.4 <6.1.0'
 
-  "@typescript-eslint/scope-manager@8.58.1":
-    resolution:
-      {
-        integrity: sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@typescript-eslint/scope-manager@8.58.1':
+    resolution: {integrity: sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  "@typescript-eslint/tsconfig-utils@8.58.1":
-    resolution:
-      {
-        integrity: sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@typescript-eslint/tsconfig-utils@8.58.1':
+    resolution: {integrity: sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: ">=4.8.4 <6.1.0"
+      typescript: '>=4.8.4 <6.1.0'
 
-  "@typescript-eslint/type-utils@8.58.1":
-    resolution:
-      {
-        integrity: sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@typescript-eslint/type-utils@8.58.1':
+    resolution: {integrity: sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: ">=4.8.4 <6.1.0"
+      typescript: '>=4.8.4 <6.1.0'
 
-  "@typescript-eslint/types@8.58.1":
-    resolution:
-      {
-        integrity: sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@typescript-eslint/types@8.58.1':
+    resolution: {integrity: sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  "@typescript-eslint/typescript-estree@8.58.1":
-    resolution:
-      {
-        integrity: sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@typescript-eslint/typescript-estree@8.58.1':
+    resolution: {integrity: sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: ">=4.8.4 <6.1.0"
+      typescript: '>=4.8.4 <6.1.0'
 
-  "@typescript-eslint/utils@8.58.1":
-    resolution:
-      {
-        integrity: sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@typescript-eslint/utils@8.58.1':
+    resolution: {integrity: sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: ">=4.8.4 <6.1.0"
+      typescript: '>=4.8.4 <6.1.0'
 
-  "@typescript-eslint/visitor-keys@8.58.1":
-    resolution:
-      {
-        integrity: sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@typescript-eslint/visitor-keys@8.58.1':
+    resolution: {integrity: sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  "@vercel/oidc@3.1.0":
-    resolution:
-      {
-        integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==,
-      }
-    engines: { node: ">= 20" }
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+    engines: {node: '>= 20'}
 
-  "@vitest/coverage-v8@4.1.4":
-    resolution:
-      {
-        integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==,
-      }
+  '@vitest/coverage-v8@4.1.4':
+    resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
     peerDependencies:
-      "@vitest/browser": 4.1.4
+      '@vitest/browser': 4.1.4
       vitest: 4.1.4
     peerDependenciesMeta:
-      "@vitest/browser":
+      '@vitest/browser':
         optional: true
 
-  "@vitest/expect@4.1.4":
-    resolution:
-      {
-        integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==,
-      }
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
 
-  "@vitest/mocker@4.1.4":
-    resolution:
-      {
-        integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==,
-      }
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1255,592 +852,334 @@ packages:
       vite:
         optional: true
 
-  "@vitest/pretty-format@4.1.4":
-    resolution:
-      {
-        integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==,
-      }
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
 
-  "@vitest/runner@4.1.4":
-    resolution:
-      {
-        integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==,
-      }
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
 
-  "@vitest/snapshot@4.1.4":
-    resolution:
-      {
-        integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==,
-      }
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
 
-  "@vitest/spy@4.1.4":
-    resolution:
-      {
-        integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==,
-      }
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
 
-  "@vitest/utils@4.1.4":
-    resolution:
-      {
-        integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==,
-      }
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
   a-sync-waterfall@1.0.1:
-    resolution:
-      {
-        integrity: sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==,
-      }
+    resolution: {integrity: sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==}
 
   abbrev@4.0.0:
-    resolution:
-      {
-        integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==,
-      }
-    engines: { node: ^20.17.0 || >=22.9.0 }
+    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   acorn-jsx@5.3.2:
-    resolution:
-      {
-        integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==,
-      }
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
   acorn@8.16.0:
-    resolution:
-      {
-        integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==,
-      }
-    engines: { node: ">=0.4.0" }
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
     hasBin: true
 
   agent-base@7.1.4:
-    resolution:
-      {
-        integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==,
-      }
-    engines: { node: ">= 14" }
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
 
   ai@6.0.154:
-    resolution:
-      {
-        integrity: sha512-HfKJKCTJsDZxqrIUDSVnBQ7DpQlx5WI4ExqtLd7Bl70epLmvkpc/HYMzU1hP9W+g9VEAcvZo4fbMqc3v5D+9gQ==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-HfKJKCTJsDZxqrIUDSVnBQ7DpQlx5WI4ExqtLd7Bl70epLmvkpc/HYMzU1hP9W+g9VEAcvZo4fbMqc3v5D+9gQ==}
+    engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
   ajv@6.14.0:
-    resolution:
-      {
-        integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==,
-      }
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
   ansi-styles@4.3.0:
-    resolution:
-      {
-        integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
 
   any-promise@1.3.0:
-    resolution:
-      {
-        integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==,
-      }
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
   argparse@2.0.1:
-    resolution:
-      {
-        integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
-      }
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   asap@2.0.6:
-    resolution:
-      {
-        integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==,
-      }
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
   assertion-error@2.0.1:
-    resolution:
-      {
-        integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-v8-to-istanbul@1.0.0:
-    resolution:
-      {
-        integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==,
-      }
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   atomic-sleep@1.0.0:
-    resolution:
-      {
-        integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==,
-      }
-    engines: { node: ">=8.0.0" }
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
 
   balanced-match@1.0.2:
-    resolution:
-      {
-        integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
-      }
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.4:
-    resolution:
-      {
-        integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==,
-      }
-    engines: { node: 18 || 20 || >=22 }
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   base64-js@1.5.1:
-    resolution:
-      {
-        integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
-      }
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
   bindings@1.5.0:
-    resolution:
-      {
-        integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==,
-      }
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   bl@4.1.0:
-    resolution:
-      {
-        integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==,
-      }
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   brace-expansion@1.1.13:
-    resolution:
-      {
-        integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==,
-      }
+    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
   brace-expansion@5.0.5:
-    resolution:
-      {
-        integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==,
-      }
-    engines: { node: 18 || 20 || >=22 }
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
 
   buffer-crc32@0.2.13:
-    resolution:
-      {
-        integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==,
-      }
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   buffer-crc32@1.0.0:
-    resolution:
-      {
-        integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==,
-      }
-    engines: { node: ">=8.0.0" }
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
 
   buffer@5.7.1:
-    resolution:
-      {
-        integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==,
-      }
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   bundle-require@5.1.0:
-    resolution:
-      {
-        integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==,
-      }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
-      esbuild: ">=0.18"
+      esbuild: '>=0.18'
 
   cac@6.7.14:
-    resolution:
-      {
-        integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   cacache@20.0.4:
-    resolution:
-      {
-        integrity: sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==,
-      }
-    engines: { node: ^20.17.0 || >=22.9.0 }
+    resolution: {integrity: sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   callsites@3.1.0:
-    resolution:
-      {
-        integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
 
   chai@6.2.2:
-    resolution:
-      {
-        integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
-    resolution:
-      {
-        integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
 
   chokidar@4.0.3:
-    resolution:
-      {
-        integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==,
-      }
-    engines: { node: ">= 14.16.0" }
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
 
   chownr@1.1.4:
-    resolution:
-      {
-        integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==,
-      }
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   chownr@3.0.0:
-    resolution:
-      {
-        integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   color-convert@2.0.1:
-    resolution:
-      {
-        integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
-      }
-    engines: { node: ">=7.0.0" }
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
 
   color-name@1.1.4:
-    resolution:
-      {
-        integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
-      }
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   colorette@2.0.20:
-    resolution:
-      {
-        integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==,
-      }
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
   commander@4.1.1:
-    resolution:
-      {
-        integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==,
-      }
-    engines: { node: ">= 6" }
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
 
   commander@5.1.0:
-    resolution:
-      {
-        integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==,
-      }
-    engines: { node: ">= 6" }
+    resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
+    engines: {node: '>= 6'}
 
   concat-map@0.0.1:
-    resolution:
-      {
-        integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
-      }
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   confbox@0.1.8:
-    resolution:
-      {
-        integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==,
-      }
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
   consola@3.4.2:
-    resolution:
-      {
-        integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==,
-      }
-    engines: { node: ^14.18.0 || >=16.10.0 }
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   convert-source-map@2.0.0:
-    resolution:
-      {
-        integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
-      }
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cross-spawn@7.0.6:
-    resolution:
-      {
-        integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==,
-      }
-    engines: { node: ">= 8" }
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   dateformat@4.6.3:
-    resolution:
-      {
-        integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==,
-      }
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
   debug@4.4.3:
-    resolution:
-      {
-        integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==,
-      }
-    engines: { node: ">=6.0" }
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
     peerDependencies:
-      supports-color: "*"
+      supports-color: '*'
     peerDependenciesMeta:
       supports-color:
         optional: true
 
   decompress-response@6.0.0:
-    resolution:
-      {
-        integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
 
   deep-extend@0.6.0:
-    resolution:
-      {
-        integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==,
-      }
-    engines: { node: ">=4.0.0" }
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   deep-is@0.1.4:
-    resolution:
-      {
-        integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==,
-      }
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
   detect-libc@2.1.2:
-    resolution:
-      {
-        integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   dom-serializer@3.0.0:
-    resolution:
-      {
-        integrity: sha512-x+9D6nkC8tdXOQUS32egtZpZFLP90+HBZmWjuT920srbJvD/zPgFB9t4k3pEhlw5BQrXStQtRc1Y1zuriXk+Nw==,
-      }
-    engines: { node: ">=20.19.0" }
+    resolution: {integrity: sha512-x+9D6nkC8tdXOQUS32egtZpZFLP90+HBZmWjuT920srbJvD/zPgFB9t4k3pEhlw5BQrXStQtRc1Y1zuriXk+Nw==}
+    engines: {node: '>=20.19.0'}
 
   domelementtype@3.0.0:
-    resolution:
-      {
-        integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==,
-      }
-    engines: { node: ">=20.19.0" }
+    resolution: {integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==}
+    engines: {node: '>=20.19.0'}
 
   domhandler@6.0.1:
-    resolution:
-      {
-        integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==,
-      }
-    engines: { node: ">=20.19.0" }
+    resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
+    engines: {node: '>=20.19.0'}
 
   domutils@4.0.2:
-    resolution:
-      {
-        integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==,
-      }
-    engines: { node: ">=20.19.0" }
+    resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
+    engines: {node: '>=20.19.0'}
 
   end-of-stream@1.4.5:
-    resolution:
-      {
-        integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==,
-      }
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   entities@8.0.0:
-    resolution:
-      {
-        integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==,
-      }
-    engines: { node: ">=20.19.0" }
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-paths@2.2.1:
-    resolution:
-      {
-        integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
 
   es-module-lexer@2.0.0:
-    resolution:
-      {
-        integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==,
-      }
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   esbuild@0.27.7:
-    resolution:
-      {
-        integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
     hasBin: true
 
   escape-string-regexp@4.0.0:
-    resolution:
-      {
-        integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
 
   eslint-config-prettier@10.1.8:
-    resolution:
-      {
-        integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==,
-      }
+    resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
     hasBin: true
     peerDependencies:
-      eslint: ">=7.0.0"
+      eslint: '>=7.0.0'
 
   eslint-scope@8.4.0:
-    resolution:
-      {
-        integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint-visitor-keys@3.4.3:
-    resolution:
-      {
-        integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==,
-      }
-    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   eslint-visitor-keys@4.2.1:
-    resolution:
-      {
-        integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint-visitor-keys@5.0.1:
-    resolution:
-      {
-        integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==,
-      }
-    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   eslint@9.39.4:
-    resolution:
-      {
-        integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
-      jiti: "*"
+      jiti: '*'
     peerDependenciesMeta:
       jiti:
         optional: true
 
   espree@10.4.0:
-    resolution:
-      {
-        integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   esquery@1.7.0:
-    resolution:
-      {
-        integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==,
-      }
-    engines: { node: ">=0.10" }
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
 
   esrecurse@4.3.0:
-    resolution:
-      {
-        integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==,
-      }
-    engines: { node: ">=4.0" }
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
 
   estraverse@5.3.0:
-    resolution:
-      {
-        integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==,
-      }
-    engines: { node: ">=4.0" }
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
 
   estree-walker@3.0.3:
-    resolution:
-      {
-        integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
-      }
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   esutils@2.0.3:
-    resolution:
-      {
-        integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   eventsource-parser@3.0.6:
-    resolution:
-      {
-        integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==,
-      }
-    engines: { node: ">=18.0.0" }
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
 
   expand-template@2.0.3:
-    resolution:
-      {
-        integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
 
   expect-type@1.3.0:
-    resolution:
-      {
-        integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==,
-      }
-    engines: { node: ">=12.0.0" }
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.3:
-    resolution:
-      {
-        integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==,
-      }
+    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
   fast-copy@4.0.3:
-    resolution:
-      {
-        integrity: sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==,
-      }
+    resolution: {integrity: sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==}
 
   fast-deep-equal@3.1.3:
-    resolution:
-      {
-        integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
-      }
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
   fast-json-stable-stringify@2.1.0:
-    resolution:
-      {
-        integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==,
-      }
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
   fast-levenshtein@2.0.6:
-    resolution:
-      {
-        integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
-      }
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
   fast-safe-stringify@2.1.1:
-    resolution:
-      {
-        integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==,
-      }
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fdir@6.5.0:
-    resolution:
-      {
-        integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
-      }
-    engines: { node: ">=12.0.0" }
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -1848,674 +1187,386 @@ packages:
         optional: true
 
   file-entry-cache@8.0.0:
-    resolution:
-      {
-        integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==,
-      }
-    engines: { node: ">=16.0.0" }
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
 
   file-uri-to-path@1.0.0:
-    resolution:
-      {
-        integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==,
-      }
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   find-up@5.0.0:
-    resolution:
-      {
-        integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
 
   fix-dts-default-cjs-exports@1.0.1:
-    resolution:
-      {
-        integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==,
-      }
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
   flat-cache@4.0.1:
-    resolution:
-      {
-        integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==,
-      }
-    engines: { node: ">=16" }
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
 
   flatted@3.4.2:
-    resolution:
-      {
-        integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==,
-      }
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   fs-constants@1.0.0:
-    resolution:
-      {
-        integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==,
-      }
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fs-minipass@3.0.3:
-    resolution:
-      {
-        integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==,
-      }
-    engines: { node: ^14.17.0 || ^16.13.0 || >=18.0.0 }
+    resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   fsevents@2.3.3:
-    resolution:
-      {
-        integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==,
-      }
-    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
   get-tsconfig@4.13.7:
-    resolution:
-      {
-        integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==,
-      }
+    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
   github-from-package@0.0.0:
-    resolution:
-      {
-        integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==,
-      }
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@6.0.2:
-    resolution:
-      {
-        integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==,
-      }
-    engines: { node: ">=10.13.0" }
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
 
   glob@13.0.6:
-    resolution:
-      {
-        integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==,
-      }
-    engines: { node: 18 || 20 || >=22 }
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   globals@14.0.0:
-    resolution:
-      {
-        integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
 
   globals@16.5.0:
-    resolution:
-      {
-        integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
+    engines: {node: '>=18'}
 
   graceful-fs@4.2.11:
-    resolution:
-      {
-        integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
-      }
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   has-flag@4.0.0:
-    resolution:
-      {
-        integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
 
   help-me@5.0.0:
-    resolution:
-      {
-        integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==,
-      }
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
   html-escaper@2.0.2:
-    resolution:
-      {
-        integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==,
-      }
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   htmlparser2@12.0.0:
-    resolution:
-      {
-        integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==,
-      }
-    engines: { node: ">=20.19.0" }
+    resolution: {integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==}
+    engines: {node: '>=20.19.0'}
 
   http-cache-semantics@4.2.0:
-    resolution:
-      {
-        integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==,
-      }
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
   http-proxy-agent@7.0.2:
-    resolution:
-      {
-        integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==,
-      }
-    engines: { node: ">= 14" }
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
 
   https-proxy-agent@7.0.6:
-    resolution:
-      {
-        integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==,
-      }
-    engines: { node: ">= 14" }
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   iconv-lite@0.7.2:
-    resolution:
-      {
-        integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
-    resolution:
-      {
-        integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==,
-      }
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
-    resolution:
-      {
-        integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==,
-      }
-    engines: { node: ">= 4" }
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
 
   ignore@7.0.5:
-    resolution:
-      {
-        integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==,
-      }
-    engines: { node: ">= 4" }
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
 
   import-fresh@3.3.1:
-    resolution:
-      {
-        integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
 
   imurmurhash@0.1.4:
-    resolution:
-      {
-        integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==,
-      }
-    engines: { node: ">=0.8.19" }
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
 
   inherits@2.0.4:
-    resolution:
-      {
-        integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
-      }
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   ini@1.3.8:
-    resolution:
-      {
-        integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==,
-      }
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   ip-address@10.1.0:
-    resolution:
-      {
-        integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==,
-      }
-    engines: { node: ">= 12" }
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
 
   is-extglob@2.1.1:
-    resolution:
-      {
-        integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
 
   is-glob@4.0.3:
-    resolution:
-      {
-        integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
 
   isexe@2.0.0:
-    resolution:
-      {
-        integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
-      }
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   isexe@4.0.0:
-    resolution:
-      {
-        integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==,
-      }
-    engines: { node: ">=20" }
+    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
+    engines: {node: '>=20'}
 
   istanbul-lib-coverage@3.2.2:
-    resolution:
-      {
-        integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
 
   istanbul-lib-report@3.0.1:
-    resolution:
-      {
-        integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
 
   istanbul-reports@3.2.0:
-    resolution:
-      {
-        integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
 
   joycon@3.1.1:
-    resolution:
-      {
-        integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
 
   js-tokens@10.0.0:
-    resolution:
-      {
-        integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==,
-      }
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-yaml@4.1.1:
-    resolution:
-      {
-        integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==,
-      }
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
   json-buffer@3.0.1:
-    resolution:
-      {
-        integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==,
-      }
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
   json-schema-traverse@0.4.1:
-    resolution:
-      {
-        integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==,
-      }
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
   json-schema@0.4.0:
-    resolution:
-      {
-        integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==,
-      }
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
-    resolution:
-      {
-        integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==,
-      }
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
   jsonrepair@3.13.3:
-    resolution:
-      {
-        integrity: sha512-BTznj0owIt2CBAH/LTo7+1I5pMvl1e1033LRl/HUowlZmJOIhzC0zbX5bxMngLkfT4WnzPP26QnW5wMr2g9tsQ==,
-      }
+    resolution: {integrity: sha512-BTznj0owIt2CBAH/LTo7+1I5pMvl1e1033LRl/HUowlZmJOIhzC0zbX5bxMngLkfT4WnzPP26QnW5wMr2g9tsQ==}
     hasBin: true
 
   keyv@4.5.4:
-    resolution:
-      {
-        integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==,
-      }
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
   levn@0.4.1:
-    resolution:
-      {
-        integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==,
-      }
-    engines: { node: ">= 0.8.0" }
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   lightningcss-android-arm64@1.32.0:
-    resolution:
-      {
-        integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [android]
 
   lightningcss-darwin-arm64@1.32.0:
-    resolution:
-      {
-        integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
 
   lightningcss-darwin-x64@1.32.0:
-    resolution:
-      {
-        integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [darwin]
 
   lightningcss-freebsd-x64@1.32.0:
-    resolution:
-      {
-        integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
 
   lightningcss-linux-arm-gnueabihf@1.32.0:
-    resolution:
-      {
-        integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
 
   lightningcss-linux-arm64-gnu@1.32.0:
-    resolution:
-      {
-        integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
-    resolution:
-      {
-        integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
-    resolution:
-      {
-        integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
-    resolution:
-      {
-        integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
-    resolution:
-      {
-        integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
 
   lightningcss-win32-x64-msvc@1.32.0:
-    resolution:
-      {
-        integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
 
   lightningcss@1.32.0:
-    resolution:
-      {
-        integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
 
   lilconfig@3.1.3:
-    resolution:
-      {
-        integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==,
-      }
-    engines: { node: ">=14" }
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
 
   lines-and-columns@1.2.4:
-    resolution:
-      {
-        integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==,
-      }
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
   load-tsconfig@0.2.5:
-    resolution:
-      {
-        integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==,
-      }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   locate-path@6.0.0:
-    resolution:
-      {
-        integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
 
   lodash.merge@4.6.2:
-    resolution:
-      {
-        integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==,
-      }
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
   lru-cache@11.3.3:
-    resolution:
-      {
-        integrity: sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==,
-      }
-    engines: { node: 20 || >=22 }
+    resolution: {integrity: sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==}
+    engines: {node: 20 || >=22}
 
   magic-string@0.30.21:
-    resolution:
-      {
-        integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
-      }
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   magicast@0.5.2:
-    resolution:
-      {
-        integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==,
-      }
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
 
   make-dir@4.0.0:
-    resolution:
-      {
-        integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   make-fetch-happen@15.0.5:
-    resolution:
-      {
-        integrity: sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==,
-      }
-    engines: { node: ^20.17.0 || >=22.9.0 }
+    resolution: {integrity: sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   mimic-response@3.1.0:
-    resolution:
-      {
-        integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
 
   minimatch@10.2.5:
-    resolution:
-      {
-        integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==,
-      }
-    engines: { node: 18 || 20 || >=22 }
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.5:
-    resolution:
-      {
-        integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==,
-      }
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
   minimist@1.2.8:
-    resolution:
-      {
-        integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==,
-      }
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass-collect@2.0.1:
-    resolution:
-      {
-        integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==,
-      }
-    engines: { node: ">=16 || 14 >=14.17" }
+    resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minipass-fetch@5.0.2:
-    resolution:
-      {
-        integrity: sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==,
-      }
-    engines: { node: ^20.17.0 || >=22.9.0 }
+    resolution: {integrity: sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   minipass-flush@1.0.7:
-    resolution:
-      {
-        integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==,
-      }
-    engines: { node: ">= 8" }
+    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
+    engines: {node: '>= 8'}
 
   minipass-pipeline@1.2.4:
-    resolution:
-      {
-        integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
+    engines: {node: '>=8'}
 
   minipass-sized@2.0.0:
-    resolution:
-      {
-        integrity: sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==}
+    engines: {node: '>=8'}
 
   minipass@3.3.6:
-    resolution:
-      {
-        integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
 
   minipass@7.1.3:
-    resolution:
-      {
-        integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==,
-      }
-    engines: { node: ">=16 || 14 >=14.17" }
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minizlib@3.1.0:
-    resolution:
-      {
-        integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==,
-      }
-    engines: { node: ">= 18" }
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
 
   mkdirp-classic@0.5.3:
-    resolution:
-      {
-        integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==,
-      }
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mlly@1.8.2:
-    resolution:
-      {
-        integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==,
-      }
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
   ms@2.1.3:
-    resolution:
-      {
-        integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
-      }
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   mz@2.7.0:
-    resolution:
-      {
-        integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==,
-      }
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
   nanoid@3.3.11:
-    resolution:
-      {
-        integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
-      }
-    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
   napi-build-utils@2.0.0:
-    resolution:
-      {
-        integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==,
-      }
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
   natural-compare@1.4.0:
-    resolution:
-      {
-        integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==,
-      }
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
   negotiator@1.0.0:
-    resolution:
-      {
-        integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==,
-      }
-    engines: { node: ">= 0.6" }
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
 
   node-abi@3.89.0:
-    resolution:
-      {
-        integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
+    engines: {node: '>=10'}
 
   node-addon-api@8.7.0:
-    resolution:
-      {
-        integrity: sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==,
-      }
-    engines: { node: ^18 || ^20 || >= 21 }
+    resolution: {integrity: sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==}
+    engines: {node: ^18 || ^20 || >= 21}
 
   node-gyp@12.2.0:
-    resolution:
-      {
-        integrity: sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==,
-      }
-    engines: { node: ^20.17.0 || >=22.9.0 }
+    resolution: {integrity: sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
   nopt@9.0.0:
-    resolution:
-      {
-        integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==,
-      }
-    engines: { node: ^20.17.0 || >=22.9.0 }
+    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
   nunjucks@3.2.4:
-    resolution:
-      {
-        integrity: sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==,
-      }
-    engines: { node: ">= 6.9.0" }
+    resolution: {integrity: sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==}
+    engines: {node: '>= 6.9.0'}
     hasBin: true
     peerDependencies:
       chokidar: ^3.3.0
@@ -2524,166 +1575,94 @@ packages:
         optional: true
 
   object-assign@4.1.1:
-    resolution:
-      {
-        integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   obug@2.1.1:
-    resolution:
-      {
-        integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==,
-      }
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   on-exit-leak-free@2.1.2:
-    resolution:
-      {
-        integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==,
-      }
-    engines: { node: ">=14.0.0" }
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
 
   once@1.4.0:
-    resolution:
-      {
-        integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==,
-      }
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   optionator@0.9.4:
-    resolution:
-      {
-        integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==,
-      }
-    engines: { node: ">= 0.8.0" }
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
 
   p-limit@3.1.0:
-    resolution:
-      {
-        integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
 
   p-locate@5.0.0:
-    resolution:
-      {
-        integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
 
   p-map@7.0.4:
-    resolution:
-      {
-        integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
+    engines: {node: '>=18'}
 
   package-json-from-dist@1.0.1:
-    resolution:
-      {
-        integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==,
-      }
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
   parent-module@1.0.1:
-    resolution:
-      {
-        integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
 
   path-exists@4.0.0:
-    resolution:
-      {
-        integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
 
   path-key@3.1.1:
-    resolution:
-      {
-        integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
 
   path-scurry@2.0.2:
-    resolution:
-      {
-        integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==,
-      }
-    engines: { node: 18 || 20 || >=22 }
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   pathe@2.0.3:
-    resolution:
-      {
-        integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
-      }
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pend@1.2.0:
-    resolution:
-      {
-        integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==,
-      }
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   picocolors@1.1.1:
-    resolution:
-      {
-        integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
-      }
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@4.0.4:
-    resolution:
-      {
-        integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
 
   pino-abstract-transport@3.0.0:
-    resolution:
-      {
-        integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==,
-      }
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
 
   pino-pretty@13.1.3:
-    resolution:
-      {
-        integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==,
-      }
+    resolution: {integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==}
     hasBin: true
 
   pino-std-serializers@7.1.0:
-    resolution:
-      {
-        integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==,
-      }
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
 
   pino@10.3.1:
-    resolution:
-      {
-        integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==,
-      }
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
     hasBin: true
 
   pirates@4.0.7:
-    resolution:
-      {
-        integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==,
-      }
-    engines: { node: ">= 6" }
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
 
   pkg-types@1.3.1:
-    resolution:
-      {
-        integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==,
-      }
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   postcss-load-config@6.0.1:
-    resolution:
-      {
-        integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==,
-      }
-    engines: { node: ">= 18" }
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
     peerDependencies:
-      jiti: ">=1.21.0"
-      postcss: ">=8.0.9"
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -2697,453 +1676,261 @@ packages:
         optional: true
 
   postcss@8.5.9:
-    resolution:
-      {
-        integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==,
-      }
-    engines: { node: ^10 || ^12 || >=14 }
+    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
+    engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.3:
-    resolution:
-      {
-        integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
-    resolution:
-      {
-        integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==,
-      }
-    engines: { node: ">= 0.8.0" }
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
 
   prettier@3.8.1:
-    resolution:
-      {
-        integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==,
-      }
-    engines: { node: ">=14" }
+    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+    engines: {node: '>=14'}
     hasBin: true
 
   proc-log@6.1.0:
-    resolution:
-      {
-        integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==,
-      }
-    engines: { node: ^20.17.0 || >=22.9.0 }
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   process-warning@5.0.0:
-    resolution:
-      {
-        integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==,
-      }
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
   pump@3.0.4:
-    resolution:
-      {
-        integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==,
-      }
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
-    resolution:
-      {
-        integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   quick-format-unescaped@4.0.4:
-    resolution:
-      {
-        integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==,
-      }
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   rc@1.2.8:
-    resolution:
-      {
-        integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==,
-      }
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
   readable-stream@3.6.2:
-    resolution:
-      {
-        integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==,
-      }
-    engines: { node: ">= 6" }
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   readdirp@4.1.2:
-    resolution:
-      {
-        integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==,
-      }
-    engines: { node: ">= 14.18.0" }
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
 
   real-require@0.2.0:
-    resolution:
-      {
-        integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==,
-      }
-    engines: { node: ">= 12.13.0" }
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
 
   resolve-from@4.0.0:
-    resolution:
-      {
-        integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
 
   resolve-from@5.0.0:
-    resolution:
-      {
-        integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
 
   resolve-pkg-maps@1.0.0:
-    resolution:
-      {
-        integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==,
-      }
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
   rimraf@6.1.3:
-    resolution:
-      {
-        integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==,
-      }
-    engines: { node: 20 || >=22 }
+    resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
+    engines: {node: 20 || >=22}
     hasBin: true
 
   rolldown@1.0.0-rc.15:
-    resolution:
-      {
-        integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
+    resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   rollup@4.60.1:
-    resolution:
-      {
-        integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==,
-      }
-    engines: { node: ">=18.0.0", npm: ">=8.0.0" }
+    resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   safe-buffer@5.2.1:
-    resolution:
-      {
-        integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
-      }
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-stable-stringify@2.5.0:
-    resolution:
-      {
-        integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
 
   safer-buffer@2.1.2:
-    resolution:
-      {
-        integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
-      }
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   saxes@6.0.0:
-    resolution:
-      {
-        integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==,
-      }
-    engines: { node: ">=v12.22.7" }
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   secure-json-parse@4.1.0:
-    resolution:
-      {
-        integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==,
-      }
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   semver@7.7.4:
-    resolution:
-      {
-        integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
     hasBin: true
 
   shebang-command@2.0.0:
-    resolution:
-      {
-        integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
 
   shebang-regex@3.0.0:
-    resolution:
-      {
-        integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   siginfo@2.0.0:
-    resolution:
-      {
-        integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==,
-      }
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   simple-concat@1.0.1:
-    resolution:
-      {
-        integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==,
-      }
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
 
   simple-get@4.0.1:
-    resolution:
-      {
-        integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==,
-      }
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
   smart-buffer@4.2.0:
-    resolution:
-      {
-        integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==,
-      }
-    engines: { node: ">= 6.0.0", npm: ">= 3.0.0" }
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
 
   socks-proxy-agent@8.0.5:
-    resolution:
-      {
-        integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==,
-      }
-    engines: { node: ">= 14" }
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
 
   socks@2.8.7:
-    resolution:
-      {
-        integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==,
-      }
-    engines: { node: ">= 10.0.0", npm: ">= 3.0.0" }
+    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   sonic-boom@4.2.1:
-    resolution:
-      {
-        integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==,
-      }
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
   source-map-js@1.2.1:
-    resolution:
-      {
-        integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
 
   source-map@0.7.6:
-    resolution:
-      {
-        integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==,
-      }
-    engines: { node: ">= 12" }
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
 
   split2@4.2.0:
-    resolution:
-      {
-        integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==,
-      }
-    engines: { node: ">= 10.x" }
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   sqlite3@6.0.1:
-    resolution:
-      {
-        integrity: sha512-X0czUUMG2tmSqJpEQa3tCuZSHKIx8PwM53vLZzKp/o6Rpy25fiVfjdbnZ988M8+O3ZWR1ih0K255VumCb3MAnQ==,
-      }
-    engines: { node: ">=20.17.0" }
+    resolution: {integrity: sha512-X0czUUMG2tmSqJpEQa3tCuZSHKIx8PwM53vLZzKp/o6Rpy25fiVfjdbnZ988M8+O3ZWR1ih0K255VumCb3MAnQ==}
+    engines: {node: '>=20.17.0'}
 
   ssri@13.0.1:
-    resolution:
-      {
-        integrity: sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==,
-      }
-    engines: { node: ^20.17.0 || >=22.9.0 }
+    resolution: {integrity: sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   stackback@0.0.2:
-    resolution:
-      {
-        integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
-      }
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@4.0.0:
-    resolution:
-      {
-        integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==,
-      }
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   string_decoder@1.3.0:
-    resolution:
-      {
-        integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==,
-      }
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-json-comments@2.0.1:
-    resolution:
-      {
-        integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
 
   strip-json-comments@3.1.1:
-    resolution:
-      {
-        integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
 
   strip-json-comments@5.0.3:
-    resolution:
-      {
-        integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==,
-      }
-    engines: { node: ">=14.16" }
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
 
   sucrase@3.35.1:
-    resolution:
-      {
-        integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==,
-      }
-    engines: { node: ">=16 || 14 >=14.17" }
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
   supports-color@7.2.0:
-    resolution:
-      {
-        integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   tar-fs@2.1.4:
-    resolution:
-      {
-        integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==,
-      }
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
   tar-stream@2.2.0:
-    resolution:
-      {
-        integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   tar@7.5.13:
-    resolution:
-      {
-        integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
+    engines: {node: '>=18'}
 
   thenify-all@1.6.0:
-    resolution:
-      {
-        integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==,
-      }
-    engines: { node: ">=0.8" }
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
 
   thenify@3.3.1:
-    resolution:
-      {
-        integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==,
-      }
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
   thread-stream@4.0.0:
-    resolution:
-      {
-        integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==,
-      }
-    engines: { node: ">=20" }
+    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
+    engines: {node: '>=20'}
 
   tinybench@2.9.0:
-    resolution:
-      {
-        integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
-      }
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
   tinyexec@0.3.2:
-    resolution:
-      {
-        integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==,
-      }
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyexec@1.1.1:
-    resolution:
-      {
-        integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.16:
-    resolution:
-      {
-        integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==,
-      }
-    engines: { node: ">=12.0.0" }
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
 
   tinyld@1.3.4:
-    resolution:
-      {
-        integrity: sha512-u26CNoaInA4XpDU+8s/6Cq8xHc2T5M4fXB3ICfXPokUQoLzmPgSZU02TAkFwFMJCWTjk53gtkS8pETTreZwCqw==,
-      }
-    engines: { node: ">= 12.10.0", npm: ">= 6.12.0", yarn: ">= 1.20.0" }
+    resolution: {integrity: sha512-u26CNoaInA4XpDU+8s/6Cq8xHc2T5M4fXB3ICfXPokUQoLzmPgSZU02TAkFwFMJCWTjk53gtkS8pETTreZwCqw==}
+    engines: {node: '>= 12.10.0', npm: '>= 6.12.0', yarn: '>= 1.20.0'}
     hasBin: true
 
   tinyrainbow@3.1.0:
-    resolution:
-      {
-        integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==,
-      }
-    engines: { node: ">=14.0.0" }
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tree-kill@1.2.2:
-    resolution:
-      {
-        integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==,
-      }
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
   ts-api-utils@2.5.0:
-    resolution:
-      {
-        integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==,
-      }
-    engines: { node: ">=18.12" }
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
     peerDependencies:
-      typescript: ">=4.8.4"
+      typescript: '>=4.8.4'
 
   ts-interface-checker@0.1.13:
-    resolution:
-      {
-        integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==,
-      }
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
   tslib@2.8.1:
-    resolution:
-      {
-        integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
-      }
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsup@8.5.1:
-    resolution:
-      {
-        integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
-      "@microsoft/api-extractor": ^7.36.0
-      "@swc/core": ^1
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
       postcss: ^8.4.12
-      typescript: ">=4.5.0"
+      typescript: '>=4.5.0'
     peerDependenciesMeta:
-      "@microsoft/api-extractor":
+      '@microsoft/api-extractor':
         optional: true
-      "@swc/core":
+      '@swc/core':
         optional: true
       postcss:
         optional: true
@@ -3151,92 +1938,62 @@ packages:
         optional: true
 
   tsx@4.21.0:
-    resolution:
-      {
-        integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==,
-      }
-    engines: { node: ">=18.0.0" }
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
     hasBin: true
 
   tunnel-agent@0.6.0:
-    resolution:
-      {
-        integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==,
-      }
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   type-check@0.4.0:
-    resolution:
-      {
-        integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==,
-      }
-    engines: { node: ">= 0.8.0" }
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
 
   typescript-eslint@8.58.1:
-    resolution:
-      {
-        integrity: sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    resolution: {integrity: sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: ">=4.8.4 <6.1.0"
+      typescript: '>=4.8.4 <6.1.0'
 
   typescript@5.9.3:
-    resolution:
-      {
-        integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==,
-      }
-    engines: { node: ">=14.17" }
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   ufo@1.6.3:
-    resolution:
-      {
-        integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==,
-      }
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
   undici-types@7.16.0:
-    resolution:
-      {
-        integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==,
-      }
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   uri-js@4.4.1:
-    resolution:
-      {
-        integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
-      }
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   util-deprecate@1.0.2:
-    resolution:
-      {
-        integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
-      }
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vite@8.0.8:
-    resolution:
-      {
-        integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
+    resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      "@types/node": ^20.19.0 || >=22.12.0
-      "@vitejs/devtools": ^0.1.0
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
       esbuild: ^0.27.0 || ^0.28.0
-      jiti: ">=1.21.0"
+      jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
       sass-embedded: ^1.70.0
-      stylus: ">=0.54.8"
+      stylus: '>=0.54.8'
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
-      "@types/node":
+      '@types/node':
         optional: true
-      "@vitejs/devtools":
+      '@vitejs/devtools':
         optional: true
       esbuild:
         optional: true
@@ -3260,43 +2017,40 @@ packages:
         optional: true
 
   vitest@4.1.4:
-    resolution:
-      {
-        integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==,
-      }
-    engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
-      "@edge-runtime/vm": "*"
-      "@opentelemetry/api": ^1.9.0
-      "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
-      "@vitest/browser-playwright": 4.1.4
-      "@vitest/browser-preview": 4.1.4
-      "@vitest/browser-webdriverio": 4.1.4
-      "@vitest/coverage-istanbul": 4.1.4
-      "@vitest/coverage-v8": 4.1.4
-      "@vitest/ui": 4.1.4
-      happy-dom: "*"
-      jsdom: "*"
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
+      happy-dom: '*'
+      jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
-      "@edge-runtime/vm":
+      '@edge-runtime/vm':
         optional: true
-      "@opentelemetry/api":
+      '@opentelemetry/api':
         optional: true
-      "@types/node":
+      '@types/node':
         optional: true
-      "@vitest/browser-playwright":
+      '@vitest/browser-playwright':
         optional: true
-      "@vitest/browser-preview":
+      '@vitest/browser-preview':
         optional: true
-      "@vitest/browser-webdriverio":
+      '@vitest/browser-webdriverio':
         optional: true
-      "@vitest/coverage-istanbul":
+      '@vitest/coverage-istanbul':
         optional: true
-      "@vitest/coverage-v8":
+      '@vitest/coverage-v8':
         optional: true
-      "@vitest/ui":
+      '@vitest/ui':
         optional: true
       happy-dom:
         optional: true
@@ -3304,263 +2058,228 @@ packages:
         optional: true
 
   which@2.0.2:
-    resolution:
-      {
-        integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
-      }
-    engines: { node: ">= 8" }
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
     hasBin: true
 
   which@6.0.1:
-    resolution:
-      {
-        integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==,
-      }
-    engines: { node: ^20.17.0 || >=22.9.0 }
+    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
   why-is-node-running@2.3.0:
-    resolution:
-      {
-        integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
-    resolution:
-      {
-        integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
 
   wrappy@1.0.2:
-    resolution:
-      {
-        integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==,
-      }
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   xmlchars@2.2.0:
-    resolution:
-      {
-        integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==,
-      }
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@4.0.0:
-    resolution:
-      {
-        integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==,
-      }
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yallist@5.0.0:
-    resolution:
-      {
-        integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yauzl@3.3.0:
-    resolution:
-      {
-        integrity: sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==}
+    engines: {node: '>=12'}
 
   yazl@3.3.1:
-    resolution:
-      {
-        integrity: sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==,
-      }
+    resolution: {integrity: sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==}
 
   yocto-queue@0.1.0:
-    resolution:
-      {
-        integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
   zod@4.3.6:
-    resolution:
-      {
-        integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==,
-      }
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
-  "@ai-sdk/anthropic@3.0.68(zod@4.3.6)":
+
+  '@ai-sdk/anthropic@3.0.68(zod@4.3.6)':
     dependencies:
-      "@ai-sdk/provider": 3.0.8
-      "@ai-sdk/provider-utils": 4.0.23(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
       zod: 4.3.6
 
-  "@ai-sdk/gateway@3.0.94(zod@4.3.6)":
+  '@ai-sdk/gateway@3.0.94(zod@4.3.6)':
     dependencies:
-      "@ai-sdk/provider": 3.0.8
-      "@ai-sdk/provider-utils": 4.0.23(zod@4.3.6)
-      "@vercel/oidc": 3.1.0
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
+      '@vercel/oidc': 3.1.0
       zod: 4.3.6
 
-  "@ai-sdk/google@3.0.61(zod@4.3.6)":
+  '@ai-sdk/google@3.0.61(zod@4.3.6)':
     dependencies:
-      "@ai-sdk/provider": 3.0.8
-      "@ai-sdk/provider-utils": 4.0.23(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
       zod: 4.3.6
 
-  "@ai-sdk/openai-compatible@2.0.41(zod@4.3.6)":
+  '@ai-sdk/openai-compatible@2.0.41(zod@4.3.6)':
     dependencies:
-      "@ai-sdk/provider": 3.0.8
-      "@ai-sdk/provider-utils": 4.0.23(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
       zod: 4.3.6
 
-  "@ai-sdk/openai@3.0.52(zod@4.3.6)":
+  '@ai-sdk/openai@3.0.52(zod@4.3.6)':
     dependencies:
-      "@ai-sdk/provider": 3.0.8
-      "@ai-sdk/provider-utils": 4.0.23(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
       zod: 4.3.6
 
-  "@ai-sdk/provider-utils@4.0.23(zod@4.3.6)":
+  '@ai-sdk/provider-utils@4.0.23(zod@4.3.6)':
     dependencies:
-      "@ai-sdk/provider": 3.0.8
-      "@standard-schema/spec": 1.1.0
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 4.3.6
 
-  "@ai-sdk/provider@3.0.8":
+  '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
 
-  "@babel/helper-string-parser@7.27.1": {}
+  '@babel/helper-string-parser@7.27.1': {}
 
-  "@babel/helper-validator-identifier@7.28.5": {}
+  '@babel/helper-validator-identifier@7.28.5': {}
 
-  "@babel/parser@7.29.2":
+  '@babel/parser@7.29.2':
     dependencies:
-      "@babel/types": 7.29.0
+      '@babel/types': 7.29.0
 
-  "@babel/types@7.29.0":
+  '@babel/types@7.29.0':
     dependencies:
-      "@babel/helper-string-parser": 7.27.1
-      "@babel/helper-validator-identifier": 7.28.5
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
-  "@bcoe/v8-coverage@1.0.2": {}
+  '@bcoe/v8-coverage@1.0.2': {}
 
-  "@emnapi/core@1.9.2":
+  '@emnapi/core@1.9.2':
     dependencies:
-      "@emnapi/wasi-threads": 1.2.1
+      '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
     optional: true
 
-  "@emnapi/runtime@1.9.2":
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  "@emnapi/wasi-threads@1.2.1":
+  '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  "@esbuild/aix-ppc64@0.27.7":
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
     optional: true
 
-  "@esbuild/android-arm64@0.27.7":
+  '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
-  "@esbuild/android-arm@0.27.7":
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
-  "@esbuild/android-x64@0.27.7":
+  '@esbuild/android-arm@0.27.7':
     optional: true
 
-  "@esbuild/darwin-arm64@0.27.7":
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
-  "@esbuild/darwin-x64@0.27.7":
+  '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
-  "@esbuild/freebsd-arm64@0.27.7":
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
-  "@esbuild/freebsd-x64@0.27.7":
+  '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
-  "@esbuild/linux-arm64@0.27.7":
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
-  "@esbuild/linux-arm@0.27.7":
+  '@esbuild/linux-arm64@0.27.7':
     optional: true
 
-  "@esbuild/linux-ia32@0.27.7":
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
-  "@esbuild/linux-loong64@0.27.7":
+  '@esbuild/linux-ia32@0.27.7':
     optional: true
 
-  "@esbuild/linux-mips64el@0.27.7":
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
-  "@esbuild/linux-ppc64@0.27.7":
+  '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
-  "@esbuild/linux-riscv64@0.27.7":
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
-  "@esbuild/linux-s390x@0.27.7":
+  '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
-  "@esbuild/linux-x64@0.27.7":
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
-  "@esbuild/netbsd-arm64@0.27.7":
+  '@esbuild/linux-x64@0.27.7':
     optional: true
 
-  "@esbuild/netbsd-x64@0.27.7":
+  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
-  "@esbuild/openbsd-arm64@0.27.7":
+  '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
-  "@esbuild/openbsd-x64@0.27.7":
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
-  "@esbuild/openharmony-arm64@0.27.7":
+  '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
-  "@esbuild/sunos-x64@0.27.7":
+  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
-  "@esbuild/win32-arm64@0.27.7":
+  '@esbuild/sunos-x64@0.27.7':
     optional: true
 
-  "@esbuild/win32-ia32@0.27.7":
+  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
-  "@esbuild/win32-x64@0.27.7":
+  '@esbuild/win32-ia32@0.27.7':
     optional: true
 
-  "@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)":
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
     dependencies:
       eslint: 9.39.4
       eslint-visitor-keys: 3.4.3
 
-  "@eslint-community/regexpp@4.12.2": {}
+  '@eslint-community/regexpp@4.12.2': {}
 
-  "@eslint/config-array@0.21.2":
+  '@eslint/config-array@0.21.2':
     dependencies:
-      "@eslint/object-schema": 2.1.7
+      '@eslint/object-schema': 2.1.7
       debug: 4.4.3
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
 
-  "@eslint/config-helpers@0.4.2":
+  '@eslint/config-helpers@0.4.2':
     dependencies:
-      "@eslint/core": 0.17.0
+      '@eslint/core': 0.17.0
 
-  "@eslint/core@0.17.0":
+  '@eslint/core@0.17.0':
     dependencies:
-      "@types/json-schema": 7.0.15
+      '@types/json-schema': 7.0.15
 
-  "@eslint/eslintrc@3.3.5":
+  '@eslint/eslintrc@3.3.5':
     dependencies:
       ajv: 6.14.0
       debug: 4.4.3
@@ -3574,55 +2293,55 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@eslint/js@9.39.4": {}
+  '@eslint/js@9.39.4': {}
 
-  "@eslint/object-schema@2.1.7": {}
+  '@eslint/object-schema@2.1.7': {}
 
-  "@eslint/plugin-kit@0.4.1":
+  '@eslint/plugin-kit@0.4.1':
     dependencies:
-      "@eslint/core": 0.17.0
+      '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  "@gar/promise-retry@1.0.3":
+  '@gar/promise-retry@1.0.3':
     optional: true
 
-  "@humanfs/core@0.19.1": {}
+  '@humanfs/core@0.19.1': {}
 
-  "@humanfs/node@0.16.7":
+  '@humanfs/node@0.16.7':
     dependencies:
-      "@humanfs/core": 0.19.1
-      "@humanwhocodes/retry": 0.4.3
+      '@humanfs/core': 0.19.1
+      '@humanwhocodes/retry': 0.4.3
 
-  "@humanwhocodes/module-importer@1.0.1": {}
+  '@humanwhocodes/module-importer@1.0.1': {}
 
-  "@humanwhocodes/retry@0.4.3": {}
+  '@humanwhocodes/retry@0.4.3': {}
 
-  "@isaacs/fs-minipass@4.0.1":
+  '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
 
-  "@jridgewell/gen-mapping@0.3.13":
+  '@jridgewell/gen-mapping@0.3.13':
     dependencies:
-      "@jridgewell/sourcemap-codec": 1.5.5
-      "@jridgewell/trace-mapping": 0.3.31
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
 
-  "@jridgewell/resolve-uri@3.1.2": {}
+  '@jridgewell/resolve-uri@3.1.2': {}
 
-  "@jridgewell/sourcemap-codec@1.5.5": {}
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  "@jridgewell/trace-mapping@0.3.31":
+  '@jridgewell/trace-mapping@0.3.31':
     dependencies:
-      "@jridgewell/resolve-uri": 3.1.2
-      "@jridgewell/sourcemap-codec": 1.5.5
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
-  "@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)":
+  '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
-      "@emnapi/core": 1.9.2
-      "@emnapi/runtime": 1.9.2
-      "@tybys/wasm-util": 0.10.1
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@tybys/wasm-util': 0.10.1
     optional: true
 
-  "@npmcli/agent@4.0.0":
+  '@npmcli/agent@4.0.0':
     dependencies:
       agent-base: 7.1.4
       http-proxy-agent: 7.0.2
@@ -3633,186 +2352,186 @@ snapshots:
       - supports-color
     optional: true
 
-  "@npmcli/fs@5.0.0":
+  '@npmcli/fs@5.0.0':
     dependencies:
       semver: 7.7.4
     optional: true
 
-  "@npmcli/redact@4.0.0":
+  '@npmcli/redact@4.0.0':
     optional: true
 
-  "@opentelemetry/api@1.9.0": {}
+  '@opentelemetry/api@1.9.0': {}
 
-  "@oxc-project/types@0.124.0": {}
+  '@oxc-project/types@0.124.0': {}
 
-  "@pinojs/redact@0.4.0": {}
+  '@pinojs/redact@0.4.0': {}
 
-  "@rolldown/binding-android-arm64@1.0.0-rc.15":
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
     optional: true
 
-  "@rolldown/binding-darwin-arm64@1.0.0-rc.15":
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
     optional: true
 
-  "@rolldown/binding-darwin-x64@1.0.0-rc.15":
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
     optional: true
 
-  "@rolldown/binding-freebsd-x64@1.0.0-rc.15":
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
     optional: true
 
-  "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15":
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
     optional: true
 
-  "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15":
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
     optional: true
 
-  "@rolldown/binding-linux-arm64-musl@1.0.0-rc.15":
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
     optional: true
 
-  "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15":
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
     optional: true
 
-  "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15":
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
     optional: true
 
-  "@rolldown/binding-linux-x64-gnu@1.0.0-rc.15":
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
     optional: true
 
-  "@rolldown/binding-linux-x64-musl@1.0.0-rc.15":
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
     optional: true
 
-  "@rolldown/binding-openharmony-arm64@1.0.0-rc.15":
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
     optional: true
 
-  "@rolldown/binding-wasm32-wasi@1.0.0-rc.15":
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
     dependencies:
-      "@emnapi/core": 1.9.2
-      "@emnapi/runtime": 1.9.2
-      "@napi-rs/wasm-runtime": 1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     optional: true
 
-  "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15":
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
     optional: true
 
-  "@rolldown/binding-win32-x64-msvc@1.0.0-rc.15":
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
     optional: true
 
-  "@rolldown/pluginutils@1.0.0-rc.15": {}
+  '@rolldown/pluginutils@1.0.0-rc.15': {}
 
-  "@rollup/rollup-android-arm-eabi@4.60.1":
+  '@rollup/rollup-android-arm-eabi@4.60.1':
     optional: true
 
-  "@rollup/rollup-android-arm64@4.60.1":
+  '@rollup/rollup-android-arm64@4.60.1':
     optional: true
 
-  "@rollup/rollup-darwin-arm64@4.60.1":
+  '@rollup/rollup-darwin-arm64@4.60.1':
     optional: true
 
-  "@rollup/rollup-darwin-x64@4.60.1":
+  '@rollup/rollup-darwin-x64@4.60.1':
     optional: true
 
-  "@rollup/rollup-freebsd-arm64@4.60.1":
+  '@rollup/rollup-freebsd-arm64@4.60.1':
     optional: true
 
-  "@rollup/rollup-freebsd-x64@4.60.1":
+  '@rollup/rollup-freebsd-x64@4.60.1':
     optional: true
 
-  "@rollup/rollup-linux-arm-gnueabihf@4.60.1":
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
     optional: true
 
-  "@rollup/rollup-linux-arm-musleabihf@4.60.1":
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     optional: true
 
-  "@rollup/rollup-linux-arm64-gnu@4.60.1":
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
     optional: true
 
-  "@rollup/rollup-linux-arm64-musl@4.60.1":
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
     optional: true
 
-  "@rollup/rollup-linux-loong64-gnu@4.60.1":
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
     optional: true
 
-  "@rollup/rollup-linux-loong64-musl@4.60.1":
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
     optional: true
 
-  "@rollup/rollup-linux-ppc64-gnu@4.60.1":
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     optional: true
 
-  "@rollup/rollup-linux-ppc64-musl@4.60.1":
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
     optional: true
 
-  "@rollup/rollup-linux-riscv64-gnu@4.60.1":
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     optional: true
 
-  "@rollup/rollup-linux-riscv64-musl@4.60.1":
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
     optional: true
 
-  "@rollup/rollup-linux-s390x-gnu@4.60.1":
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
     optional: true
 
-  "@rollup/rollup-linux-x64-gnu@4.60.1":
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
     optional: true
 
-  "@rollup/rollup-linux-x64-musl@4.60.1":
+  '@rollup/rollup-linux-x64-musl@4.60.1':
     optional: true
 
-  "@rollup/rollup-openbsd-x64@4.60.1":
+  '@rollup/rollup-openbsd-x64@4.60.1':
     optional: true
 
-  "@rollup/rollup-openharmony-arm64@4.60.1":
+  '@rollup/rollup-openharmony-arm64@4.60.1':
     optional: true
 
-  "@rollup/rollup-win32-arm64-msvc@4.60.1":
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
     optional: true
 
-  "@rollup/rollup-win32-ia32-msvc@4.60.1":
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
     optional: true
 
-  "@rollup/rollup-win32-x64-gnu@4.60.1":
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
     optional: true
 
-  "@rollup/rollup-win32-x64-msvc@4.60.1":
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
 
-  "@standard-schema/spec@1.1.0": {}
+  '@standard-schema/spec@1.1.0': {}
 
-  "@tybys/wasm-util@0.10.1":
+  '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  "@types/chai@5.2.3":
+  '@types/chai@5.2.3':
     dependencies:
-      "@types/deep-eql": 4.0.2
+      '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
-  "@types/deep-eql@4.0.2": {}
+  '@types/deep-eql@4.0.2': {}
 
-  "@types/estree@1.0.8": {}
+  '@types/estree@1.0.8': {}
 
-  "@types/json-schema@7.0.15": {}
+  '@types/json-schema@7.0.15': {}
 
-  "@types/node@24.12.2":
+  '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
 
-  "@types/nunjucks@3.2.6": {}
+  '@types/nunjucks@3.2.6': {}
 
-  "@types/yauzl@2.10.3":
+  '@types/yauzl@2.10.3':
     dependencies:
-      "@types/node": 24.12.2
+      '@types/node': 24.12.2
 
-  "@types/yazl@3.3.1":
+  '@types/yazl@3.3.1':
     dependencies:
-      "@types/node": 24.12.2
+      '@types/node': 24.12.2
 
-  "@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)":
+  '@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
-      "@eslint-community/regexpp": 4.12.2
-      "@typescript-eslint/parser": 8.58.1(eslint@9.39.4)(typescript@5.9.3)
-      "@typescript-eslint/scope-manager": 8.58.1
-      "@typescript-eslint/type-utils": 8.58.1(eslint@9.39.4)(typescript@5.9.3)
-      "@typescript-eslint/utils": 8.58.1(eslint@9.39.4)(typescript@5.9.3)
-      "@typescript-eslint/visitor-keys": 8.58.1
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.58.1
+      '@typescript-eslint/type-utils': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.58.1
       eslint: 9.39.4
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -3821,41 +2540,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3)":
+  '@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
-      "@typescript-eslint/scope-manager": 8.58.1
-      "@typescript-eslint/types": 8.58.1
-      "@typescript-eslint/typescript-estree": 8.58.1(typescript@5.9.3)
-      "@typescript-eslint/visitor-keys": 8.58.1
+      '@typescript-eslint/scope-manager': 8.58.1
+      '@typescript-eslint/types': 8.58.1
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.58.1
       debug: 4.4.3
       eslint: 9.39.4
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/project-service@8.58.1(typescript@5.9.3)":
+  '@typescript-eslint/project-service@8.58.1(typescript@5.9.3)':
     dependencies:
-      "@typescript-eslint/tsconfig-utils": 8.58.1(typescript@5.9.3)
-      "@typescript-eslint/types": 8.58.1
+      '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.1
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/scope-manager@8.58.1":
+  '@typescript-eslint/scope-manager@8.58.1':
     dependencies:
-      "@typescript-eslint/types": 8.58.1
-      "@typescript-eslint/visitor-keys": 8.58.1
+      '@typescript-eslint/types': 8.58.1
+      '@typescript-eslint/visitor-keys': 8.58.1
 
-  "@typescript-eslint/tsconfig-utils@8.58.1(typescript@5.9.3)":
+  '@typescript-eslint/tsconfig-utils@8.58.1(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  "@typescript-eslint/type-utils@8.58.1(eslint@9.39.4)(typescript@5.9.3)":
+  '@typescript-eslint/type-utils@8.58.1(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
-      "@typescript-eslint/types": 8.58.1
-      "@typescript-eslint/typescript-estree": 8.58.1(typescript@5.9.3)
-      "@typescript-eslint/utils": 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.1
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
       debug: 4.4.3
       eslint: 9.39.4
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -3863,14 +2582,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/types@8.58.1": {}
+  '@typescript-eslint/types@8.58.1': {}
 
-  "@typescript-eslint/typescript-estree@8.58.1(typescript@5.9.3)":
+  '@typescript-eslint/typescript-estree@8.58.1(typescript@5.9.3)':
     dependencies:
-      "@typescript-eslint/project-service": 8.58.1(typescript@5.9.3)
-      "@typescript-eslint/tsconfig-utils": 8.58.1(typescript@5.9.3)
-      "@typescript-eslint/types": 8.58.1
-      "@typescript-eslint/visitor-keys": 8.58.1
+      '@typescript-eslint/project-service': 8.58.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.1
+      '@typescript-eslint/visitor-keys': 8.58.1
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
@@ -3880,28 +2599,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/utils@8.58.1(eslint@9.39.4)(typescript@5.9.3)":
+  '@typescript-eslint/utils@8.58.1(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
-      "@eslint-community/eslint-utils": 4.9.1(eslint@9.39.4)
-      "@typescript-eslint/scope-manager": 8.58.1
-      "@typescript-eslint/types": 8.58.1
-      "@typescript-eslint/typescript-estree": 8.58.1(typescript@5.9.3)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@typescript-eslint/scope-manager': 8.58.1
+      '@typescript-eslint/types': 8.58.1
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
       eslint: 9.39.4
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/visitor-keys@8.58.1":
+  '@typescript-eslint/visitor-keys@8.58.1':
     dependencies:
-      "@typescript-eslint/types": 8.58.1
+      '@typescript-eslint/types': 8.58.1
       eslint-visitor-keys: 5.0.1
 
-  "@vercel/oidc@3.1.0": {}
+  '@vercel/oidc@3.1.0': {}
 
-  "@vitest/coverage-v8@4.1.4(vitest@4.1.4)":
+  '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
     dependencies:
-      "@bcoe/v8-coverage": 1.0.2
-      "@vitest/utils": 4.1.4
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.4
       ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -3912,44 +2631,44 @@ snapshots:
       tinyrainbow: 3.1.0
       vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))
 
-  "@vitest/expect@4.1.4":
+  '@vitest/expect@4.1.4':
     dependencies:
-      "@standard-schema/spec": 1.1.0
-      "@types/chai": 5.2.3
-      "@vitest/spy": 4.1.4
-      "@vitest/utils": 4.1.4
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  "@vitest/mocker@4.1.4(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))":
+  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))':
     dependencies:
-      "@vitest/spy": 4.1.4
+      '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)
 
-  "@vitest/pretty-format@4.1.4":
+  '@vitest/pretty-format@4.1.4':
     dependencies:
       tinyrainbow: 3.1.0
 
-  "@vitest/runner@4.1.4":
+  '@vitest/runner@4.1.4':
     dependencies:
-      "@vitest/utils": 4.1.4
+      '@vitest/utils': 4.1.4
       pathe: 2.0.3
 
-  "@vitest/snapshot@4.1.4":
+  '@vitest/snapshot@4.1.4':
     dependencies:
-      "@vitest/pretty-format": 4.1.4
-      "@vitest/utils": 4.1.4
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  "@vitest/spy@4.1.4": {}
+  '@vitest/spy@4.1.4': {}
 
-  "@vitest/utils@4.1.4":
+  '@vitest/utils@4.1.4':
     dependencies:
-      "@vitest/pretty-format": 4.1.4
+      '@vitest/pretty-format': 4.1.4
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -3969,10 +2688,10 @@ snapshots:
 
   ai@6.0.154(zod@4.3.6):
     dependencies:
-      "@ai-sdk/gateway": 3.0.94(zod@4.3.6)
-      "@ai-sdk/provider": 3.0.8
-      "@ai-sdk/provider-utils": 4.0.23(zod@4.3.6)
-      "@opentelemetry/api": 1.9.0
+      '@ai-sdk/gateway': 3.0.94(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
+      '@opentelemetry/api': 1.9.0
       zod: 4.3.6
 
   ajv@6.14.0:
@@ -3996,7 +2715,7 @@ snapshots:
 
   ast-v8-to-istanbul@1.0.0:
     dependencies:
-      "@jridgewell/trace-mapping": 0.3.31
+      '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
@@ -4045,7 +2764,7 @@ snapshots:
 
   cacache@20.0.4:
     dependencies:
-      "@npmcli/fs": 5.0.0
+      '@npmcli/fs': 5.0.0
       fs-minipass: 3.0.3
       glob: 13.0.6
       lru-cache: 11.3.3
@@ -4147,32 +2866,32 @@ snapshots:
 
   esbuild@0.27.7:
     optionalDependencies:
-      "@esbuild/aix-ppc64": 0.27.7
-      "@esbuild/android-arm": 0.27.7
-      "@esbuild/android-arm64": 0.27.7
-      "@esbuild/android-x64": 0.27.7
-      "@esbuild/darwin-arm64": 0.27.7
-      "@esbuild/darwin-x64": 0.27.7
-      "@esbuild/freebsd-arm64": 0.27.7
-      "@esbuild/freebsd-x64": 0.27.7
-      "@esbuild/linux-arm": 0.27.7
-      "@esbuild/linux-arm64": 0.27.7
-      "@esbuild/linux-ia32": 0.27.7
-      "@esbuild/linux-loong64": 0.27.7
-      "@esbuild/linux-mips64el": 0.27.7
-      "@esbuild/linux-ppc64": 0.27.7
-      "@esbuild/linux-riscv64": 0.27.7
-      "@esbuild/linux-s390x": 0.27.7
-      "@esbuild/linux-x64": 0.27.7
-      "@esbuild/netbsd-arm64": 0.27.7
-      "@esbuild/netbsd-x64": 0.27.7
-      "@esbuild/openbsd-arm64": 0.27.7
-      "@esbuild/openbsd-x64": 0.27.7
-      "@esbuild/openharmony-arm64": 0.27.7
-      "@esbuild/sunos-x64": 0.27.7
-      "@esbuild/win32-arm64": 0.27.7
-      "@esbuild/win32-ia32": 0.27.7
-      "@esbuild/win32-x64": 0.27.7
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   escape-string-regexp@4.0.0: {}
 
@@ -4193,18 +2912,18 @@ snapshots:
 
   eslint@9.39.4:
     dependencies:
-      "@eslint-community/eslint-utils": 4.9.1(eslint@9.39.4)
-      "@eslint-community/regexpp": 4.12.2
-      "@eslint/config-array": 0.21.2
-      "@eslint/config-helpers": 0.4.2
-      "@eslint/core": 0.17.0
-      "@eslint/eslintrc": 3.3.5
-      "@eslint/js": 9.39.4
-      "@eslint/plugin-kit": 0.4.1
-      "@humanfs/node": 0.16.7
-      "@humanwhocodes/module-importer": 1.0.1
-      "@humanwhocodes/retry": 0.4.3
-      "@types/estree": 1.0.8
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.7
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
@@ -4248,7 +2967,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
 
   esutils@2.0.3: {}
 
@@ -4505,12 +3224,12 @@ snapshots:
 
   magic-string@0.30.21:
     dependencies:
-      "@jridgewell/sourcemap-codec": 1.5.5
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   magicast@0.5.2:
     dependencies:
-      "@babel/parser": 7.29.2
-      "@babel/types": 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
@@ -4519,9 +3238,9 @@ snapshots:
 
   make-fetch-happen@15.0.5:
     dependencies:
-      "@gar/promise-retry": 1.0.3
-      "@npmcli/agent": 4.0.0
-      "@npmcli/redact": 4.0.0
+      '@gar/promise-retry': 1.0.3
+      '@npmcli/agent': 4.0.0
+      '@npmcli/redact': 4.0.0
       cacache: 20.0.4
       http-cache-semantics: 4.2.0
       minipass: 7.1.3
@@ -4723,7 +3442,7 @@ snapshots:
 
   pino@10.3.1:
     dependencies:
-      "@pinojs/redact": 0.4.0
+      '@pinojs/redact': 0.4.0
       atomic-sleep: 1.0.0
       on-exit-leak-free: 2.1.2
       pino-abstract-transport: 3.0.0
@@ -4819,54 +3538,54 @@ snapshots:
 
   rolldown@1.0.0-rc.15:
     dependencies:
-      "@oxc-project/types": 0.124.0
-      "@rolldown/pluginutils": 1.0.0-rc.15
+      '@oxc-project/types': 0.124.0
+      '@rolldown/pluginutils': 1.0.0-rc.15
     optionalDependencies:
-      "@rolldown/binding-android-arm64": 1.0.0-rc.15
-      "@rolldown/binding-darwin-arm64": 1.0.0-rc.15
-      "@rolldown/binding-darwin-x64": 1.0.0-rc.15
-      "@rolldown/binding-freebsd-x64": 1.0.0-rc.15
-      "@rolldown/binding-linux-arm-gnueabihf": 1.0.0-rc.15
-      "@rolldown/binding-linux-arm64-gnu": 1.0.0-rc.15
-      "@rolldown/binding-linux-arm64-musl": 1.0.0-rc.15
-      "@rolldown/binding-linux-ppc64-gnu": 1.0.0-rc.15
-      "@rolldown/binding-linux-s390x-gnu": 1.0.0-rc.15
-      "@rolldown/binding-linux-x64-gnu": 1.0.0-rc.15
-      "@rolldown/binding-linux-x64-musl": 1.0.0-rc.15
-      "@rolldown/binding-openharmony-arm64": 1.0.0-rc.15
-      "@rolldown/binding-wasm32-wasi": 1.0.0-rc.15
-      "@rolldown/binding-win32-arm64-msvc": 1.0.0-rc.15
-      "@rolldown/binding-win32-x64-msvc": 1.0.0-rc.15
+      '@rolldown/binding-android-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.15
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.15
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.15
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.15
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.15
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
 
   rollup@4.60.1:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
     optionalDependencies:
-      "@rollup/rollup-android-arm-eabi": 4.60.1
-      "@rollup/rollup-android-arm64": 4.60.1
-      "@rollup/rollup-darwin-arm64": 4.60.1
-      "@rollup/rollup-darwin-x64": 4.60.1
-      "@rollup/rollup-freebsd-arm64": 4.60.1
-      "@rollup/rollup-freebsd-x64": 4.60.1
-      "@rollup/rollup-linux-arm-gnueabihf": 4.60.1
-      "@rollup/rollup-linux-arm-musleabihf": 4.60.1
-      "@rollup/rollup-linux-arm64-gnu": 4.60.1
-      "@rollup/rollup-linux-arm64-musl": 4.60.1
-      "@rollup/rollup-linux-loong64-gnu": 4.60.1
-      "@rollup/rollup-linux-loong64-musl": 4.60.1
-      "@rollup/rollup-linux-ppc64-gnu": 4.60.1
-      "@rollup/rollup-linux-ppc64-musl": 4.60.1
-      "@rollup/rollup-linux-riscv64-gnu": 4.60.1
-      "@rollup/rollup-linux-riscv64-musl": 4.60.1
-      "@rollup/rollup-linux-s390x-gnu": 4.60.1
-      "@rollup/rollup-linux-x64-gnu": 4.60.1
-      "@rollup/rollup-linux-x64-musl": 4.60.1
-      "@rollup/rollup-openbsd-x64": 4.60.1
-      "@rollup/rollup-openharmony-arm64": 4.60.1
-      "@rollup/rollup-win32-arm64-msvc": 4.60.1
-      "@rollup/rollup-win32-ia32-msvc": 4.60.1
-      "@rollup/rollup-win32-x64-gnu": 4.60.1
-      "@rollup/rollup-win32-x64-msvc": 4.60.1
+      '@rollup/rollup-android-arm-eabi': 4.60.1
+      '@rollup/rollup-android-arm64': 4.60.1
+      '@rollup/rollup-darwin-arm64': 4.60.1
+      '@rollup/rollup-darwin-x64': 4.60.1
+      '@rollup/rollup-freebsd-arm64': 4.60.1
+      '@rollup/rollup-freebsd-x64': 4.60.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.1
+      '@rollup/rollup-linux-arm64-gnu': 4.60.1
+      '@rollup/rollup-linux-arm64-musl': 4.60.1
+      '@rollup/rollup-linux-loong64-gnu': 4.60.1
+      '@rollup/rollup-linux-loong64-musl': 4.60.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.1
+      '@rollup/rollup-linux-ppc64-musl': 4.60.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.1
+      '@rollup/rollup-linux-riscv64-musl': 4.60.1
+      '@rollup/rollup-linux-s390x-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-musl': 4.60.1
+      '@rollup/rollup-openbsd-x64': 4.60.1
+      '@rollup/rollup-openharmony-arm64': 4.60.1
+      '@rollup/rollup-win32-arm64-msvc': 4.60.1
+      '@rollup/rollup-win32-ia32-msvc': 4.60.1
+      '@rollup/rollup-win32-x64-gnu': 4.60.1
+      '@rollup/rollup-win32-x64-msvc': 4.60.1
       fsevents: 2.3.3
 
   safe-buffer@5.2.1: {}
@@ -4960,7 +3679,7 @@ snapshots:
 
   sucrase@3.35.1:
     dependencies:
-      "@jridgewell/gen-mapping": 0.3.13
+      '@jridgewell/gen-mapping': 0.3.13
       commander: 4.1.1
       lines-and-columns: 1.2.4
       mz: 2.7.0
@@ -4989,7 +3708,7 @@ snapshots:
 
   tar@7.5.13:
     dependencies:
-      "@isaacs/fs-minipass": 4.0.1
+      '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
       minipass: 7.1.3
       minizlib: 3.1.0
@@ -5078,10 +3797,10 @@ snapshots:
 
   typescript-eslint@8.58.1(eslint@9.39.4)(typescript@5.9.3):
     dependencies:
-      "@typescript-eslint/eslint-plugin": 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
-      "@typescript-eslint/parser": 8.58.1(eslint@9.39.4)(typescript@5.9.3)
-      "@typescript-eslint/typescript-estree": 8.58.1(typescript@5.9.3)
-      "@typescript-eslint/utils": 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
       eslint: 9.39.4
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -5107,20 +3826,20 @@ snapshots:
       rolldown: 1.0.0-rc.15
       tinyglobby: 0.2.16
     optionalDependencies:
-      "@types/node": 24.12.2
+      '@types/node': 24.12.2
       esbuild: 0.27.7
       fsevents: 2.3.3
       tsx: 4.21.0
 
   vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)):
     dependencies:
-      "@vitest/expect": 4.1.4
-      "@vitest/mocker": 4.1.4(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))
-      "@vitest/pretty-format": 4.1.4
-      "@vitest/runner": 4.1.4
-      "@vitest/snapshot": 4.1.4
-      "@vitest/spy": 4.1.4
-      "@vitest/utils": 4.1.4
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -5135,9 +3854,9 @@ snapshots:
       vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      "@opentelemetry/api": 1.9.0
-      "@types/node": 24.12.2
-      "@vitest/coverage-v8": 4.1.4(vitest@4.1.4)
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 24.12.2
+      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,29 +1,28 @@
-lockfileVersion: '9.0'
+lockfileVersion: "9.0"
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
-
   .:
     devDependencies:
-      '@eslint/js':
+      "@eslint/js":
         specifier: ^9.39.1
         version: 9.39.4
-      '@types/node':
+      "@types/node":
         specifier: ^24.6.1
         version: 24.12.2
-      '@types/nunjucks':
+      "@types/nunjucks":
         specifier: ^3.2.6
         version: 3.2.6
-      '@types/yauzl':
+      "@types/yauzl":
         specifier: ^2.10.3
         version: 2.10.3
-      '@types/yazl':
+      "@types/yazl":
         specifier: ^3.3.1
         version: 3.3.1
-      '@vitest/coverage-v8':
+      "@vitest/coverage-v8":
         specifier: ^4.1.4
         version: 4.1.4(vitest@4.1.4)
       ai:
@@ -74,16 +73,16 @@ importers:
 
   packages/cli:
     dependencies:
-      '@ai-sdk/anthropic':
+      "@ai-sdk/anthropic":
         specifier: ^3.0.68
         version: 3.0.68(zod@4.3.6)
-      '@ai-sdk/google':
+      "@ai-sdk/google":
         specifier: ^3.0.61
         version: 3.0.61(zod@4.3.6)
-      '@ai-sdk/openai':
+      "@ai-sdk/openai":
         specifier: ^3.0.52
         version: 3.0.52(zod@4.3.6)
-      '@ai-sdk/openai-compatible':
+      "@ai-sdk/openai-compatible":
         specifier: ^2.0.41
         version: 2.0.41(zod@4.3.6)
       ai:
@@ -129,16 +128,16 @@ importers:
 
   packages/core:
     dependencies:
-      '@ai-sdk/anthropic':
+      "@ai-sdk/anthropic":
         specifier: ^3.0.68
         version: 3.0.68(zod@4.3.6)
-      '@ai-sdk/google':
+      "@ai-sdk/google":
         specifier: ^3.0.61
         version: 3.0.61(zod@4.3.6)
-      '@ai-sdk/openai':
+      "@ai-sdk/openai":
         specifier: ^3.0.52
         version: 3.0.52(zod@4.3.6)
-      '@ai-sdk/openai-compatible':
+      "@ai-sdk/openai-compatible":
         specifier: ^2.0.41
         version: 2.0.41(zod@4.3.6)
       ai:
@@ -164,679 +163,1074 @@ importers:
         version: 4.3.6
 
 packages:
-
-  '@ai-sdk/anthropic@3.0.68':
-    resolution: {integrity: sha512-BAd+fmgYoJMmGw0/uV+jRlXX60PyGxelA6Clp4cK/NI0dsyv9jOOwzQmKNaz2nwb+Jz7HqI7I70KK4XtU5EcXQ==}
-    engines: {node: '>=18'}
+  "@ai-sdk/anthropic@3.0.68":
+    resolution:
+      {
+        integrity: sha512-BAd+fmgYoJMmGw0/uV+jRlXX60PyGxelA6Clp4cK/NI0dsyv9jOOwzQmKNaz2nwb+Jz7HqI7I70KK4XtU5EcXQ==,
+      }
+    engines: { node: ">=18" }
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@3.0.94':
-    resolution: {integrity: sha512-uDDwLZhCkvC89crVS3S90D5L7AcVN8WriGuYVNYgVAaVcvy3Mthy3R9ICfzG75BObhz6pm2FWnhxDfNRK+t69Q==}
-    engines: {node: '>=18'}
+  "@ai-sdk/gateway@3.0.94":
+    resolution:
+      {
+        integrity: sha512-uDDwLZhCkvC89crVS3S90D5L7AcVN8WriGuYVNYgVAaVcvy3Mthy3R9ICfzG75BObhz6pm2FWnhxDfNRK+t69Q==,
+      }
+    engines: { node: ">=18" }
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/google@3.0.61':
-    resolution: {integrity: sha512-jEKU1Mjcy5CoicejdJQIzM0ntYwyXR8vtYgAZYriKaOuLAiAhiiU538++fGU3CC9HJH/mL1OfsCwMM3gFiCNsw==}
-    engines: {node: '>=18'}
+  "@ai-sdk/google@3.0.61":
+    resolution:
+      {
+        integrity: sha512-jEKU1Mjcy5CoicejdJQIzM0ntYwyXR8vtYgAZYriKaOuLAiAhiiU538++fGU3CC9HJH/mL1OfsCwMM3gFiCNsw==,
+      }
+    engines: { node: ">=18" }
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai-compatible@2.0.41':
-    resolution: {integrity: sha512-kNAGINk71AlOXx10Dq/PXw4t/9XjdK8uxfpVElRwtSFMdeSiLVt58p9TPx4/FJD+hxZuVhvxYj9r42osxWq79g==}
-    engines: {node: '>=18'}
+  "@ai-sdk/openai-compatible@2.0.41":
+    resolution:
+      {
+        integrity: sha512-kNAGINk71AlOXx10Dq/PXw4t/9XjdK8uxfpVElRwtSFMdeSiLVt58p9TPx4/FJD+hxZuVhvxYj9r42osxWq79g==,
+      }
+    engines: { node: ">=18" }
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@3.0.52':
-    resolution: {integrity: sha512-4Rr8NCGmfWTz6DCUvixn9UmyZcMatiHn0zWoMzI3JCUe9R1P/vsPOpCBALKoSzVYOjyJnhtnVIbfUKujcS39uw==}
-    engines: {node: '>=18'}
+  "@ai-sdk/openai@3.0.52":
+    resolution:
+      {
+        integrity: sha512-4Rr8NCGmfWTz6DCUvixn9UmyZcMatiHn0zWoMzI3JCUe9R1P/vsPOpCBALKoSzVYOjyJnhtnVIbfUKujcS39uw==,
+      }
+    engines: { node: ">=18" }
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.23':
-    resolution: {integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==}
-    engines: {node: '>=18'}
+  "@ai-sdk/provider-utils@4.0.23":
+    resolution:
+      {
+        integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==,
+      }
+    engines: { node: ">=18" }
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@3.0.8':
-    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
-    engines: {node: '>=18'}
+  "@ai-sdk/provider@3.0.8":
+    resolution:
+      {
+        integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==,
+      }
+    engines: { node: ">=18" }
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-string-parser@7.27.1":
+    resolution:
+      {
+        integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-validator-identifier@7.28.5":
+    resolution:
+      {
+        integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
-    engines: {node: '>=6.0.0'}
+  "@babel/parser@7.29.2":
+    resolution:
+      {
+        integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==,
+      }
+    engines: { node: ">=6.0.0" }
     hasBin: true
 
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
-    engines: {node: '>=6.9.0'}
+  "@babel/types@7.29.0":
+    resolution:
+      {
+        integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@bcoe/v8-coverage@1.0.2':
-    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
-    engines: {node: '>=18'}
+  "@bcoe/v8-coverage@1.0.2":
+    resolution:
+      {
+        integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==,
+      }
+    engines: { node: ">=18" }
 
-  '@emnapi/core@1.9.2':
-    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+  "@emnapi/core@1.9.2":
+    resolution:
+      {
+        integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==,
+      }
 
-  '@emnapi/runtime@1.9.2':
-    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+  "@emnapi/runtime@1.9.2":
+    resolution:
+      {
+        integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==,
+      }
 
-  '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+  "@emnapi/wasi-threads@1.2.1":
+    resolution:
+      {
+        integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==,
+      }
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
-    engines: {node: '>=18'}
+  "@esbuild/aix-ppc64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==,
+      }
+    engines: { node: ">=18" }
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
-    engines: {node: '>=18'}
+  "@esbuild/android-arm64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
-    engines: {node: '>=18'}
+  "@esbuild/android-arm@0.27.7":
+    resolution:
+      {
+        integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
-    engines: {node: '>=18'}
+  "@esbuild/android-x64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
-    engines: {node: '>=18'}
+  "@esbuild/darwin-arm64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
-    engines: {node: '>=18'}
+  "@esbuild/darwin-x64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
-    engines: {node: '>=18'}
+  "@esbuild/freebsd-arm64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
-    engines: {node: '>=18'}
+  "@esbuild/freebsd-x64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-arm64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-arm@0.27.7":
+    resolution:
+      {
+        integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-ia32@0.27.7":
+    resolution:
+      {
+        integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==,
+      }
+    engines: { node: ">=18" }
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-loong64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==,
+      }
+    engines: { node: ">=18" }
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-mips64el@0.27.7":
+    resolution:
+      {
+        integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==,
+      }
+    engines: { node: ">=18" }
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-ppc64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-riscv64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-s390x@0.27.7":
+    resolution:
+      {
+        integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==,
+      }
+    engines: { node: ">=18" }
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-x64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
-    engines: {node: '>=18'}
+  "@esbuild/netbsd-arm64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
-    engines: {node: '>=18'}
+  "@esbuild/netbsd-x64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
-    engines: {node: '>=18'}
+  "@esbuild/openbsd-arm64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
-    engines: {node: '>=18'}
+  "@esbuild/openbsd-x64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
-    engines: {node: '>=18'}
+  "@esbuild/openharmony-arm64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
-    engines: {node: '>=18'}
+  "@esbuild/sunos-x64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
-    engines: {node: '>=18'}
+  "@esbuild/win32-arm64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
-    engines: {node: '>=18'}
+  "@esbuild/win32-ia32@0.27.7":
+    resolution:
+      {
+        integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==,
+      }
+    engines: { node: ">=18" }
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
-    engines: {node: '>=18'}
+  "@esbuild/win32-x64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [win32]
 
-  '@eslint-community/eslint-utils@4.9.1':
-    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  "@eslint-community/eslint-utils@4.9.1":
+    resolution:
+      {
+        integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==,
+      }
+    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
-  '@eslint-community/regexpp@4.12.2':
-    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+  "@eslint-community/regexpp@4.12.2":
+    resolution:
+      {
+        integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==,
+      }
+    engines: { node: ^12.0.0 || ^14.0.0 || >=16.0.0 }
 
-  '@eslint/config-array@0.21.2':
-    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@eslint/config-array@0.21.2":
+    resolution:
+      {
+        integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@eslint/config-helpers@0.4.2':
-    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@eslint/config-helpers@0.4.2":
+    resolution:
+      {
+        integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@eslint/core@0.17.0':
-    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@eslint/core@0.17.0":
+    resolution:
+      {
+        integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@eslint/eslintrc@3.3.5':
-    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@eslint/eslintrc@3.3.5":
+    resolution:
+      {
+        integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@eslint/js@9.39.4':
-    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@eslint/js@9.39.4":
+    resolution:
+      {
+        integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@eslint/object-schema@2.1.7':
-    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@eslint/object-schema@2.1.7":
+    resolution:
+      {
+        integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@eslint/plugin-kit@0.4.1':
-    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@eslint/plugin-kit@0.4.1":
+    resolution:
+      {
+        integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@gar/promise-retry@1.0.3':
-    resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  "@gar/promise-retry@1.0.3":
+    resolution:
+      {
+        integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==,
+      }
+    engines: { node: ^20.17.0 || >=22.9.0 }
 
-  '@humanfs/core@0.19.1':
-    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
-    engines: {node: '>=18.18.0'}
+  "@humanfs/core@0.19.1":
+    resolution:
+      {
+        integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==,
+      }
+    engines: { node: ">=18.18.0" }
 
-  '@humanfs/node@0.16.7':
-    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
-    engines: {node: '>=18.18.0'}
+  "@humanfs/node@0.16.7":
+    resolution:
+      {
+        integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==,
+      }
+    engines: { node: ">=18.18.0" }
 
-  '@humanwhocodes/module-importer@1.0.1':
-    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
-    engines: {node: '>=12.22'}
+  "@humanwhocodes/module-importer@1.0.1":
+    resolution:
+      {
+        integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==,
+      }
+    engines: { node: ">=12.22" }
 
-  '@humanwhocodes/retry@0.4.3':
-    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
-    engines: {node: '>=18.18'}
+  "@humanwhocodes/retry@0.4.3":
+    resolution:
+      {
+        integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==,
+      }
+    engines: { node: ">=18.18" }
 
-  '@isaacs/fs-minipass@4.0.1':
-    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
-    engines: {node: '>=18.0.0'}
+  "@isaacs/fs-minipass@4.0.1":
+    resolution:
+      {
+        integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==,
+      }
+    engines: { node: ">=18.0.0" }
 
-  '@jridgewell/gen-mapping@0.3.13':
-    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+  "@jridgewell/gen-mapping@0.3.13":
+    resolution:
+      {
+        integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==,
+      }
 
-  '@jridgewell/resolve-uri@3.1.2':
-    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
-    engines: {node: '>=6.0.0'}
+  "@jridgewell/resolve-uri@3.1.2":
+    resolution:
+      {
+        integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
+      }
+    engines: { node: ">=6.0.0" }
 
-  '@jridgewell/sourcemap-codec@1.5.5':
-    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+  "@jridgewell/sourcemap-codec@1.5.5":
+    resolution:
+      {
+        integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==,
+      }
 
-  '@jridgewell/trace-mapping@0.3.31':
-    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+  "@jridgewell/trace-mapping@0.3.31":
+    resolution:
+      {
+        integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
+      }
 
-  '@napi-rs/wasm-runtime@1.1.3':
-    resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
+  "@napi-rs/wasm-runtime@1.1.3":
+    resolution:
+      {
+        integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==,
+      }
     peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
+      "@emnapi/core": ^1.7.1
+      "@emnapi/runtime": ^1.7.1
 
-  '@npmcli/agent@4.0.0':
-    resolution: {integrity: sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  "@npmcli/agent@4.0.0":
+    resolution:
+      {
+        integrity: sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==,
+      }
+    engines: { node: ^20.17.0 || >=22.9.0 }
 
-  '@npmcli/fs@5.0.0':
-    resolution: {integrity: sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  "@npmcli/fs@5.0.0":
+    resolution:
+      {
+        integrity: sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==,
+      }
+    engines: { node: ^20.17.0 || >=22.9.0 }
 
-  '@npmcli/redact@4.0.0':
-    resolution: {integrity: sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  "@npmcli/redact@4.0.0":
+    resolution:
+      {
+        integrity: sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==,
+      }
+    engines: { node: ^20.17.0 || >=22.9.0 }
 
-  '@opentelemetry/api@1.9.0':
-    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
-    engines: {node: '>=8.0.0'}
+  "@opentelemetry/api@1.9.0":
+    resolution:
+      {
+        integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==,
+      }
+    engines: { node: ">=8.0.0" }
 
-  '@oxc-project/types@0.124.0':
-    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
+  "@oxc-project/types@0.124.0":
+    resolution:
+      {
+        integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==,
+      }
 
-  '@pinojs/redact@0.4.0':
-    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+  "@pinojs/redact@0.4.0":
+    resolution:
+      {
+        integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==,
+      }
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@rolldown/binding-android-arm64@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@rolldown/binding-darwin-arm64@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
-    resolution: {integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@rolldown/binding-darwin-x64@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
-    resolution: {integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@rolldown/binding-freebsd-x64@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
-    resolution: {integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
-    resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@rolldown/binding-linux-arm64-musl@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@rolldown/binding-linux-x64-gnu@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
-    resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@rolldown/binding-linux-x64-musl@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@rolldown/binding-openharmony-arm64@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
-    resolution: {integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==}
-    engines: {node: '>=14.0.0'}
+  "@rolldown/binding-wasm32-wasi@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==,
+      }
+    engines: { node: ">=14.0.0" }
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
-    resolution: {integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
-    resolution: {integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@rolldown/binding-win32-x64-msvc@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-rc.15':
-    resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
+  "@rolldown/pluginutils@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==,
+      }
 
-  '@rollup/rollup-android-arm-eabi@4.60.1':
-    resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
+  "@rollup/rollup-android-arm-eabi@4.60.1":
+    resolution:
+      {
+        integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==,
+      }
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.60.1':
-    resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==}
+  "@rollup/rollup-android-arm64@4.60.1":
+    resolution:
+      {
+        integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==,
+      }
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.60.1':
-    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
+  "@rollup/rollup-darwin-arm64@4.60.1":
+    resolution:
+      {
+        integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==,
+      }
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.60.1':
-    resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==}
+  "@rollup/rollup-darwin-x64@4.60.1":
+    resolution:
+      {
+        integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==,
+      }
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.60.1':
-    resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==}
+  "@rollup/rollup-freebsd-arm64@4.60.1":
+    resolution:
+      {
+        integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==,
+      }
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.60.1':
-    resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==}
+  "@rollup/rollup-freebsd-x64@4.60.1":
+    resolution:
+      {
+        integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==,
+      }
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
-    resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
+  "@rollup/rollup-linux-arm-gnueabihf@4.60.1":
+    resolution:
+      {
+        integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==,
+      }
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
-    resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
+  "@rollup/rollup-linux-arm-musleabihf@4.60.1":
+    resolution:
+      {
+        integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==,
+      }
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.1':
-    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
+  "@rollup/rollup-linux-arm64-gnu@4.60.1":
+    resolution:
+      {
+        integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==,
+      }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.60.1':
-    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
+  "@rollup/rollup-linux-arm64-musl@4.60.1":
+    resolution:
+      {
+        integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==,
+      }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.1':
-    resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
+  "@rollup/rollup-linux-loong64-gnu@4.60.1":
+    resolution:
+      {
+        integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==,
+      }
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-loong64-musl@4.60.1':
-    resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
+  "@rollup/rollup-linux-loong64-musl@4.60.1":
+    resolution:
+      {
+        integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==,
+      }
     cpu: [loong64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
-    resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
+  "@rollup/rollup-linux-ppc64-gnu@4.60.1":
+    resolution:
+      {
+        integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==,
+      }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.1':
-    resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
+  "@rollup/rollup-linux-ppc64-musl@4.60.1":
+    resolution:
+      {
+        integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==,
+      }
     cpu: [ppc64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
-    resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
+  "@rollup/rollup-linux-riscv64-gnu@4.60.1":
+    resolution:
+      {
+        integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==,
+      }
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.1':
-    resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
+  "@rollup/rollup-linux-riscv64-musl@4.60.1":
+    resolution:
+      {
+        integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==,
+      }
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.1':
-    resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
+  "@rollup/rollup-linux-s390x-gnu@4.60.1":
+    resolution:
+      {
+        integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==,
+      }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.60.1':
-    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
+  "@rollup/rollup-linux-x64-gnu@4.60.1":
+    resolution:
+      {
+        integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==,
+      }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.60.1':
-    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
+  "@rollup/rollup-linux-x64-musl@4.60.1":
+    resolution:
+      {
+        integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==,
+      }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.60.1':
-    resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
+  "@rollup/rollup-openbsd-x64@4.60.1":
+    resolution:
+      {
+        integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==,
+      }
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.60.1':
-    resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
+  "@rollup/rollup-openharmony-arm64@4.60.1":
+    resolution:
+      {
+        integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==,
+      }
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.1':
-    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
+  "@rollup/rollup-win32-arm64-msvc@4.60.1":
+    resolution:
+      {
+        integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==,
+      }
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.1':
-    resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==}
+  "@rollup/rollup-win32-ia32-msvc@4.60.1":
+    resolution:
+      {
+        integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==,
+      }
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.60.1':
-    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
+  "@rollup/rollup-win32-x64-gnu@4.60.1":
+    resolution:
+      {
+        integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==,
+      }
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.60.1':
-    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
+  "@rollup/rollup-win32-x64-msvc@4.60.1":
+    resolution:
+      {
+        integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==,
+      }
     cpu: [x64]
     os: [win32]
 
-  '@standard-schema/spec@1.1.0':
-    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+  "@standard-schema/spec@1.1.0":
+    resolution:
+      {
+        integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
+      }
 
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+  "@tybys/wasm-util@0.10.1":
+    resolution:
+      {
+        integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==,
+      }
 
-  '@types/chai@5.2.3':
-    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+  "@types/chai@5.2.3":
+    resolution:
+      {
+        integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==,
+      }
 
-  '@types/deep-eql@4.0.2':
-    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+  "@types/deep-eql@4.0.2":
+    resolution:
+      {
+        integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
+      }
 
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+  "@types/estree@1.0.8":
+    resolution:
+      {
+        integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
+      }
 
-  '@types/json-schema@7.0.15':
-    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+  "@types/json-schema@7.0.15":
+    resolution:
+      {
+        integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==,
+      }
 
-  '@types/node@24.12.2':
-    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+  "@types/node@24.12.2":
+    resolution:
+      {
+        integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==,
+      }
 
-  '@types/nunjucks@3.2.6':
-    resolution: {integrity: sha512-pHiGtf83na1nCzliuAdq8GowYiXvH5l931xZ0YEHaLMNFgynpEqx+IPStlu7UaDkehfvl01e4x/9Tpwhy7Ue3w==}
+  "@types/nunjucks@3.2.6":
+    resolution:
+      {
+        integrity: sha512-pHiGtf83na1nCzliuAdq8GowYiXvH5l931xZ0YEHaLMNFgynpEqx+IPStlu7UaDkehfvl01e4x/9Tpwhy7Ue3w==,
+      }
 
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+  "@types/yauzl@2.10.3":
+    resolution:
+      {
+        integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==,
+      }
 
-  '@types/yazl@3.3.1':
-    resolution: {integrity: sha512-DIWfCKpsTp6hE5BDBHV3+fIL/bLUF9Bv13iDrWnMlmhQpH67buNvI291ZauQ1xcccxK3FqQ9honnXpq4R8NMuQ==}
+  "@types/yazl@3.3.1":
+    resolution:
+      {
+        integrity: sha512-DIWfCKpsTp6hE5BDBHV3+fIL/bLUF9Bv13iDrWnMlmhQpH67buNvI291ZauQ1xcccxK3FqQ9honnXpq4R8NMuQ==,
+      }
 
-  '@typescript-eslint/eslint-plugin@8.58.1':
-    resolution: {integrity: sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@typescript-eslint/eslint-plugin@8.58.1":
+    resolution:
+      {
+        integrity: sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      '@typescript-eslint/parser': ^8.58.1
+      "@typescript-eslint/parser": ^8.58.1
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: ">=4.8.4 <6.1.0"
 
-  '@typescript-eslint/parser@8.58.1':
-    resolution: {integrity: sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/project-service@8.58.1':
-    resolution: {integrity: sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/scope-manager@8.58.1':
-    resolution: {integrity: sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.58.1':
-    resolution: {integrity: sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/type-utils@8.58.1':
-    resolution: {integrity: sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/types@8.58.1':
-    resolution: {integrity: sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.58.1':
-    resolution: {integrity: sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/utils@8.58.1':
-    resolution: {integrity: sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@typescript-eslint/parser@8.58.1":
+    resolution:
+      {
+        integrity: sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: ">=4.8.4 <6.1.0"
 
-  '@typescript-eslint/visitor-keys@8.58.1':
-    resolution: {integrity: sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@vercel/oidc@3.1.0':
-    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
-    engines: {node: '>= 20'}
-
-  '@vitest/coverage-v8@4.1.4':
-    resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
+  "@typescript-eslint/project-service@8.58.1":
+    resolution:
+      {
+        integrity: sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      '@vitest/browser': 4.1.4
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/scope-manager@8.58.1":
+    resolution:
+      {
+        integrity: sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@typescript-eslint/tsconfig-utils@8.58.1":
+    resolution:
+      {
+        integrity: sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/type-utils@8.58.1":
+    resolution:
+      {
+        integrity: sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/types@8.58.1":
+    resolution:
+      {
+        integrity: sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@typescript-eslint/typescript-estree@8.58.1":
+    resolution:
+      {
+        integrity: sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/utils@8.58.1":
+    resolution:
+      {
+        integrity: sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/visitor-keys@8.58.1":
+    resolution:
+      {
+        integrity: sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@vercel/oidc@3.1.0":
+    resolution:
+      {
+        integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==,
+      }
+    engines: { node: ">= 20" }
+
+  "@vitest/coverage-v8@4.1.4":
+    resolution:
+      {
+        integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==,
+      }
+    peerDependencies:
+      "@vitest/browser": 4.1.4
       vitest: 4.1.4
     peerDependenciesMeta:
-      '@vitest/browser':
+      "@vitest/browser":
         optional: true
 
-  '@vitest/expect@4.1.4':
-    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
+  "@vitest/expect@4.1.4":
+    resolution:
+      {
+        integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==,
+      }
 
-  '@vitest/mocker@4.1.4':
-    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
+  "@vitest/mocker@4.1.4":
+    resolution:
+      {
+        integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==,
+      }
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -846,334 +1240,592 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.4':
-    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
+  "@vitest/pretty-format@4.1.4":
+    resolution:
+      {
+        integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==,
+      }
 
-  '@vitest/runner@4.1.4':
-    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+  "@vitest/runner@4.1.4":
+    resolution:
+      {
+        integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==,
+      }
 
-  '@vitest/snapshot@4.1.4':
-    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
+  "@vitest/snapshot@4.1.4":
+    resolution:
+      {
+        integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==,
+      }
 
-  '@vitest/spy@4.1.4':
-    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
+  "@vitest/spy@4.1.4":
+    resolution:
+      {
+        integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==,
+      }
 
-  '@vitest/utils@4.1.4':
-    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
+  "@vitest/utils@4.1.4":
+    resolution:
+      {
+        integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==,
+      }
 
   a-sync-waterfall@1.0.1:
-    resolution: {integrity: sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==}
+    resolution:
+      {
+        integrity: sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==,
+      }
 
   abbrev@4.0.0:
-    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+    resolution:
+      {
+        integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==,
+      }
+    engines: { node: ^20.17.0 || >=22.9.0 }
 
   acorn-jsx@5.3.2:
-    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    resolution:
+      {
+        integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==,
+      }
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
   acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
-    engines: {node: '>=0.4.0'}
+    resolution:
+      {
+        integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==,
+      }
+    engines: { node: ">=0.4.0" }
     hasBin: true
 
   agent-base@7.1.4:
-    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
-    engines: {node: '>= 14'}
+    resolution:
+      {
+        integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==,
+      }
+    engines: { node: ">= 14" }
 
   ai@6.0.154:
-    resolution: {integrity: sha512-HfKJKCTJsDZxqrIUDSVnBQ7DpQlx5WI4ExqtLd7Bl70epLmvkpc/HYMzU1hP9W+g9VEAcvZo4fbMqc3v5D+9gQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-HfKJKCTJsDZxqrIUDSVnBQ7DpQlx5WI4ExqtLd7Bl70epLmvkpc/HYMzU1hP9W+g9VEAcvZo4fbMqc3v5D+9gQ==,
+      }
+    engines: { node: ">=18" }
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
   ajv@6.14.0:
-    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+    resolution:
+      {
+        integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==,
+      }
 
   ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
+      }
+    engines: { node: ">=8" }
 
   any-promise@1.3.0:
-    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+    resolution:
+      {
+        integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==,
+      }
 
   argparse@2.0.1:
-    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+    resolution:
+      {
+        integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
+      }
 
   asap@2.0.6:
-    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+    resolution:
+      {
+        integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==,
+      }
 
   assertion-error@2.0.1:
-    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==,
+      }
+    engines: { node: ">=12" }
 
   ast-v8-to-istanbul@1.0.0:
-    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
+    resolution:
+      {
+        integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==,
+      }
 
   atomic-sleep@1.0.0:
-    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
-    engines: {node: '>=8.0.0'}
+    resolution:
+      {
+        integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==,
+      }
+    engines: { node: ">=8.0.0" }
 
   balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    resolution:
+      {
+        integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
+      }
 
   balanced-match@4.0.4:
-    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
-    engines: {node: 18 || 20 || >=22}
+    resolution:
+      {
+        integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==,
+      }
+    engines: { node: 18 || 20 || >=22 }
 
   base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    resolution:
+      {
+        integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
+      }
 
   bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+    resolution:
+      {
+        integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==,
+      }
 
   bl@4.1.0:
-    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+    resolution:
+      {
+        integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==,
+      }
 
   brace-expansion@1.1.13:
-    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+    resolution:
+      {
+        integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==,
+      }
 
   brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
-    engines: {node: 18 || 20 || >=22}
+    resolution:
+      {
+        integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==,
+      }
+    engines: { node: 18 || 20 || >=22 }
 
   buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+    resolution:
+      {
+        integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==,
+      }
 
   buffer-crc32@1.0.0:
-    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
-    engines: {node: '>=8.0.0'}
+    resolution:
+      {
+        integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==,
+      }
+    engines: { node: ">=8.0.0" }
 
   buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+    resolution:
+      {
+        integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==,
+      }
 
   bundle-require@5.1.0:
-    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    resolution:
+      {
+        integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
     peerDependencies:
-      esbuild: '>=0.18'
+      esbuild: ">=0.18"
 
   cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==,
+      }
+    engines: { node: ">=8" }
 
   cacache@20.0.4:
-    resolution: {integrity: sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+    resolution:
+      {
+        integrity: sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==,
+      }
+    engines: { node: ^20.17.0 || >=22.9.0 }
 
   callsites@3.1.0:
-    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==,
+      }
+    engines: { node: ">=6" }
 
   chai@6.2.2:
-    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==,
+      }
+    engines: { node: ">=18" }
 
   chalk@4.1.2:
-    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==,
+      }
+    engines: { node: ">=10" }
 
   chokidar@4.0.3:
-    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
-    engines: {node: '>= 14.16.0'}
+    resolution:
+      {
+        integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==,
+      }
+    engines: { node: ">= 14.16.0" }
 
   chownr@1.1.4:
-    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+    resolution:
+      {
+        integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==,
+      }
 
   chownr@3.0.0:
-    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==,
+      }
+    engines: { node: ">=18" }
 
   color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
+    resolution:
+      {
+        integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
+      }
+    engines: { node: ">=7.0.0" }
 
   color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    resolution:
+      {
+        integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
+      }
 
   colorette@2.0.20:
-    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+    resolution:
+      {
+        integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==,
+      }
 
   commander@4.1.1:
-    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==,
+      }
+    engines: { node: ">= 6" }
 
   commander@5.1.0:
-    resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==,
+      }
+    engines: { node: ">= 6" }
 
   concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution:
+      {
+        integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
+      }
 
   confbox@0.1.8:
-    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+    resolution:
+      {
+        integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==,
+      }
 
   consola@3.4.2:
-    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
-    engines: {node: ^14.18.0 || >=16.10.0}
+    resolution:
+      {
+        integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==,
+      }
+    engines: { node: ^14.18.0 || >=16.10.0 }
 
   convert-source-map@2.0.0:
-    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+    resolution:
+      {
+        integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
+      }
 
   cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==,
+      }
+    engines: { node: ">= 8" }
 
   dateformat@4.6.3:
-    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
+    resolution:
+      {
+        integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==,
+      }
 
   debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
-    engines: {node: '>=6.0'}
+    resolution:
+      {
+        integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==,
+      }
+    engines: { node: ">=6.0" }
     peerDependencies:
-      supports-color: '*'
+      supports-color: "*"
     peerDependenciesMeta:
       supports-color:
         optional: true
 
   decompress-response@6.0.0:
-    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==,
+      }
+    engines: { node: ">=10" }
 
   deep-extend@0.6.0:
-    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
-    engines: {node: '>=4.0.0'}
+    resolution:
+      {
+        integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==,
+      }
+    engines: { node: ">=4.0.0" }
 
   deep-is@0.1.4:
-    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+    resolution:
+      {
+        integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==,
+      }
 
   detect-libc@2.1.2:
-    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==,
+      }
+    engines: { node: ">=8" }
 
   dom-serializer@3.0.0:
-    resolution: {integrity: sha512-x+9D6nkC8tdXOQUS32egtZpZFLP90+HBZmWjuT920srbJvD/zPgFB9t4k3pEhlw5BQrXStQtRc1Y1zuriXk+Nw==}
-    engines: {node: '>=20.19.0'}
+    resolution:
+      {
+        integrity: sha512-x+9D6nkC8tdXOQUS32egtZpZFLP90+HBZmWjuT920srbJvD/zPgFB9t4k3pEhlw5BQrXStQtRc1Y1zuriXk+Nw==,
+      }
+    engines: { node: ">=20.19.0" }
 
   domelementtype@3.0.0:
-    resolution: {integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==}
-    engines: {node: '>=20.19.0'}
+    resolution:
+      {
+        integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==,
+      }
+    engines: { node: ">=20.19.0" }
 
   domhandler@6.0.1:
-    resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
-    engines: {node: '>=20.19.0'}
+    resolution:
+      {
+        integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==,
+      }
+    engines: { node: ">=20.19.0" }
 
   domutils@4.0.2:
-    resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
-    engines: {node: '>=20.19.0'}
+    resolution:
+      {
+        integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==,
+      }
+    engines: { node: ">=20.19.0" }
 
   end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+    resolution:
+      {
+        integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==,
+      }
 
   entities@8.0.0:
-    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
-    engines: {node: '>=20.19.0'}
+    resolution:
+      {
+        integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==,
+      }
+    engines: { node: ">=20.19.0" }
 
   env-paths@2.2.1:
-    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==,
+      }
+    engines: { node: ">=6" }
 
   es-module-lexer@2.0.0:
-    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+    resolution:
+      {
+        integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==,
+      }
 
   esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==,
+      }
+    engines: { node: ">=18" }
     hasBin: true
 
   escape-string-regexp@4.0.0:
-    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==,
+      }
+    engines: { node: ">=10" }
 
   eslint-config-prettier@10.1.8:
-    resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
+    resolution:
+      {
+        integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==,
+      }
     hasBin: true
     peerDependencies:
-      eslint: '>=7.0.0'
+      eslint: ">=7.0.0"
 
   eslint-scope@8.4.0:
-    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   eslint-visitor-keys@3.4.3:
-    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    resolution:
+      {
+        integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==,
+      }
+    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
 
   eslint-visitor-keys@4.2.1:
-    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   eslint-visitor-keys@5.0.1:
-    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    resolution:
+      {
+        integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==,
+      }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
   eslint@9.39.4:
-    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     hasBin: true
     peerDependencies:
-      jiti: '*'
+      jiti: "*"
     peerDependenciesMeta:
       jiti:
         optional: true
 
   espree@10.4.0:
-    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   esquery@1.7.0:
-    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
-    engines: {node: '>=0.10'}
+    resolution:
+      {
+        integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==,
+      }
+    engines: { node: ">=0.10" }
 
   esrecurse@4.3.0:
-    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
-    engines: {node: '>=4.0'}
+    resolution:
+      {
+        integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==,
+      }
+    engines: { node: ">=4.0" }
 
   estraverse@5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
-    engines: {node: '>=4.0'}
+    resolution:
+      {
+        integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==,
+      }
+    engines: { node: ">=4.0" }
 
   estree-walker@3.0.3:
-    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    resolution:
+      {
+        integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
+      }
 
   esutils@2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==,
+      }
+    engines: { node: ">=0.10.0" }
 
   eventsource-parser@3.0.6:
-    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
-    engines: {node: '>=18.0.0'}
+    resolution:
+      {
+        integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==,
+      }
+    engines: { node: ">=18.0.0" }
 
   expand-template@2.0.3:
-    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==,
+      }
+    engines: { node: ">=6" }
 
   expect-type@1.3.0:
-    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
-    engines: {node: '>=12.0.0'}
+    resolution:
+      {
+        integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==,
+      }
+    engines: { node: ">=12.0.0" }
 
   exponential-backoff@3.1.3:
-    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+    resolution:
+      {
+        integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==,
+      }
 
   fast-copy@4.0.3:
-    resolution: {integrity: sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==}
+    resolution:
+      {
+        integrity: sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==,
+      }
 
   fast-deep-equal@3.1.3:
-    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    resolution:
+      {
+        integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
+      }
 
   fast-json-stable-stringify@2.1.0:
-    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+    resolution:
+      {
+        integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==,
+      }
 
   fast-levenshtein@2.0.6:
-    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+    resolution:
+      {
+        integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
+      }
 
   fast-safe-stringify@2.1.1:
-    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+    resolution:
+      {
+        integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==,
+      }
 
   fdir@6.5.0:
-    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
-    engines: {node: '>=12.0.0'}
+    resolution:
+      {
+        integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
+      }
+    engines: { node: ">=12.0.0" }
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -1181,386 +1833,674 @@ packages:
         optional: true
 
   file-entry-cache@8.0.0:
-    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
-    engines: {node: '>=16.0.0'}
+    resolution:
+      {
+        integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==,
+      }
+    engines: { node: ">=16.0.0" }
 
   file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+    resolution:
+      {
+        integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==,
+      }
 
   find-up@5.0.0:
-    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==,
+      }
+    engines: { node: ">=10" }
 
   fix-dts-default-cjs-exports@1.0.1:
-    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+    resolution:
+      {
+        integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==,
+      }
 
   flat-cache@4.0.1:
-    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
-    engines: {node: '>=16'}
+    resolution:
+      {
+        integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==,
+      }
+    engines: { node: ">=16" }
 
   flatted@3.4.2:
-    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+    resolution:
+      {
+        integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==,
+      }
 
   fs-constants@1.0.0:
-    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+    resolution:
+      {
+        integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==,
+      }
 
   fs-minipass@3.0.3:
-    resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    resolution:
+      {
+        integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==,
+      }
+    engines: { node: ^14.17.0 || ^16.13.0 || >=18.0.0 }
 
   fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    resolution:
+      {
+        integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
     os: [darwin]
 
   get-tsconfig@4.13.7:
-    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+    resolution:
+      {
+        integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==,
+      }
 
   github-from-package@0.0.0:
-    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+    resolution:
+      {
+        integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==,
+      }
 
   glob-parent@6.0.2:
-    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
-    engines: {node: '>=10.13.0'}
+    resolution:
+      {
+        integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==,
+      }
+    engines: { node: ">=10.13.0" }
 
   glob@13.0.6:
-    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
-    engines: {node: 18 || 20 || >=22}
+    resolution:
+      {
+        integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==,
+      }
+    engines: { node: 18 || 20 || >=22 }
 
   globals@14.0.0:
-    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==,
+      }
+    engines: { node: ">=18" }
 
   globals@16.5.0:
-    resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==,
+      }
+    engines: { node: ">=18" }
 
   graceful-fs@4.2.11:
-    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+    resolution:
+      {
+        integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
+      }
 
   has-flag@4.0.0:
-    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
+      }
+    engines: { node: ">=8" }
 
   help-me@5.0.0:
-    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
+    resolution:
+      {
+        integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==,
+      }
 
   html-escaper@2.0.2:
-    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+    resolution:
+      {
+        integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==,
+      }
 
   htmlparser2@12.0.0:
-    resolution: {integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==}
-    engines: {node: '>=20.19.0'}
+    resolution:
+      {
+        integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==,
+      }
+    engines: { node: ">=20.19.0" }
 
   http-cache-semantics@4.2.0:
-    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+    resolution:
+      {
+        integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==,
+      }
 
   http-proxy-agent@7.0.2:
-    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
-    engines: {node: '>= 14'}
+    resolution:
+      {
+        integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==,
+      }
+    engines: { node: ">= 14" }
 
   https-proxy-agent@7.0.6:
-    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
-    engines: {node: '>= 14'}
+    resolution:
+      {
+        integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==,
+      }
+    engines: { node: ">= 14" }
 
   iconv-lite@0.7.2:
-    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==,
+      }
+    engines: { node: ">=0.10.0" }
 
   ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+    resolution:
+      {
+        integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==,
+      }
 
   ignore@5.3.2:
-    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
-    engines: {node: '>= 4'}
+    resolution:
+      {
+        integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==,
+      }
+    engines: { node: ">= 4" }
 
   ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
-    engines: {node: '>= 4'}
+    resolution:
+      {
+        integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==,
+      }
+    engines: { node: ">= 4" }
 
   import-fresh@3.3.1:
-    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==,
+      }
+    engines: { node: ">=6" }
 
   imurmurhash@0.1.4:
-    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
-    engines: {node: '>=0.8.19'}
+    resolution:
+      {
+        integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==,
+      }
+    engines: { node: ">=0.8.19" }
 
   inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    resolution:
+      {
+        integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
+      }
 
   ini@1.3.8:
-    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+    resolution:
+      {
+        integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==,
+      }
 
   ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
-    engines: {node: '>= 12'}
+    resolution:
+      {
+        integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==,
+      }
+    engines: { node: ">= 12" }
 
   is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
+      }
+    engines: { node: ">=0.10.0" }
 
   is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==,
+      }
+    engines: { node: ">=0.10.0" }
 
   isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    resolution:
+      {
+        integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
+      }
 
   isexe@4.0.0:
-    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==,
+      }
+    engines: { node: ">=20" }
 
   istanbul-lib-coverage@3.2.2:
-    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==,
+      }
+    engines: { node: ">=8" }
 
   istanbul-lib-report@3.0.1:
-    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==,
+      }
+    engines: { node: ">=10" }
 
   istanbul-reports@3.2.0:
-    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==,
+      }
+    engines: { node: ">=8" }
 
   joycon@3.1.1:
-    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==,
+      }
+    engines: { node: ">=10" }
 
   js-tokens@10.0.0:
-    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+    resolution:
+      {
+        integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==,
+      }
 
   js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    resolution:
+      {
+        integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==,
+      }
     hasBin: true
 
   json-buffer@3.0.1:
-    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+    resolution:
+      {
+        integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==,
+      }
 
   json-schema-traverse@0.4.1:
-    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+    resolution:
+      {
+        integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==,
+      }
 
   json-schema@0.4.0:
-    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+    resolution:
+      {
+        integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==,
+      }
 
   json-stable-stringify-without-jsonify@1.0.1:
-    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+    resolution:
+      {
+        integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==,
+      }
 
   jsonrepair@3.13.3:
-    resolution: {integrity: sha512-BTznj0owIt2CBAH/LTo7+1I5pMvl1e1033LRl/HUowlZmJOIhzC0zbX5bxMngLkfT4WnzPP26QnW5wMr2g9tsQ==}
+    resolution:
+      {
+        integrity: sha512-BTznj0owIt2CBAH/LTo7+1I5pMvl1e1033LRl/HUowlZmJOIhzC0zbX5bxMngLkfT4WnzPP26QnW5wMr2g9tsQ==,
+      }
     hasBin: true
 
   keyv@4.5.4:
-    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+    resolution:
+      {
+        integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==,
+      }
 
   levn@0.4.1:
-    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==,
+      }
+    engines: { node: ">= 0.8.0" }
 
   lightningcss-android-arm64@1.32.0:
-    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==,
+      }
+    engines: { node: ">= 12.0.0" }
     cpu: [arm64]
     os: [android]
 
   lightningcss-darwin-arm64@1.32.0:
-    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==,
+      }
+    engines: { node: ">= 12.0.0" }
     cpu: [arm64]
     os: [darwin]
 
   lightningcss-darwin-x64@1.32.0:
-    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==,
+      }
+    engines: { node: ">= 12.0.0" }
     cpu: [x64]
     os: [darwin]
 
   lightningcss-freebsd-x64@1.32.0:
-    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==,
+      }
+    engines: { node: ">= 12.0.0" }
     cpu: [x64]
     os: [freebsd]
 
   lightningcss-linux-arm-gnueabihf@1.32.0:
-    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==,
+      }
+    engines: { node: ">= 12.0.0" }
     cpu: [arm]
     os: [linux]
 
   lightningcss-linux-arm64-gnu@1.32.0:
-    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==,
+      }
+    engines: { node: ">= 12.0.0" }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
-    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==,
+      }
+    engines: { node: ">= 12.0.0" }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
-    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==,
+      }
+    engines: { node: ">= 12.0.0" }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
-    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==,
+      }
+    engines: { node: ">= 12.0.0" }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
-    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==,
+      }
+    engines: { node: ">= 12.0.0" }
     cpu: [arm64]
     os: [win32]
 
   lightningcss-win32-x64-msvc@1.32.0:
-    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==,
+      }
+    engines: { node: ">= 12.0.0" }
     cpu: [x64]
     os: [win32]
 
   lightningcss@1.32.0:
-    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==,
+      }
+    engines: { node: ">= 12.0.0" }
 
   lilconfig@3.1.3:
-    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
-    engines: {node: '>=14'}
+    resolution:
+      {
+        integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==,
+      }
+    engines: { node: ">=14" }
 
   lines-and-columns@1.2.4:
-    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+    resolution:
+      {
+        integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==,
+      }
 
   load-tsconfig@0.2.5:
-    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    resolution:
+      {
+        integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
 
   locate-path@6.0.0:
-    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==,
+      }
+    engines: { node: ">=10" }
 
   lodash.merge@4.6.2:
-    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+    resolution:
+      {
+        integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==,
+      }
 
   lru-cache@11.3.3:
-    resolution: {integrity: sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==}
-    engines: {node: 20 || >=22}
+    resolution:
+      {
+        integrity: sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==,
+      }
+    engines: { node: 20 || >=22 }
 
   magic-string@0.30.21:
-    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+    resolution:
+      {
+        integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
+      }
 
   magicast@0.5.2:
-    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+    resolution:
+      {
+        integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==,
+      }
 
   make-dir@4.0.0:
-    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==,
+      }
+    engines: { node: ">=10" }
 
   make-fetch-happen@15.0.5:
-    resolution: {integrity: sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+    resolution:
+      {
+        integrity: sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==,
+      }
+    engines: { node: ^20.17.0 || >=22.9.0 }
 
   mimic-response@3.1.0:
-    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==,
+      }
+    engines: { node: ">=10" }
 
   minimatch@10.2.5:
-    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
-    engines: {node: 18 || 20 || >=22}
+    resolution:
+      {
+        integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==,
+      }
+    engines: { node: 18 || 20 || >=22 }
 
   minimatch@3.1.5:
-    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+    resolution:
+      {
+        integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==,
+      }
 
   minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+    resolution:
+      {
+        integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==,
+      }
 
   minipass-collect@2.0.1:
-    resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
-    engines: {node: '>=16 || 14 >=14.17'}
+    resolution:
+      {
+        integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==,
+      }
+    engines: { node: ">=16 || 14 >=14.17" }
 
   minipass-fetch@5.0.2:
-    resolution: {integrity: sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+    resolution:
+      {
+        integrity: sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==,
+      }
+    engines: { node: ^20.17.0 || >=22.9.0 }
 
   minipass-flush@1.0.7:
-    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==,
+      }
+    engines: { node: ">= 8" }
 
   minipass-pipeline@1.2.4:
-    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==,
+      }
+    engines: { node: ">=8" }
 
   minipass-sized@2.0.0:
-    resolution: {integrity: sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==,
+      }
+    engines: { node: ">=8" }
 
   minipass@3.3.6:
-    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==,
+      }
+    engines: { node: ">=8" }
 
   minipass@7.1.3:
-    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
-    engines: {node: '>=16 || 14 >=14.17'}
+    resolution:
+      {
+        integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==,
+      }
+    engines: { node: ">=16 || 14 >=14.17" }
 
   minizlib@3.1.0:
-    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
-    engines: {node: '>= 18'}
+    resolution:
+      {
+        integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==,
+      }
+    engines: { node: ">= 18" }
 
   mkdirp-classic@0.5.3:
-    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+    resolution:
+      {
+        integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==,
+      }
 
   mlly@1.8.2:
-    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+    resolution:
+      {
+        integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==,
+      }
 
   ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    resolution:
+      {
+        integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
+      }
 
   mz@2.7.0:
-    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+    resolution:
+      {
+        integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==,
+      }
 
   nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    resolution:
+      {
+        integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
+      }
+    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
 
   napi-build-utils@2.0.0:
-    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+    resolution:
+      {
+        integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==,
+      }
 
   natural-compare@1.4.0:
-    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+    resolution:
+      {
+        integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==,
+      }
 
   negotiator@1.0.0:
-    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==,
+      }
+    engines: { node: ">= 0.6" }
 
   node-abi@3.89.0:
-    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==,
+      }
+    engines: { node: ">=10" }
 
   node-addon-api@8.7.0:
-    resolution: {integrity: sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==}
-    engines: {node: ^18 || ^20 || >= 21}
+    resolution:
+      {
+        integrity: sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==,
+      }
+    engines: { node: ^18 || ^20 || >= 21 }
 
   node-gyp@12.2.0:
-    resolution: {integrity: sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+    resolution:
+      {
+        integrity: sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==,
+      }
+    engines: { node: ^20.17.0 || >=22.9.0 }
     hasBin: true
 
   nopt@9.0.0:
-    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+    resolution:
+      {
+        integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==,
+      }
+    engines: { node: ^20.17.0 || >=22.9.0 }
     hasBin: true
 
   nunjucks@3.2.4:
-    resolution: {integrity: sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==}
-    engines: {node: '>= 6.9.0'}
+    resolution:
+      {
+        integrity: sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==,
+      }
+    engines: { node: ">= 6.9.0" }
     hasBin: true
     peerDependencies:
       chokidar: ^3.3.0
@@ -1569,94 +2509,166 @@ packages:
         optional: true
 
   object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==,
+      }
+    engines: { node: ">=0.10.0" }
 
   obug@2.1.1:
-    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+    resolution:
+      {
+        integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==,
+      }
 
   on-exit-leak-free@2.1.2:
-    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
-    engines: {node: '>=14.0.0'}
+    resolution:
+      {
+        integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==,
+      }
+    engines: { node: ">=14.0.0" }
 
   once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+    resolution:
+      {
+        integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==,
+      }
 
   optionator@0.9.4:
-    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==,
+      }
+    engines: { node: ">= 0.8.0" }
 
   p-limit@3.1.0:
-    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==,
+      }
+    engines: { node: ">=10" }
 
   p-locate@5.0.0:
-    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==,
+      }
+    engines: { node: ">=10" }
 
   p-map@7.0.4:
-    resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==,
+      }
+    engines: { node: ">=18" }
 
   package-json-from-dist@1.0.1:
-    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+    resolution:
+      {
+        integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==,
+      }
 
   parent-module@1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==,
+      }
+    engines: { node: ">=6" }
 
   path-exists@4.0.0:
-    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==,
+      }
+    engines: { node: ">=8" }
 
   path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==,
+      }
+    engines: { node: ">=8" }
 
   path-scurry@2.0.2:
-    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
-    engines: {node: 18 || 20 || >=22}
+    resolution:
+      {
+        integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==,
+      }
+    engines: { node: 18 || 20 || >=22 }
 
   pathe@2.0.3:
-    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+    resolution:
+      {
+        integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
+      }
 
   pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+    resolution:
+      {
+        integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==,
+      }
 
   picocolors@1.1.1:
-    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+    resolution:
+      {
+        integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
+      }
 
   picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
+      }
+    engines: { node: ">=12" }
 
   pino-abstract-transport@3.0.0:
-    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+    resolution:
+      {
+        integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==,
+      }
 
   pino-pretty@13.1.3:
-    resolution: {integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==}
+    resolution:
+      {
+        integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==,
+      }
     hasBin: true
 
   pino-std-serializers@7.1.0:
-    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+    resolution:
+      {
+        integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==,
+      }
 
   pino@10.3.1:
-    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    resolution:
+      {
+        integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==,
+      }
     hasBin: true
 
   pirates@4.0.7:
-    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==,
+      }
+    engines: { node: ">= 6" }
 
   pkg-types@1.3.1:
-    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+    resolution:
+      {
+        integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==,
+      }
 
   postcss-load-config@6.0.1:
-    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
-    engines: {node: '>= 18'}
+    resolution:
+      {
+        integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==,
+      }
+    engines: { node: ">= 18" }
     peerDependencies:
-      jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
+      jiti: ">=1.21.0"
+      postcss: ">=8.0.9"
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -1670,261 +2682,453 @@ packages:
         optional: true
 
   postcss@8.5.9:
-    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
-    engines: {node: ^10 || ^12 || >=14}
+    resolution:
+      {
+        integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==,
+      }
+    engines: { node: ^10 || ^12 || >=14 }
 
   prebuild-install@7.1.3:
-    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==,
+      }
+    engines: { node: ">=10" }
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
-    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==,
+      }
+    engines: { node: ">= 0.8.0" }
 
   prettier@3.8.1:
-    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
-    engines: {node: '>=14'}
+    resolution:
+      {
+        integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==,
+      }
+    engines: { node: ">=14" }
     hasBin: true
 
   proc-log@6.1.0:
-    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+    resolution:
+      {
+        integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==,
+      }
+    engines: { node: ^20.17.0 || >=22.9.0 }
 
   process-warning@5.0.0:
-    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+    resolution:
+      {
+        integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==,
+      }
 
   pump@3.0.4:
-    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+    resolution:
+      {
+        integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==,
+      }
 
   punycode@2.3.1:
-    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==,
+      }
+    engines: { node: ">=6" }
 
   quick-format-unescaped@4.0.4:
-    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+    resolution:
+      {
+        integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==,
+      }
 
   rc@1.2.8:
-    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    resolution:
+      {
+        integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==,
+      }
     hasBin: true
 
   readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==,
+      }
+    engines: { node: ">= 6" }
 
   readdirp@4.1.2:
-    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
-    engines: {node: '>= 14.18.0'}
+    resolution:
+      {
+        integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==,
+      }
+    engines: { node: ">= 14.18.0" }
 
   real-require@0.2.0:
-    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
-    engines: {node: '>= 12.13.0'}
+    resolution:
+      {
+        integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==,
+      }
+    engines: { node: ">= 12.13.0" }
 
   resolve-from@4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==,
+      }
+    engines: { node: ">=4" }
 
   resolve-from@5.0.0:
-    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==,
+      }
+    engines: { node: ">=8" }
 
   resolve-pkg-maps@1.0.0:
-    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    resolution:
+      {
+        integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==,
+      }
 
   rimraf@6.1.3:
-    resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
-    engines: {node: 20 || >=22}
+    resolution:
+      {
+        integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==,
+      }
+    engines: { node: 20 || >=22 }
     hasBin: true
 
   rolldown@1.0.0-rc.15:
-    resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+    resolution:
+      {
+        integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
 
   rollup@4.60.1:
-    resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    resolution:
+      {
+        integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==,
+      }
+    engines: { node: ">=18.0.0", npm: ">=8.0.0" }
     hasBin: true
 
   safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    resolution:
+      {
+        integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
+      }
 
   safe-stable-stringify@2.5.0:
-    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==,
+      }
+    engines: { node: ">=10" }
 
   safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    resolution:
+      {
+        integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
+      }
 
   saxes@6.0.0:
-    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
-    engines: {node: '>=v12.22.7'}
+    resolution:
+      {
+        integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==,
+      }
+    engines: { node: ">=v12.22.7" }
 
   secure-json-parse@4.1.0:
-    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
+    resolution:
+      {
+        integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==,
+      }
 
   semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==,
+      }
+    engines: { node: ">=10" }
     hasBin: true
 
   shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==,
+      }
+    engines: { node: ">=8" }
 
   shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
+      }
+    engines: { node: ">=8" }
 
   siginfo@2.0.0:
-    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+    resolution:
+      {
+        integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==,
+      }
 
   simple-concat@1.0.1:
-    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+    resolution:
+      {
+        integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==,
+      }
 
   simple-get@4.0.1:
-    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+    resolution:
+      {
+        integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==,
+      }
 
   smart-buffer@4.2.0:
-    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
-    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+    resolution:
+      {
+        integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==,
+      }
+    engines: { node: ">= 6.0.0", npm: ">= 3.0.0" }
 
   socks-proxy-agent@8.0.5:
-    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
-    engines: {node: '>= 14'}
+    resolution:
+      {
+        integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==,
+      }
+    engines: { node: ">= 14" }
 
   socks@2.8.7:
-    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
-    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+    resolution:
+      {
+        integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==,
+      }
+    engines: { node: ">= 10.0.0", npm: ">= 3.0.0" }
 
   sonic-boom@4.2.1:
-    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+    resolution:
+      {
+        integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==,
+      }
 
   source-map-js@1.2.1:
-    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
+      }
+    engines: { node: ">=0.10.0" }
 
   source-map@0.7.6:
-    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
-    engines: {node: '>= 12'}
+    resolution:
+      {
+        integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==,
+      }
+    engines: { node: ">= 12" }
 
   split2@4.2.0:
-    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
-    engines: {node: '>= 10.x'}
+    resolution:
+      {
+        integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==,
+      }
+    engines: { node: ">= 10.x" }
 
   sqlite3@6.0.1:
-    resolution: {integrity: sha512-X0czUUMG2tmSqJpEQa3tCuZSHKIx8PwM53vLZzKp/o6Rpy25fiVfjdbnZ988M8+O3ZWR1ih0K255VumCb3MAnQ==}
-    engines: {node: '>=20.17.0'}
+    resolution:
+      {
+        integrity: sha512-X0czUUMG2tmSqJpEQa3tCuZSHKIx8PwM53vLZzKp/o6Rpy25fiVfjdbnZ988M8+O3ZWR1ih0K255VumCb3MAnQ==,
+      }
+    engines: { node: ">=20.17.0" }
 
   ssri@13.0.1:
-    resolution: {integrity: sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+    resolution:
+      {
+        integrity: sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==,
+      }
+    engines: { node: ^20.17.0 || >=22.9.0 }
 
   stackback@0.0.2:
-    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+    resolution:
+      {
+        integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
+      }
 
   std-env@4.0.0:
-    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+    resolution:
+      {
+        integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==,
+      }
 
   string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+    resolution:
+      {
+        integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==,
+      }
 
   strip-json-comments@2.0.1:
-    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==,
+      }
+    engines: { node: ">=0.10.0" }
 
   strip-json-comments@3.1.1:
-    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==,
+      }
+    engines: { node: ">=8" }
 
   strip-json-comments@5.0.3:
-    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
-    engines: {node: '>=14.16'}
+    resolution:
+      {
+        integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==,
+      }
+    engines: { node: ">=14.16" }
 
   sucrase@3.35.1:
-    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
-    engines: {node: '>=16 || 14 >=14.17'}
+    resolution:
+      {
+        integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==,
+      }
+    engines: { node: ">=16 || 14 >=14.17" }
     hasBin: true
 
   supports-color@7.2.0:
-    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
+      }
+    engines: { node: ">=8" }
 
   tar-fs@2.1.4:
-    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+    resolution:
+      {
+        integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==,
+      }
 
   tar-stream@2.2.0:
-    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==,
+      }
+    engines: { node: ">=6" }
 
   tar@7.5.13:
-    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==,
+      }
+    engines: { node: ">=18" }
 
   thenify-all@1.6.0:
-    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
-    engines: {node: '>=0.8'}
+    resolution:
+      {
+        integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==,
+      }
+    engines: { node: ">=0.8" }
 
   thenify@3.3.1:
-    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+    resolution:
+      {
+        integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==,
+      }
 
   thread-stream@4.0.0:
-    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==,
+      }
+    engines: { node: ">=20" }
 
   tinybench@2.9.0:
-    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+    resolution:
+      {
+        integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
+      }
 
   tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+    resolution:
+      {
+        integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==,
+      }
 
   tinyexec@1.1.1:
-    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==,
+      }
+    engines: { node: ">=18" }
 
   tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
-    engines: {node: '>=12.0.0'}
+    resolution:
+      {
+        integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==,
+      }
+    engines: { node: ">=12.0.0" }
 
   tinyld@1.3.4:
-    resolution: {integrity: sha512-u26CNoaInA4XpDU+8s/6Cq8xHc2T5M4fXB3ICfXPokUQoLzmPgSZU02TAkFwFMJCWTjk53gtkS8pETTreZwCqw==}
-    engines: {node: '>= 12.10.0', npm: '>= 6.12.0', yarn: '>= 1.20.0'}
+    resolution:
+      {
+        integrity: sha512-u26CNoaInA4XpDU+8s/6Cq8xHc2T5M4fXB3ICfXPokUQoLzmPgSZU02TAkFwFMJCWTjk53gtkS8pETTreZwCqw==,
+      }
+    engines: { node: ">= 12.10.0", npm: ">= 6.12.0", yarn: ">= 1.20.0" }
     hasBin: true
 
   tinyrainbow@3.1.0:
-    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
-    engines: {node: '>=14.0.0'}
+    resolution:
+      {
+        integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==,
+      }
+    engines: { node: ">=14.0.0" }
 
   tree-kill@1.2.2:
-    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    resolution:
+      {
+        integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==,
+      }
     hasBin: true
 
   ts-api-utils@2.5.0:
-    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
-    engines: {node: '>=18.12'}
+    resolution:
+      {
+        integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==,
+      }
+    engines: { node: ">=18.12" }
     peerDependencies:
-      typescript: '>=4.8.4'
+      typescript: ">=4.8.4"
 
   ts-interface-checker@0.1.13:
-    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+    resolution:
+      {
+        integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==,
+      }
 
   tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+    resolution:
+      {
+        integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
+      }
 
   tsup@8.5.1:
-    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==,
+      }
+    engines: { node: ">=18" }
     hasBin: true
     peerDependencies:
-      '@microsoft/api-extractor': ^7.36.0
-      '@swc/core': ^1
+      "@microsoft/api-extractor": ^7.36.0
+      "@swc/core": ^1
       postcss: ^8.4.12
-      typescript: '>=4.5.0'
+      typescript: ">=4.5.0"
     peerDependenciesMeta:
-      '@microsoft/api-extractor':
+      "@microsoft/api-extractor":
         optional: true
-      '@swc/core':
+      "@swc/core":
         optional: true
       postcss:
         optional: true
@@ -1932,62 +3136,92 @@ packages:
         optional: true
 
   tsx@4.21.0:
-    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
-    engines: {node: '>=18.0.0'}
+    resolution:
+      {
+        integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==,
+      }
+    engines: { node: ">=18.0.0" }
     hasBin: true
 
   tunnel-agent@0.6.0:
-    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+    resolution:
+      {
+        integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==,
+      }
 
   type-check@0.4.0:
-    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==,
+      }
+    engines: { node: ">= 0.8.0" }
 
   typescript-eslint@8.58.1:
-    resolution: {integrity: sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: ">=4.8.4 <6.1.0"
 
   typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
+    resolution:
+      {
+        integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==,
+      }
+    engines: { node: ">=14.17" }
     hasBin: true
 
   ufo@1.6.3:
-    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+    resolution:
+      {
+        integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==,
+      }
 
   undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+    resolution:
+      {
+        integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==,
+      }
 
   uri-js@4.4.1:
-    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+    resolution:
+      {
+        integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
+      }
 
   util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    resolution:
+      {
+        integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
+      }
 
   vite@8.0.8:
-    resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+    resolution:
+      {
+        integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
     peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.1.0
+      "@types/node": ^20.19.0 || >=22.12.0
+      "@vitejs/devtools": ^0.1.0
       esbuild: ^0.27.0 || ^0.28.0
-      jiti: '>=1.21.0'
+      jiti: ">=1.21.0"
       less: ^4.0.0
       sass: ^1.70.0
       sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
+      stylus: ">=0.54.8"
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
-      '@types/node':
+      "@types/node":
         optional: true
-      '@vitejs/devtools':
+      "@vitejs/devtools":
         optional: true
       esbuild:
         optional: true
@@ -2011,40 +3245,43 @@ packages:
         optional: true
 
   vitest@4.1.4:
-    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
-    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    resolution:
+      {
+        integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==,
+      }
+    engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
     hasBin: true
     peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@opentelemetry/api': ^1.9.0
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.4
-      '@vitest/browser-preview': 4.1.4
-      '@vitest/browser-webdriverio': 4.1.4
-      '@vitest/coverage-istanbul': 4.1.4
-      '@vitest/coverage-v8': 4.1.4
-      '@vitest/ui': 4.1.4
-      happy-dom: '*'
-      jsdom: '*'
+      "@edge-runtime/vm": "*"
+      "@opentelemetry/api": ^1.9.0
+      "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+      "@vitest/browser-playwright": 4.1.4
+      "@vitest/browser-preview": 4.1.4
+      "@vitest/browser-webdriverio": 4.1.4
+      "@vitest/coverage-istanbul": 4.1.4
+      "@vitest/coverage-v8": 4.1.4
+      "@vitest/ui": 4.1.4
+      happy-dom: "*"
+      jsdom: "*"
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
-      '@edge-runtime/vm':
+      "@edge-runtime/vm":
         optional: true
-      '@opentelemetry/api':
+      "@opentelemetry/api":
         optional: true
-      '@types/node':
+      "@types/node":
         optional: true
-      '@vitest/browser-playwright':
+      "@vitest/browser-playwright":
         optional: true
-      '@vitest/browser-preview':
+      "@vitest/browser-preview":
         optional: true
-      '@vitest/browser-webdriverio':
+      "@vitest/browser-webdriverio":
         optional: true
-      '@vitest/coverage-istanbul':
+      "@vitest/coverage-istanbul":
         optional: true
-      '@vitest/coverage-v8':
+      "@vitest/coverage-v8":
         optional: true
-      '@vitest/ui':
+      "@vitest/ui":
         optional: true
       happy-dom:
         optional: true
@@ -2052,228 +3289,263 @@ packages:
         optional: true
 
   which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
+      }
+    engines: { node: ">= 8" }
     hasBin: true
 
   which@6.0.1:
-    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+    resolution:
+      {
+        integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==,
+      }
+    engines: { node: ^20.17.0 || >=22.9.0 }
     hasBin: true
 
   why-is-node-running@2.3.0:
-    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==,
+      }
+    engines: { node: ">=8" }
     hasBin: true
 
   word-wrap@1.2.5:
-    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==,
+      }
+    engines: { node: ">=0.10.0" }
 
   wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    resolution:
+      {
+        integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==,
+      }
 
   xmlchars@2.2.0:
-    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+    resolution:
+      {
+        integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==,
+      }
 
   yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    resolution:
+      {
+        integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==,
+      }
 
   yallist@5.0.0:
-    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==,
+      }
+    engines: { node: ">=18" }
 
   yauzl@3.3.0:
-    resolution: {integrity: sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==,
+      }
+    engines: { node: ">=12" }
 
   yazl@3.3.1:
-    resolution: {integrity: sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==}
+    resolution:
+      {
+        integrity: sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==,
+      }
 
   yocto-queue@0.1.0:
-    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==,
+      }
+    engines: { node: ">=10" }
 
   zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+    resolution:
+      {
+        integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==,
+      }
 
 snapshots:
-
-  '@ai-sdk/anthropic@3.0.68(zod@4.3.6)':
+  "@ai-sdk/anthropic@3.0.68(zod@4.3.6)":
     dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
+      "@ai-sdk/provider": 3.0.8
+      "@ai-sdk/provider-utils": 4.0.23(zod@4.3.6)
       zod: 4.3.6
 
-  '@ai-sdk/gateway@3.0.94(zod@4.3.6)':
+  "@ai-sdk/gateway@3.0.94(zod@4.3.6)":
     dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
-      '@vercel/oidc': 3.1.0
+      "@ai-sdk/provider": 3.0.8
+      "@ai-sdk/provider-utils": 4.0.23(zod@4.3.6)
+      "@vercel/oidc": 3.1.0
       zod: 4.3.6
 
-  '@ai-sdk/google@3.0.61(zod@4.3.6)':
+  "@ai-sdk/google@3.0.61(zod@4.3.6)":
     dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
+      "@ai-sdk/provider": 3.0.8
+      "@ai-sdk/provider-utils": 4.0.23(zod@4.3.6)
       zod: 4.3.6
 
-  '@ai-sdk/openai-compatible@2.0.41(zod@4.3.6)':
+  "@ai-sdk/openai-compatible@2.0.41(zod@4.3.6)":
     dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
+      "@ai-sdk/provider": 3.0.8
+      "@ai-sdk/provider-utils": 4.0.23(zod@4.3.6)
       zod: 4.3.6
 
-  '@ai-sdk/openai@3.0.52(zod@4.3.6)':
+  "@ai-sdk/openai@3.0.52(zod@4.3.6)":
     dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
+      "@ai-sdk/provider": 3.0.8
+      "@ai-sdk/provider-utils": 4.0.23(zod@4.3.6)
       zod: 4.3.6
 
-  '@ai-sdk/provider-utils@4.0.23(zod@4.3.6)':
+  "@ai-sdk/provider-utils@4.0.23(zod@4.3.6)":
     dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@standard-schema/spec': 1.1.0
+      "@ai-sdk/provider": 3.0.8
+      "@standard-schema/spec": 1.1.0
       eventsource-parser: 3.0.6
       zod: 4.3.6
 
-  '@ai-sdk/provider@3.0.8':
+  "@ai-sdk/provider@3.0.8":
     dependencies:
       json-schema: 0.4.0
 
-  '@babel/helper-string-parser@7.27.1': {}
+  "@babel/helper-string-parser@7.27.1": {}
 
-  '@babel/helper-validator-identifier@7.28.5': {}
+  "@babel/helper-validator-identifier@7.28.5": {}
 
-  '@babel/parser@7.29.2':
+  "@babel/parser@7.29.2":
     dependencies:
-      '@babel/types': 7.29.0
+      "@babel/types": 7.29.0
 
-  '@babel/types@7.29.0':
+  "@babel/types@7.29.0":
     dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
+      "@babel/helper-string-parser": 7.27.1
+      "@babel/helper-validator-identifier": 7.28.5
 
-  '@bcoe/v8-coverage@1.0.2': {}
+  "@bcoe/v8-coverage@1.0.2": {}
 
-  '@emnapi/core@1.9.2':
+  "@emnapi/core@1.9.2":
     dependencies:
-      '@emnapi/wasi-threads': 1.2.1
+      "@emnapi/wasi-threads": 1.2.1
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.2':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.2.1':
+  "@emnapi/runtime@1.9.2":
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.7':
+  "@emnapi/wasi-threads@1.2.1":
+    dependencies:
+      tslib: 2.8.1
     optional: true
 
-  '@esbuild/android-arm64@0.27.7':
+  "@esbuild/aix-ppc64@0.27.7":
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
+  "@esbuild/android-arm64@0.27.7":
     optional: true
 
-  '@esbuild/android-x64@0.27.7':
+  "@esbuild/android-arm@0.27.7":
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
+  "@esbuild/android-x64@0.27.7":
     optional: true
 
-  '@esbuild/darwin-x64@0.27.7':
+  "@esbuild/darwin-arm64@0.27.7":
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
+  "@esbuild/darwin-x64@0.27.7":
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.7':
+  "@esbuild/freebsd-arm64@0.27.7":
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
+  "@esbuild/freebsd-x64@0.27.7":
     optional: true
 
-  '@esbuild/linux-arm@0.27.7':
+  "@esbuild/linux-arm64@0.27.7":
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
+  "@esbuild/linux-arm@0.27.7":
     optional: true
 
-  '@esbuild/linux-loong64@0.27.7':
+  "@esbuild/linux-ia32@0.27.7":
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
+  "@esbuild/linux-loong64@0.27.7":
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.7':
+  "@esbuild/linux-mips64el@0.27.7":
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
+  "@esbuild/linux-ppc64@0.27.7":
     optional: true
 
-  '@esbuild/linux-s390x@0.27.7':
+  "@esbuild/linux-riscv64@0.27.7":
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
+  "@esbuild/linux-s390x@0.27.7":
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.7':
+  "@esbuild/linux-x64@0.27.7":
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
+  "@esbuild/netbsd-arm64@0.27.7":
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.7':
+  "@esbuild/netbsd-x64@0.27.7":
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
+  "@esbuild/openbsd-arm64@0.27.7":
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.7':
+  "@esbuild/openbsd-x64@0.27.7":
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
+  "@esbuild/openharmony-arm64@0.27.7":
     optional: true
 
-  '@esbuild/win32-arm64@0.27.7':
+  "@esbuild/sunos-x64@0.27.7":
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
+  "@esbuild/win32-arm64@0.27.7":
     optional: true
 
-  '@esbuild/win32-x64@0.27.7':
+  "@esbuild/win32-ia32@0.27.7":
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
+  "@esbuild/win32-x64@0.27.7":
+    optional: true
+
+  "@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)":
     dependencies:
       eslint: 9.39.4
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/regexpp@4.12.2': {}
+  "@eslint-community/regexpp@4.12.2": {}
 
-  '@eslint/config-array@0.21.2':
+  "@eslint/config-array@0.21.2":
     dependencies:
-      '@eslint/object-schema': 2.1.7
+      "@eslint/object-schema": 2.1.7
       debug: 4.4.3
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.4.2':
+  "@eslint/config-helpers@0.4.2":
     dependencies:
-      '@eslint/core': 0.17.0
+      "@eslint/core": 0.17.0
 
-  '@eslint/core@0.17.0':
+  "@eslint/core@0.17.0":
     dependencies:
-      '@types/json-schema': 7.0.15
+      "@types/json-schema": 7.0.15
 
-  '@eslint/eslintrc@3.3.5':
+  "@eslint/eslintrc@3.3.5":
     dependencies:
       ajv: 6.14.0
       debug: 4.4.3
@@ -2287,55 +3559,55 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@9.39.4': {}
+  "@eslint/js@9.39.4": {}
 
-  '@eslint/object-schema@2.1.7': {}
+  "@eslint/object-schema@2.1.7": {}
 
-  '@eslint/plugin-kit@0.4.1':
+  "@eslint/plugin-kit@0.4.1":
     dependencies:
-      '@eslint/core': 0.17.0
+      "@eslint/core": 0.17.0
       levn: 0.4.1
 
-  '@gar/promise-retry@1.0.3':
+  "@gar/promise-retry@1.0.3":
     optional: true
 
-  '@humanfs/core@0.19.1': {}
+  "@humanfs/core@0.19.1": {}
 
-  '@humanfs/node@0.16.7':
+  "@humanfs/node@0.16.7":
     dependencies:
-      '@humanfs/core': 0.19.1
-      '@humanwhocodes/retry': 0.4.3
+      "@humanfs/core": 0.19.1
+      "@humanwhocodes/retry": 0.4.3
 
-  '@humanwhocodes/module-importer@1.0.1': {}
+  "@humanwhocodes/module-importer@1.0.1": {}
 
-  '@humanwhocodes/retry@0.4.3': {}
+  "@humanwhocodes/retry@0.4.3": {}
 
-  '@isaacs/fs-minipass@4.0.1':
+  "@isaacs/fs-minipass@4.0.1":
     dependencies:
       minipass: 7.1.3
 
-  '@jridgewell/gen-mapping@0.3.13':
+  "@jridgewell/gen-mapping@0.3.13":
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.31
+      "@jridgewell/sourcemap-codec": 1.5.5
+      "@jridgewell/trace-mapping": 0.3.31
 
-  '@jridgewell/resolve-uri@3.1.2': {}
+  "@jridgewell/resolve-uri@3.1.2": {}
 
-  '@jridgewell/sourcemap-codec@1.5.5': {}
+  "@jridgewell/sourcemap-codec@1.5.5": {}
 
-  '@jridgewell/trace-mapping@0.3.31':
+  "@jridgewell/trace-mapping@0.3.31":
     dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.5
+      "@jridgewell/resolve-uri": 3.1.2
+      "@jridgewell/sourcemap-codec": 1.5.5
 
-  '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+  "@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)":
     dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
-      '@tybys/wasm-util': 0.10.1
+      "@emnapi/core": 1.9.2
+      "@emnapi/runtime": 1.9.2
+      "@tybys/wasm-util": 0.10.1
     optional: true
 
-  '@npmcli/agent@4.0.0':
+  "@npmcli/agent@4.0.0":
     dependencies:
       agent-base: 7.1.4
       http-proxy-agent: 7.0.2
@@ -2346,186 +3618,186 @@ snapshots:
       - supports-color
     optional: true
 
-  '@npmcli/fs@5.0.0':
+  "@npmcli/fs@5.0.0":
     dependencies:
       semver: 7.7.4
     optional: true
 
-  '@npmcli/redact@4.0.0':
+  "@npmcli/redact@4.0.0":
     optional: true
 
-  '@opentelemetry/api@1.9.0': {}
+  "@opentelemetry/api@1.9.0": {}
 
-  '@oxc-project/types@0.124.0': {}
+  "@oxc-project/types@0.124.0": {}
 
-  '@pinojs/redact@0.4.0': {}
+  "@pinojs/redact@0.4.0": {}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+  "@rolldown/binding-android-arm64@1.0.0-rc.15":
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+  "@rolldown/binding-darwin-arm64@1.0.0-rc.15":
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+  "@rolldown/binding-darwin-x64@1.0.0-rc.15":
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+  "@rolldown/binding-freebsd-x64@1.0.0-rc.15":
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+  "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15":
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+  "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15":
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+  "@rolldown/binding-linux-arm64-musl@1.0.0-rc.15":
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+  "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15":
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+  "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15":
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+  "@rolldown/binding-linux-x64-gnu@1.0.0-rc.15":
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+  "@rolldown/binding-linux-x64-musl@1.0.0-rc.15":
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+  "@rolldown/binding-openharmony-arm64@1.0.0-rc.15":
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+  "@rolldown/binding-wasm32-wasi@1.0.0-rc.15":
     dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
-      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      "@emnapi/core": 1.9.2
+      "@emnapi/runtime": 1.9.2
+      "@napi-rs/wasm-runtime": 1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+  "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15":
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+  "@rolldown/binding-win32-x64-msvc@1.0.0-rc.15":
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.15': {}
+  "@rolldown/pluginutils@1.0.0-rc.15": {}
 
-  '@rollup/rollup-android-arm-eabi@4.60.1':
+  "@rollup/rollup-android-arm-eabi@4.60.1":
     optional: true
 
-  '@rollup/rollup-android-arm64@4.60.1':
+  "@rollup/rollup-android-arm64@4.60.1":
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.60.1':
+  "@rollup/rollup-darwin-arm64@4.60.1":
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.60.1':
+  "@rollup/rollup-darwin-x64@4.60.1":
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.60.1':
+  "@rollup/rollup-freebsd-arm64@4.60.1":
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.60.1':
+  "@rollup/rollup-freebsd-x64@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+  "@rollup/rollup-linux-arm-gnueabihf@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+  "@rollup/rollup-linux-arm-musleabihf@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+  "@rollup/rollup-linux-arm64-gnu@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.60.1':
+  "@rollup/rollup-linux-arm64-musl@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+  "@rollup/rollup-linux-loong64-gnu@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.60.1':
+  "@rollup/rollup-linux-loong64-musl@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+  "@rollup/rollup-linux-ppc64-gnu@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+  "@rollup/rollup-linux-ppc64-musl@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+  "@rollup/rollup-linux-riscv64-gnu@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+  "@rollup/rollup-linux-riscv64-musl@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+  "@rollup/rollup-linux-s390x-gnu@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.60.1':
+  "@rollup/rollup-linux-x64-gnu@4.60.1":
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.60.1':
+  "@rollup/rollup-linux-x64-musl@4.60.1":
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.60.1':
+  "@rollup/rollup-openbsd-x64@4.60.1":
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.60.1':
+  "@rollup/rollup-openharmony-arm64@4.60.1":
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+  "@rollup/rollup-win32-arm64-msvc@4.60.1":
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+  "@rollup/rollup-win32-ia32-msvc@4.60.1":
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.60.1':
+  "@rollup/rollup-win32-x64-gnu@4.60.1":
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.60.1':
+  "@rollup/rollup-win32-x64-msvc@4.60.1":
     optional: true
 
-  '@standard-schema/spec@1.1.0': {}
+  "@standard-schema/spec@1.1.0": {}
 
-  '@tybys/wasm-util@0.10.1':
+  "@tybys/wasm-util@0.10.1":
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@types/chai@5.2.3':
+  "@types/chai@5.2.3":
     dependencies:
-      '@types/deep-eql': 4.0.2
+      "@types/deep-eql": 4.0.2
       assertion-error: 2.0.1
 
-  '@types/deep-eql@4.0.2': {}
+  "@types/deep-eql@4.0.2": {}
 
-  '@types/estree@1.0.8': {}
+  "@types/estree@1.0.8": {}
 
-  '@types/json-schema@7.0.15': {}
+  "@types/json-schema@7.0.15": {}
 
-  '@types/node@24.12.2':
+  "@types/node@24.12.2":
     dependencies:
       undici-types: 7.16.0
 
-  '@types/nunjucks@3.2.6': {}
+  "@types/nunjucks@3.2.6": {}
 
-  '@types/yauzl@2.10.3':
+  "@types/yauzl@2.10.3":
     dependencies:
-      '@types/node': 24.12.2
+      "@types/node": 24.12.2
 
-  '@types/yazl@3.3.1':
+  "@types/yazl@3.3.1":
     dependencies:
-      '@types/node': 24.12.2
+      "@types/node": 24.12.2
 
-  '@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
+  "@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)":
     dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.58.1
-      '@typescript-eslint/type-utils': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.58.1
+      "@eslint-community/regexpp": 4.12.2
+      "@typescript-eslint/parser": 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+      "@typescript-eslint/scope-manager": 8.58.1
+      "@typescript-eslint/type-utils": 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+      "@typescript-eslint/utils": 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+      "@typescript-eslint/visitor-keys": 8.58.1
       eslint: 9.39.4
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -2534,41 +3806,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3)':
+  "@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3)":
     dependencies:
-      '@typescript-eslint/scope-manager': 8.58.1
-      '@typescript-eslint/types': 8.58.1
-      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.58.1
+      "@typescript-eslint/scope-manager": 8.58.1
+      "@typescript-eslint/types": 8.58.1
+      "@typescript-eslint/typescript-estree": 8.58.1(typescript@5.9.3)
+      "@typescript-eslint/visitor-keys": 8.58.1
       debug: 4.4.3
       eslint: 9.39.4
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.58.1(typescript@5.9.3)':
+  "@typescript-eslint/project-service@8.58.1(typescript@5.9.3)":
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.58.1
+      "@typescript-eslint/tsconfig-utils": 8.58.1(typescript@5.9.3)
+      "@typescript-eslint/types": 8.58.1
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.58.1':
+  "@typescript-eslint/scope-manager@8.58.1":
     dependencies:
-      '@typescript-eslint/types': 8.58.1
-      '@typescript-eslint/visitor-keys': 8.58.1
+      "@typescript-eslint/types": 8.58.1
+      "@typescript-eslint/visitor-keys": 8.58.1
 
-  '@typescript-eslint/tsconfig-utils@8.58.1(typescript@5.9.3)':
+  "@typescript-eslint/tsconfig-utils@8.58.1(typescript@5.9.3)":
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.58.1(eslint@9.39.4)(typescript@5.9.3)':
+  "@typescript-eslint/type-utils@8.58.1(eslint@9.39.4)(typescript@5.9.3)":
     dependencies:
-      '@typescript-eslint/types': 8.58.1
-      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+      "@typescript-eslint/types": 8.58.1
+      "@typescript-eslint/typescript-estree": 8.58.1(typescript@5.9.3)
+      "@typescript-eslint/utils": 8.58.1(eslint@9.39.4)(typescript@5.9.3)
       debug: 4.4.3
       eslint: 9.39.4
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -2576,14 +3848,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.58.1': {}
+  "@typescript-eslint/types@8.58.1": {}
 
-  '@typescript-eslint/typescript-estree@8.58.1(typescript@5.9.3)':
+  "@typescript-eslint/typescript-estree@8.58.1(typescript@5.9.3)":
     dependencies:
-      '@typescript-eslint/project-service': 8.58.1(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.58.1
-      '@typescript-eslint/visitor-keys': 8.58.1
+      "@typescript-eslint/project-service": 8.58.1(typescript@5.9.3)
+      "@typescript-eslint/tsconfig-utils": 8.58.1(typescript@5.9.3)
+      "@typescript-eslint/types": 8.58.1
+      "@typescript-eslint/visitor-keys": 8.58.1
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
@@ -2593,28 +3865,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.58.1(eslint@9.39.4)(typescript@5.9.3)':
+  "@typescript-eslint/utils@8.58.1(eslint@9.39.4)(typescript@5.9.3)":
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
-      '@typescript-eslint/scope-manager': 8.58.1
-      '@typescript-eslint/types': 8.58.1
-      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
+      "@eslint-community/eslint-utils": 4.9.1(eslint@9.39.4)
+      "@typescript-eslint/scope-manager": 8.58.1
+      "@typescript-eslint/types": 8.58.1
+      "@typescript-eslint/typescript-estree": 8.58.1(typescript@5.9.3)
       eslint: 9.39.4
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.58.1':
+  "@typescript-eslint/visitor-keys@8.58.1":
     dependencies:
-      '@typescript-eslint/types': 8.58.1
+      "@typescript-eslint/types": 8.58.1
       eslint-visitor-keys: 5.0.1
 
-  '@vercel/oidc@3.1.0': {}
+  "@vercel/oidc@3.1.0": {}
 
-  '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
+  "@vitest/coverage-v8@4.1.4(vitest@4.1.4)":
     dependencies:
-      '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.4
+      "@bcoe/v8-coverage": 1.0.2
+      "@vitest/utils": 4.1.4
       ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -2625,44 +3897,44 @@ snapshots:
       tinyrainbow: 3.1.0
       vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))
 
-  '@vitest/expect@4.1.4':
+  "@vitest/expect@4.1.4":
     dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.4
-      '@vitest/utils': 4.1.4
+      "@standard-schema/spec": 1.1.0
+      "@types/chai": 5.2.3
+      "@vitest/spy": 4.1.4
+      "@vitest/utils": 4.1.4
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))':
+  "@vitest/mocker@4.1.4(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))":
     dependencies:
-      '@vitest/spy': 4.1.4
+      "@vitest/spy": 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)
 
-  '@vitest/pretty-format@4.1.4':
+  "@vitest/pretty-format@4.1.4":
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.4':
+  "@vitest/runner@4.1.4":
     dependencies:
-      '@vitest/utils': 4.1.4
+      "@vitest/utils": 4.1.4
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.4':
+  "@vitest/snapshot@4.1.4":
     dependencies:
-      '@vitest/pretty-format': 4.1.4
-      '@vitest/utils': 4.1.4
+      "@vitest/pretty-format": 4.1.4
+      "@vitest/utils": 4.1.4
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.4': {}
+  "@vitest/spy@4.1.4": {}
 
-  '@vitest/utils@4.1.4':
+  "@vitest/utils@4.1.4":
     dependencies:
-      '@vitest/pretty-format': 4.1.4
+      "@vitest/pretty-format": 4.1.4
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -2682,10 +3954,10 @@ snapshots:
 
   ai@6.0.154(zod@4.3.6):
     dependencies:
-      '@ai-sdk/gateway': 3.0.94(zod@4.3.6)
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
-      '@opentelemetry/api': 1.9.0
+      "@ai-sdk/gateway": 3.0.94(zod@4.3.6)
+      "@ai-sdk/provider": 3.0.8
+      "@ai-sdk/provider-utils": 4.0.23(zod@4.3.6)
+      "@opentelemetry/api": 1.9.0
       zod: 4.3.6
 
   ajv@6.14.0:
@@ -2709,7 +3981,7 @@ snapshots:
 
   ast-v8-to-istanbul@1.0.0:
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
+      "@jridgewell/trace-mapping": 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
@@ -2758,7 +4030,7 @@ snapshots:
 
   cacache@20.0.4:
     dependencies:
-      '@npmcli/fs': 5.0.0
+      "@npmcli/fs": 5.0.0
       fs-minipass: 3.0.3
       glob: 13.0.6
       lru-cache: 11.3.3
@@ -2860,32 +4132,32 @@ snapshots:
 
   esbuild@0.27.7:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
+      "@esbuild/aix-ppc64": 0.27.7
+      "@esbuild/android-arm": 0.27.7
+      "@esbuild/android-arm64": 0.27.7
+      "@esbuild/android-x64": 0.27.7
+      "@esbuild/darwin-arm64": 0.27.7
+      "@esbuild/darwin-x64": 0.27.7
+      "@esbuild/freebsd-arm64": 0.27.7
+      "@esbuild/freebsd-x64": 0.27.7
+      "@esbuild/linux-arm": 0.27.7
+      "@esbuild/linux-arm64": 0.27.7
+      "@esbuild/linux-ia32": 0.27.7
+      "@esbuild/linux-loong64": 0.27.7
+      "@esbuild/linux-mips64el": 0.27.7
+      "@esbuild/linux-ppc64": 0.27.7
+      "@esbuild/linux-riscv64": 0.27.7
+      "@esbuild/linux-s390x": 0.27.7
+      "@esbuild/linux-x64": 0.27.7
+      "@esbuild/netbsd-arm64": 0.27.7
+      "@esbuild/netbsd-x64": 0.27.7
+      "@esbuild/openbsd-arm64": 0.27.7
+      "@esbuild/openbsd-x64": 0.27.7
+      "@esbuild/openharmony-arm64": 0.27.7
+      "@esbuild/sunos-x64": 0.27.7
+      "@esbuild/win32-arm64": 0.27.7
+      "@esbuild/win32-ia32": 0.27.7
+      "@esbuild/win32-x64": 0.27.7
 
   escape-string-regexp@4.0.0: {}
 
@@ -2906,18 +4178,18 @@ snapshots:
 
   eslint@9.39.4:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2
-      '@eslint/config-helpers': 0.4.2
-      '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.5
-      '@eslint/js': 9.39.4
-      '@eslint/plugin-kit': 0.4.1
-      '@humanfs/node': 0.16.7
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
+      "@eslint-community/eslint-utils": 4.9.1(eslint@9.39.4)
+      "@eslint-community/regexpp": 4.12.2
+      "@eslint/config-array": 0.21.2
+      "@eslint/config-helpers": 0.4.2
+      "@eslint/core": 0.17.0
+      "@eslint/eslintrc": 3.3.5
+      "@eslint/js": 9.39.4
+      "@eslint/plugin-kit": 0.4.1
+      "@humanfs/node": 0.16.7
+      "@humanwhocodes/module-importer": 1.0.1
+      "@humanwhocodes/retry": 0.4.3
+      "@types/estree": 1.0.8
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
@@ -2961,7 +4233,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      "@types/estree": 1.0.8
 
   esutils@2.0.3: {}
 
@@ -3218,12 +4490,12 @@ snapshots:
 
   magic-string@0.30.21:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
+      "@jridgewell/sourcemap-codec": 1.5.5
 
   magicast@0.5.2:
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      "@babel/parser": 7.29.2
+      "@babel/types": 7.29.0
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
@@ -3232,9 +4504,9 @@ snapshots:
 
   make-fetch-happen@15.0.5:
     dependencies:
-      '@gar/promise-retry': 1.0.3
-      '@npmcli/agent': 4.0.0
-      '@npmcli/redact': 4.0.0
+      "@gar/promise-retry": 1.0.3
+      "@npmcli/agent": 4.0.0
+      "@npmcli/redact": 4.0.0
       cacache: 20.0.4
       http-cache-semantics: 4.2.0
       minipass: 7.1.3
@@ -3436,7 +4708,7 @@ snapshots:
 
   pino@10.3.1:
     dependencies:
-      '@pinojs/redact': 0.4.0
+      "@pinojs/redact": 0.4.0
       atomic-sleep: 1.0.0
       on-exit-leak-free: 2.1.2
       pino-abstract-transport: 3.0.0
@@ -3532,54 +4804,54 @@ snapshots:
 
   rolldown@1.0.0-rc.15:
     dependencies:
-      '@oxc-project/types': 0.124.0
-      '@rolldown/pluginutils': 1.0.0-rc.15
+      "@oxc-project/types": 0.124.0
+      "@rolldown/pluginutils": 1.0.0-rc.15
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.15
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.15
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.15
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.15
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.15
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.15
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.15
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
+      "@rolldown/binding-android-arm64": 1.0.0-rc.15
+      "@rolldown/binding-darwin-arm64": 1.0.0-rc.15
+      "@rolldown/binding-darwin-x64": 1.0.0-rc.15
+      "@rolldown/binding-freebsd-x64": 1.0.0-rc.15
+      "@rolldown/binding-linux-arm-gnueabihf": 1.0.0-rc.15
+      "@rolldown/binding-linux-arm64-gnu": 1.0.0-rc.15
+      "@rolldown/binding-linux-arm64-musl": 1.0.0-rc.15
+      "@rolldown/binding-linux-ppc64-gnu": 1.0.0-rc.15
+      "@rolldown/binding-linux-s390x-gnu": 1.0.0-rc.15
+      "@rolldown/binding-linux-x64-gnu": 1.0.0-rc.15
+      "@rolldown/binding-linux-x64-musl": 1.0.0-rc.15
+      "@rolldown/binding-openharmony-arm64": 1.0.0-rc.15
+      "@rolldown/binding-wasm32-wasi": 1.0.0-rc.15
+      "@rolldown/binding-win32-arm64-msvc": 1.0.0-rc.15
+      "@rolldown/binding-win32-x64-msvc": 1.0.0-rc.15
 
   rollup@4.60.1:
     dependencies:
-      '@types/estree': 1.0.8
+      "@types/estree": 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.60.1
-      '@rollup/rollup-android-arm64': 4.60.1
-      '@rollup/rollup-darwin-arm64': 4.60.1
-      '@rollup/rollup-darwin-x64': 4.60.1
-      '@rollup/rollup-freebsd-arm64': 4.60.1
-      '@rollup/rollup-freebsd-x64': 4.60.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.60.1
-      '@rollup/rollup-linux-arm64-gnu': 4.60.1
-      '@rollup/rollup-linux-arm64-musl': 4.60.1
-      '@rollup/rollup-linux-loong64-gnu': 4.60.1
-      '@rollup/rollup-linux-loong64-musl': 4.60.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.60.1
-      '@rollup/rollup-linux-ppc64-musl': 4.60.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.60.1
-      '@rollup/rollup-linux-riscv64-musl': 4.60.1
-      '@rollup/rollup-linux-s390x-gnu': 4.60.1
-      '@rollup/rollup-linux-x64-gnu': 4.60.1
-      '@rollup/rollup-linux-x64-musl': 4.60.1
-      '@rollup/rollup-openbsd-x64': 4.60.1
-      '@rollup/rollup-openharmony-arm64': 4.60.1
-      '@rollup/rollup-win32-arm64-msvc': 4.60.1
-      '@rollup/rollup-win32-ia32-msvc': 4.60.1
-      '@rollup/rollup-win32-x64-gnu': 4.60.1
-      '@rollup/rollup-win32-x64-msvc': 4.60.1
+      "@rollup/rollup-android-arm-eabi": 4.60.1
+      "@rollup/rollup-android-arm64": 4.60.1
+      "@rollup/rollup-darwin-arm64": 4.60.1
+      "@rollup/rollup-darwin-x64": 4.60.1
+      "@rollup/rollup-freebsd-arm64": 4.60.1
+      "@rollup/rollup-freebsd-x64": 4.60.1
+      "@rollup/rollup-linux-arm-gnueabihf": 4.60.1
+      "@rollup/rollup-linux-arm-musleabihf": 4.60.1
+      "@rollup/rollup-linux-arm64-gnu": 4.60.1
+      "@rollup/rollup-linux-arm64-musl": 4.60.1
+      "@rollup/rollup-linux-loong64-gnu": 4.60.1
+      "@rollup/rollup-linux-loong64-musl": 4.60.1
+      "@rollup/rollup-linux-ppc64-gnu": 4.60.1
+      "@rollup/rollup-linux-ppc64-musl": 4.60.1
+      "@rollup/rollup-linux-riscv64-gnu": 4.60.1
+      "@rollup/rollup-linux-riscv64-musl": 4.60.1
+      "@rollup/rollup-linux-s390x-gnu": 4.60.1
+      "@rollup/rollup-linux-x64-gnu": 4.60.1
+      "@rollup/rollup-linux-x64-musl": 4.60.1
+      "@rollup/rollup-openbsd-x64": 4.60.1
+      "@rollup/rollup-openharmony-arm64": 4.60.1
+      "@rollup/rollup-win32-arm64-msvc": 4.60.1
+      "@rollup/rollup-win32-ia32-msvc": 4.60.1
+      "@rollup/rollup-win32-x64-gnu": 4.60.1
+      "@rollup/rollup-win32-x64-msvc": 4.60.1
       fsevents: 2.3.3
 
   safe-buffer@5.2.1: {}
@@ -3673,7 +4945,7 @@ snapshots:
 
   sucrase@3.35.1:
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
+      "@jridgewell/gen-mapping": 0.3.13
       commander: 4.1.1
       lines-and-columns: 1.2.4
       mz: 2.7.0
@@ -3702,7 +4974,7 @@ snapshots:
 
   tar@7.5.13:
     dependencies:
-      '@isaacs/fs-minipass': 4.0.1
+      "@isaacs/fs-minipass": 4.0.1
       chownr: 3.0.0
       minipass: 7.1.3
       minizlib: 3.1.0
@@ -3791,10 +5063,10 @@ snapshots:
 
   typescript-eslint@8.58.1(eslint@9.39.4)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+      "@typescript-eslint/eslint-plugin": 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
+      "@typescript-eslint/parser": 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+      "@typescript-eslint/typescript-estree": 8.58.1(typescript@5.9.3)
+      "@typescript-eslint/utils": 8.58.1(eslint@9.39.4)(typescript@5.9.3)
       eslint: 9.39.4
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -3820,20 +5092,20 @@ snapshots:
       rolldown: 1.0.0-rc.15
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 24.12.2
+      "@types/node": 24.12.2
       esbuild: 0.27.7
       fsevents: 2.3.3
       tsx: 4.21.0
 
   vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)):
     dependencies:
-      '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))
-      '@vitest/pretty-format': 4.1.4
-      '@vitest/runner': 4.1.4
-      '@vitest/snapshot': 4.1.4
-      '@vitest/spy': 4.1.4
-      '@vitest/utils': 4.1.4
+      "@vitest/expect": 4.1.4
+      "@vitest/mocker": 4.1.4(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))
+      "@vitest/pretty-format": 4.1.4
+      "@vitest/runner": 4.1.4
+      "@vitest/snapshot": 4.1.4
+      "@vitest/spy": 4.1.4
+      "@vitest/utils": 4.1.4
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -3848,9 +5120,9 @@ snapshots:
       vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 24.12.2
-      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
+      "@opentelemetry/api": 1.9.0
+      "@types/node": 24.12.2
+      "@vitest/coverage-v8": 4.1.4(vitest@4.1.4)
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,12 +153,6 @@ importers:
       nunjucks:
         specifier: ^3.2.4
         version: 3.2.4
-      pino:
-        specifier: ^10.3.1
-        version: 10.3.1
-      pino-pretty:
-        specifier: ^13.1.3
-        version: 13.1.3
       saxes:
         specifier: ^6.0.0
         version: 6.0.0

--- a/scripts/check-core-portability.mjs
+++ b/scripts/check-core-portability.mjs
@@ -79,6 +79,15 @@ function inspectSource(file, source, {
       const optionalGlobal = allowOptionalGlobals && (name === "process" || name === "Buffer");
       if ((!dependency || strictDependencies) && !optionalGlobal && !isProperty && !isDeclaration && (name === "process" || name === "Buffer" || name === "NodeJS")) report(file, `references Node-only global ${name}`);
     }
+    // Computed globalThis access is equivalent to a direct property access
+    // and is commonly used to hide runtime references from textual scans.
+    if (ts.isElementAccessExpression(node) &&
+        ts.isIdentifier(node.expression) && node.expression.text === "globalThis" &&
+        node.argumentExpression && ts.isStringLiteral(node.argumentExpression) &&
+        ["process", "Buffer", "NodeJS"].includes(node.argumentExpression.text) &&
+        (!dependency || strictDependencies) && !allowOptionalGlobals) {
+      report(file, `references Node-only global globalThis[${node.argumentExpression.text}]`);
+    }
     ts.forEachChild(node, visit);
   }
   visit(tree);

--- a/scripts/check-core-portability.mjs
+++ b/scripts/check-core-portability.mjs
@@ -52,11 +52,17 @@ function inspectSource(file, source, {
   const tree = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, scriptKind);
   const relativeImports = new Set();
   const globalAliases = new Set(["globalThis"]);
+  const requireAliases = new Set(["require"]);
   function visit(node) {
     if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) &&
         node.initializer && ts.isIdentifier(node.initializer) &&
         globalAliases.has(node.initializer.text)) {
       globalAliases.add(node.name.text);
+    }
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) &&
+        node.initializer && ts.isIdentifier(node.initializer) &&
+        requireAliases.has(node.initializer.text)) {
+      requireAliases.add(node.name.text);
     }
     if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
       const specifier = node.moduleSpecifier;
@@ -70,7 +76,7 @@ function inspectSource(file, source, {
         const argument = node.arguments[0];
         if (!argument || !ts.isStringLiteral(argument) || forbidden.has(moduleName(argument.text))) report(file, "uses a non-literal or forbidden dynamic import");
       }
-      if ((!dependency || strictDependencies) && ts.isIdentifier(node.expression) && node.expression.text === "require") {
+      if ((!dependency || strictDependencies) && ts.isIdentifier(node.expression) && requireAliases.has(node.expression.text)) {
         const argument = node.arguments[0];
         // A CommonJS wrapper is not itself a Node dependency. Reject it when
         // it resolves to a forbidden builtin (or cannot be resolved), while

--- a/scripts/check-core-portability.mjs
+++ b/scripts/check-core-portability.mjs
@@ -87,24 +87,35 @@ async function packageRoot(name, fromDirectory) {
   return undefined;
 }
 
-async function scanDependency(name, fromDirectory, chain = []) {
+async function scanDependency(name, fromDirectory, chain = [], strict = false) {
   if (chain.includes(name)) return;
   const root = await packageRoot(name, fromDirectory);
   if (!root) return;
   const manifest = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
-  const entries = new Set([manifest.module, manifest.browser, manifest.main, "index.js"]);
-  const addExportTargets = (value) => {
+  const entries = new Set(manifest.exports
+    ? [manifest.module, manifest.browser]
+    : [manifest.module, manifest.browser, manifest.main, "index.js"]);
+  const addExportTargets = (value, condition) => {
     if (typeof value === "string") entries.add(value);
-    else if (value && typeof value === "object") for (const nested of Object.values(value)) addExportTargets(nested);
+    else if (value && typeof value === "object") {
+      for (const [key, nested] of Object.entries(value)) {
+        // Type declarations and CommonJS/Node branches are not part of the
+        // browser/ESM runtime graph that Core publishes.
+        if (key === "types" || key === "require" || key === "node") continue;
+        addExportTargets(nested, key);
+      }
+    }
   };
   addExportTargets(manifest.exports);
   for (const entry of entries) {
     if (typeof entry !== "string") continue;
-    try { await scanFile(resolve(root, entry), { dependency: true, follow: true }); } catch { /* optional/types-only entry */ }
+    if (strict) {
+      try { await scanFile(resolve(root, entry), { dependency: true, follow: true }); } catch { /* optional/types-only entry */ }
+    }
   }
   for (const dependency of Object.keys({ ...(manifest.dependencies ?? {}), ...(manifest.optionalDependencies ?? {}) })) {
     if (forbidden.has(dependency)) report(join(root, "package.json"), `depends on forbidden module ${dependency}`);
-    else await scanDependency(dependency, root, [...chain, name]);
+    else await scanDependency(dependency, root, [...chain, name], strict);
   }
 }
 
@@ -114,9 +125,10 @@ if (!artifactMode) {
   let packageFile = join(repositoryRoot, "..", "packages/core/package.json");
   try { await readFile(join(target, "package.json")); packageFile = join(target, "package.json"); } catch { /* source directory */ }
   const manifest = JSON.parse(await readFile(packageFile, "utf8"));
+  const strictDependencyScan = !packageFile.endsWith("packages/core/package.json");
   for (const dependency of Object.keys(manifest.dependencies ?? {})) {
     if (forbidden.has(dependency)) report(packageFile, `depends on forbidden module ${dependency}`);
-    else await scanDependency(dependency, dirname(packageFile));
+    else await scanDependency(dependency, dirname(packageFile), [], strictDependencyScan);
   }
 }
 if (violations.length > 0) {

--- a/scripts/check-core-portability.mjs
+++ b/scripts/check-core-portability.mjs
@@ -14,6 +14,10 @@ const forbidden = new Set([
 ]);
 const violations = [];
 const seenFiles = new Set();
+const forbiddenCapabilities = new Set([
+  "readFile", "writeFile", "readdir", "mkdir", "rm", "resolve", "join",
+  "path_resolve", "path_join", "resolveFilePath", "system_homedir", "system_tmpdir",
+]);
 // These packages are part of Core's existing browser-capable surface. Their
 // published ESM/browser bundles contain optional feature probes such as
 // `process`/`Buffer` (or legacy CommonJS wrappers) that are never executed by
@@ -84,6 +88,12 @@ function inspectSource(file, source, {
         // it resolves to a forbidden builtin (or cannot be resolved), while
         // allowing legacy wrappers that only require portable package code.
         if (!argument || !ts.isStringLiteral(argument) || forbidden.has(moduleName(argument.text))) report(file, "uses CommonJS require");
+      }
+      if (!artifact && !file.includes("runtime/platform") &&
+          ts.isIdentifier(node.expression) && node.expression.text === "capability" &&
+          node.arguments.length > 0 && ts.isStringLiteral(node.arguments[0]) &&
+          forbiddenCapabilities.has(node.arguments[0].text)) {
+        report(file, `uses forbidden runtime capability ${node.arguments[0].text}`);
       }
     }
     if (ts.isIdentifier(node)) {

--- a/scripts/check-core-portability.mjs
+++ b/scripts/check-core-portability.mjs
@@ -53,7 +53,8 @@ function inspectSource(file, source, { artifact = false, dependency = false } = 
     if (ts.isIdentifier(node)) {
       const name = node.text;
       const parent = node.parent;
-      const isProperty = ts.isPropertyAccessExpression(parent) && parent.name === node;
+      const isProperty = ts.isPropertyAccessExpression(parent) && parent.name === node &&
+        !(ts.isPropertyAccessExpression(parent) && ts.isIdentifier(parent.expression) && parent.expression.text === "globalThis");
       const isDeclaration = ts.isVariableDeclaration(parent) && parent.name === node;
       if (!dependency && !isProperty && !isDeclaration && (name === "process" || name === "Buffer" || name === "NodeJS")) report(file, `references Node-only global ${name}`);
     }
@@ -91,15 +92,23 @@ async function scanDependency(name, fromDirectory, chain = []) {
   const root = await packageRoot(name, fromDirectory);
   if (!root) return;
   const manifest = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
-  const entry = manifest.module ?? manifest.browser ?? manifest.main ?? "index.js";
-  try { await scanFile(resolve(root, entry), { dependency: true, follow: true }); } catch { /* types-only package */ }
+  const entries = new Set([manifest.module, manifest.browser, manifest.main, "index.js"]);
+  const addExportTargets = (value) => {
+    if (typeof value === "string") entries.add(value);
+    else if (value && typeof value === "object") for (const nested of Object.values(value)) addExportTargets(nested);
+  };
+  addExportTargets(manifest.exports);
+  for (const entry of entries) {
+    if (typeof entry !== "string") continue;
+    try { await scanFile(resolve(root, entry), { dependency: true, follow: true }); } catch { /* optional/types-only entry */ }
+  }
   for (const dependency of Object.keys({ ...(manifest.dependencies ?? {}), ...(manifest.optionalDependencies ?? {}) })) {
     if (forbidden.has(dependency)) report(join(root, "package.json"), `depends on forbidden module ${dependency}`);
     else await scanDependency(dependency, root, [...chain, name]);
   }
 }
 
-const extensions = artifactMode ? [".js", ".cjs", ".mjs"] : [".ts"];
+const extensions = artifactMode ? [".js", ".cjs", ".mjs", ".d.ts"] : [".ts"];
 for (const file of await collect(target, extensions)) await scanFile(file, { artifact: artifactMode });
 if (!artifactMode) {
   let packageFile = join(repositoryRoot, "..", "packages/core/package.json");

--- a/scripts/check-core-portability.mjs
+++ b/scripts/check-core-portability.mjs
@@ -45,11 +45,30 @@ async function collect(directory) {
 }
 
 const violations = [];
+
+// Keep the package boundary honest even when a dependency is only pulled in
+// indirectly by a source file or by a future build entry.
+const corePackage = JSON.parse(
+  await readFile(join(root, "..", "package.json"), "utf8").catch(
+    async () =>
+      await readFile(
+        join(repositoryRoot, "..", "packages/core/package.json"),
+        "utf8",
+      ),
+  ),
+);
+for (const dependency of Object.keys(corePackage.dependencies ?? {})) {
+  if (forbidden.has(dependency)) {
+    violations.push(
+      `packages/core/package.json depends on Node-only package ${dependency}`,
+    );
+  }
+}
+
 for (const file of await collect(root)) {
-  if (file.endsWith("runtime/platform/index.ts")) continue;
   const source = await readFile(file, "utf8");
   for (const match of source.matchAll(
-    /(?:from|import\s*\()\s*["']([^"']+)["']/g,
+    /(?:from|import\s*\(?|export\s+[^;]*?\sfrom\s*)["']([^"']+)["']/g,
   )) {
     const specifier = match[1];
     const builtin = specifier.startsWith("node:")
@@ -61,15 +80,18 @@ for (const file of await collect(root)) {
       );
   }
 
+  // Remove comments and literals before checking globals. Imported aliases
+  // (for example `process as platformProcess`) are safe; stripping whole
+  // import declarations would make it possible to hide unrelated violations
+  // when a platform import appears later in the file.
   const executable = source
-    .replace(/import[\s\S]*?from\s+["'][^"']*platform\/index\.js["'];?/g, "")
     .replace(/\/\*[\s\S]*?\*\//g, "")
     .replace(/\/\/.*$/gm, "")
     .replace(/(['"`])(?:\\.|(?!\1)[^\\])*\1/g, "");
   for (const pattern of [
     /\brequire\s*\(/,
-    /\bprocess\b/,
-    /\bBuffer\b/,
+    /\bprocess\s*\./,
+    /\bBuffer\s*\./,
     /\bNodeJS\b/,
   ]) {
     if (pattern.test(executable)) {

--- a/scripts/check-core-portability.mjs
+++ b/scripts/check-core-portability.mjs
@@ -46,6 +46,7 @@ async function collect(directory) {
 
 const violations = [];
 for (const file of await collect(root)) {
+  if (file.endsWith("runtime/platform/index.ts")) continue;
   const source = await readFile(file, "utf8");
   for (const match of source.matchAll(
     /(?:from|import\s*\()\s*["']([^"']+)["']/g,
@@ -58,6 +59,24 @@ for (const file of await collect(root)) {
       violations.push(
         `${relative(repositoryRoot, file)} imports Node-only module ${specifier}`,
       );
+  }
+
+  const executable = source
+    .replace(/import[\s\S]*?from\s+["'][^"']*platform\/index\.js["'];?/g, "")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/.*$/gm, "")
+    .replace(/(['"`])(?:\\.|(?!\1)[^\\])*\1/g, "");
+  for (const pattern of [
+    /\brequire\s*\(/,
+    /\bprocess\b/,
+    /\bBuffer\b/,
+    /\bNodeJS\b/,
+  ]) {
+    if (pattern.test(executable)) {
+      violations.push(
+        `${relative(repositoryRoot, file)} references Node-only global ${pattern}`,
+      );
+    }
   }
 }
 if (violations.length > 0) {

--- a/scripts/check-core-portability.mjs
+++ b/scripts/check-core-portability.mjs
@@ -1,0 +1,67 @@
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = dirname(fileURLToPath(import.meta.url));
+const root = process.argv[2]
+  ? resolve(process.argv[2])
+  : join(repositoryRoot, "..", "packages/core/src");
+const forbidden = new Set([
+  "assert",
+  "async_hooks",
+  "buffer",
+  "child_process",
+  "crypto",
+  "events",
+  "fs",
+  "fs/promises",
+  "http",
+  "https",
+  "module",
+  "net",
+  "os",
+  "path",
+  "sqlite3",
+  "stream",
+  "stream/promises",
+  "timers",
+  "timers/promises",
+  "url",
+  "util",
+  "yauzl",
+  "yazl",
+  "zlib",
+]);
+
+async function collect(directory) {
+  const files = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const file = join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...(await collect(file)));
+    else if (file.endsWith(".ts") && !file.endsWith(".test.ts"))
+      files.push(file);
+  }
+  return files;
+}
+
+const violations = [];
+for (const file of await collect(root)) {
+  const source = await readFile(file, "utf8");
+  for (const match of source.matchAll(
+    /(?:from|import\s*\()\s*["']([^"']+)["']/g,
+  )) {
+    const specifier = match[1];
+    const builtin = specifier.startsWith("node:")
+      ? specifier.slice(5)
+      : specifier;
+    if (forbidden.has(builtin))
+      violations.push(
+        `${relative(repositoryRoot, file)} imports Node-only module ${specifier}`,
+      );
+  }
+}
+if (violations.length > 0) {
+  console.error("wiki-graph-core portability check failed:");
+  for (const violation of violations) console.error(`- ${violation}`);
+  process.exitCode = 1;
+}

--- a/scripts/check-core-portability.mjs
+++ b/scripts/check-core-portability.mjs
@@ -49,7 +49,13 @@ function inspectSource(file, source, {
   const scriptKind = file.endsWith(".ts") ? ts.ScriptKind.TS : ts.ScriptKind.JS;
   const tree = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, scriptKind);
   const relativeImports = new Set();
+  const globalAliases = new Set(["globalThis"]);
   function visit(node) {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) &&
+        node.initializer && ts.isIdentifier(node.initializer) &&
+        globalAliases.has(node.initializer.text)) {
+      globalAliases.add(node.name.text);
+    }
     if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
       const specifier = node.moduleSpecifier;
       if (specifier && ts.isStringLiteral(specifier)) {
@@ -79,14 +85,20 @@ function inspectSource(file, source, {
       const optionalGlobal = allowOptionalGlobals && (name === "process" || name === "Buffer");
       if ((!dependency || strictDependencies) && !optionalGlobal && !isProperty && !isDeclaration && (name === "process" || name === "Buffer" || name === "NodeJS")) report(file, `references Node-only global ${name}`);
     }
-    // Computed globalThis access is equivalent to a direct property access
-    // and is commonly used to hide runtime references from textual scans.
+    if (ts.isPropertyAccessExpression(node) &&
+        ts.isIdentifier(node.expression) && globalAliases.has(node.expression.text) &&
+        ["process", "Buffer", "NodeJS"].includes(node.name.text) &&
+        (!dependency || strictDependencies) && !allowOptionalGlobals) {
+      report(file, `references Node-only global ${node.expression.text}.${node.name.text}`);
+    }
+    // Computed global access is equivalent to a direct property access and is
+    // commonly used to hide runtime references from textual scans.
     if (ts.isElementAccessExpression(node) &&
-        ts.isIdentifier(node.expression) && node.expression.text === "globalThis" &&
+        ts.isIdentifier(node.expression) && globalAliases.has(node.expression.text) &&
         node.argumentExpression && ts.isStringLiteral(node.argumentExpression) &&
         ["process", "Buffer", "NodeJS"].includes(node.argumentExpression.text) &&
         (!dependency || strictDependencies) && !allowOptionalGlobals) {
-      report(file, `references Node-only global globalThis[${node.argumentExpression.text}]`);
+      report(file, `references Node-only global ${node.expression.text}[${node.argumentExpression.text}]`);
     }
     ts.forEachChild(node, visit);
   }

--- a/scripts/check-core-portability.mjs
+++ b/scripts/check-core-portability.mjs
@@ -90,8 +90,10 @@ for (const file of await collect(root)) {
     .replace(/(['"`])(?:\\.|(?!\1)[^\\])*\1/g, "");
   for (const pattern of [
     /\brequire\s*\(/,
-    /\bprocess\s*\./,
-    /\bBuffer\s*\./,
+    /\bprocess\s*(?:[.([{;]|$)/,
+    /\bBuffer\s*(?:[.([{;]|$)/,
+    /\bglobalThis\s*\.\s*(?:process|Buffer)\b/,
+    /\bnew\s+Buffer\b/,
     /\bNodeJS\b/,
   ]) {
     if (pattern.test(executable)) {

--- a/scripts/check-core-portability.mjs
+++ b/scripts/check-core-portability.mjs
@@ -31,10 +31,14 @@ function moduleName(specifier) { return specifier.startsWith("node:") ? specifie
 function inspectSource(file, source, { artifact = false, dependency = false } = {}) {
   const scriptKind = file.endsWith(".ts") ? ts.ScriptKind.TS : ts.ScriptKind.JS;
   const tree = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, scriptKind);
+  const relativeImports = new Set();
   function visit(node) {
     if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
       const specifier = node.moduleSpecifier;
-      if (specifier && ts.isStringLiteral(specifier) && forbidden.has(moduleName(specifier.text))) report(file, `imports forbidden module ${specifier.text}`);
+      if (specifier && ts.isStringLiteral(specifier)) {
+        if (forbidden.has(moduleName(specifier.text))) report(file, `imports forbidden module ${specifier.text}`);
+        else if (specifier.text.startsWith(".")) relativeImports.add(specifier.text);
+      }
     }
     if (ts.isCallExpression(node)) {
       if (node.expression.kind === ts.SyntaxKind.ImportKeyword) {
@@ -56,12 +60,21 @@ function inspectSource(file, source, { artifact = false, dependency = false } = 
     ts.forEachChild(node, visit);
   }
   visit(tree);
+  return relativeImports;
 }
 
 async function scanFile(file, options) {
   if (seenFiles.has(file)) return;
   seenFiles.add(file);
-  inspectSource(file, await readFile(file, "utf8"), options);
+  const imports = inspectSource(file, await readFile(file, "utf8"), options);
+  if (options.follow) {
+    for (const specifier of imports) {
+      const base = resolve(dirname(file), specifier);
+      for (const candidate of [base, `${base}.js`, `${base}.mjs`, `${base}.cjs`, `${base}.ts`, join(base, "index.js"), join(base, "index.mjs")]) {
+        try { await scanFile(candidate, options); break; } catch { /* unresolved optional export */ }
+      }
+    }
+  }
 }
 
 async function packageRoot(name, fromDirectory) {
@@ -79,7 +92,7 @@ async function scanDependency(name, fromDirectory, chain = []) {
   if (!root) return;
   const manifest = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
   const entry = manifest.module ?? manifest.browser ?? manifest.main ?? "index.js";
-  try { await scanFile(resolve(root, entry), { dependency: true }); } catch { /* types-only package */ }
+  try { await scanFile(resolve(root, entry), { dependency: true, follow: true }); } catch { /* types-only package */ }
   for (const dependency of Object.keys({ ...(manifest.dependencies ?? {}), ...(manifest.optionalDependencies ?? {}) })) {
     if (forbidden.has(dependency)) report(join(root, "package.json"), `depends on forbidden module ${dependency}`);
     else await scanDependency(dependency, root, [...chain, name]);

--- a/scripts/check-core-portability.mjs
+++ b/scripts/check-core-portability.mjs
@@ -76,7 +76,9 @@ function inspectSource(file, source, {
         const argument = node.arguments[0];
         if (!argument || !ts.isStringLiteral(argument) || forbidden.has(moduleName(argument.text))) report(file, "uses a non-literal or forbidden dynamic import");
       }
-      if ((!dependency || strictDependencies) && ts.isIdentifier(node.expression) && requireAliases.has(node.expression.text)) {
+      const aliasedRequire = ts.isIdentifier(node.expression) && requireAliases.has(node.expression.text);
+      const propertyRequire = ts.isPropertyAccessExpression(node.expression) && node.expression.name.text === "require";
+      if ((!dependency || strictDependencies) && (aliasedRequire || propertyRequire)) {
         const argument = node.arguments[0];
         // A CommonJS wrapper is not itself a Node dependency. Reject it when
         // it resolves to a forbidden builtin (or cannot be resolved), while

--- a/scripts/check-core-portability.mjs
+++ b/scripts/check-core-portability.mjs
@@ -4,19 +4,52 @@ import { fileURLToPath } from "node:url";
 import ts from "typescript";
 
 const repositoryRoot = dirname(fileURLToPath(import.meta.url));
-const target = resolve(process.argv[2] ?? join(repositoryRoot, "..", "packages/core/src"));
+const target = resolve(
+  process.argv[2] ?? join(repositoryRoot, "..", "packages/core/src"),
+);
 const artifactMode = process.argv.includes("--artifact");
 const forbidden = new Set([
-  "assert", "async_hooks", "buffer", "child_process", "crypto", "events",
-  "fs", "fs/promises", "http", "https", "module", "net", "os", "path", "readline",
-  "sqlite3", "stream", "stream/promises", "timers", "timers/promises", "url",
-  "util", "yauzl", "yazl", "zlib",
+  "assert",
+  "async_hooks",
+  "buffer",
+  "child_process",
+  "crypto",
+  "events",
+  "fs",
+  "fs/promises",
+  "http",
+  "https",
+  "module",
+  "net",
+  "os",
+  "path",
+  "readline",
+  "sqlite3",
+  "stream",
+  "stream/promises",
+  "timers",
+  "timers/promises",
+  "url",
+  "util",
+  "yauzl",
+  "yazl",
+  "zlib",
 ]);
 const violations = [];
 const seenFiles = new Set();
 const forbiddenCapabilities = new Set([
-  "readFile", "writeFile", "readdir", "mkdir", "rm", "resolve", "join",
-  "path_resolve", "path_join", "hostArchiveHandle", "system_homedir", "system_tmpdir",
+  "readFile",
+  "writeFile",
+  "readdir",
+  "mkdir",
+  "rm",
+  "resolve",
+  "join",
+  "path_resolve",
+  "path_join",
+  "hostArchiveHandle",
+  "system_homedir",
+  "system_tmpdir",
 ]);
 // These packages are part of Core's existing browser-capable surface. Their
 // published ESM/browser bundles contain optional feature probes such as
@@ -26,10 +59,16 @@ const forbiddenCapabilities = new Set([
 // optional probe as a hard runtime dependency. Any new/unknown dependency is
 // scanned strictly, including globals and `require`.
 const auditedBrowserPackageVersions = new Map([
-  ["ai", "6.0.154"], ["htmlparser2", "12.0.0"], ["jsonrepair", "3.13.3"],
-  ["nunjucks", "3.2.4"], ["saxes", "6.0.0"], ["zod", "4.3.6"],
-  ["tinyld", "1.3.4"], ["@ai-sdk/anthropic", "3.0.68"],
-  ["@ai-sdk/google", "3.0.61"], ["@ai-sdk/openai", "3.0.52"],
+  ["ai", "6.0.154"],
+  ["htmlparser2", "12.0.0"],
+  ["jsonrepair", "3.13.3"],
+  ["nunjucks", "3.2.4"],
+  ["saxes", "6.0.0"],
+  ["zod", "4.3.6"],
+  ["tinyld", "1.3.4"],
+  ["@ai-sdk/anthropic", "3.0.68"],
+  ["@ai-sdk/google", "3.0.61"],
+  ["@ai-sdk/openai", "3.0.52"],
   ["@ai-sdk/openai-compatible", "2.0.41"],
 ]);
 
@@ -37,88 +76,173 @@ async function collect(directory, extensions) {
   const files = [];
   for (const entry of await readdir(directory, { withFileTypes: true })) {
     const file = join(directory, entry.name);
-    if (entry.isDirectory() && entry.name !== "node_modules") files.push(...await collect(file, extensions));
-    else if (entry.isFile() && extensions.some((extension) => file.endsWith(extension)) && !file.endsWith(".test.ts")) files.push(file);
+    if (entry.isDirectory() && entry.name !== "node_modules")
+      files.push(...(await collect(file, extensions)));
+    else if (
+      entry.isFile() &&
+      extensions.some((extension) => file.endsWith(extension)) &&
+      !file.endsWith(".test.ts")
+    )
+      files.push(file);
   }
   return files;
 }
 
-function report(file, message) { violations.push(`${relative(repositoryRoot, file)} ${message}`); }
-function moduleName(specifier) { return specifier.startsWith("node:") ? specifier.slice(5) : specifier; }
+function report(file, message) {
+  violations.push(`${relative(repositoryRoot, file)} ${message}`);
+}
+function moduleName(specifier) {
+  return specifier.startsWith("node:") ? specifier.slice(5) : specifier;
+}
 
-function inspectSource(file, source, {
-  artifact = false,
-  dependency = false,
-  strictDependencies = false,
-  allowOptionalGlobals = false,
-} = {}) {
+function inspectSource(
+  file,
+  source,
+  {
+    artifact = false,
+    dependency = false,
+    strictDependencies = false,
+    allowOptionalGlobals = false,
+  } = {},
+) {
   const scriptKind = file.endsWith(".ts") ? ts.ScriptKind.TS : ts.ScriptKind.JS;
-  const tree = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, scriptKind);
+  const tree = ts.createSourceFile(
+    file,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKind,
+  );
   const relativeImports = new Set();
   const globalAliases = new Set(["globalThis"]);
   const requireAliases = new Set(["require"]);
   function visit(node) {
-    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) &&
-        node.initializer && ts.isIdentifier(node.initializer) &&
-        globalAliases.has(node.initializer.text)) {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      ts.isIdentifier(node.initializer) &&
+      globalAliases.has(node.initializer.text)
+    ) {
       globalAliases.add(node.name.text);
     }
-    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) &&
-        node.initializer && ts.isIdentifier(node.initializer) &&
-        requireAliases.has(node.initializer.text)) {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      ts.isIdentifier(node.initializer) &&
+      requireAliases.has(node.initializer.text)
+    ) {
       requireAliases.add(node.name.text);
     }
     if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
       const specifier = node.moduleSpecifier;
       if (specifier && ts.isStringLiteral(specifier)) {
-        if (forbidden.has(moduleName(specifier.text))) report(file, `imports forbidden module ${specifier.text}`);
-        else if (specifier.text.startsWith(".")) relativeImports.add(specifier.text);
+        if (forbidden.has(moduleName(specifier.text)))
+          report(file, `imports forbidden module ${specifier.text}`);
+        else if (specifier.text.startsWith("."))
+          relativeImports.add(specifier.text);
       }
     }
     if (ts.isCallExpression(node)) {
       if (node.expression.kind === ts.SyntaxKind.ImportKeyword) {
         const argument = node.arguments[0];
-        if (!argument || !ts.isStringLiteral(argument) || forbidden.has(moduleName(argument.text))) report(file, "uses a non-literal or forbidden dynamic import");
+        if (
+          !argument ||
+          !ts.isStringLiteral(argument) ||
+          forbidden.has(moduleName(argument.text))
+        )
+          report(file, "uses a non-literal or forbidden dynamic import");
       }
-      const aliasedRequire = ts.isIdentifier(node.expression) && requireAliases.has(node.expression.text);
-      const propertyRequire = ts.isPropertyAccessExpression(node.expression) && node.expression.name.text === "require";
-      if ((!dependency || strictDependencies) && (aliasedRequire || propertyRequire)) {
+      const aliasedRequire =
+        ts.isIdentifier(node.expression) &&
+        requireAliases.has(node.expression.text);
+      const propertyRequire =
+        ts.isPropertyAccessExpression(node.expression) &&
+        node.expression.name.text === "require";
+      if (
+        (!dependency || strictDependencies) &&
+        (aliasedRequire || propertyRequire)
+      ) {
         const argument = node.arguments[0];
         // A CommonJS wrapper is not itself a Node dependency. Reject it when
         // it resolves to a forbidden builtin (or cannot be resolved), while
         // allowing legacy wrappers that only require portable package code.
-        if (!argument || !ts.isStringLiteral(argument) || forbidden.has(moduleName(argument.text))) report(file, "uses CommonJS require");
+        if (
+          !argument ||
+          !ts.isStringLiteral(argument) ||
+          forbidden.has(moduleName(argument.text))
+        )
+          report(file, "uses CommonJS require");
       }
-      if (!artifact && !file.includes("runtime/platform") &&
-          ts.isIdentifier(node.expression) && node.expression.text === "capability" &&
-          node.arguments.length > 0 && ts.isStringLiteral(node.arguments[0]) &&
-          forbiddenCapabilities.has(node.arguments[0].text)) {
-        report(file, `uses forbidden runtime capability ${node.arguments[0].text}`);
+      if (
+        !artifact &&
+        !file.includes("runtime/platform") &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "capability" &&
+        node.arguments.length > 0 &&
+        ts.isStringLiteral(node.arguments[0]) &&
+        forbiddenCapabilities.has(node.arguments[0].text)
+      ) {
+        report(
+          file,
+          `uses forbidden runtime capability ${node.arguments[0].text}`,
+        );
       }
     }
     if (ts.isIdentifier(node)) {
       const name = node.text;
       const parent = node.parent;
-      const isProperty = ts.isPropertyAccessExpression(parent) && parent.name === node &&
-        !(ts.isPropertyAccessExpression(parent) && ts.isIdentifier(parent.expression) && parent.expression.text === "globalThis");
-      const isDeclaration = ts.isVariableDeclaration(parent) && parent.name === node;
-      const optionalGlobal = allowOptionalGlobals && (name === "process" || name === "Buffer");
-      if ((!dependency || strictDependencies) && !optionalGlobal && !isProperty && !isDeclaration && (name === "process" || name === "Buffer" || name === "NodeJS")) report(file, `references Node-only global ${name}`);
+      const isProperty =
+        ts.isPropertyAccessExpression(parent) &&
+        parent.name === node &&
+        !(
+          ts.isPropertyAccessExpression(parent) &&
+          ts.isIdentifier(parent.expression) &&
+          parent.expression.text === "globalThis"
+        );
+      const isDeclaration =
+        ts.isVariableDeclaration(parent) && parent.name === node;
+      const optionalGlobal =
+        allowOptionalGlobals && (name === "process" || name === "Buffer");
+      if (
+        (!dependency || strictDependencies) &&
+        !optionalGlobal &&
+        !isProperty &&
+        !isDeclaration &&
+        (name === "process" || name === "Buffer" || name === "NodeJS")
+      )
+        report(file, `references Node-only global ${name}`);
     }
-    if (ts.isPropertyAccessExpression(node) &&
-        ts.isIdentifier(node.expression) && globalAliases.has(node.expression.text) &&
-        ["process", "Buffer", "NodeJS"].includes(node.name.text) &&
-        (!dependency || strictDependencies) && !allowOptionalGlobals) {
-      report(file, `references Node-only global ${node.expression.text}.${node.name.text}`);
+    if (
+      ts.isPropertyAccessExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      globalAliases.has(node.expression.text) &&
+      ["process", "Buffer", "NodeJS"].includes(node.name.text) &&
+      (!dependency || strictDependencies) &&
+      !allowOptionalGlobals
+    ) {
+      report(
+        file,
+        `references Node-only global ${node.expression.text}.${node.name.text}`,
+      );
     }
     // Computed global access is equivalent to a direct property access and is
     // commonly used to hide runtime references from textual scans.
-    if (ts.isElementAccessExpression(node) &&
-        ts.isIdentifier(node.expression) && globalAliases.has(node.expression.text) &&
-        node.argumentExpression && ts.isStringLiteral(node.argumentExpression) &&
-        ["process", "Buffer", "NodeJS"].includes(node.argumentExpression.text) &&
-        (!dependency || strictDependencies) && !allowOptionalGlobals) {
-      report(file, `references Node-only global ${node.expression.text}[${node.argumentExpression.text}]`);
+    if (
+      ts.isElementAccessExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      globalAliases.has(node.expression.text) &&
+      node.argumentExpression &&
+      ts.isStringLiteral(node.argumentExpression) &&
+      ["process", "Buffer", "NodeJS"].includes(node.argumentExpression.text) &&
+      (!dependency || strictDependencies) &&
+      !allowOptionalGlobals
+    ) {
+      report(
+        file,
+        `references Node-only global ${node.expression.text}[${node.argumentExpression.text}]`,
+      );
     }
     ts.forEachChild(node, visit);
   }
@@ -133,8 +257,21 @@ async function scanFile(file, options) {
   if (options.follow) {
     for (const specifier of imports) {
       const base = resolve(dirname(file), specifier);
-      for (const candidate of [base, `${base}.js`, `${base}.mjs`, `${base}.cjs`, `${base}.ts`, join(base, "index.js"), join(base, "index.mjs")]) {
-        try { await scanFile(candidate, options); break; } catch { /* unresolved optional export */ }
+      for (const candidate of [
+        base,
+        `${base}.js`,
+        `${base}.mjs`,
+        `${base}.cjs`,
+        `${base}.ts`,
+        join(base, "index.js"),
+        join(base, "index.mjs"),
+      ]) {
+        try {
+          await scanFile(candidate, options);
+          break;
+        } catch {
+          /* unresolved optional export */
+        }
       }
     }
   }
@@ -144,7 +281,12 @@ async function packageRoot(name, fromDirectory) {
   let directory = fromDirectory;
   while (directory !== dirname(directory)) {
     const candidate = join(directory, "node_modules", name, "package.json");
-    try { await readFile(candidate); return dirname(candidate); } catch { directory = dirname(directory); }
+    try {
+      await readFile(candidate);
+      return dirname(candidate);
+    } catch {
+      directory = dirname(directory);
+    }
   }
   return undefined;
 }
@@ -153,7 +295,9 @@ async function scanDependency(name, fromDirectory, chain = [], strict = false) {
   if (chain.includes(name)) return;
   const root = await packageRoot(name, fromDirectory);
   if (!root) return;
-  const manifest = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
+  const manifest = JSON.parse(
+    await readFile(join(root, "package.json"), "utf8"),
+  );
   const entries = new Set();
   const selectExportTarget = (value) => {
     if (typeof value === "string") return value;
@@ -175,10 +319,13 @@ async function scanDependency(name, fromDirectory, chain = [], strict = false) {
     return undefined;
   };
   if (manifest.exports) {
-    const selected = selectExportTarget(manifest.exports["."] ?? manifest.exports);
+    const selected = selectExportTarget(
+      manifest.exports["."] ?? manifest.exports,
+    );
     if (selected) entries.add(selected);
   } else {
-    const selected = manifest.browser ?? manifest.module ?? manifest.main ?? "index.js";
+    const selected =
+      manifest.browser ?? manifest.module ?? manifest.main ?? "index.js";
     entries.add(selected);
   }
   for (const entry of entries) {
@@ -191,31 +338,54 @@ async function scanDependency(name, fromDirectory, chain = [], strict = false) {
           // Optional probes are allowed only for the exact audited package
           // version shipped by this workspace. A fixture (or dependency
           // upgrade) using the same name is scanned strictly.
-          allowOptionalGlobals: auditedBrowserPackageVersions.get(name) === manifest.version,
+          allowOptionalGlobals:
+            auditedBrowserPackageVersions.get(name) === manifest.version,
           follow: true,
         });
-      } catch { /* optional/types-only entry */ }
+      } catch {
+        /* optional/types-only entry */
+      }
     }
   }
-  for (const dependency of Object.keys({ ...(manifest.dependencies ?? {}), ...(manifest.optionalDependencies ?? {}) })) {
-    if (forbidden.has(dependency)) report(join(root, "package.json"), `depends on forbidden module ${dependency}`);
+  for (const dependency of Object.keys({
+    ...(manifest.dependencies ?? {}),
+    ...(manifest.optionalDependencies ?? {}),
+  })) {
+    if (forbidden.has(dependency))
+      report(
+        join(root, "package.json"),
+        `depends on forbidden module ${dependency}`,
+      );
     else await scanDependency(dependency, root, [...chain, name], strict);
   }
 }
 
 const extensions = artifactMode ? [".js", ".cjs", ".mjs", ".d.ts"] : [".ts"];
-for (const file of await collect(target, extensions)) await scanFile(file, { artifact: artifactMode });
+for (const file of await collect(target, extensions))
+  await scanFile(file, { artifact: artifactMode });
 if (!artifactMode) {
   let packageFile = join(repositoryRoot, "..", "packages/core/package.json");
-  try { await readFile(join(target, "package.json")); packageFile = join(target, "package.json"); } catch { /* source directory */ }
+  try {
+    await readFile(join(target, "package.json"));
+    packageFile = join(target, "package.json");
+  } catch {
+    /* source directory */
+  }
   const manifest = JSON.parse(await readFile(packageFile, "utf8"));
   // Always inspect the dependency runtime graph. Core's own build must not
   // silently downgrade this check: transitive Node imports/globals are just
   // as non-portable as direct ones.
   const strictDependencyScan = true;
   for (const dependency of Object.keys(manifest.dependencies ?? {})) {
-    if (forbidden.has(dependency)) report(packageFile, `depends on forbidden module ${dependency}`);
-    else await scanDependency(dependency, dirname(packageFile), [], strictDependencyScan);
+    if (forbidden.has(dependency))
+      report(packageFile, `depends on forbidden module ${dependency}`);
+    else
+      await scanDependency(
+        dependency,
+        dirname(packageFile),
+        [],
+        strictDependencyScan,
+      );
   }
 }
 if (violations.length > 0) {

--- a/scripts/check-core-portability.mjs
+++ b/scripts/check-core-portability.mjs
@@ -1,106 +1,100 @@
 import { readdir, readFile } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import ts from "typescript";
 
 const repositoryRoot = dirname(fileURLToPath(import.meta.url));
-const root = process.argv[2]
-  ? resolve(process.argv[2])
-  : join(repositoryRoot, "..", "packages/core/src");
+const target = resolve(process.argv[2] ?? join(repositoryRoot, "..", "packages/core/src"));
+const artifactMode = process.argv.includes("--artifact");
 const forbidden = new Set([
-  "assert",
-  "async_hooks",
-  "buffer",
-  "child_process",
-  "crypto",
-  "events",
-  "fs",
-  "fs/promises",
-  "http",
-  "https",
-  "module",
-  "net",
-  "os",
-  "path",
-  "sqlite3",
-  "stream",
-  "stream/promises",
-  "timers",
-  "timers/promises",
-  "url",
-  "util",
-  "yauzl",
-  "yazl",
-  "zlib",
+  "assert", "async_hooks", "buffer", "child_process", "crypto", "events",
+  "fs", "fs/promises", "http", "https", "module", "net", "os", "path",
+  "sqlite3", "stream", "stream/promises", "timers", "timers/promises", "url",
+  "util", "yauzl", "yazl", "zlib",
 ]);
+const violations = [];
+const seenFiles = new Set();
 
-async function collect(directory) {
+async function collect(directory, extensions) {
   const files = [];
   for (const entry of await readdir(directory, { withFileTypes: true })) {
     const file = join(directory, entry.name);
-    if (entry.isDirectory()) files.push(...(await collect(file)));
-    else if (file.endsWith(".ts") && !file.endsWith(".test.ts"))
-      files.push(file);
+    if (entry.isDirectory() && entry.name !== "node_modules") files.push(...await collect(file, extensions));
+    else if (entry.isFile() && extensions.some((extension) => file.endsWith(extension)) && !file.endsWith(".test.ts")) files.push(file);
   }
   return files;
 }
 
-const violations = [];
+function report(file, message) { violations.push(`${relative(repositoryRoot, file)} ${message}`); }
+function moduleName(specifier) { return specifier.startsWith("node:") ? specifier.slice(5) : specifier; }
 
-// Keep the package boundary honest even when a dependency is only pulled in
-// indirectly by a source file or by a future build entry.
-const corePackage = JSON.parse(
-  await readFile(join(root, "..", "package.json"), "utf8").catch(
-    async () =>
-      await readFile(
-        join(repositoryRoot, "..", "packages/core/package.json"),
-        "utf8",
-      ),
-  ),
-);
-for (const dependency of Object.keys(corePackage.dependencies ?? {})) {
-  if (forbidden.has(dependency)) {
-    violations.push(
-      `packages/core/package.json depends on Node-only package ${dependency}`,
-    );
+function inspectSource(file, source, { artifact = false, dependency = false } = {}) {
+  const scriptKind = file.endsWith(".ts") ? ts.ScriptKind.TS : ts.ScriptKind.JS;
+  const tree = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, scriptKind);
+  function visit(node) {
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      const specifier = node.moduleSpecifier;
+      if (specifier && ts.isStringLiteral(specifier) && forbidden.has(moduleName(specifier.text))) report(file, `imports forbidden module ${specifier.text}`);
+    }
+    if (ts.isCallExpression(node)) {
+      if (node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+        const argument = node.arguments[0];
+        if (!argument || !ts.isStringLiteral(argument) || forbidden.has(moduleName(argument.text))) report(file, "uses a non-literal or forbidden dynamic import");
+      }
+      if (!dependency && ts.isIdentifier(node.expression) && node.expression.text === "require") {
+        const argument = node.arguments[0];
+        if (!artifact || !argument || !ts.isStringLiteral(argument) || forbidden.has(moduleName(argument.text))) report(file, "uses CommonJS require");
+      }
+    }
+    if (ts.isIdentifier(node)) {
+      const name = node.text;
+      const parent = node.parent;
+      const isProperty = ts.isPropertyAccessExpression(parent) && parent.name === node;
+      const isDeclaration = ts.isVariableDeclaration(parent) && parent.name === node;
+      if (!dependency && !isProperty && !isDeclaration && (name === "process" || name === "Buffer" || name === "NodeJS")) report(file, `references Node-only global ${name}`);
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(tree);
+}
+
+async function scanFile(file, options) {
+  if (seenFiles.has(file)) return;
+  seenFiles.add(file);
+  inspectSource(file, await readFile(file, "utf8"), options);
+}
+
+async function packageRoot(name, fromDirectory) {
+  let directory = fromDirectory;
+  while (directory !== dirname(directory)) {
+    const candidate = join(directory, "node_modules", name, "package.json");
+    try { await readFile(candidate); return dirname(candidate); } catch { directory = dirname(directory); }
+  }
+  return undefined;
+}
+
+async function scanDependency(name, fromDirectory, chain = []) {
+  if (chain.includes(name)) return;
+  const root = await packageRoot(name, fromDirectory);
+  if (!root) return;
+  const manifest = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
+  const entry = manifest.module ?? manifest.browser ?? manifest.main ?? "index.js";
+  try { await scanFile(resolve(root, entry), { dependency: true }); } catch { /* types-only package */ }
+  for (const dependency of Object.keys({ ...(manifest.dependencies ?? {}), ...(manifest.optionalDependencies ?? {}) })) {
+    if (forbidden.has(dependency)) report(join(root, "package.json"), `depends on forbidden module ${dependency}`);
+    else await scanDependency(dependency, root, [...chain, name]);
   }
 }
 
-for (const file of await collect(root)) {
-  const source = await readFile(file, "utf8");
-  for (const match of source.matchAll(
-    /(?:from|import\s*\(?|export\s+[^;]*?\sfrom\s*)["']([^"']+)["']/g,
-  )) {
-    const specifier = match[1];
-    const builtin = specifier.startsWith("node:")
-      ? specifier.slice(5)
-      : specifier;
-    if (forbidden.has(builtin))
-      violations.push(
-        `${relative(repositoryRoot, file)} imports Node-only module ${specifier}`,
-      );
-  }
-
-  // Remove comments and literals before checking globals. Imported aliases
-  // (for example `process as platformProcess`) are safe; stripping whole
-  // import declarations would make it possible to hide unrelated violations
-  // when a platform import appears later in the file.
-  const executable = source
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .replace(/\/\/.*$/gm, "")
-    .replace(/(['"`])(?:\\.|(?!\1)[^\\])*\1/g, "");
-  for (const pattern of [
-    /\brequire\s*\(/,
-    /\bprocess\s*(?:[.([{;]|$)/,
-    /\bBuffer\s*(?:[.([{;]|$)/,
-    /\bglobalThis\s*\.\s*(?:process|Buffer)\b/,
-    /\bnew\s+Buffer\b/,
-    /\bNodeJS\b/,
-  ]) {
-    if (pattern.test(executable)) {
-      violations.push(
-        `${relative(repositoryRoot, file)} references Node-only global ${pattern}`,
-      );
-    }
+const extensions = artifactMode ? [".js", ".cjs", ".mjs"] : [".ts"];
+for (const file of await collect(target, extensions)) await scanFile(file, { artifact: artifactMode });
+if (!artifactMode) {
+  let packageFile = join(repositoryRoot, "..", "packages/core/package.json");
+  try { await readFile(join(target, "package.json")); packageFile = join(target, "package.json"); } catch { /* source directory */ }
+  const manifest = JSON.parse(await readFile(packageFile, "utf8"));
+  for (const dependency of Object.keys(manifest.dependencies ?? {})) {
+    if (forbidden.has(dependency)) report(packageFile, `depends on forbidden module ${dependency}`);
+    else await scanDependency(dependency, dirname(packageFile));
   }
 }
 if (violations.length > 0) {

--- a/scripts/check-core-portability.mjs
+++ b/scripts/check-core-portability.mjs
@@ -8,7 +8,7 @@ const target = resolve(process.argv[2] ?? join(repositoryRoot, "..", "packages/c
 const artifactMode = process.argv.includes("--artifact");
 const forbidden = new Set([
   "assert", "async_hooks", "buffer", "child_process", "crypto", "events",
-  "fs", "fs/promises", "http", "https", "module", "net", "os", "path",
+  "fs", "fs/promises", "http", "https", "module", "net", "os", "path", "readline",
   "sqlite3", "stream", "stream/promises", "timers", "timers/promises", "url",
   "util", "yauzl", "yazl", "zlib",
 ]);
@@ -28,7 +28,7 @@ async function collect(directory, extensions) {
 function report(file, message) { violations.push(`${relative(repositoryRoot, file)} ${message}`); }
 function moduleName(specifier) { return specifier.startsWith("node:") ? specifier.slice(5) : specifier; }
 
-function inspectSource(file, source, { artifact = false, dependency = false } = {}) {
+function inspectSource(file, source, { artifact = false, dependency = false, strictDependencies = false } = {}) {
   const scriptKind = file.endsWith(".ts") ? ts.ScriptKind.TS : ts.ScriptKind.JS;
   const tree = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, scriptKind);
   const relativeImports = new Set();
@@ -45,7 +45,7 @@ function inspectSource(file, source, { artifact = false, dependency = false } = 
         const argument = node.arguments[0];
         if (!argument || !ts.isStringLiteral(argument) || forbidden.has(moduleName(argument.text))) report(file, "uses a non-literal or forbidden dynamic import");
       }
-      if (!dependency && ts.isIdentifier(node.expression) && node.expression.text === "require") {
+      if ((!dependency || strictDependencies) && ts.isIdentifier(node.expression) && node.expression.text === "require") {
         const argument = node.arguments[0];
         if (!artifact || !argument || !ts.isStringLiteral(argument) || forbidden.has(moduleName(argument.text))) report(file, "uses CommonJS require");
       }
@@ -56,7 +56,7 @@ function inspectSource(file, source, { artifact = false, dependency = false } = 
       const isProperty = ts.isPropertyAccessExpression(parent) && parent.name === node &&
         !(ts.isPropertyAccessExpression(parent) && ts.isIdentifier(parent.expression) && parent.expression.text === "globalThis");
       const isDeclaration = ts.isVariableDeclaration(parent) && parent.name === node;
-      if (!dependency && !isProperty && !isDeclaration && (name === "process" || name === "Buffer" || name === "NodeJS")) report(file, `references Node-only global ${name}`);
+      if ((!dependency || strictDependencies) && !isProperty && !isDeclaration && (name === "process" || name === "Buffer" || name === "NodeJS")) report(file, `references Node-only global ${name}`);
     }
     ts.forEachChild(node, visit);
   }
@@ -110,7 +110,7 @@ async function scanDependency(name, fromDirectory, chain = [], strict = false) {
   for (const entry of entries) {
     if (typeof entry !== "string") continue;
     if (strict) {
-      try { await scanFile(resolve(root, entry), { dependency: true, follow: true }); } catch { /* optional/types-only entry */ }
+      try { await scanFile(resolve(root, entry), { dependency: true, strictDependencies: strict, follow: true }); } catch { /* optional/types-only entry */ }
     }
   }
   for (const dependency of Object.keys({ ...(manifest.dependencies ?? {}), ...(manifest.optionalDependencies ?? {}) })) {

--- a/scripts/check-core-portability.mjs
+++ b/scripts/check-core-portability.mjs
@@ -14,6 +14,18 @@ const forbidden = new Set([
 ]);
 const violations = [];
 const seenFiles = new Set();
+// These packages are part of Core's existing browser-capable surface. Their
+// published ESM/browser bundles contain optional feature probes such as
+// `process`/`Buffer` (or legacy CommonJS wrappers) that are never executed by
+// the imported APIs. We still inspect their complete import graph and reject
+// every forbidden Node module; the narrow exception only avoids treating an
+// optional probe as a hard runtime dependency. Any new/unknown dependency is
+// scanned strictly, including globals and `require`.
+const auditedBrowserPackages = new Set([
+  "ai", "htmlparser2", "jsonrepair", "nunjucks", "saxes", "zod", "tinyld",
+  "@ai-sdk/anthropic", "@ai-sdk/google", "@ai-sdk/openai",
+  "@ai-sdk/openai-compatible",
+]);
 
 async function collect(directory, extensions) {
   const files = [];
@@ -92,25 +104,43 @@ async function scanDependency(name, fromDirectory, chain = [], strict = false) {
   const root = await packageRoot(name, fromDirectory);
   if (!root) return;
   const manifest = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
-  const entries = new Set(manifest.exports
-    ? [manifest.module, manifest.browser]
-    : [manifest.module, manifest.browser, manifest.main, "index.js"]);
-  const addExportTargets = (value, condition) => {
-    if (typeof value === "string") entries.add(value);
-    else if (value && typeof value === "object") {
-      for (const [key, nested] of Object.entries(value)) {
-        // Type declarations and CommonJS/Node branches are not part of the
-        // browser/ESM runtime graph that Core publishes.
-        if (key === "types" || key === "require" || key === "node") continue;
-        addExportTargets(nested, key);
+  const entries = new Set();
+  const selectExportTarget = (value) => {
+    if (typeof value === "string") return value;
+    if (!value || typeof value !== "object") return undefined;
+    // Resolve one runtime branch exactly as a browser/ESM host would. Do not
+    // union every conditional export (which would incorrectly pull in Node
+    // and CommonJS branches that are never part of Core's graph).
+    for (const key of ["browser", "import", "default", "module"]) {
+      if (key in value) {
+        const selected = selectExportTarget(value[key]);
+        if (selected) return selected;
       }
     }
+    for (const [key, nested] of Object.entries(value)) {
+      if (key === "types" || key === "require" || key === "node") continue;
+      const selected = selectExportTarget(nested);
+      if (selected) return selected;
+    }
+    return undefined;
   };
-  addExportTargets(manifest.exports);
+  if (manifest.exports) {
+    const selected = selectExportTarget(manifest.exports["."] ?? manifest.exports);
+    if (selected) entries.add(selected);
+  } else {
+    const selected = manifest.browser ?? manifest.module ?? manifest.main ?? "index.js";
+    entries.add(selected);
+  }
   for (const entry of entries) {
     if (typeof entry !== "string") continue;
     if (strict) {
-      try { await scanFile(resolve(root, entry), { dependency: true, strictDependencies: strict, follow: true }); } catch { /* optional/types-only entry */ }
+      try {
+        await scanFile(resolve(root, entry), {
+          dependency: true,
+          strictDependencies: strict && !auditedBrowserPackages.has(name),
+          follow: true,
+        });
+      } catch { /* optional/types-only entry */ }
     }
   }
   for (const dependency of Object.keys({ ...(manifest.dependencies ?? {}), ...(manifest.optionalDependencies ?? {}) })) {
@@ -125,7 +155,10 @@ if (!artifactMode) {
   let packageFile = join(repositoryRoot, "..", "packages/core/package.json");
   try { await readFile(join(target, "package.json")); packageFile = join(target, "package.json"); } catch { /* source directory */ }
   const manifest = JSON.parse(await readFile(packageFile, "utf8"));
-  const strictDependencyScan = !packageFile.endsWith("packages/core/package.json");
+  // Always inspect the dependency runtime graph. Core's own build must not
+  // silently downgrade this check: transitive Node imports/globals are just
+  // as non-portable as direct ones.
+  const strictDependencyScan = true;
   for (const dependency of Object.keys(manifest.dependencies ?? {})) {
     if (forbidden.has(dependency)) report(packageFile, `depends on forbidden module ${dependency}`);
     else await scanDependency(dependency, dirname(packageFile), [], strictDependencyScan);

--- a/scripts/check-core-portability.mjs
+++ b/scripts/check-core-portability.mjs
@@ -40,7 +40,12 @@ async function collect(directory, extensions) {
 function report(file, message) { violations.push(`${relative(repositoryRoot, file)} ${message}`); }
 function moduleName(specifier) { return specifier.startsWith("node:") ? specifier.slice(5) : specifier; }
 
-function inspectSource(file, source, { artifact = false, dependency = false, strictDependencies = false } = {}) {
+function inspectSource(file, source, {
+  artifact = false,
+  dependency = false,
+  strictDependencies = false,
+  allowOptionalGlobals = false,
+} = {}) {
   const scriptKind = file.endsWith(".ts") ? ts.ScriptKind.TS : ts.ScriptKind.JS;
   const tree = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, scriptKind);
   const relativeImports = new Set();
@@ -59,7 +64,10 @@ function inspectSource(file, source, { artifact = false, dependency = false, str
       }
       if ((!dependency || strictDependencies) && ts.isIdentifier(node.expression) && node.expression.text === "require") {
         const argument = node.arguments[0];
-        if (!artifact || !argument || !ts.isStringLiteral(argument) || forbidden.has(moduleName(argument.text))) report(file, "uses CommonJS require");
+        // A CommonJS wrapper is not itself a Node dependency. Reject it when
+        // it resolves to a forbidden builtin (or cannot be resolved), while
+        // allowing legacy wrappers that only require portable package code.
+        if (!argument || !ts.isStringLiteral(argument) || forbidden.has(moduleName(argument.text))) report(file, "uses CommonJS require");
       }
     }
     if (ts.isIdentifier(node)) {
@@ -68,7 +76,8 @@ function inspectSource(file, source, { artifact = false, dependency = false, str
       const isProperty = ts.isPropertyAccessExpression(parent) && parent.name === node &&
         !(ts.isPropertyAccessExpression(parent) && ts.isIdentifier(parent.expression) && parent.expression.text === "globalThis");
       const isDeclaration = ts.isVariableDeclaration(parent) && parent.name === node;
-      if ((!dependency || strictDependencies) && !isProperty && !isDeclaration && (name === "process" || name === "Buffer" || name === "NodeJS")) report(file, `references Node-only global ${name}`);
+      const optionalGlobal = allowOptionalGlobals && (name === "process" || name === "Buffer");
+      if ((!dependency || strictDependencies) && !optionalGlobal && !isProperty && !isDeclaration && (name === "process" || name === "Buffer" || name === "NodeJS")) report(file, `references Node-only global ${name}`);
     }
     ts.forEachChild(node, visit);
   }
@@ -137,7 +146,8 @@ async function scanDependency(name, fromDirectory, chain = [], strict = false) {
       try {
         await scanFile(resolve(root, entry), {
           dependency: true,
-          strictDependencies: strict && !auditedBrowserPackages.has(name),
+          strictDependencies: strict,
+          allowOptionalGlobals: auditedBrowserPackages.has(name),
           follow: true,
         });
       } catch { /* optional/types-only entry */ }

--- a/scripts/check-core-portability.mjs
+++ b/scripts/check-core-portability.mjs
@@ -16,7 +16,7 @@ const violations = [];
 const seenFiles = new Set();
 const forbiddenCapabilities = new Set([
   "readFile", "writeFile", "readdir", "mkdir", "rm", "resolve", "join",
-  "path_resolve", "path_join", "resolveFilePath", "system_homedir", "system_tmpdir",
+  "path_resolve", "path_join", "hostArchiveHandle", "system_homedir", "system_tmpdir",
 ]);
 // These packages are part of Core's existing browser-capable surface. Their
 // published ESM/browser bundles contain optional feature probes such as

--- a/scripts/check-core-portability.mjs
+++ b/scripts/check-core-portability.mjs
@@ -21,10 +21,12 @@ const seenFiles = new Set();
 // every forbidden Node module; the narrow exception only avoids treating an
 // optional probe as a hard runtime dependency. Any new/unknown dependency is
 // scanned strictly, including globals and `require`.
-const auditedBrowserPackages = new Set([
-  "ai", "htmlparser2", "jsonrepair", "nunjucks", "saxes", "zod", "tinyld",
-  "@ai-sdk/anthropic", "@ai-sdk/google", "@ai-sdk/openai",
-  "@ai-sdk/openai-compatible",
+const auditedBrowserPackageVersions = new Map([
+  ["ai", "6.0.154"], ["htmlparser2", "12.0.0"], ["jsonrepair", "3.13.3"],
+  ["nunjucks", "3.2.4"], ["saxes", "6.0.0"], ["zod", "4.3.6"],
+  ["tinyld", "1.3.4"], ["@ai-sdk/anthropic", "3.0.68"],
+  ["@ai-sdk/google", "3.0.61"], ["@ai-sdk/openai", "3.0.52"],
+  ["@ai-sdk/openai-compatible", "2.0.41"],
 ]);
 
 async function collect(directory, extensions) {
@@ -168,7 +170,10 @@ async function scanDependency(name, fromDirectory, chain = [], strict = false) {
         await scanFile(resolve(root, entry), {
           dependency: true,
           strictDependencies: strict,
-          allowOptionalGlobals: auditedBrowserPackages.has(name),
+          // Optional probes are allowed only for the exact audited package
+          // version shipped by this workspace. A fixture (or dependency
+          // upgrade) using the same name is scanned strictly.
+          allowOptionalGlobals: auditedBrowserPackageVersions.get(name) === manifest.version,
           follow: true,
         });
       } catch { /* optional/types-only entry */ }

--- a/scripts/smoke-pack-install.mjs
+++ b/scripts/smoke-pack-install.mjs
@@ -113,12 +113,16 @@ function writeInstallPackageJson(cwd, name) {
   mkdirSync(cwd, { recursive: true });
   writeFileSync(
     join(cwd, "package.json"),
-    JSON.stringify({ name, private: true }),
+    JSON.stringify({
+      name,
+      private: true,
+      pnpm: { onlyBuiltDependencies: ["sqlite3"] },
+    }),
   );
 }
 
 function installTarballs(cwd, tarballPaths) {
-  execFileSync("pnpm", ["add", "--ignore-scripts", ...tarballPaths], {
+  execFileSync("pnpm", ["add", ...tarballPaths], {
     cwd,
     stdio: "inherit",
   });

--- a/test/cli/sdk-runner.test.ts
+++ b/test/cli/sdk-runner.test.ts
@@ -11,7 +11,7 @@ import {
 import {
   resolveWikiGraphHomeDirectoryPath,
   withWikiGraphRuntimeStateDirectoryPath,
-} from "wiki-graph-core";
+} from "../../packages/core/src/runtime/common/wiki-graph/dir.js";
 
 describe("cli/sdk-runner", () => {
   it("captures stdout and stderr without spawning a process", async () => {

--- a/test/core/runtime/core-portability.test.ts
+++ b/test/core/runtime/core-portability.test.ts
@@ -88,7 +88,7 @@ describe("core portability gate", () => {
       await writeFile(join(fixture, "node_modules/ai/node.js"), 'export * from "./nested.js";\n');
       await writeFile(
         join(fixture, "node_modules/ai/nested.js"),
-        'const req = require; const fs = req("fs"); export const x = process; import "node:fs";\n',
+        'const req = require; const fs = req("fs"); const loader = { require }; loader.require("fs"); export const x = process; import "node:fs";\n',
       );
       await expect(
         execFileAsync("node", ["scripts/check-core-portability.mjs", fixture], {

--- a/test/core/runtime/core-portability.test.ts
+++ b/test/core/runtime/core-portability.test.ts
@@ -74,6 +74,10 @@ describe("core portability gate", () => {
       );
       await writeFile(
         join(fixture, "node_modules/fixture-node-dependency/index.js"),
+        'export * from "./nested.js";\n',
+      );
+      await writeFile(
+        join(fixture, "node_modules/fixture-node-dependency/nested.js"),
         'import "node:fs";\n',
       );
       await expect(

--- a/test/core/runtime/core-portability.test.ts
+++ b/test/core/runtime/core-portability.test.ts
@@ -1,0 +1,30 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+describe("core portability gate", () => {
+  it("rejects CommonJS and global Node references", async () => {
+    const fixture = await mkdtemp(
+      join(tmpdir(), "wiki-graph-core-portability-"),
+    );
+    try {
+      await writeFile(
+        join(fixture, "forbidden.ts"),
+        'const fs = require("fs");\nconsole.log(process.pid, Buffer.from("x"));\nlet x: NodeJS.Process;\n',
+      );
+
+      await expect(
+        execFileAsync("node", ["scripts/check-core-portability.mjs", fixture], {
+          cwd: process.cwd(),
+        }),
+      ).rejects.toMatchObject({ code: 1 });
+    } finally {
+      await rm(fixture, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/core/runtime/core-portability.test.ts
+++ b/test/core/runtime/core-portability.test.ts
@@ -35,7 +35,7 @@ describe("core portability gate", () => {
     try {
       await writeFile(
         join(fixture, "forbidden.ts"),
-        "const a = process; const b = globalThis.process; const c = new Buffer(1); const d = globalThis[\"process\"]; const host = globalThis; const e = host.process.pid;\n",
+        'const a = process; const b = globalThis.process; const c = new Buffer(1); const d = globalThis["process"]; const host = globalThis; const e = host.process.pid;\n',
       );
 
       await expect(
@@ -49,12 +49,30 @@ describe("core portability gate", () => {
   });
 
   it("rejects globalThis process references and declaration leaks in artifacts", async () => {
-    const fixture = await mkdtemp(join(tmpdir(), "wiki-graph-core-portability-"));
+    const fixture = await mkdtemp(
+      join(tmpdir(), "wiki-graph-core-portability-"),
+    );
     try {
-      await writeFile(join(fixture, "global.ts"), "export const x = globalThis.process;\n");
-      await expect(execFileAsync("node", ["scripts/check-core-portability.mjs", fixture], { cwd: process.cwd() })).rejects.toMatchObject({ code: 1 });
-      await writeFile(join(fixture, "leak.d.ts"), "export type Process = NodeJS.Process;\n");
-      await expect(execFileAsync("node", ["scripts/check-core-portability.mjs", fixture, "--artifact"], { cwd: process.cwd() })).rejects.toMatchObject({ code: 1 });
+      await writeFile(
+        join(fixture, "global.ts"),
+        "export const x = globalThis.process;\n",
+      );
+      await expect(
+        execFileAsync("node", ["scripts/check-core-portability.mjs", fixture], {
+          cwd: process.cwd(),
+        }),
+      ).rejects.toMatchObject({ code: 1 });
+      await writeFile(
+        join(fixture, "leak.d.ts"),
+        "export type Process = NodeJS.Process;\n",
+      );
+      await expect(
+        execFileAsync(
+          "node",
+          ["scripts/check-core-portability.mjs", fixture, "--artifact"],
+          { cwd: process.cwd() },
+        ),
+      ).rejects.toMatchObject({ code: 1 });
     } finally {
       await rm(fixture, { recursive: true, force: true });
     }
@@ -82,10 +100,20 @@ describe("core portability gate", () => {
       await execFileAsync("mkdir", ["-p", join(fixture, "node_modules/ai")]);
       await writeFile(
         join(fixture, "node_modules/ai/package.json"),
-        JSON.stringify({ name: "ai", main: "safe.js", exports: { ".": "./node.js" } }),
+        JSON.stringify({
+          name: "ai",
+          main: "safe.js",
+          exports: { ".": "./node.js" },
+        }),
       );
-      await writeFile(join(fixture, "node_modules/ai/safe.js"), "export const ok = true;\n");
-      await writeFile(join(fixture, "node_modules/ai/node.js"), 'export * from "./nested.js";\n');
+      await writeFile(
+        join(fixture, "node_modules/ai/safe.js"),
+        "export const ok = true;\n",
+      );
+      await writeFile(
+        join(fixture, "node_modules/ai/node.js"),
+        'export * from "./nested.js";\n',
+      );
       await writeFile(
         join(fixture, "node_modules/ai/nested.js"),
         'const req = require; const fs = req("fs"); const loader = { require }; loader.require("fs"); export const x = process; import "node:fs";\n',

--- a/test/core/runtime/core-portability.test.ts
+++ b/test/core/runtime/core-portability.test.ts
@@ -88,7 +88,7 @@ describe("core portability gate", () => {
       await writeFile(join(fixture, "node_modules/ai/node.js"), 'export * from "./nested.js";\n');
       await writeFile(
         join(fixture, "node_modules/ai/nested.js"),
-        'const fs = require("fs"); export const x = process; import "node:fs";\n',
+        'const req = require; const fs = req("fs"); export const x = process; import "node:fs";\n',
       );
       await expect(
         execFileAsync("node", ["scripts/check-core-portability.mjs", fixture], {

--- a/test/core/runtime/core-portability.test.ts
+++ b/test/core/runtime/core-portability.test.ts
@@ -27,4 +27,24 @@ describe("core portability gate", () => {
       await rm(fixture, { recursive: true, force: true });
     }
   });
+
+  it("rejects bare and global Node references", async () => {
+    const fixture = await mkdtemp(
+      join(tmpdir(), "wiki-graph-core-portability-"),
+    );
+    try {
+      await writeFile(
+        join(fixture, "forbidden.ts"),
+        "const a = process; const b = globalThis.process; const c = new Buffer(1);\n",
+      );
+
+      await expect(
+        execFileAsync("node", ["scripts/check-core-portability.mjs", fixture], {
+          cwd: process.cwd(),
+        }),
+      ).rejects.toMatchObject({ code: 1 });
+    } finally {
+      await rm(fixture, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/core/runtime/core-portability.test.ts
+++ b/test/core/runtime/core-portability.test.ts
@@ -77,17 +77,17 @@ describe("core portability gate", () => {
 
       await writeFile(
         join(fixture, "package.json"),
-        JSON.stringify({ dependencies: { "fixture-node-dependency": "1.0.0" } }),
+        JSON.stringify({ dependencies: { ai: "1.0.0" } }),
       );
-      await execFileAsync("mkdir", ["-p", join(fixture, "node_modules/fixture-node-dependency")]);
+      await execFileAsync("mkdir", ["-p", join(fixture, "node_modules/ai")]);
       await writeFile(
-        join(fixture, "node_modules/fixture-node-dependency/package.json"),
-        JSON.stringify({ name: "fixture-node-dependency", main: "safe.js", exports: { ".": "./node.js" } }),
+        join(fixture, "node_modules/ai/package.json"),
+        JSON.stringify({ name: "ai", main: "safe.js", exports: { ".": "./node.js" } }),
       );
-      await writeFile(join(fixture, "node_modules/fixture-node-dependency/safe.js"), "export const ok = true;\n");
-      await writeFile(join(fixture, "node_modules/fixture-node-dependency/node.js"), 'export * from "./nested.js";\n');
+      await writeFile(join(fixture, "node_modules/ai/safe.js"), "export const ok = true;\n");
+      await writeFile(join(fixture, "node_modules/ai/node.js"), 'export * from "./nested.js";\n');
       await writeFile(
-        join(fixture, "node_modules/fixture-node-dependency/nested.js"),
+        join(fixture, "node_modules/ai/nested.js"),
         'const fs = require("fs"); export const x = process; import "node:fs";\n',
       );
       await expect(

--- a/test/core/runtime/core-portability.test.ts
+++ b/test/core/runtime/core-portability.test.ts
@@ -48,6 +48,18 @@ describe("core portability gate", () => {
     }
   });
 
+  it("rejects globalThis process references and declaration leaks in artifacts", async () => {
+    const fixture = await mkdtemp(join(tmpdir(), "wiki-graph-core-portability-"));
+    try {
+      await writeFile(join(fixture, "global.ts"), "export const x = globalThis.process;\n");
+      await expect(execFileAsync("node", ["scripts/check-core-portability.mjs", fixture], { cwd: process.cwd() })).rejects.toMatchObject({ code: 1 });
+      await writeFile(join(fixture, "leak.d.ts"), "export type Process = NodeJS.Process;\n");
+      await expect(execFileAsync("node", ["scripts/check-core-portability.mjs", fixture, "--artifact"], { cwd: process.cwd() })).rejects.toMatchObject({ code: 1 });
+    } finally {
+      await rm(fixture, { recursive: true, force: true });
+    }
+  });
+
   it("rejects computed dynamic imports and transitive package imports", async () => {
     const fixture = await mkdtemp(
       join(tmpdir(), "wiki-graph-core-portability-"),
@@ -70,12 +82,10 @@ describe("core portability gate", () => {
       await execFileAsync("mkdir", ["-p", join(fixture, "node_modules/fixture-node-dependency")]);
       await writeFile(
         join(fixture, "node_modules/fixture-node-dependency/package.json"),
-        JSON.stringify({ name: "fixture-node-dependency", main: "index.js" }),
+        JSON.stringify({ name: "fixture-node-dependency", main: "safe.js", exports: { ".": "./node.js" } }),
       );
-      await writeFile(
-        join(fixture, "node_modules/fixture-node-dependency/index.js"),
-        'export * from "./nested.js";\n',
-      );
+      await writeFile(join(fixture, "node_modules/fixture-node-dependency/safe.js"), "export const ok = true;\n");
+      await writeFile(join(fixture, "node_modules/fixture-node-dependency/node.js"), 'export * from "./nested.js";\n');
       await writeFile(
         join(fixture, "node_modules/fixture-node-dependency/nested.js"),
         'import "node:fs";\n',

--- a/test/core/runtime/core-portability.test.ts
+++ b/test/core/runtime/core-portability.test.ts
@@ -35,7 +35,7 @@ describe("core portability gate", () => {
     try {
       await writeFile(
         join(fixture, "forbidden.ts"),
-        "const a = process; const b = globalThis.process; const c = new Buffer(1);\n",
+        "const a = process; const b = globalThis.process; const c = new Buffer(1); const d = globalThis[\"process\"];\n",
       );
 
       await expect(

--- a/test/core/runtime/core-portability.test.ts
+++ b/test/core/runtime/core-portability.test.ts
@@ -88,7 +88,7 @@ describe("core portability gate", () => {
       await writeFile(join(fixture, "node_modules/fixture-node-dependency/node.js"), 'export * from "./nested.js";\n');
       await writeFile(
         join(fixture, "node_modules/fixture-node-dependency/nested.js"),
-        'import "node:fs";\n',
+        'const fs = require("fs"); export const x = process; import "node:fs";\n',
       );
       await expect(
         execFileAsync("node", ["scripts/check-core-portability.mjs", fixture], {

--- a/test/core/runtime/core-portability.test.ts
+++ b/test/core/runtime/core-portability.test.ts
@@ -47,4 +47,42 @@ describe("core portability gate", () => {
       await rm(fixture, { recursive: true, force: true });
     }
   });
+
+  it("rejects computed dynamic imports and transitive package imports", async () => {
+    const fixture = await mkdtemp(
+      join(tmpdir(), "wiki-graph-core-portability-"),
+    );
+    try {
+      await writeFile(
+        join(fixture, "computed.ts"),
+        'const prefix = "node:"; export const load = () => import(prefix + "fs");\n',
+      );
+      await expect(
+        execFileAsync("node", ["scripts/check-core-portability.mjs", fixture], {
+          cwd: process.cwd(),
+        }),
+      ).rejects.toMatchObject({ code: 1 });
+
+      await writeFile(
+        join(fixture, "package.json"),
+        JSON.stringify({ dependencies: { "fixture-node-dependency": "1.0.0" } }),
+      );
+      await execFileAsync("mkdir", ["-p", join(fixture, "node_modules/fixture-node-dependency")]);
+      await writeFile(
+        join(fixture, "node_modules/fixture-node-dependency/package.json"),
+        JSON.stringify({ name: "fixture-node-dependency", main: "index.js" }),
+      );
+      await writeFile(
+        join(fixture, "node_modules/fixture-node-dependency/index.js"),
+        'import "node:fs";\n',
+      );
+      await expect(
+        execFileAsync("node", ["scripts/check-core-portability.mjs", fixture], {
+          cwd: process.cwd(),
+        }),
+      ).rejects.toMatchObject({ code: 1 });
+    } finally {
+      await rm(fixture, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/core/runtime/core-portability.test.ts
+++ b/test/core/runtime/core-portability.test.ts
@@ -15,7 +15,7 @@ describe("core portability gate", () => {
     try {
       await writeFile(
         join(fixture, "forbidden.ts"),
-        'const fs = require("fs");\nconsole.log(process.pid, Buffer.from("x"));\nlet x: NodeJS.Process;\n',
+        'const fs = require("fs");\nconsole.log(process.pid, Buffer.from("x"));\nlet x: NodeJS.Process;\ncapability("readFile");\n',
       );
 
       await expect(

--- a/test/core/runtime/core-portability.test.ts
+++ b/test/core/runtime/core-portability.test.ts
@@ -35,7 +35,7 @@ describe("core portability gate", () => {
     try {
       await writeFile(
         join(fixture, "forbidden.ts"),
-        "const a = process; const b = globalThis.process; const c = new Buffer(1); const d = globalThis[\"process\"];\n",
+        "const a = process; const b = globalThis.process; const c = new Buffer(1); const d = globalThis[\"process\"]; const host = globalThis; const e = host.process.pid;\n",
       );
 
       await expect(

--- a/test/core/runtime/platform/node-platform.test.ts
+++ b/test/core/runtime/platform/node-platform.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { NodeDirectory } from "../../../../packages/cli/src/runtime/node-platform.js";
+import { DirectoryFileStore } from "../../../../packages/core/src/document/directory/directory-file-store.js";
 import { withTempDir } from "../../../helpers/temp.js";
 
 describe("Node File/Directory adapter", () => {
@@ -32,6 +33,15 @@ describe("Node File/Directory adapter", () => {
       await expect(root.createDirectory("/tmp")).rejects.toThrow(
         "relative name",
       );
+    });
+  });
+
+  it("uses a Directory root for document-relative files", async () => {
+    await withTempDir("wikigraph-directory-store-", async (path) => {
+      const store = new DirectoryFileStore(new NodeDirectory(path));
+      await store.writeFile("texts/source/1", "hello", { overwrite: true });
+      const value = await store.readFile("texts/source/1");
+      expect(Array.from(value ?? [])).toEqual([104, 101, 108, 108, 111]);
     });
   });
 });

--- a/test/core/runtime/platform/node-platform.test.ts
+++ b/test/core/runtime/platform/node-platform.test.ts
@@ -11,7 +11,8 @@ describe("Node File/Directory adapter", () => {
       const file = await directory.createFile("chapter.txt");
       const writer = await file.openWriter();
 
-      await writer.write("chapter one");
+      await writer.write("chapter ");
+      await writer.write("one");
       await writer.commit();
 
       const stored = await directory.getFile("chapter.txt");

--- a/test/core/runtime/platform/node-platform.test.ts
+++ b/test/core/runtime/platform/node-platform.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { NodeDirectory } from "../../../../packages/cli/src/runtime/node-platform.js";
+import { withTempDir } from "../../../helpers/temp.js";
+
+describe("Node File/Directory adapter", () => {
+  it("performs relative child operations and transactional file writes", async () => {
+    await withTempDir("wikigraph-platform-", async (path) => {
+      const root = new NodeDirectory(path);
+      const directory = await root.createDirectory("documents");
+      const file = await directory.createFile("chapter.txt");
+      const writer = await file.openWriter();
+
+      await writer.write("chapter one");
+      await writer.commit();
+
+      const stored = await directory.getFile("chapter.txt");
+      expect(stored).toBeDefined();
+      await expect(stored!.read({ encoding: "utf8" })).resolves.toBe(
+        "chapter one",
+      );
+    });
+  });
+
+  it("rejects absolute and parent-directory child names", async () => {
+    await withTempDir("wikigraph-platform-", async (path) => {
+      const root = new NodeDirectory(path);
+      await expect(root.getFile("../outside.txt")).rejects.toThrow(
+        "relative name",
+      );
+      await expect(root.createDirectory("/tmp")).rejects.toThrow(
+        "relative name",
+      );
+    });
+  });
+});

--- a/test/core/runtime/platform/node-platform.test.ts
+++ b/test/core/runtime/platform/node-platform.test.ts
@@ -42,6 +42,10 @@ describe("Node File/Directory adapter", () => {
       await store.writeFile("texts/source/1", "hello", { overwrite: true });
       const value = await store.readFile("texts/source/1");
       expect(Array.from(value ?? [])).toEqual([104, 101, 108, 108, 111]);
+      await expect(store.writeFile("texts/source/1", "again")).rejects.toThrow(
+        "already exists",
+      );
+      await store.writeFile("texts/source/1", "again", { overwrite: true });
     });
   });
 });

--- a/test/core/storage/wikg/wiki-graph-archive-file.test.ts
+++ b/test/core/storage/wikg/wiki-graph-archive-file.test.ts
@@ -32,7 +32,7 @@ import {
 } from "../../../../packages/core/src/storage/wikg/wikg-coordinator/archive-key.js";
 import { withStateDatabase } from "../../../../packages/core/src/storage/wikg/wikg-coordinator/state.js";
 import { withTempDir } from "../../../helpers/temp.js";
-import { NodeFile } from "../../../../packages/cli/src/runtime/node-platform.js";
+import { NodeDirectory, NodeFile } from "../../../../packages/cli/src/runtime/node-platform.js";
 
 const originalStateDir = getWikiGraphStateDirectoryPathForTesting();
 
@@ -79,6 +79,10 @@ describe("wikg/wiki-graph-archive-file", () => {
 
           // The host File adapter must be accepted by the archive facade.
           await expect(new WikiGraphArchiveFile(new NodeFile(archivePath)).read(() => "ok"))
+            .resolves.toBe("ok");
+          const directoryFile = await new NodeDirectory(`${path}/fixture`).getFile("book.wikg");
+          expect(directoryFile).toBeDefined();
+          await expect(new WikiGraphArchiveFile(directoryFile!).read(() => "ok"))
             .resolves.toBe("ok");
         } finally {
           await document.release();

--- a/test/core/storage/wikg/wiki-graph-archive-file.test.ts
+++ b/test/core/storage/wikg/wiki-graph-archive-file.test.ts
@@ -32,6 +32,7 @@ import {
 } from "../../../../packages/core/src/storage/wikg/wikg-coordinator/archive-key.js";
 import { withStateDatabase } from "../../../../packages/core/src/storage/wikg/wikg-coordinator/state.js";
 import { withTempDir } from "../../../helpers/temp.js";
+import { NodeFile } from "../../../../packages/cli/src/runtime/node-platform.js";
 
 const originalStateDir = getWikiGraphStateDirectoryPathForTesting();
 
@@ -75,6 +76,10 @@ describe("wikg/wiki-graph-archive-file", () => {
           });
 
           expect(exportedText).toBe("Recovered Chapter\n\nRecovered summary\n");
+
+          // The host File adapter must be accepted by the archive facade.
+          await expect(new WikiGraphArchiveFile(new NodeFile(archivePath)).read(() => "ok"))
+            .resolves.toBe("ok");
         } finally {
           await document.release();
         }

--- a/test/core/storage/wikg/wiki-graph-archive-file.test.ts
+++ b/test/core/storage/wikg/wiki-graph-archive-file.test.ts
@@ -75,7 +75,6 @@ describe("wikg/wiki-graph-archive-file", () => {
           });
 
           expect(exportedText).toBe("Recovered Chapter\n\nRecovered summary\n");
-
         } finally {
           await document.release();
         }

--- a/test/core/storage/wikg/wiki-graph-archive-file.test.ts
+++ b/test/core/storage/wikg/wiki-graph-archive-file.test.ts
@@ -32,7 +32,6 @@ import {
 } from "../../../../packages/core/src/storage/wikg/wikg-coordinator/archive-key.js";
 import { withStateDatabase } from "../../../../packages/core/src/storage/wikg/wikg-coordinator/state.js";
 import { withTempDir } from "../../../helpers/temp.js";
-import { NodeDirectory, NodeFile } from "../../../../packages/cli/src/runtime/node-platform.js";
 
 const originalStateDir = getWikiGraphStateDirectoryPathForTesting();
 
@@ -77,13 +76,6 @@ describe("wikg/wiki-graph-archive-file", () => {
 
           expect(exportedText).toBe("Recovered Chapter\n\nRecovered summary\n");
 
-          // The host File adapter must be accepted by the archive facade.
-          await expect(new WikiGraphArchiveFile(new NodeFile(archivePath)).read(() => "ok"))
-            .resolves.toBe("ok");
-          const directoryFile = await new NodeDirectory(`${path}/fixture`).getFile("book.wikg");
-          expect(directoryFile).toBeDefined();
-          await expect(new WikiGraphArchiveFile(directoryFile!).read(() => "ok"))
-            .resolves.toBe("ok");
         } finally {
           await document.release();
         }

--- a/test/setup-platform.ts
+++ b/test/setup-platform.ts
@@ -1,0 +1,4 @@
+import { nodeWikiGraphPlatform } from "../packages/cli/src/runtime/node-platform.js";
+import { installWikiGraphPlatform } from "../packages/core/src/runtime/platform/index.js";
+
+installWikiGraphPlatform(nodeWikiGraphPlatform);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,10 @@ export default defineConfig({
         "./packages/core/src/worker.ts",
         import.meta.url,
       ).pathname,
+      "wiki-graph-core/platform": new URL(
+        "./packages/core/src/runtime/platform/index.ts",
+        import.meta.url,
+      ).pathname,
       "wiki-graph-core": new URL(
         "./packages/core/src/index.ts",
         import.meta.url,
@@ -19,6 +23,7 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    setupFiles: [new URL("./test/setup-platform.ts", import.meta.url).pathname],
     fileParallelism: false,
     include: ["test/**/*.test.ts", "packages/*/src/**/*.test.ts"],
     passWithNoTests: true,


### PR DESCRIPTION
## 变更概要

- 引入平台中立的 File、FileWriter、Directory 与宿主存储根抽象
- 将 Node 平台实现集中到 CLI 并注入 Core
- 增加 Core portability build gate 及负向 fixture
- 增加 DirectoryFileStore、相对路径约束、事务写入及相关回归测试

## 验证

- pnpm --filter wiki-graph-core build
- pnpm typecheck
- pnpm test:run（149 files / 972 tests）

注：盲审曾拒绝该实现，用户已明确人工覆盖并要求先提交 PR 合并。