### PR TITLE
Archive 与 Document 的 File/Directory 全链路迁移

### DIFF
--- a/docs/en/sdk.md
+++ b/docs/en/sdk.md
@@ -64,6 +64,10 @@ await wikiGraph.openSession(archive, (session) => session.readMeta());
 `File`/`Directory` are platform primitives. Core never interprets their URI or
 absolute path; browser and extension hosts can back them with IndexedDB,
 OPFS, or another scoped store. The `wiki-graph` CLI supplies the Node adapter.
+Each `File.identity` and `Directory.identity` is a stable, opaque coordination
+key—not a path or URI.
+Archive SQLite workspaces are created only below the supplied `documentStore`
+and are removed after the archive session settles.
 `WikiGraphPlatform` is process-wide host infrastructure for async context,
 database, and ZIP operations, so an application installs it once after import.
 The two storage roots belong to each `WikiGraph` instance and remain isolated

--- a/docs/zh-CN/sdk.md
+++ b/docs/zh-CN/sdk.md
@@ -57,6 +57,7 @@ await wikiGraph.openSession(archive, (session) => session.readMeta());
 ```
 
 `File`/`Directory` 是平台原语，Core 不解析它们背后的 URI 或绝对路径。浏览器、Extension 等宿主可以使用 IndexedDB、OPFS 或其他受限存储；`wiki-graph` CLI 提供 Node 适配器。
+每个 `File.identity` 和 `Directory.identity` 都是稳定、不透明的协调标识，而不是路径或 URI。归档使用的 SQLite 工作区只会创建在传入的 `documentStore` 下，并在会话完成后清理。
 `WikiGraphPlatform` 是进程级宿主基础设施，负责异步上下文、数据库和 ZIP；应用在 import 后安装一次即可。两个存储目录根则归各自的 `WikiGraph` 实例所有，并发运行多个实例时不会互相覆盖。
 
 ```ts

--- a/packages/cli/src/runtime/node-platform.ts
+++ b/packages/cli/src/runtime/node-platform.ts
@@ -38,12 +38,17 @@ import {
 
 /** Install the Node implementation used by the CLI and its workers. */
 export class NodeFile implements File {
+  public readonly identity: string;
   public readonly name: string;
 
   public constructor(
     public readonly path: string,
     name = pathModule.basename(path),
   ) {
+    this.identity = crypto
+      .createHash("sha256")
+      .update(pathModule.resolve(path))
+      .digest("hex");
     this.name = name;
   }
 
@@ -56,6 +61,10 @@ export class NodeFile implements File {
         ? undefined
         : { encoding: options.encoding as BufferEncoding },
     );
+  }
+
+  public async getSize(): Promise<number> {
+    return (await fsPromises.stat(this.path)).size;
   }
 
   public async openWriter(): Promise<FileWriter> {
@@ -87,9 +96,14 @@ export class NodeFile implements File {
 }
 
 export class NodeDirectory implements Directory {
+  public readonly identity: string;
   public readonly name: string;
 
   public constructor(public readonly path: string) {
+    this.identity = crypto
+      .createHash("sha256")
+      .update(`directory\0${pathModule.resolve(path)}`)
+      .digest("hex");
     this.name = pathModule.basename(path);
   }
 
@@ -294,7 +308,7 @@ async function writeNodeZip(
   const zipFile = new yazl.ZipFile();
   const output = collectNodeStream(zipFile.outputStream);
   for await (const entry of entries) {
-    zipFile.addBuffer(Buffer.from(entry.data), entry.name);
+    zipFile.addBuffer(Buffer.from(entry.data), entry.name, { compress: false });
   }
   zipFile.end();
 

--- a/packages/core/src/api/wiki-graph-archive.ts
+++ b/packages/core/src/api/wiki-graph-archive.ts
@@ -1,4 +1,5 @@
 import type { ReadonlyDocument } from "../document/index.js";
+import type { File } from "../runtime/platform/index.js";
 import { writeEpub, writePlainText } from "../text/output/index.js";
 import type {
   BookMeta,
@@ -9,6 +10,7 @@ import type {
 
 import {
   readWikgArchiveFormatVersion,
+  readWikgArchiveEntry,
   writeWikgArchive,
 } from "../storage/wikg/index.js";
 import type { ChapterStage } from "./chapter/index.js";
@@ -16,14 +18,17 @@ import type { WikiGraphSerialEntry } from "./types.js";
 
 export class WikiGraphArchive {
   readonly #document: ReadonlyDocument;
-  readonly #documentDirectoryPath: string;
+  readonly #source: File | string;
+  readonly #sourceKind: "archive" | "directory";
 
   public constructor(
     document: ReadonlyDocument,
-    documentDirectoryPath: string,
+    source: File | string,
+    options: { readonly sourceKind?: "archive" | "directory" } = {},
   ) {
     this.#document = document;
-    this.#documentDirectoryPath = documentDirectoryPath;
+    this.#source = source;
+    this.#sourceKind = options.sourceKind ?? "directory";
   }
 
   public async exportEpub(path: string): Promise<void> {
@@ -53,7 +58,18 @@ export class WikiGraphArchive {
   }
 
   public async readArchiveFormatVersion(): Promise<number> {
-    return await readWikgArchiveFormatVersion(this.#documentDirectoryPath);
+    if (this.#sourceKind === "directory") {
+      if (typeof this.#source !== "string") {
+        throw new Error("A document directory cannot be represented by File");
+      }
+      return await readWikgArchiveFormatVersion(this.#source);
+    }
+    const manifest = await readWikgArchiveEntry(this.#source, "manifest.json");
+    if (manifest === undefined) throw new Error("WIKG manifest is missing");
+    const parsed = JSON.parse(new TextDecoder().decode(manifest)) as {
+      formatVersion: number;
+    };
+    return parsed.formatVersion;
   }
 
   public async readChapterStage(serialId: number): Promise<ChapterStage> {
@@ -126,8 +142,13 @@ export class WikiGraphArchive {
   }
 
   public async saveAs(path: string): Promise<void> {
+    if (this.#sourceKind !== "directory" || typeof this.#source !== "string") {
+      throw new Error(
+        "saveAs(path) is unavailable for an opened archive; use a host File writer.",
+      );
+    }
     await flushDocument(this.#document);
-    await writeWikgArchive(this.#documentDirectoryPath, path);
+    await writeWikgArchive(this.#source, path);
   }
 }
 

--- a/packages/core/src/document/database.ts
+++ b/packages/core/src/document/database.ts
@@ -1,12 +1,15 @@
 import { binary as platformBinary } from "../runtime/platform/index.js";
 import {
   AsyncLocalStorage,
+  getWikiGraphPlatform,
   getDatabaseCapability,
-  openDatabase,
   resolve,
   stat,
 } from "../runtime/platform/index.js";
-import type { File } from "../runtime/platform/index.js";
+import type {
+  File,
+  HostDatabaseConnection,
+} from "../runtime/platform/index.js";
 
 type SqliteDatabase = {
   run(
@@ -27,6 +30,16 @@ type SqliteDatabase = {
   exec(sql: string, callback: (error?: Error | null) => void): any;
   close(callback: (error?: Error | null) => void): void;
 };
+interface DatabaseBackend {
+  close(): Promise<void>;
+  execute(sql: string): Promise<void>;
+  queryAll(sql: string, params: SqlBindParams | undefined): Promise<SqlRow[]>;
+  queryOne(
+    sql: string,
+    params: SqlBindParams | undefined,
+  ): Promise<SqlRow | undefined>;
+  run(sql: string, params: SqlBindParams | undefined): Promise<void>;
+}
 type Sqlite3Module = {
   readonly OPEN_READONLY: number;
   readonly OPEN_READWRITE: number;
@@ -50,7 +63,12 @@ type DatabaseOperationScope = symbol;
 
 async function isMissingOrEmptyFile(path: File | string): Promise<boolean> {
   if (typeof path !== "string") {
-    return path.size === undefined || path.size === 0;
+    if (path.size !== undefined) return path.size === 0;
+    if (path.getSize !== undefined) return (await path.getSize()) === 0;
+    const content = await path.read();
+    return typeof content === "string"
+      ? content.length === 0
+      : content.byteLength === 0;
   }
   const stats = await stat(path).catch((error: unknown) => {
     if (
@@ -69,7 +87,7 @@ async function isMissingOrEmptyFile(path: File | string): Promise<boolean> {
 }
 
 export class Database {
-  readonly #database: SqliteDatabase;
+  readonly #database: DatabaseBackend;
   readonly #onWrite: (() => void) | undefined;
   readonly #operationScope = new AsyncLocalStorage<DatabaseOperationScope>();
   #activeTransactionScope: DatabaseOperationScope | undefined;
@@ -78,7 +96,7 @@ export class Database {
   #transactionDepth = 0;
 
   public constructor(
-    database: SqliteDatabase,
+    database: DatabaseBackend,
     options: { readonly onWrite?: () => void } = {},
   ) {
     this.#database = database;
@@ -116,7 +134,7 @@ export class Database {
   }
 
   public static async initialize(
-    databasePath: string,
+    databasePath: File | string,
     schemaSql: string,
   ): Promise<void> {
     const database = await Database.open(databasePath);
@@ -266,85 +284,32 @@ export class Database {
   }
 
   async #closeDatabase(): Promise<void> {
-    await new Promise<void>((resolveClose, rejectClose) => {
-      this.#database.close((error: any) => {
-        if (error !== null) {
-          rejectClose(error);
-          return;
-        }
-
-        resolveClose();
-      });
-    });
+    await this.#database.close();
   }
 
   async #executeSql(sql: string): Promise<void> {
-    await new Promise<void>((resolveExec, rejectExec) => {
-      this.#database.exec(sql, (error: any) => {
-        if (error !== null) {
-          rejectExec(error);
-          return;
-        }
-
-        resolveExec();
-      });
-    });
+    await this.#database.execute(sql);
   }
 
   async #queryAllRows(
     sql: string,
     params: SqlBindParams | undefined,
   ): Promise<SqlRow[]> {
-    return await new Promise<SqlRow[]>((resolveAll, rejectAll) => {
-      this.#database.all<SqlRow>(
-        sql,
-        normalizeSqlBindParams(params),
-        (error, rows) => {
-          if (error !== null) {
-            rejectAll(error);
-            return;
-          }
-
-          resolveAll(rows);
-        },
-      );
-    });
+    return await this.#database.queryAll(sql, params);
   }
 
   async #queryOneRow(
     sql: string,
     params: SqlBindParams | undefined,
   ): Promise<SqlRow | undefined> {
-    return await new Promise<SqlRow | undefined>((resolveGet, rejectGet) => {
-      this.#database.get<SqlRow>(
-        sql,
-        normalizeSqlBindParams(params),
-        (error, row) => {
-          if (error !== null) {
-            rejectGet(error);
-            return;
-          }
-
-          resolveGet(row);
-        },
-      );
-    });
+    return await this.#database.queryOne(sql, params);
   }
 
   async #runStatement(
     sql: string,
     params: SqlBindParams | undefined,
   ): Promise<void> {
-    await new Promise<void>((resolveRun, rejectRun) => {
-      this.#database.run(sql, normalizeSqlBindParams(params), (error: any) => {
-        if (error !== null) {
-          rejectRun(error);
-          return;
-        }
-
-        resolveRun();
-      });
-    });
+    await this.#database.run(sql, params);
   }
 }
 
@@ -388,27 +353,135 @@ export function getOptionalString(
 async function openSqliteDatabase(
   databasePath: File | string,
   options: { readonly readonly?: boolean } = {},
-): Promise<SqliteDatabase> {
+): Promise<DatabaseBackend> {
+  if (typeof databasePath !== "string") {
+    return new HostDatabaseBackend(
+      await getWikiGraphPlatform().database.open(databasePath, options),
+    );
+  }
+
   const sqlite3 = await loadSqlite3();
   const flags =
     (options.readonly === true
       ? sqlite3.OPEN_READONLY
       : sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE) | sqlite3.OPEN_FULLMUTEX;
 
-  if (typeof databasePath !== "string") {
-    return await openDatabase(databasePath, flags);
+  const database = await new Promise<SqliteDatabase>(
+    (resolveOpen, rejectOpen) => {
+      const database = new sqlite3.Database(
+        databasePath,
+        flags,
+        (error: any) => {
+          if (error !== null) {
+            rejectOpen(error);
+            return;
+          }
+
+          resolveOpen(database);
+        },
+      );
+    },
+  );
+  return new LegacyDatabaseBackend(database);
+}
+
+class HostDatabaseBackend implements DatabaseBackend {
+  readonly #connection: HostDatabaseConnection;
+
+  public constructor(connection: HostDatabaseConnection) {
+    this.#connection = connection;
   }
 
-  return await new Promise<SqliteDatabase>((resolveOpen, rejectOpen) => {
-    const database = new sqlite3.Database(databasePath, flags, (error: any) => {
-      if (error !== null) {
-        rejectOpen(error);
-        return;
-      }
+  public async close(): Promise<void> {
+    await this.#connection.close();
+  }
+  public async execute(sql: string): Promise<void> {
+    await this.#connection.execute(sql);
+  }
+  public async queryAll(
+    sql: string,
+    params: SqlBindParams | undefined,
+  ): Promise<SqlRow[]> {
+    return [...(await this.#connection.queryAll(sql, params))] as SqlRow[];
+  }
+  public async queryOne(
+    sql: string,
+    params: SqlBindParams | undefined,
+  ): Promise<SqlRow | undefined> {
+    return (await this.#connection.queryOne(sql, params)) as SqlRow | undefined;
+  }
+  public async run(
+    sql: string,
+    params: SqlBindParams | undefined,
+  ): Promise<void> {
+    await this.#connection.run(sql, params);
+  }
+}
 
-      resolveOpen(database);
+class LegacyDatabaseBackend implements DatabaseBackend {
+  readonly #database: SqliteDatabase;
+
+  public constructor(database: SqliteDatabase) {
+    this.#database = database;
+  }
+
+  public async close(): Promise<void> {
+    await new Promise<void>((resolveClose, rejectClose) => {
+      this.#database.close((error) => {
+        if (error != null) rejectClose(error);
+        else resolveClose();
+      });
     });
-  });
+  }
+  public async execute(sql: string): Promise<void> {
+    await new Promise<void>((resolveExec, rejectExec) => {
+      this.#database.exec(sql, (error) => {
+        if (error != null) rejectExec(error);
+        else resolveExec();
+      });
+    });
+  }
+  public async queryAll(
+    sql: string,
+    params: SqlBindParams | undefined,
+  ): Promise<SqlRow[]> {
+    return await new Promise((resolveAll, rejectAll) => {
+      this.#database.all<SqlRow>(
+        sql,
+        normalizeSqlBindParams(params),
+        (error, rows) => {
+          if (error != null) rejectAll(error);
+          else resolveAll(rows);
+        },
+      );
+    });
+  }
+  public async queryOne(
+    sql: string,
+    params: SqlBindParams | undefined,
+  ): Promise<SqlRow | undefined> {
+    return await new Promise((resolveGet, rejectGet) => {
+      this.#database.get<SqlRow>(
+        sql,
+        normalizeSqlBindParams(params),
+        (error, row) => {
+          if (error != null) rejectGet(error);
+          else resolveGet(row);
+        },
+      );
+    });
+  }
+  public async run(
+    sql: string,
+    params: SqlBindParams | undefined,
+  ): Promise<void> {
+    await new Promise<void>((resolveRun, rejectRun) => {
+      this.#database.run(sql, normalizeSqlBindParams(params), (error) => {
+        if (error != null) rejectRun(error);
+        else resolveRun();
+      });
+    });
+  }
 }
 
 async function loadSqlite3(): Promise<Sqlite3Module> {

--- a/packages/core/src/document/directory/core.ts
+++ b/packages/core/src/document/directory/core.ts
@@ -1,7 +1,5 @@
 import {
   AsyncLocalStorage,
-  getRelativeFile,
-  join,
   resolve,
   type Directory,
 } from "../../runtime/platform/index.js";
@@ -45,6 +43,7 @@ import {
   writeNewFile,
 } from "./files.js";
 import { openSearchIndexDatabase } from "./search-index.js";
+import { joinDocumentPath } from "./path.js";
 import {
   deleteSerialGraphRecords,
   deleteSerialKnowledgeGraphRecords,
@@ -117,12 +116,26 @@ export class DirectoryDocument implements Document {
       (typeof documentPath === "string"
         ? LOCAL_DOCUMENT_FILE_STORE
         : new DirectoryFileStore(documentPath));
+    return await DirectoryDocument.#openFileStore(
+      resolvedDocumentPath,
+      fileStore,
+    );
+  }
+
+  /** Open a document whose files are addressed only by logical relative names. */
+  public static async openFileStore(
+    fileStore: DocumentFileStore,
+  ): Promise<DirectoryDocument> {
+    return await DirectoryDocument.#openFileStore("", fileStore);
+  }
+
+  static async #openFileStore(
+    resolvedDocumentPath: string,
+    fileStore: DocumentFileStore,
+  ): Promise<DirectoryDocument> {
     try {
       const databasePath =
-        typeof documentPath === "string"
-          ? await fileStore.resolveDatabasePath(resolvedDocumentPath)
-          : ((await getRelativeFile(documentPath, "database.db")) ??
-            (await documentPath.createFile("database.db")));
+        await fileStore.resolveDatabasePath(resolvedDocumentPath);
       await fileStore.ensureDirectory(resolvedDocumentPath);
 
       const shouldInitializeDatabaseSchema =
@@ -140,19 +153,24 @@ export class DirectoryDocument implements Document {
       if (shouldInitializeDatabaseSchema) {
         await initializeDocumentSchema(database);
       }
-      const textStreams = new TextStreams(resolvedDocumentPath, database, {
-        deleteTree: async (path) => {
-          await fileStore.deleteTree(path);
+      const textStreams = new TextStreams(
+        resolvedDocumentPath,
+        database,
+        {
+          deleteTree: async (path) => {
+            await fileStore.deleteTree(path);
+          },
+          ensureDirectory: async (path) => {
+            await fileStore.ensureDirectory(path);
+          },
+          listFiles: async (path) => await fileStore.listFiles(path),
+          readFile: async (path) => await fileStore.readFile(path),
+          writeFile: async (path, content, options) => {
+            await fileStore.writeFile(path, content, options);
+          },
         },
-        ensureDirectory: async (path) => {
-          await fileStore.ensureDirectory(path);
-        },
-        listFiles: async (path) => await fileStore.listFiles(path),
-        readFile: async (path) => await fileStore.readFile(path),
-        writeFile: async (path, content, options) => {
-          await fileStore.writeFile(path, content, options);
-        },
-      });
+        fileStore.documentIdentity?.() ?? resolvedDocumentPath,
+      );
       await textStreams.ensureCreated();
 
       const document = new DirectoryDocument(
@@ -320,9 +338,9 @@ export class DirectoryDocument implements Document {
   }
 
   public async deleteSearchIndexDatabase(): Promise<void> {
-    await this.#fileStore.deleteFile(join(this.path, "index.db"));
+    await this.#fileStore.deleteFile(joinDocumentPath(this.path, "index.db"));
     await this.#fileStore
-      .deleteFile(join(this.path, "fts.db"))
+      .deleteFile(joinDocumentPath(this.path, "fts.db"))
       .catch(() => undefined);
   }
 

--- a/packages/core/src/document/directory/directory-file-store.ts
+++ b/packages/core/src/document/directory/directory-file-store.ts
@@ -13,6 +13,12 @@ export class DirectoryFileStore implements DocumentFileStore {
   public close(): Promise<void> {
     return Promise.resolve();
   }
+  public documentIdentity(): string {
+    return this.#root.identity;
+  }
+  public searchIndexLockKey(): string {
+    return this.#root.identity;
+  }
   public initializeDatabaseSchema(): boolean {
     return true;
   }

--- a/packages/core/src/document/directory/files.ts
+++ b/packages/core/src/document/directory/files.ts
@@ -1,8 +1,6 @@
-import { binary as platformBinary } from "../../runtime/platform/index.js";
-import { join } from "../../runtime/platform/index.js";
-
 import { isNodeError } from "../../utils/node-error.js";
 import type { DirectoryDocumentContext } from "./context.js";
+import { joinDocumentPath } from "./path.js";
 import type { DocumentFileStore } from "./types.js";
 
 export async function readJsonFile<T>(input: {
@@ -58,19 +56,19 @@ export async function writeNewFile(input: {
 }
 
 export function getCoverDataPath(documentPath: string): string {
-  return join(getCoverDirectoryPath(documentPath), "data.bin");
+  return joinDocumentPath(getCoverDirectoryPath(documentPath), "data.bin");
 }
 
 export function getCoverDirectoryPath(documentPath: string): string {
-  return join(documentPath, "cover");
+  return joinDocumentPath(documentPath, "cover");
 }
 
 export function getCoverInfoPath(documentPath: string): string {
-  return join(getCoverDirectoryPath(documentPath), "info.json");
+  return joinDocumentPath(getCoverDirectoryPath(documentPath), "info.json");
 }
 
 export function getTocPath(documentPath: string): string {
-  return join(documentPath, "toc.json");
+  return joinDocumentPath(documentPath, "toc.json");
 }
 
 async function readOptionalTextFile(
@@ -79,9 +77,7 @@ async function readOptionalTextFile(
 ): Promise<string | undefined> {
   const content = await fileStore.readFile(path);
 
-  return content === undefined
-    ? undefined
-    : platformBinary.from(content).toString("utf8");
+  return content === undefined ? undefined : new TextDecoder().decode(content);
 }
 
 async function writeFile(input: {

--- a/packages/core/src/document/directory/path.ts
+++ b/packages/core/src/document/directory/path.ts
@@ -1,0 +1,19 @@
+import { join, resolve } from "../../runtime/platform/index.js";
+
+/** Preserve logical archive names without asking the host to resolve a path. */
+export function resolveDocumentPath(path: string): string {
+  return path === "" ? "" : resolve(path);
+}
+
+/** Join relative document names; OS paths remain a legacy string concern. */
+export function joinDocumentPath(root: string, ...parts: string[]): string {
+  return isLogicalRoot(root)
+    ? [root, ...parts].filter((part) => part !== "").join("/")
+    : join(root, ...parts);
+}
+
+function isLogicalRoot(root: string): boolean {
+  return (
+    root === "" || (!root.startsWith("/") && !/^[A-Za-z]:[\\/]/u.test(root))
+  );
+}

--- a/packages/core/src/document/directory/search-index.ts
+++ b/packages/core/src/document/directory/search-index.ts
@@ -1,4 +1,4 @@
-import { stat } from "../../runtime/platform/index.js";
+import { stat, type File } from "../../runtime/platform/index.js";
 import { join, resolve } from "../../runtime/platform/index.js";
 
 import { isNodeError } from "../../utils/node-error.js";
@@ -10,7 +10,7 @@ import {
 import type { DocumentFileStore } from "./types.js";
 import { SEARCH_INDEX_VERSION } from "../../retrieval/search-index/search/types.js";
 
-const searchIndexLifecycleLocks = new Map<string, Promise<void>>();
+const searchIndexLifecycleLocks = new Map<object | string, Promise<void>>();
 
 export async function openSearchIndexDatabase<T>(input: {
   readonly documentPath: string;
@@ -18,8 +18,9 @@ export async function openSearchIndexDatabase<T>(input: {
   readonly operation: (database: Database) => Promise<T> | T;
   readonly readonly: boolean;
 }): Promise<T> {
-  return await withSearchIndexLifecycleLock(resolve(input.documentPath), () =>
-    openSearchIndexDatabaseLocked(input),
+  return await withSearchIndexLifecycleLock(
+    input.fileStore.searchIndexLockKey?.() ?? resolve(input.documentPath),
+    () => openSearchIndexDatabaseLocked(input),
   );
 }
 
@@ -78,7 +79,7 @@ async function openSearchIndexDatabaseLocked<T>(input: {
 }
 
 async function withSearchIndexLifecycleLock<T>(
-  key: string,
+  key: object | string,
   operation: () => Promise<T>,
 ): Promise<T> {
   const previous = searchIndexLifecycleLocks.get(key) ?? Promise.resolve();
@@ -101,7 +102,15 @@ async function withSearchIndexLifecycleLock<T>(
   }
 }
 
-async function isMissingOrEmptyFile(path: string): Promise<boolean> {
+async function isMissingOrEmptyFile(path: File | string): Promise<boolean> {
+  if (typeof path !== "string") {
+    if (path.size !== undefined) return path.size === 0;
+    if (path.getSize !== undefined) return (await path.getSize()) === 0;
+    const content = await path.read();
+    return typeof content === "string"
+      ? content.length === 0
+      : content.byteLength === 0;
+  }
   const stats = await stat(path).catch((error: unknown) => {
     if (isNodeError(error) && error.code === "ENOENT") {
       return undefined;
@@ -114,7 +123,7 @@ async function isMissingOrEmptyFile(path: string): Promise<boolean> {
 }
 
 async function isSearchIndexDatabaseCompatible(
-  databasePath: string,
+  databasePath: File | string,
 ): Promise<boolean> {
   const database = await Database.open(databasePath, "", {
     readonly: true,
@@ -148,7 +157,9 @@ async function deleteSearchIndexDatabaseFile(
   documentPath: string,
 ): Promise<void> {
   try {
-    await fileStore.deleteFile(join(documentPath, "index.db"));
+    await fileStore.deleteFile(
+      documentPath === "" ? "index.db" : join(documentPath, "index.db"),
+    );
   } catch (error) {
     if (isNodeError(error) && error.code === "ENOENT") {
       return;

--- a/packages/core/src/document/directory/types.ts
+++ b/packages/core/src/document/directory/types.ts
@@ -41,10 +41,12 @@ export interface DocumentFileStore {
   deleteFile(path: string): Promise<void>;
   deleteTree(path: string): Promise<void>;
   ensureDirectory(path: string): Promise<void>;
+  documentIdentity?(): string;
   initializeDatabaseSchema(): boolean;
   markDatabaseDirty?(): void;
   markSearchIndexDatabaseDirty?(): void;
   openDatabaseReadonly(): boolean;
+  searchIndexLockKey?(): object | string;
   listFileContents?(path: string): Promise<ReadonlyMap<string, Uint8Array>>;
   listFiles(path: string): Promise<readonly string[]>;
   readFile(path: string): Promise<Uint8Array | undefined>;

--- a/packages/core/src/document/text-streams/core.ts
+++ b/packages/core/src/document/text-streams/core.ts
@@ -1,6 +1,5 @@
-import { join, resolve } from "../../runtime/platform/index.js";
-
 import type { Database } from "../database.js";
+import { joinDocumentPath, resolveDocumentPath } from "../directory/path.js";
 import type { SentenceId } from "../types.js";
 import { DEFAULT_FILE_ACCESS } from "./file-access.js";
 import { SerialTextStream } from "./serial.js";
@@ -14,15 +13,18 @@ export class TextStreams implements ReadonlyTextStreams {
   readonly #database: Database;
   readonly #documentPath: string;
   readonly #fileAccess: TextStreamFileAccess;
+  readonly #identity: string;
 
   public constructor(
     documentPath: string,
     database: Database,
     fileAccess: TextStreamFileAccess = DEFAULT_FILE_ACCESS,
+    identity = documentPath,
   ) {
     this.#database = database;
-    this.#documentPath = resolve(documentPath);
+    this.#documentPath = resolveDocumentPath(documentPath);
     this.#fileAccess = fileAccess;
+    this.#identity = identity;
   }
 
   public async ensureCreated(): Promise<void> {
@@ -42,6 +44,7 @@ export class TextStreams implements ReadonlyTextStreams {
       this.#fileAccess,
       "source",
       serialId,
+      this.#identity,
     );
   }
 
@@ -52,10 +55,11 @@ export class TextStreams implements ReadonlyTextStreams {
       this.#fileAccess,
       "summary",
       serialId,
+      this.#identity,
     );
   }
 
   #getRootPath(stream: TextStreamName): string {
-    return join(this.#documentPath, "texts", stream);
+    return joinDocumentPath(this.#documentPath, "texts", stream);
   }
 }

--- a/packages/core/src/document/text-streams/sentence.ts
+++ b/packages/core/src/document/text-streams/sentence.ts
@@ -1,4 +1,3 @@
-import { binary as platformBinary } from "../../runtime/platform/index.js";
 import { countTextWords } from "../../utils/text-word-count.js";
 import { Sentence, type SentenceRecord } from "../types.js";
 import type { TextStreamSentenceSegmenter } from "./types.js";
@@ -34,11 +33,8 @@ export async function splitTextIntoSentenceSpans(
     const sentence = new Sentence(rawText, countTextWords(rawText));
 
     Object.assign(sentence, {
-      byteLength: platformBinary.byteLength(rawText, "utf8"),
-      byteOffset: platformBinary.byteLength(
-        text.slice(0, segment.index),
-        "utf8",
-      ),
+      byteLength: utf8ByteLength(rawText),
+      byteOffset: utf8ByteLength(text.slice(0, segment.index)),
     });
     spans.push(
       sentence as unknown as SentenceRecord & {
@@ -81,11 +77,8 @@ async function splitTextIntoCustomSentenceSpans(
     const sentence = new Sentence(rawText, segment.wordsCount);
 
     Object.assign(sentence, {
-      byteLength: platformBinary.byteLength(rawText, "utf8"),
-      byteOffset: platformBinary.byteLength(
-        text.slice(0, segment.offset),
-        "utf8",
-      ),
+      byteLength: utf8ByteLength(rawText),
+      byteOffset: utf8ByteLength(text.slice(0, segment.offset)),
     });
     spans.push(
       sentence as unknown as SentenceRecord & {
@@ -126,7 +119,11 @@ export function getSentenceByteLength(sentence: SentenceRecord): number {
 
   return typeof value === "number"
     ? value
-    : platformBinary.byteLength(getSentenceRawText(sentence), "utf8");
+    : utf8ByteLength(getSentenceRawText(sentence));
+}
+
+function utf8ByteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
 }
 
 export function getSentenceRawText(sentence: SentenceRecord): string {

--- a/packages/core/src/document/text-streams/serial.ts
+++ b/packages/core/src/document/text-streams/serial.ts
@@ -1,7 +1,5 @@
-import { binary as platformBinary } from "../../runtime/platform/index.js";
-import { join, resolve } from "../../runtime/platform/index.js";
-
 import type { Database } from "../database.js";
+import { joinDocumentPath, resolveDocumentPath } from "../directory/path.js";
 import {
   Sentence,
   type FragmentRecord,
@@ -34,6 +32,7 @@ export class SerialTextStream implements ReadonlySerialTextStream {
   readonly #fileAccess: TextStreamFileAccess;
   readonly #stream: TextStreamName;
   readonly #serialId: number;
+  readonly #identity: string;
 
   public constructor(
     documentPath: string,
@@ -41,12 +40,14 @@ export class SerialTextStream implements ReadonlySerialTextStream {
     fileAccess: TextStreamFileAccess,
     stream: TextStreamName,
     serialId: number,
+    identity = documentPath,
   ) {
     this.#database = database;
-    this.#documentPath = resolve(documentPath);
+    this.#documentPath = resolveDocumentPath(documentPath);
     this.#fileAccess = fileAccess;
     this.#stream = stream;
     this.#serialId = serialId;
+    this.#identity = identity;
   }
 
   public async createDraft(): Promise<TextStreamDraft> {
@@ -162,9 +163,9 @@ export class SerialTextStream implements ReadonlySerialTextStream {
 
     const content = await this.#readContent();
 
-    return content
-      .subarray(first.byteOffset, last.byteOffset + last.byteLength)
-      .toString("utf8");
+    return new TextDecoder().decode(
+      content.subarray(first.byteOffset, last.byteOffset + last.byteLength),
+    );
   }
 
   async #getSentenceLocation(
@@ -196,15 +197,15 @@ export class SerialTextStream implements ReadonlySerialTextStream {
 
   #readSentenceLocation(
     location: TextSentenceLocation,
-    content: platformBinary,
+    content: Uint8Array,
   ): SentenceRecord {
     return new Sentence(
-      content
-        .subarray(
+      new TextDecoder().decode(
+        content.subarray(
           location.byteOffset,
           location.byteOffset + location.byteLength,
-        )
-        .toString("utf8"),
+        ),
+      ),
       location.wordsCount,
     );
   }
@@ -214,7 +215,7 @@ export class SerialTextStream implements ReadonlySerialTextStream {
 
     return content === undefined
       ? undefined
-      : platformBinary.from(content).toString("utf8");
+      : new TextDecoder().decode(content);
   }
 
   public async writeTextStream(
@@ -265,21 +266,18 @@ export class SerialTextStream implements ReadonlySerialTextStream {
     draftState.draftOpen = false;
 
     const existing = await this.#fileAccess.readFile(this.#getTextPath());
-    const existingBuffer =
-      existing === undefined
-        ? platformBinary.alloc(0)
-        : platformBinary.from(existing);
+    const existingBuffer = existing ?? new Uint8Array();
     const text =
       textOverride === ""
         ? sentences.map(getSentenceRawText).join("")
         : textOverride;
-    const appendBuffer = platformBinary.from(text, "utf8");
+    const appendBuffer = new TextEncoder().encode(text);
     let offset = existingBuffer.length;
 
     await this.#fileAccess.ensureDirectory(this.#getDirectoryPath());
     await this.#fileAccess.writeFile(
       this.#getTextPath(),
-      platformBinary.concat([existingBuffer, appendBuffer]),
+      concatenateBytes(existingBuffer, appendBuffer),
       { overwrite: true },
     );
 
@@ -399,22 +397,22 @@ export class SerialTextStream implements ReadonlySerialTextStream {
     return draftState.nextSentenceIndex;
   }
 
-  async #readContent(): Promise<platformBinary> {
+  async #readContent(): Promise<Uint8Array> {
     const content = await this.#fileAccess.readFile(this.#getTextPath());
 
-    return platformBinary.from(content ?? new Uint8Array());
+    return content ?? new Uint8Array();
   }
 
   #getDirectoryPath(): string {
-    return join(this.#documentPath, "texts", this.#stream);
+    return joinDocumentPath(this.#documentPath, "texts", this.#stream);
   }
 
   #getTextPath(): string {
-    return join(this.#getDirectoryPath(), `${this.#serialId}.txt`);
+    return joinDocumentPath(this.#getDirectoryPath(), `${this.#serialId}.txt`);
   }
 
   #getDraftState(): TextStreamDraftState {
-    const key = `${this.#documentPath}\0${this.#stream}\0${this.#serialId}`;
+    const key = `${this.#identity}\0${this.#stream}\0${this.#serialId}`;
     let state = SerialTextStream.#draftStates.get(key);
 
     if (state === undefined) {
@@ -424,6 +422,13 @@ export class SerialTextStream implements ReadonlySerialTextStream {
 
     return state;
   }
+}
+
+function concatenateBytes(left: Uint8Array, right: Uint8Array): Uint8Array {
+  const result = new Uint8Array(left.byteLength + right.byteLength);
+  result.set(left);
+  result.set(right, left.byteLength);
+  return result;
 }
 
 function mapTextSentenceLocation(

--- a/packages/core/src/runtime/common/logging.ts
+++ b/packages/core/src/runtime/common/logging.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from "../platform/index.js";
-import { appendFile, randomUUID } from "../platform/index.js";
+import { appendFile } from "../platform/index.js";
 import { existsSync, mkdirSync } from "../platform/index.js";
 import { join, resolve } from "../platform/index.js";
 import { runtimeContext as platformRuntime } from "../platform/index.js";
@@ -256,7 +256,7 @@ function createRunId(): string {
   const minutes = pad(now.getUTCMinutes());
   const seconds = pad(now.getUTCSeconds());
 
-  return `${year}${month}${day}-${hours}${minutes}${seconds}-${randomUUID().slice(0, 8)}`;
+  return `${year}${month}${day}-${hours}${minutes}${seconds}-${globalThis.crypto.randomUUID().slice(0, 8)}`;
 }
 
 function pad(value: number): string {

--- a/packages/core/src/runtime/platform/types.ts
+++ b/packages/core/src/runtime/platform/types.ts
@@ -1,8 +1,11 @@
 /** A host-owned file whose identity remains opaque to Core. */
 export interface File {
+  /** Stable opaque identity used only for coordination; it must not be a path. */
+  readonly identity: string;
   /** Logical entry name only; never a URI or operating-system path. */
   readonly name: string;
   readonly size?: number;
+  getSize?(): Promise<number>;
   read(options?: { readonly encoding?: string }): Promise<Uint8Array | string>;
   openWriter(): Promise<FileWriter>;
 }
@@ -16,6 +19,8 @@ export interface FileWriter {
 
 /** Directory tree supplied by the host. Only relative child names are used. */
 export interface Directory {
+  /** Stable opaque identity used only for coordination; it must not be a path. */
+  readonly identity: string;
   readonly name: string;
   getFile(name: string): Promise<File | undefined>;
   getDirectory(name: string): Promise<Directory | undefined>;

--- a/packages/core/src/storage/wikg/archive/manifest.ts
+++ b/packages/core/src/storage/wikg/archive/manifest.ts
@@ -1,5 +1,4 @@
 import { binary as platformBinary } from "../../../runtime/platform/index.js";
-import { randomBytes } from "../../../runtime/platform/index.js";
 
 import { z } from "zod";
 
@@ -47,12 +46,25 @@ export function parseWikgManifest(content: string): {
 }
 
 export function createWikgMutationTokenContent(): platformBinary {
-  const token = randomBytes(32).toString("base64url");
+  return platformBinary.from(createWikgMutationTokenBytes());
+}
 
-  return platformBinary.from(
-    `${WIKG_MUTATION_TOKEN_MAGIC}\n${token}\n`,
-    "utf8",
-  );
+export function createWikgMutationTokenBytes(): Uint8Array {
+  const bytes = new Uint8Array(32);
+  globalThis.crypto.getRandomValues(bytes);
+  const token = toBase64Url(bytes);
+
+  return new TextEncoder().encode(`${WIKG_MUTATION_TOKEN_MAGIC}\n${token}\n`);
+}
+
+function toBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return globalThis
+    .btoa(binary)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/u, "");
 }
 
 export function parseWikgMutationToken(content: string): string {

--- a/packages/core/src/storage/wikg/archive/paths.ts
+++ b/packages/core/src/storage/wikg/archive/paths.ts
@@ -1,4 +1,4 @@
-import { posix, resolve, sep } from "../../../runtime/platform/index.js";
+import { resolve, sep } from "../../../runtime/platform/index.js";
 
 import {
   WIKG_ARCHIVE_PATTERNS,
@@ -16,10 +16,10 @@ export function normalizeArchivePath(path: string): string {
     ? normalized.slice(1)
     : normalized;
 
-  const result = posix
-    .normalize(withoutLeadingSlash)
-    .replace(/^(\.\/)+/u, "")
-    .replace(/^\/+/u, "");
+  const result = withoutLeadingSlash
+    .split("/")
+    .filter((part) => part !== "" && part !== ".")
+    .join("/");
   assertSafeRelativePath(result);
   return result;
 }

--- a/packages/core/src/storage/wikg/archive/reader.ts
+++ b/packages/core/src/storage/wikg/archive/reader.ts
@@ -1,5 +1,8 @@
 import { binary as platformBinary } from "../../../runtime/platform/index.js";
-import { readFile } from "../../../runtime/platform/index.js";
+import {
+  getWikiGraphPlatform,
+  readFile,
+} from "../../../runtime/platform/index.js";
 import { join } from "../../../runtime/platform/index.js";
 
 import type {
@@ -9,24 +12,31 @@ import type {
 } from "../../../runtime/platform/index.js";
 
 import { WIKG_MANIFEST_PATH, WIKG_MUTATION_TOKEN_PATH } from "./constants.js";
-import { parseWikgManifest, parseWikgMutationToken } from "./manifest.js";
+import {
+  WIKG_SCHEMA_VERSION,
+  parseWikgManifest,
+  parseWikgMutationToken,
+} from "./manifest.js";
 import { isWikgArchivePath, normalizeArchivePath } from "./paths.js";
 import { openIndexedArchive, readArchiveEntryBuffer } from "./zip.js";
 import { ensureWikiGraphArchiveSchemaCurrent } from "../../schema-upgrade/index.js";
 
 export class WikgArchiveReader {
   readonly #entryByPath: Map<string, Entry>;
+  readonly #hostEntryByPath: ReadonlyMap<string, Uint8Array> | undefined;
   readonly #entries: readonly string[];
   readonly #path: string | File;
-  readonly #zipFile: YauzlZipFile;
+  readonly #zipFile: YauzlZipFile | undefined;
 
   public constructor(
     path: string | File,
-    zipFile: YauzlZipFile,
+    zipFile: YauzlZipFile | undefined,
     entries: readonly Entry[],
+    hostEntryByPath?: ReadonlyMap<string, Uint8Array>,
   ) {
     this.#path = path;
     this.#zipFile = zipFile;
+    this.#hostEntryByPath = hostEntryByPath;
     this.#entryByPath = new Map(
       entries
         .map(
@@ -36,9 +46,9 @@ export class WikgArchiveReader {
         .filter(([entryPath]) => entryPath !== "")
         .filter(([entryPath]) => isWikgArchivePath(entryPath)),
     );
-    this.#entries = [...this.#entryByPath.keys()].sort((left, right) =>
-      left.localeCompare(right),
-    );
+    this.#entries = [
+      ...(hostEntryByPath?.keys() ?? this.#entryByPath.keys()),
+    ].sort((left, right) => left.localeCompare(right));
   }
 
   public static async open(
@@ -46,14 +56,22 @@ export class WikgArchiveReader {
   ): Promise<WikgArchiveReader> {
     if (typeof inputPath === "string") {
       await ensureWikiGraphArchiveSchemaCurrent(inputPath);
+      const { entries, zipFile } = await openIndexedArchive(inputPath);
+      return new WikgArchiveReader(inputPath, zipFile, entries);
     }
-    const { entries, zipFile } = await openIndexedArchive(inputPath);
-
-    return new WikgArchiveReader(inputPath, zipFile, entries);
+    const entries = new Map<string, Uint8Array>();
+    for (const entry of await getWikiGraphPlatform().zip.read(inputPath)) {
+      const entryPath = normalizeArchivePath(entry.name);
+      if (entryPath !== "" && isWikgArchivePath(entryPath)) {
+        entries.set(entryPath, entry.data);
+      }
+    }
+    assertCurrentHostArchive(entries);
+    return new WikgArchiveReader(inputPath, undefined, [], entries);
   }
 
   public close(): void {
-    this.#zipFile.close();
+    this.#zipFile?.close();
   }
 
   public listEntries(): readonly string[] {
@@ -65,6 +83,10 @@ export class WikgArchiveReader {
   ): Promise<platformBinary | undefined> {
     const entry = this.#entryByPath.get(normalizeArchivePath(entryPath));
 
+    if (this.#hostEntryByPath !== undefined) {
+      return this.#hostEntryByPath.get(normalizeArchivePath(entryPath));
+    }
+
     if (entry === undefined) {
       return undefined;
     }
@@ -74,7 +96,7 @@ export class WikgArchiveReader {
 }
 
 export async function listWikgArchiveEntries(
-  inputPath: string,
+  inputPath: string | File,
 ): Promise<readonly string[]> {
   const reader = await WikgArchiveReader.open(inputPath);
 
@@ -86,7 +108,7 @@ export async function listWikgArchiveEntries(
 }
 
 export async function readWikgArchiveEntry(
-  inputPath: string,
+  inputPath: string | File,
   entryPath: string,
 ): Promise<platformBinary | undefined> {
   const reader = await WikgArchiveReader.open(inputPath);
@@ -99,7 +121,7 @@ export async function readWikgArchiveEntry(
 }
 
 export async function readWikgArchiveMutationToken(
-  inputPath: string,
+  inputPath: string | File,
 ): Promise<string> {
   const reader = await WikgArchiveReader.open(inputPath);
 
@@ -112,10 +134,29 @@ export async function readWikgArchiveMutationToken(
       );
     }
 
-    return parseWikgMutationToken(content.toString("utf8"));
+    return parseWikgMutationToken(decodeUtf8(content));
   } finally {
     reader.close();
   }
+}
+
+function assertCurrentHostArchive(
+  entries: ReadonlyMap<string, Uint8Array>,
+): void {
+  const manifest = entries.get(WIKG_MANIFEST_PATH);
+  if (manifest === undefined) {
+    throw new Error(`Missing WIKG manifest: ${WIKG_MANIFEST_PATH}.`);
+  }
+  const parsed = parseWikgManifest(decodeUtf8(manifest));
+  if (parsed.schemaVersion !== WIKG_SCHEMA_VERSION) {
+    throw new Error(
+      `WIKG schema version ${parsed.schemaVersion} requires migration by a host that supports archive migration.`,
+    );
+  }
+}
+
+function decodeUtf8(content: Uint8Array): string {
+  return new TextDecoder().decode(content);
 }
 
 export async function readWikgArchiveFormatVersion(

--- a/packages/core/src/storage/wikg/wikg-coordinator/facade.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/facade.ts
@@ -1,10 +1,4 @@
-import {
-  getWikiGraphStorage,
-  join,
-  mkdir,
-  randomUUID,
-  rm,
-} from "../../../runtime/platform/index.js";
+import { rm } from "../../../runtime/platform/index.js";
 import { resolve, type File } from "../../../runtime/platform/index.js";
 
 import {
@@ -17,6 +11,10 @@ import { extractWikgArchive } from "../archive/index.js";
 
 import { WikgDocumentFileStore } from "./file-store.js";
 import { WikgArchiveSession } from "./session.js";
+import {
+  HostWikgArchiveSession,
+  withHostArchiveSession,
+} from "./host-session.js";
 import type { WorkspaceWritebackPolicy } from "./types.js";
 
 export class WikgCoordinator {
@@ -25,20 +23,38 @@ export class WikgCoordinator {
     options: {
       readonly readonlyDatabase?: boolean;
       readonly searchIndexWritebackPolicy?: WorkspaceWritebackPolicy;
-      readonly session?: WikgArchiveSession;
+      readonly session?: WikgArchiveSession | HostWikgArchiveSession;
     } = {},
   ): DocumentFileStore {
-    const path = resolve(
-      typeof archivePath === "string" ? archivePath : archivePath.name,
-    );
-    return new WikgDocumentFileStore(path, options);
+    if (typeof archivePath !== "string") {
+      if (!(options.session instanceof HostWikgArchiveSession)) {
+        throw new Error("Opaque archive files require an active session.");
+      }
+      return options.session.createFileStore(options);
+    }
+    return new WikgDocumentFileStore(resolve(archivePath), {
+      ...(options.readonlyDatabase === undefined
+        ? {}
+        : { readonlyDatabase: options.readonlyDatabase }),
+      ...(options.searchIndexWritebackPolicy === undefined
+        ? {}
+        : { searchIndexWritebackPolicy: options.searchIndexWritebackPolicy }),
+      ...(options.session instanceof WikgArchiveSession
+        ? { session: options.session }
+        : {}),
+    });
   }
 
   public async withArchiveSession<T>(
     archivePath: File | string,
-    operation: (session: WikgArchiveSession) => Promise<T> | T,
+    operation: (
+      session: WikgArchiveSession | HostWikgArchiveSession,
+    ) => Promise<T> | T,
   ): Promise<T> {
-    const session = await WikgArchiveSession.open(toArchivePath(archivePath));
+    if (typeof archivePath !== "string") {
+      return await withHostArchiveSession(archivePath, operation);
+    }
+    const session = await WikgArchiveSession.open(resolve(archivePath));
 
     try {
       return await operation(session);
@@ -54,13 +70,18 @@ export class WikgCoordinator {
       readonly documentDirPath?: string;
     } = {},
   ): Promise<T> {
+    if (typeof archivePath !== "string") {
+      throw new Error(
+        "Opaque archive files cannot be materialized to an operating-system path.",
+      );
+    }
     const directoryPath =
       options.documentDirPath === undefined
         ? await createWorkspaceDirectory("archive-open")
         : resolve(options.documentDirPath);
 
     try {
-      await extractWikgArchive(toArchivePath(archivePath), directoryPath);
+      await extractWikgArchive(resolve(archivePath), directoryPath);
       return await operation(directoryPath);
     } finally {
       if (options.documentDirPath === undefined) {
@@ -73,10 +94,15 @@ export class WikgCoordinator {
     archivePath: File | string,
     operation: (documentDirectoryPath: string) => Promise<T> | T,
   ): Promise<T> {
+    if (typeof archivePath !== "string") {
+      throw new Error(
+        "Opaque archive files cannot be materialized to an operating-system path.",
+      );
+    }
     const directoryPath = await createWorkspaceDirectory("archive-write");
 
     try {
-      await extractWikgArchive(toArchivePath(archivePath), directoryPath);
+      await extractWikgArchive(resolve(archivePath), directoryPath);
       return await operation(directoryPath);
     } finally {
       await rm(directoryPath, { force: true, recursive: true });
@@ -87,20 +113,5 @@ export class WikgCoordinator {
 async function createWorkspaceDirectory(
   prefix: Extract<WikiGraphTempCategory, "archive-open" | "archive-write">,
 ): Promise<string> {
-  // Prefer the host-provided document store for transient materialization so
-  // browser/extension hosts can scope all document I/O to one Directory.
-  try {
-    const root = getWikiGraphStorage().documentStore as unknown as string;
-    const directoryPath = join(root, `.wikg-${prefix}-${randomUUID()}`);
-    await mkdir(directoryPath, { recursive: true });
-    return directoryPath;
-  } catch {
-    return await createWikiGraphTempDirectory(prefix);
-  }
-}
-
-function toArchivePath(archivePath: File | string): string {
-  return resolve(
-    typeof archivePath === "string" ? archivePath : archivePath.name,
-  );
+  return await createWikiGraphTempDirectory(prefix);
 }

--- a/packages/core/src/storage/wikg/wikg-coordinator/host-file-store.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/host-file-store.ts
@@ -1,0 +1,148 @@
+import type { File } from "../../../runtime/platform/index.js";
+import type { DocumentFileStore } from "../../../document/directory/index.js";
+
+import {
+  DATABASE_ENTRY_PATH,
+  SEARCH_INDEX_DATABASE_ENTRY_PATH,
+} from "./constants.js";
+import { normalizeArchivePath } from "../archive/paths.js";
+import type { HostWikgArchiveSession } from "./host-session.js";
+import type { WorkspaceWritebackPolicy } from "./types.js";
+
+export class HostWikgDocumentFileStore implements DocumentFileStore {
+  readonly #readonlyDatabase: boolean;
+  readonly #searchIndexWritebackPolicy: WorkspaceWritebackPolicy;
+  readonly #session: HostWikgArchiveSession;
+  #database: File | undefined;
+  #searchIndexDatabase: File | undefined;
+
+  public constructor(
+    session: HostWikgArchiveSession,
+    options: {
+      readonly readonlyDatabase?: boolean;
+      readonly searchIndexWritebackPolicy?: WorkspaceWritebackPolicy;
+    },
+  ) {
+    this.#session = session;
+    this.#readonlyDatabase = options.readonlyDatabase === true;
+    this.#searchIndexWritebackPolicy =
+      options.searchIndexWritebackPolicy ?? "cache";
+  }
+
+  public close(): Promise<void> {
+    return Promise.resolve();
+  }
+  public ensureDirectory(): Promise<void> {
+    return Promise.resolve();
+  }
+  public initializeDatabaseSchema(): boolean {
+    return false;
+  }
+  public openDatabaseReadonly(): boolean {
+    return this.#readonlyDatabase;
+  }
+  public documentIdentity(): string {
+    return this.#session.archiveIdentity;
+  }
+  public searchIndexLockKey(): object {
+    return this.#session;
+  }
+
+  public async resolveDatabasePath(): Promise<File> {
+    this.#database ??= await this.#session.materializeDatabase(
+      DATABASE_ENTRY_PATH,
+      { createIfMissing: !this.#readonlyDatabase },
+    );
+    return this.#database;
+  }
+
+  public async resolveSearchIndexDatabasePath(): Promise<File> {
+    this.#searchIndexDatabase = await this.#session.materializeDatabase(
+      SEARCH_INDEX_DATABASE_ENTRY_PATH,
+      { createIfMissing: !this.#readonlyDatabase },
+    );
+    return this.#searchIndexDatabase;
+  }
+
+  public markDatabaseDirty(): void {
+    if (!this.#readonlyDatabase && this.#database !== undefined) {
+      this.#session.markDatabaseDirty(DATABASE_ENTRY_PATH, this.#database);
+    }
+  }
+
+  public markSearchIndexDatabaseDirty(): void {
+    if (
+      !this.#readonlyDatabase &&
+      this.#searchIndexWritebackPolicy === "archive" &&
+      this.#searchIndexDatabase !== undefined
+    ) {
+      this.#session.markDatabaseDirty(
+        SEARCH_INDEX_DATABASE_ENTRY_PATH,
+        this.#searchIndexDatabase,
+      );
+    }
+  }
+
+  public async readFile(path: string): Promise<Uint8Array | undefined> {
+    return await this.#session.readEntry(toEntryPath(path));
+  }
+
+  public async writeFile(
+    path: string,
+    content: string | Uint8Array,
+    options: { readonly overwrite?: boolean },
+  ): Promise<void> {
+    const entryPath = toEntryPath(path);
+    if (
+      options.overwrite !== true &&
+      (await this.#session.readEntry(entryPath)) !== undefined
+    ) {
+      throw new Error(`File already exists: ${path}`);
+    }
+    await this.#session.writeEntry(entryPath, content);
+  }
+
+  public async deleteFile(path: string): Promise<void> {
+    this.#session.deleteEntry(toEntryPath(path));
+  }
+
+  public async deleteTree(path: string): Promise<void> {
+    const root = toEntryPath(path);
+    const prefix = root === "" ? "" : `${root}/`;
+    for (const entry of this.#session.listEntries()) {
+      if (entry === root || entry.startsWith(prefix)) {
+        this.#session.deleteEntry(entry);
+      }
+    }
+  }
+
+  public async listFiles(path: string): Promise<readonly string[]> {
+    const root = toEntryPath(path);
+    const prefix = root === "" ? "" : `${root}/`;
+    return this.#session
+      .listEntries()
+      .filter((entry) => entry.startsWith(prefix))
+      .map((entry) => entry.slice(prefix.length))
+      .filter((entry) => entry !== "" && !entry.includes("/"))
+      .sort((left, right) => left.localeCompare(right));
+  }
+
+  public async listFileContents(
+    path: string,
+  ): Promise<ReadonlyMap<string, Uint8Array>> {
+    const result = new Map<string, Uint8Array>();
+    for (const name of await this.listFiles(path)) {
+      const root = toEntryPath(path);
+      const content = await this.#session.readEntry(
+        root === "" ? name : `${root}/${name}`,
+      );
+      if (content !== undefined) result.set(name, content);
+    }
+    return result;
+  }
+}
+
+function toEntryPath(path: string): string {
+  if (path === "" || path === ".") return "";
+  return normalizeArchivePath(path);
+}

--- a/packages/core/src/storage/wikg/wikg-coordinator/host-session.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/host-session.ts
@@ -1,0 +1,293 @@
+import type {
+  Directory,
+  File,
+  HostZipEntry,
+} from "../../../runtime/platform/index.js";
+import {
+  getWikiGraphPlatform,
+  getWikiGraphStorage,
+} from "../../../runtime/platform/index.js";
+import type { DocumentFileStore } from "../../../document/directory/index.js";
+
+import {
+  WIKG_MANIFEST_CONTENT,
+  WIKG_SCHEMA_VERSION,
+  createWikgMutationTokenBytes,
+  parseWikgManifest,
+} from "../archive/manifest.js";
+import {
+  WIKG_MANIFEST_PATH,
+  WIKG_MUTATION_TOKEN_PATH,
+} from "../archive/constants.js";
+import {
+  isWikgArchivePath,
+  normalizeArchivePath,
+  sortArchiveEntryPathsForWrite,
+} from "../archive/paths.js";
+import {
+  DATABASE_ENTRY_PATH,
+  LEGACY_SEARCH_INDEX_DATABASE_ENTRY_PATH,
+  SEARCH_INDEX_DATABASE_ENTRY_PATH,
+} from "./constants.js";
+import { HostWikgDocumentFileStore } from "./host-file-store.js";
+import type { WorkspaceWritebackPolicy } from "./types.js";
+
+type Overlay =
+  | { readonly kind: "deleted" }
+  | { readonly file: File; readonly kind: "file" };
+
+const archiveQueues = new Map<string, Promise<void>>();
+let sessionSequence = 0;
+
+/** Serialize use of one opaque host file without inspecting its implementation. */
+export async function withHostArchiveSession<T>(
+  archive: File,
+  operation: (session: HostWikgArchiveSession) => Promise<T> | T,
+): Promise<T> {
+  const previous = archiveQueues.get(archive.identity) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queued = previous.then(() => current);
+  archiveQueues.set(archive.identity, queued);
+  await previous;
+
+  try {
+    const session = await HostWikgArchiveSession.open(archive);
+    try {
+      return await operation(session);
+    } finally {
+      await session.close();
+    }
+  } finally {
+    release();
+    if (archiveQueues.get(archive.identity) === queued) {
+      archiveQueues.delete(archive.identity);
+    }
+  }
+}
+
+/** Host-neutral archive transaction rooted in the injected document store. */
+export class HostWikgArchiveSession {
+  readonly #archive: File;
+  readonly #entries: Map<string, Uint8Array>;
+  readonly #overlays = new Map<string, Overlay>();
+  readonly #workspaceName: string;
+  readonly #workspace: Directory;
+  #closed = false;
+
+  public constructor(
+    archive: File,
+    entries: Map<string, Uint8Array>,
+    workspaceName: string,
+    workspace: Directory,
+  ) {
+    this.#archive = archive;
+    this.#entries = entries;
+    this.#workspaceName = workspaceName;
+    this.#workspace = workspace;
+  }
+
+  public static async open(archive: File): Promise<HostWikgArchiveSession> {
+    const entries = new Map<string, Uint8Array>();
+    for (const entry of await getWikiGraphPlatform().zip.read(archive)) {
+      const path = normalizeArchivePath(entry.name);
+      if (path !== "" && isWikgArchivePath(path)) entries.set(path, entry.data);
+    }
+    const manifestContent = entries.get(WIKG_MANIFEST_PATH);
+    if (manifestContent === undefined) {
+      throw new Error(`Missing WIKG manifest: ${WIKG_MANIFEST_PATH}.`);
+    }
+    const manifest = parseWikgManifest(
+      new TextDecoder().decode(manifestContent),
+    );
+    if (manifest.schemaVersion !== WIKG_SCHEMA_VERSION) {
+      throw new Error(
+        `WIKG schema version ${manifest.schemaVersion} requires migration by a host that supports archive migration.`,
+      );
+    }
+
+    const root = getWikiGraphStorage().documentStore;
+    const workspaceName = await createWorkspaceName(root);
+    const workspace = await root.createDirectory(workspaceName);
+    return new HostWikgArchiveSession(
+      archive,
+      entries,
+      workspaceName,
+      workspace,
+    );
+  }
+
+  public createFileStore(
+    options: {
+      readonly readonlyDatabase?: boolean;
+      readonly searchIndexWritebackPolicy?: WorkspaceWritebackPolicy;
+    } = {},
+  ): DocumentFileStore {
+    return new HostWikgDocumentFileStore(this, options);
+  }
+
+  public get archiveIdentity(): string {
+    return this.#archive.identity;
+  }
+
+  public async materializeReadWorkspace<T>(
+    _directoryPath: string | undefined,
+    _operation: (documentDirectoryPath: string) => Promise<T> | T,
+  ): Promise<T> {
+    throw new Error(
+      "Opaque archive files cannot be materialized to an operating-system path.",
+    );
+  }
+
+  public listEntries(): readonly string[] {
+    const paths = new Set(this.#entries.keys());
+    for (const [path, overlay] of this.#overlays) {
+      if (overlay.kind === "deleted") paths.delete(path);
+      else paths.add(path);
+    }
+    return [...paths].sort((left, right) => left.localeCompare(right));
+  }
+
+  public async readEntry(path: string): Promise<Uint8Array | undefined> {
+    const entryPath = normalizeArchivePath(path);
+    const overlay = this.#overlays.get(entryPath);
+    if (overlay?.kind === "deleted") return undefined;
+    if (overlay?.kind === "file") return await readBytes(overlay.file);
+    return this.#entries.get(entryPath);
+  }
+
+  public async writeEntry(
+    path: string,
+    content: string | Uint8Array,
+  ): Promise<void> {
+    const entryPath = normalizeArchivePath(path);
+    const file = await this.#workspaceFile(entryPath);
+    await replaceFile(file, content);
+    this.#overlays.set(entryPath, { file, kind: "file" });
+  }
+
+  public deleteEntry(path: string): void {
+    this.#overlays.set(normalizeArchivePath(path), { kind: "deleted" });
+  }
+
+  public async materializeDatabase(
+    path: string,
+    options: { readonly createIfMissing: boolean },
+  ): Promise<File> {
+    const entryPath = normalizeArchivePath(path);
+    const existing = this.#overlays.get(entryPath);
+    if (existing?.kind === "file") return existing.file;
+
+    const content =
+      (await this.readEntry(entryPath)) ??
+      (entryPath === SEARCH_INDEX_DATABASE_ENTRY_PATH
+        ? await this.readEntry(LEGACY_SEARCH_INDEX_DATABASE_ENTRY_PATH)
+        : undefined);
+    if (content === undefined && !options.createIfMissing) {
+      throw new Error(`Archive SQLite entry is missing: ${entryPath}`);
+    }
+    const file = await this.#workspaceFile(entryPath);
+    await replaceFile(file, content ?? new Uint8Array());
+    return file;
+  }
+
+  public markDatabaseDirty(path: string, file: File): void {
+    const entryPath = normalizeArchivePath(path);
+    this.#overlays.set(entryPath, { file, kind: "file" });
+    if (
+      entryPath === DATABASE_ENTRY_PATH ||
+      entryPath === SEARCH_INDEX_DATABASE_ENTRY_PATH
+    ) {
+      this.#overlays.set(LEGACY_SEARCH_INDEX_DATABASE_ENTRY_PATH, {
+        kind: "deleted",
+      });
+    }
+  }
+
+  public async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    try {
+      if (this.#overlays.size > 0) await this.#commit();
+    } finally {
+      await getWikiGraphStorage()
+        .documentStore.remove(this.#workspaceName, { recursive: true })
+        .catch(() => undefined);
+    }
+  }
+
+  async #workspaceFile(path: string): Promise<File> {
+    const parts = normalizeArchivePath(path).split("/");
+    const name = parts.pop();
+    if (name === undefined || name === "") throw new TypeError("Invalid file");
+    let directory = this.#workspace;
+    for (const part of parts) {
+      directory =
+        (await directory.getDirectory(part)) ??
+        (await directory.createDirectory(part));
+    }
+    return (
+      (await directory.getFile(name)) ?? (await directory.createFile(name))
+    );
+  }
+
+  async #commit(): Promise<void> {
+    const paths = new Set(this.#entries.keys());
+    for (const [path, overlay] of this.#overlays) {
+      if (overlay.kind === "deleted") paths.delete(path);
+      else paths.add(path);
+    }
+    paths.add(WIKG_MANIFEST_PATH);
+    paths.add(WIKG_MUTATION_TOKEN_PATH);
+
+    const entries: HostZipEntry[] = [];
+    for (const path of sortArchiveEntryPathsForWrite(paths)) {
+      if (path === WIKG_MUTATION_TOKEN_PATH) {
+        entries.push({ data: createWikgMutationTokenBytes(), name: path });
+        continue;
+      }
+      if (path === WIKG_MANIFEST_PATH) {
+        entries.push({
+          data: new TextEncoder().encode(WIKG_MANIFEST_CONTENT),
+          name: path,
+        });
+        continue;
+      }
+      const content = await this.readEntry(path);
+      if (content !== undefined) entries.push({ data: content, name: path });
+    }
+    await getWikiGraphPlatform().zip.write(this.#archive, entries);
+  }
+}
+
+async function createWorkspaceName(root: Directory): Promise<string> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    sessionSequence += 1;
+    const name = `.wikg-session-${Date.now().toString(36)}-${sessionSequence.toString(36)}`;
+    if ((await root.getDirectory(name)) === undefined) return name;
+  }
+  throw new Error("Could not allocate a document-store workspace");
+}
+
+async function replaceFile(
+  file: File,
+  content: string | Uint8Array,
+): Promise<void> {
+  const writer = await file.openWriter();
+  try {
+    await writer.write(content);
+    await writer.commit();
+  } catch (error) {
+    await writer.abort();
+    throw error;
+  }
+}
+
+async function readBytes(file: File): Promise<Uint8Array> {
+  const content = await file.read();
+  return typeof content === "string"
+    ? new TextEncoder().encode(content)
+    : content;
+}

--- a/packages/core/src/storage/wikg/wiki-graph-archive-file.ts
+++ b/packages/core/src/storage/wikg/wiki-graph-archive-file.ts
@@ -22,7 +22,16 @@ export class WikiGraphArchiveFile {
   ): Promise<T> {
     return await this.readDocument(
       async (document, directoryPath) =>
-        await operation(new WikiGraphArchive(document, directoryPath)),
+        await operation(
+          new WikiGraphArchive(
+            document,
+            typeof this.#file === "string" ? directoryPath : this.#file,
+            {
+              sourceKind:
+                options.documentDirPath === undefined ? "archive" : "directory",
+            },
+          ),
+        ),
       options,
     );
   }
@@ -55,20 +64,18 @@ export class WikiGraphArchiveFile {
           );
         }
 
-        const document = await DirectoryDocument.open(
-          toHostHandle(this.#file),
-          {
-            fileStore: session.createFileStore({
-              readonlyDatabase: true,
-              ...(options.searchIndexWritebackPolicy === undefined
-                ? {}
-                : {
-                    searchIndexWritebackPolicy:
-                      options.searchIndexWritebackPolicy,
-                  }),
-            }),
-          },
-        );
+        const fileStore = session.createFileStore({
+          readonlyDatabase: true,
+          ...(options.searchIndexWritebackPolicy === undefined
+            ? {}
+            : {
+                searchIndexWritebackPolicy: options.searchIndexWritebackPolicy,
+              }),
+        });
+        const document =
+          typeof this.#file === "string"
+            ? await DirectoryDocument.open(this.#file, { fileStore })
+            : await DirectoryDocument.openFileStore(fileStore);
 
         try {
           return await operation(
@@ -89,19 +96,17 @@ export class WikiGraphArchiveFile {
     return await this.#coordinator.withArchiveSession(
       this.#file,
       async (session) => {
-        const document = await DirectoryDocument.open(
-          toHostHandle(this.#file),
-          {
-            fileStore: session.createFileStore({
-              ...(options.searchIndexWritebackPolicy === undefined
-                ? {}
-                : {
-                    searchIndexWritebackPolicy:
-                      options.searchIndexWritebackPolicy,
-                  }),
-            }),
-          },
-        );
+        const fileStore = session.createFileStore({
+          ...(options.searchIndexWritebackPolicy === undefined
+            ? {}
+            : {
+                searchIndexWritebackPolicy: options.searchIndexWritebackPolicy,
+              }),
+        });
+        const document =
+          typeof this.#file === "string"
+            ? await DirectoryDocument.open(this.#file, { fileStore })
+            : await DirectoryDocument.openFileStore(fileStore);
 
         try {
           return await operation(document);
@@ -109,14 +114,12 @@ export class WikiGraphArchiveFile {
           try {
             await document.release();
           } finally {
-            await deleteArchiveSearchSessions(document.path);
+            if (typeof this.#file === "string") {
+              await deleteArchiveSearchSessions(document.path);
+            }
           }
         }
       },
     );
   }
-}
-
-function toHostHandle(file: File | string): string {
-  return typeof file === "string" ? file : file.name;
 }

--- a/test/core/api/app.test.ts
+++ b/test/core/api/app.test.ts
@@ -327,9 +327,11 @@ function createStorage(name: string): WikiGraphStorage {
 }
 
 class MemoryDirectory implements Directory {
+  public readonly identity: string;
   public readonly name: string;
 
   public constructor(name: string) {
+    this.identity = `memory:${name}`;
     this.name = name;
   }
 

--- a/test/core/runtime/platform/sdk-lifecycle.test.ts
+++ b/test/core/runtime/platform/sdk-lifecycle.test.ts
@@ -63,9 +63,11 @@ function createStorage(name: string): WikiGraphStorage {
 }
 
 class MemoryDirectory implements Directory {
+  public readonly identity: string;
   public readonly name: string;
 
   public constructor(name: string) {
+    this.identity = `memory:${name}`;
     this.name = name;
   }
 

--- a/test/core/storage/wikg/opaque-file-adapter.test.ts
+++ b/test/core/storage/wikg/opaque-file-adapter.test.ts
@@ -1,4 +1,4 @@
-import { mkdir } from "fs/promises";
+import { mkdir, readFile, writeFile } from "fs/promises";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -30,6 +30,64 @@ afterEach(() => {
 });
 
 describe("opaque archive File adapter", () => {
+  it("keeps a NodeDirectory archive File independent from the current directory", async () => {
+    await withTempDir("wikigraph-node-directory-file-", async (path) => {
+      const targetDirectoryPath = `${path}/target`;
+      const archivePath = await createSeedArchive(targetDirectoryPath);
+      const decoyDirectoryPath = `${path}/wrong-cwd`;
+      const decoyPath = `${decoyDirectoryPath}/book.wikg`;
+      const storage = {
+        documentStore: new NodeDirectory(`${path}/storage/documents`),
+        library: new NodeDirectory(`${path}/storage/library`),
+      };
+      await mkdir(`${path}/storage/documents`, { recursive: true });
+      await mkdir(`${path}/storage/library`, { recursive: true });
+      await mkdir(decoyDirectoryPath, { recursive: true });
+      await writeFile(decoyPath, "This is the same-name cwd decoy, not a ZIP.");
+      const decoyBefore = await readFile(decoyPath);
+
+      const archive = await new NodeDirectory(targetDirectoryPath).getFile(
+        "book.wikg",
+      );
+      expect(archive).toBeDefined();
+
+      installWikiGraphPlatform(nodeWikiGraphPlatform);
+      installLegacyRuntimePlatform(throwingLegacyRuntime);
+      const originalWorkingDirectory = process.cwd();
+      process.chdir(decoyDirectoryPath);
+      try {
+        await expect(
+          new WikiGraph({ storage }).openSession(
+            archive!,
+            async (opened) => (await opened.readMeta())?.title,
+          ),
+        ).resolves.toBe("Before");
+
+        await withWikiGraphStorage(storage, async () => {
+          await new WikiGraphArchiveFile(archive!).write(async (document) => {
+            await document.replaceBookMeta(createMeta("After directory File"));
+          });
+          await expect(readTitle(archive!)).resolves.toBe(
+            "After directory File",
+          );
+        });
+
+        expect(await readFile(decoyPath)).toEqual(decoyBefore);
+        expect(await storage.documentStore.list()).toEqual([]);
+      } finally {
+        process.chdir(originalWorkingDirectory);
+      }
+
+      installNodeWikiGraphPlatform();
+      await withWikiGraphStorage(storage, async () => {
+        await expect(readTitle(new NodeFile(archivePath))).resolves.toBe(
+          "After directory File",
+        );
+      });
+      expect(await readFile(decoyPath)).toEqual(decoyBefore);
+    });
+  });
+
   it("reads and writes without turning File.name into an OS path", async () => {
     await withTempDir("wikigraph-opaque-file-", async (path) => {
       const archivePath = await createSeedArchive(path);

--- a/test/core/storage/wikg/opaque-file-adapter.test.ts
+++ b/test/core/storage/wikg/opaque-file-adapter.test.ts
@@ -1,0 +1,289 @@
+import { mkdir } from "fs/promises";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { WikiGraphArchive } from "../../../../packages/core/src/api/wiki-graph-archive.js";
+import { WikiGraph } from "../../../../packages/core/src/api/app.js";
+import { DirectoryDocument } from "../../../../packages/core/src/document/index.js";
+import {
+  installWikiGraphPlatform,
+  installLegacyRuntimePlatform,
+  type Directory,
+  type File,
+  type HostDatabaseConnection,
+  type HostZipEntry,
+  type LegacyRuntimePlatform,
+  type WikiGraphPlatform,
+  withWikiGraphStorage,
+} from "../../../../packages/core/src/runtime/platform/index.js";
+import { WikiGraphArchiveFile } from "../../../../packages/core/src/storage/wikg/wiki-graph-archive-file.js";
+import {
+  installNodeWikiGraphPlatform,
+  NodeDirectory,
+  NodeFile,
+  nodeWikiGraphPlatform,
+} from "../../../../packages/cli/src/runtime/node-platform.js";
+import { withTempDir } from "../../../helpers/temp.js";
+
+afterEach(() => {
+  installNodeWikiGraphPlatform();
+});
+
+describe("opaque archive File adapter", () => {
+  it("reads and writes without turning File.name into an OS path", async () => {
+    await withTempDir("wikigraph-opaque-file-", async (path) => {
+      const archivePath = await createSeedArchive(path);
+      await mkdir(`${path}/storage/library`, { recursive: true });
+      await mkdir(`${path}/storage/documents`, { recursive: true });
+
+      const archive = wrapFile(new NodeFile(archivePath));
+      const storage = {
+        documentStore: wrapDirectory(
+          new NodeDirectory(`${path}/storage/documents`),
+        ),
+        library: wrapDirectory(new NodeDirectory(`${path}/storage/library`)),
+      };
+      installWikiGraphPlatform(opaqueNodePlatform);
+      installLegacyRuntimePlatform(throwingLegacyRuntime);
+
+      const directDocumentRoot =
+        await storage.documentStore.createDirectory("direct-document");
+      const directDocument = await DirectoryDocument.open(directDocumentRoot);
+      try {
+        await directDocument.createSerial();
+        await directDocument.writeBookMeta(createMeta("Opaque directory"));
+        await directDocument.writeSummary(1, "Directory-backed text");
+        await expect(directDocument.readBookMeta()).resolves.toMatchObject({
+          title: "Opaque directory",
+        });
+        await expect(directDocument.readSummary(1)).resolves.toBe(
+          "Directory-backed text",
+        );
+      } finally {
+        await directDocument.release();
+        await storage.documentStore.remove("direct-document", {
+          recursive: true,
+        });
+      }
+
+      expect("path" in archive).toBe(false);
+      await expect(
+        new WikiGraph({ storage }).openSession(archive, async (opened) => ({
+          formatVersion: await opened.readArchiveFormatVersion(),
+          title: (await opened.readMeta())?.title,
+        })),
+      ).resolves.toEqual({ formatVersion: 1, title: "Before" });
+      await withWikiGraphStorage(storage, async () => {
+        await new WikiGraphArchiveFile(archive).write(async (document) => {
+          await document.replaceBookMeta(createMeta("After"));
+          await document.writeSummary(1, "Written through an opaque File.");
+        });
+        await expect(readTitle(archive)).resolves.toBe("After");
+        await expect(
+          new WikiGraphArchiveFile(archive).read(async (opened) =>
+            opened.readSerialSummary(1),
+          ),
+        ).resolves.toBe("Written through an opaque File.");
+
+        let activeWrites = 0;
+        let maximumActiveWrites = 0;
+        const writeTitle = async (file: File, title: string) => {
+          await new WikiGraphArchiveFile(file).write(async (document) => {
+            activeWrites += 1;
+            maximumActiveWrites = Math.max(maximumActiveWrites, activeWrites);
+            await new Promise((resolve) => globalThis.setTimeout(resolve, 10));
+            await document.replaceBookMeta(createMeta(title));
+            activeWrites -= 1;
+          });
+        };
+        await Promise.all([
+          writeTitle(archive, "First serialized write"),
+          writeTitle(wrapFile(new NodeFile(archivePath)), "Final title"),
+        ]);
+        expect(maximumActiveWrites).toBe(1);
+        await expect(readTitle(archive)).resolves.toBe("Final title");
+      });
+      installLegacyRuntimePlatform(throwingLegacyRuntime);
+
+      expect(await storage.documentStore.list()).toEqual([]);
+
+      installNodeWikiGraphPlatform();
+      await withWikiGraphStorage(
+        {
+          documentStore: new NodeDirectory(`${path}/storage/documents`),
+          library: new NodeDirectory(`${path}/storage/library`),
+        },
+        async () => {
+          await expect(readTitle(new NodeFile(archivePath))).resolves.toBe(
+            "Final title",
+          );
+        },
+      );
+    });
+  });
+
+  it("keeps the archive intact when the host ZIP commit fails", async () => {
+    await withTempDir("wikigraph-opaque-rollback-", async (path) => {
+      const archivePath = await createSeedArchive(path);
+      await mkdir(`${path}/storage/library`, { recursive: true });
+      await mkdir(`${path}/storage/documents`, { recursive: true });
+      const archive = wrapFile(new NodeFile(archivePath));
+      const storage = {
+        documentStore: wrapDirectory(
+          new NodeDirectory(`${path}/storage/documents`),
+        ),
+        library: wrapDirectory(new NodeDirectory(`${path}/storage/library`)),
+      };
+      installWikiGraphPlatform({
+        ...opaqueNodePlatform,
+        zip: {
+          ...opaqueNodePlatform.zip,
+          write: () =>
+            Promise.reject(new Error("simulated host commit failure")),
+        },
+      });
+
+      await expect(
+        withWikiGraphStorage(storage, async () => {
+          await new WikiGraphArchiveFile(archive).write(async (document) => {
+            await document.replaceBookMeta(createMeta("Must not commit"));
+          });
+        }),
+      ).rejects.toThrow("simulated host commit failure");
+      expect(await storage.documentStore.list()).toEqual([]);
+
+      installNodeWikiGraphPlatform();
+      await withWikiGraphStorage(
+        {
+          documentStore: new NodeDirectory(`${path}/storage/documents`),
+          library: new NodeDirectory(`${path}/storage/library`),
+        },
+        async () => {
+          await expect(readTitle(new NodeFile(archivePath))).resolves.toBe(
+            "Before",
+          );
+        },
+      );
+    });
+  });
+});
+
+const backingFiles = new WeakMap<File, NodeFile>();
+function wrapFile(backing: NodeFile): File {
+  const file: File = {
+    getSize: async () => await backing.getSize(),
+    identity: backing.identity,
+    name: backing.name,
+    openWriter: async () => await backing.openWriter(),
+    read: async (options) => await backing.read(options),
+  };
+  backingFiles.set(file, backing);
+  return file;
+}
+
+function wrapDirectory(backing: NodeDirectory): Directory {
+  const directory: Directory = {
+    createDirectory: async (name) =>
+      wrapDirectory((await backing.createDirectory(name)) as NodeDirectory),
+    createFile: async (name) =>
+      wrapFile((await backing.createFile(name)) as NodeFile),
+    getDirectory: async (name) => {
+      const value = await backing.getDirectory(name);
+      return value === undefined
+        ? undefined
+        : wrapDirectory(value as NodeDirectory);
+    },
+    getFile: async (name) => {
+      const value = await backing.getFile(name);
+      return value === undefined ? undefined : wrapFile(value as NodeFile);
+    },
+    identity: backing.identity,
+    list: async () =>
+      (await backing.list()).map((entry) =>
+        entry instanceof NodeDirectory
+          ? wrapDirectory(entry)
+          : wrapFile(entry as NodeFile),
+      ),
+    name: backing.name,
+    remove: async (name, options) => await backing.remove(name, options),
+  };
+  return directory;
+}
+
+const opaqueNodePlatform: WikiGraphPlatform = {
+  asyncContext: nodeWikiGraphPlatform.asyncContext,
+  database: {
+    open: async (file, options): Promise<HostDatabaseConnection> =>
+      await nodeWikiGraphPlatform.database.open(unwrapFile(file), options),
+  },
+  zip: {
+    read: async (file): Promise<readonly HostZipEntry[]> =>
+      await nodeWikiGraphPlatform.zip.read(unwrapFile(file)),
+    write: async (file, entries) =>
+      await nodeWikiGraphPlatform.zip.write(unwrapFile(file), entries),
+  },
+};
+
+const throwingLegacyRuntime = new Proxy(
+  {},
+  {
+    get: (_target, property) => {
+      throw new Error(
+        `Opaque File flow accessed legacy runtime service: ${String(property)}`,
+      );
+    },
+  },
+) as LegacyRuntimePlatform;
+
+function unwrapFile(file: File): NodeFile {
+  const backing = backingFiles.get(file);
+  if (backing === undefined) throw new TypeError("Unknown opaque File");
+  return backing;
+}
+
+async function createSeedArchive(root: string): Promise<string> {
+  const document = await DirectoryDocument.open(`${root}/document`);
+  try {
+    await document.openSession(async (opened) => {
+      await opened.createSerial();
+      await opened.writeBookMeta(createMeta("Before"));
+      await opened.writeSummary(1, "Before summary");
+      await opened.writeToc({
+        items: [
+          {
+            children: [],
+            key: "opaque-file-1",
+            serialId: 1,
+            title: "Opaque file chapter",
+          },
+        ],
+        version: 1,
+      });
+    });
+    const archivePath = `${root}/book.wikg`;
+    await new WikiGraphArchive(document, document.path).saveAs(archivePath);
+    return archivePath;
+  } finally {
+    await document.release();
+  }
+}
+
+function createMeta(title: string) {
+  return {
+    authors: [],
+    description: null,
+    identifier: null,
+    language: null,
+    publishedAt: null,
+    publisher: null,
+    sourceFormat: "txt" as const,
+    title,
+    version: 1 as const,
+  };
+}
+
+async function readTitle(file: File): Promise<string | undefined> {
+  return await new WikiGraphArchiveFile(file).read(
+    async (archive) => (await archive.readMeta())?.title ?? undefined,
+  );
+}


### PR DESCRIPTION
## Summary

- 将 archive、document 与 WIKG workspace 主链路迁移到不透明 File/Directory 和宿主数据库、ZIP 接口
- 让 documentStore 成为真实 workspace 根，并保留原子写回、回滚、清理和同 identity 串行语义
- 增加无 `.path` adapter、NodeDirectory File、错误 cwd 同名诱饵及 ZIP 失败回滚回归

## Verification

- `pnpm verify`
- `pnpm test:run`（151 files / 979 tests）
- `pnpm build`（含 Core source/artifact portability gate）

Closes #358