### PR TITLE
恢复 Archive 跨进程协调、崩溃恢复与懒读取

### DIFF
--- a/docs/en/sdk.md
+++ b/docs/en/sdk.md
@@ -71,7 +71,12 @@ and are removed after the archive session settles. Derived search indexes are
 kept there as persistent caches under opaque, path-free keys; they remain
 outside the `.wikg` archive and can be rebuilt at any time.
 `WikiGraphPlatform` is process-wide host infrastructure for async context,
-database, and ZIP operations, so an application installs it once after import.
+database, ZIP, resource resolution, and execution-liveness operations, so an
+application installs it once after import. Its ZIP reader lists entry names and
+reads entry data on demand; hosts must not require Core to load the complete
+archive for an ordinary read. Its lifecycle provider gives each running host
+instance an opaque ID and reports whether a previously recorded instance is
+still alive, allowing archive sessions to recover published work after a crash.
 The two storage roots belong to each `WikiGraph` instance and remain isolated
 when instances run concurrently.
 

--- a/docs/zh-CN/sdk.md
+++ b/docs/zh-CN/sdk.md
@@ -58,7 +58,7 @@ await wikiGraph.openSession(archive, (session) => session.readMeta());
 
 `File`/`Directory` 是平台原语，Core 不解析它们背后的 URI 或绝对路径。浏览器、Extension 等宿主可以使用 IndexedDB、OPFS 或其他受限存储；`wiki-graph` CLI 提供 Node 适配器。
 每个 `File.identity` 和 `Directory.identity` 都是稳定、不透明的协调标识，而不是路径或 URI。归档使用的 SQLite 工作区只会创建在传入的 `documentStore` 下，并在会话完成后清理。派生搜索索引也保存在该目录中，但使用不含路径的 opaque key 作为持久缓存；它不会写入 `.wikg`，且随时可以重建。
-`WikiGraphPlatform` 是进程级宿主基础设施，负责异步上下文、数据库和 ZIP；应用在 import 后安装一次即可。两个存储目录根则归各自的 `WikiGraph` 实例所有，并发运行多个实例时不会互相覆盖。
+`WikiGraphPlatform` 是进程级宿主基础设施，负责异步上下文、数据库、ZIP、资源解析和执行实例存活探测；应用在 import 后安装一次即可。ZIP reader 只列出 entry 名，并在实际访问时按需读取 entry 数据，宿主不应要求 Core 为普通读取加载整份归档。lifecycle provider 为每个运行中的宿主实例提供 opaque ID，并能判断先前记录的实例是否仍然存活，使 archive session 可以在进程异常退出后接管已发布的工作。两个存储目录根则归各自的 `WikiGraph` 实例所有，并发运行多个实例时不会互相覆盖。
 
 ```ts
 import { WikiGraph, type File } from "wiki-graph-core";

--- a/packages/cli/src/runtime/node-platform.ts
+++ b/packages/cli/src/runtime/node-platform.ts
@@ -13,6 +13,8 @@ import { Environment, Loader, type LoaderSource } from "nunjucks";
 
 const nodeProcess =
   (process as unknown as { default?: typeof process }).default ?? process;
+const nodeSqlite3 =
+  (sqlite3 as unknown as { default?: typeof sqlite3 }).default ?? sqlite3;
 
 import {
   installWikiGraphPlatform,
@@ -25,6 +27,7 @@ import {
   type HostDatabaseRow,
   type HostDatabaseValue,
   type HostZipEntry,
+  type HostZipReader,
   type WikiGraphPlatform,
   type WikiGraphStorage,
 } from "../../../core/src/runtime/platform/index.js";
@@ -318,8 +321,9 @@ async function openNodeDatabase(
 ): Promise<NodeDatabaseConnection> {
   const flags =
     (options.readonly === true
-      ? sqlite3.OPEN_READONLY
-      : sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE) | sqlite3.OPEN_FULLMUTEX;
+      ? nodeSqlite3.OPEN_READONLY
+      : nodeSqlite3.OPEN_READWRITE | nodeSqlite3.OPEN_CREATE) |
+    nodeSqlite3.OPEN_FULLMUTEX;
   return new NodeDatabaseConnection(await openNativeNodeDatabase(file, flags));
 }
 
@@ -331,52 +335,87 @@ async function openNativeNodeDatabase(
     throw new TypeError("The Node database adapter requires a NodeFile");
   }
   return await new Promise((resolve, reject) => {
-    const database = new sqlite3.Database(file.path, flags, (error) => {
+    const database = new nodeSqlite3.Database(file.path, flags, (error) => {
       if (error) reject(error);
       else resolve(database);
     });
   });
 }
 
-async function readNodeZip(file: File): Promise<readonly HostZipEntry[]> {
-  const content = await file.read();
-  const source =
-    typeof content === "string" ? Buffer.from(content) : Buffer.from(content);
+async function openNodeZip(file: File): Promise<HostZipReader> {
+  if (!(file instanceof NodeFile)) {
+    throw new TypeError("The Node ZIP adapter requires a NodeFile");
+  }
   const zipFile = await new Promise<yauzl.ZipFile>((resolve, reject) => {
-    yauzl.fromBuffer(source, { lazyEntries: true }, (error, opened) => {
-      if (error || opened === undefined)
-        reject(error ?? new Error("Cannot open ZIP"));
-      else resolve(opened);
-    });
+    yauzl.open(
+      file.path,
+      { autoClose: false, lazyEntries: true },
+      (error, opened) => {
+        if (error || opened === undefined)
+          reject(error ?? new Error("Cannot open ZIP"));
+        else resolve(opened);
+      },
+    );
   });
 
-  return await new Promise((resolve, reject) => {
-    const entries: HostZipEntry[] = [];
-    zipFile.on("entry", (entry: yauzl.Entry) => {
-      if (entry.fileName.endsWith("/")) {
-        zipFile.readEntry();
-        return;
-      }
-      zipFile.openReadStream(entry, (error, stream) => {
-        if (error || stream === undefined) {
-          reject(
-            error ?? new Error(`Cannot read ZIP entry: ${entry.fileName}`),
-          );
-          return;
+  const entries = await new Promise<Map<string, yauzl.Entry>>(
+    (resolve, reject) => {
+      const discovered = new Map<string, yauzl.Entry>();
+      const rejectAndClose = (error: unknown) => {
+        zipFile.close();
+        reject(
+          error instanceof Error
+            ? error
+            : new Error("Cannot scan ZIP central directory"),
+        );
+      };
+      const resolveEntries = () => {
+        zipFile.off("error", rejectAndClose);
+        resolve(discovered);
+      };
+      zipFile.on("entry", (entry: yauzl.Entry) => {
+        if (!entry.fileName.endsWith("/")) {
+          discovered.set(entry.fileName, entry);
         }
-        const chunks: Buffer[] = [];
-        stream.on("data", (chunk: Buffer) => chunks.push(chunk));
-        stream.once("error", reject);
-        stream.once("end", () => {
-          entries.push({ data: Buffer.concat(chunks), name: entry.fileName });
-          zipFile.readEntry();
-        });
+        zipFile.readEntry();
       });
+      zipFile.once("error", rejectAndClose);
+      zipFile.once("end", resolveEntries);
+      zipFile.readEntry();
+    },
+  );
+
+  let closed = false;
+  return {
+    close: () => {
+      if (!closed) zipFile.close();
+      closed = true;
+      return Promise.resolve();
+    },
+    listEntries: () => Promise.resolve([...entries.keys()]),
+    readEntry: async (name) => {
+      if (closed) throw new Error("Cannot read a closed ZIP archive");
+      const entry = entries.get(name);
+      if (entry === undefined) return undefined;
+      return await readNodeZipEntry(zipFile, entry);
+    },
+  };
+}
+
+async function readNodeZipEntry(
+  zipFile: yauzl.ZipFile,
+  entry: yauzl.Entry,
+): Promise<Uint8Array> {
+  const stream = await new Promise<NodeJS.ReadableStream>((resolve, reject) => {
+    zipFile.openReadStream(entry, (error, opened) => {
+      if (error || opened === undefined) {
+        reject(error ?? new Error(`Cannot read ZIP entry: ${entry.fileName}`));
+      } else {
+        resolve(opened);
+      }
     });
-    zipFile.once("error", reject);
-    zipFile.once("end", () => resolve(entries));
-    zipFile.readEntry();
   });
+  return await collectNodeStream(stream);
 }
 
 async function writeNodeZip(
@@ -416,6 +455,27 @@ export const nodeWikiGraphPlatform: WikiGraphPlatform = {
     create: <T>() => new asyncHooks.AsyncLocalStorage<T>(),
   },
   database: { open: openNodeDatabase },
+  lifecycle: {
+    instanceId: `node-process:${nodeProcess.pid}`,
+    isInstanceAlive: (instanceId) => {
+      const match = /^node-process:(\d+)$/u.exec(instanceId);
+      if (match === null) return Promise.resolve(undefined);
+      try {
+        nodeProcess.kill(Number(match[1]), 0);
+        return Promise.resolve(true);
+      } catch (error) {
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          "code" in error &&
+          error.code === "ESRCH"
+        ) {
+          return Promise.resolve(false);
+        }
+        return Promise.resolve(true);
+      }
+    },
+  },
   resources: {
     getDirectory: (identity) => {
       const path = decodeNodeResourceIdentity(identity, "directory");
@@ -434,7 +494,7 @@ export const nodeWikiGraphPlatform: WikiGraphPlatform = {
     createEnvironment: (options) =>
       new Environment(new NodeTemplateLoader(), options),
   },
-  zip: { read: readNodeZip, write: writeNodeZip },
+  zip: { open: openNodeZip, write: writeNodeZip },
 };
 
 class NodeTemplateLoader extends Loader {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -476,9 +476,11 @@ export {
   type HostDatabaseProvider,
   type HostDatabaseRow,
   type HostDatabaseValue,
+  type HostLifecycleProvider,
   type HostResourceProvider,
   type HostZipEntry,
   type HostZipProvider,
+  type HostZipReader,
   type WikiGraphPlatform,
   type WikiGraphStorage,
 } from "./runtime/platform/index.js";

--- a/packages/core/src/runtime/platform/index.ts
+++ b/packages/core/src/runtime/platform/index.ts
@@ -2,6 +2,7 @@ import type {
   Directory,
   File,
   HostAsyncContext,
+  HostZipEntry,
   WikiGraphPlatform,
   WikiGraphStorage,
 } from "./types.js";
@@ -17,11 +18,13 @@ export type {
   HostDatabaseRow,
   HostDatabaseValue,
   HostError,
+  HostLifecycleProvider,
   HostResourceProvider,
   HostTemplateProvider,
   HostTemplateEnvironment,
   HostZipEntry,
   HostZipProvider,
+  HostZipReader,
   WikiGraphPlatform,
   WikiGraphStorage,
 } from "./types.js";
@@ -49,6 +52,21 @@ export function getWikiGraphPlatform(): WikiGraphPlatform {
   }
 
   return installedPlatform;
+}
+
+/** Materialize a ZIP only for workflows that inherently consume every entry. */
+export async function readHostZipEntries(file: File): Promise<HostZipEntry[]> {
+  const reader = await getWikiGraphPlatform().zip.open(file);
+  try {
+    const entries: HostZipEntry[] = [];
+    for (const name of await reader.listEntries()) {
+      const data = await reader.readEntry(name);
+      if (data !== undefined) entries.push({ data, name });
+    }
+    return entries;
+  } finally {
+    await reader.close();
+  }
 }
 
 /** Resolve an opaque persisted identity into its host file capability. */

--- a/packages/core/src/runtime/platform/types.ts
+++ b/packages/core/src/runtime/platform/types.ts
@@ -92,12 +92,25 @@ export interface HostZipEntry {
   readonly name: string;
 }
 
+/** Lazily reads entries from one host-owned ZIP archive. */
+export interface HostZipReader {
+  close(): Promise<void>;
+  listEntries(): Promise<readonly string[]>;
+  readEntry(name: string): Promise<Uint8Array | undefined>;
+}
+
 export interface HostZipProvider {
-  read(file: File): Promise<readonly HostZipEntry[]>;
+  open(file: File): Promise<HostZipReader>;
   write(
     file: File,
     entries: Iterable<HostZipEntry> | AsyncIterable<HostZipEntry>,
   ): Promise<void>;
+}
+
+/** Identifies one host execution and probes executions that may have died. */
+export interface HostLifecycleProvider {
+  readonly instanceId: string;
+  isInstanceAlive(instanceId: string): Promise<boolean | undefined>;
 }
 
 export interface HostTemplateProvider {
@@ -118,6 +131,7 @@ export interface HostTemplateEnvironment {
 export interface WikiGraphPlatform {
   readonly asyncContext: HostAsyncContextProvider;
   readonly database: HostDatabaseProvider;
+  readonly lifecycle: HostLifecycleProvider;
   readonly resources: HostResourceProvider;
   readonly templates: HostTemplateProvider;
   readonly zip: HostZipProvider;

--- a/packages/core/src/storage/migration/legacy-sdpub/upgrade/extract.ts
+++ b/packages/core/src/storage/migration/legacy-sdpub/upgrade/extract.ts
@@ -1,6 +1,6 @@
 import {
   ensureRelativeDirectory,
-  getWikiGraphPlatform,
+  readHostZipEntries,
   type Directory,
   type File,
 } from "../../../../runtime/platform/index.js";
@@ -19,7 +19,7 @@ export async function extractLegacySdpubArchive(
   inputFile: File,
   outputDirectory: Directory,
 ): Promise<void> {
-  const entries = await getWikiGraphPlatform().zip.read(inputFile);
+  const entries = await readHostZipEntries(inputFile);
   const paths = new Set(entries.map((entry) => normalize(entry.name)));
   if (!paths.has("database.db") || !paths.has("toc.json")) {
     throw new Error("Unsupported legacy sdpub archive.");

--- a/packages/core/src/storage/schema-upgrade/index.ts
+++ b/packages/core/src/storage/schema-upgrade/index.ts
@@ -8,6 +8,7 @@ import {
   ensureRelativeDirectory,
   getWikiGraphPlatform,
   getWikiGraphStorage,
+  readHostZipEntries,
   resolveHostFile,
   type Directory,
   type File,
@@ -156,7 +157,7 @@ async function readArchiveEntries(
   archive: File,
 ): Promise<Map<string, Uint8Array>> {
   const entries = new Map<string, Uint8Array>();
-  for (const entry of await getWikiGraphPlatform().zip.read(archive)) {
+  for (const entry of await readHostZipEntries(archive)) {
     const name = normalizeArchivePath(entry.name);
     if (name !== "" && isWikgArchivePath(name)) entries.set(name, entry.data);
   }

--- a/packages/core/src/storage/wikg/archive/extract.ts
+++ b/packages/core/src/storage/wikg/archive/extract.ts
@@ -1,6 +1,6 @@
 import {
   ensureRelativeDirectory,
-  getWikiGraphPlatform,
+  readHostZipEntries,
   resolveHostDirectory,
   resolveHostFile,
   type Directory,
@@ -16,7 +16,7 @@ export async function extractWikgArchive(
 ): Promise<void> {
   const inputFile = await resolveHostFile(inputFileRef);
   const outputDirectory = await resolveHostDirectory(outputDirectoryRef);
-  const archiveEntries = await getWikiGraphPlatform().zip.read(inputFile);
+  const archiveEntries = await readHostZipEntries(inputFile);
   const entries = new Map(
     archiveEntries.map((entry) => [
       normalizeArchivePath(entry.name),

--- a/packages/core/src/storage/wikg/archive/reader.ts
+++ b/packages/core/src/storage/wikg/archive/reader.ts
@@ -6,8 +6,8 @@ import {
   resolveHostFile,
   type Directory,
   type File,
+  type HostZipReader,
 } from "../../../runtime/platform/index.js";
-import { ensureWikiGraphArchiveSchemaCurrent } from "../../schema-upgrade/index.js";
 import { WIKG_MANIFEST_PATH, WIKG_MUTATION_TOKEN_PATH } from "./constants.js";
 import {
   WIKG_SCHEMA_VERSION,
@@ -17,27 +17,37 @@ import {
 import { isWikgArchivePath, normalizeArchivePath } from "./paths.js";
 
 export class WikgArchiveReader {
-  readonly #entries: ReadonlyMap<string, Uint8Array>;
+  readonly #entries: ReadonlyMap<string, string>;
+  readonly #reader: HostZipReader;
 
   // eslint-disable-next-line no-restricted-syntax -- constructors cannot use JavaScript #private syntax.
-  private constructor(entries: ReadonlyMap<string, Uint8Array>) {
+  private constructor(
+    reader: HostZipReader,
+    entries: ReadonlyMap<string, string>,
+  ) {
+    this.#reader = reader;
     this.#entries = entries;
   }
 
   public static async open(fileRef: File | string): Promise<WikgArchiveReader> {
     const file = await resolveHostFile(fileRef);
-    await ensureWikiGraphArchiveSchemaCurrent(file);
-    const entries = new Map<string, Uint8Array>();
-    for (const entry of await getWikiGraphPlatform().zip.read(file)) {
-      const name = normalizeArchivePath(entry.name);
-      if (name !== "" && isWikgArchivePath(name)) entries.set(name, entry.data);
+    const reader = await getWikiGraphPlatform().zip.open(file);
+    try {
+      const entries = new Map<string, string>();
+      for (const hostName of await reader.listEntries()) {
+        const name = normalizeArchivePath(hostName);
+        if (name !== "" && isWikgArchivePath(name)) entries.set(name, hostName);
+      }
+      await assertCurrentArchive(reader, entries);
+      return new WikgArchiveReader(reader, entries);
+    } catch (error) {
+      await reader.close();
+      throw error;
     }
-    assertCurrentArchive(entries);
-    return new WikgArchiveReader(entries);
   }
 
-  public close(): void {
-    // The host owns archive reader resources.
+  public async close(): Promise<void> {
+    await this.#reader.close();
   }
 
   public listEntries(): readonly string[] {
@@ -47,7 +57,10 @@ export class WikgArchiveReader {
   }
 
   public async readEntry(entryPath: string): Promise<Uint8Array | undefined> {
-    return this.#entries.get(normalizeArchivePath(entryPath));
+    const hostName = this.#entries.get(normalizeArchivePath(entryPath));
+    return hostName === undefined
+      ? undefined
+      : await this.#reader.readEntry(hostName);
   }
 }
 
@@ -55,7 +68,11 @@ export async function listWikgArchiveEntries(
   file: File | string,
 ): Promise<readonly string[]> {
   const reader = await WikgArchiveReader.open(file);
-  return reader.listEntries();
+  try {
+    return reader.listEntries();
+  } finally {
+    await reader.close();
+  }
 }
 
 export async function readWikgArchiveEntry(
@@ -63,27 +80,43 @@ export async function readWikgArchiveEntry(
   entryPath: string,
 ): Promise<Uint8Array | undefined> {
   const reader = await WikgArchiveReader.open(file);
-  return await reader.readEntry(entryPath);
+  try {
+    return await reader.readEntry(entryPath);
+  } finally {
+    await reader.close();
+  }
 }
 
 export async function readWikgArchiveMutationToken(
   file: File | string,
 ): Promise<string> {
-  const resolved = await resolveHostFile(file);
-  const tokenEntry = (await getWikiGraphPlatform().zip.read(resolved)).find(
-    (entry) => normalizeArchivePath(entry.name) === WIKG_MUTATION_TOKEN_PATH,
+  const reader = await getWikiGraphPlatform().zip.open(
+    await resolveHostFile(file),
   );
-  const content = tokenEntry?.data;
-  if (content === undefined) {
-    throw new Error(
-      `Missing WIKG mutation token: ${WIKG_MUTATION_TOKEN_PATH}.`,
+  try {
+    const hostName = (await reader.listEntries()).find(
+      (name) => normalizeArchivePath(name) === WIKG_MUTATION_TOKEN_PATH,
     );
+    const content =
+      hostName === undefined ? undefined : await reader.readEntry(hostName);
+    if (content === undefined) {
+      throw new Error(
+        `Missing WIKG mutation token: ${WIKG_MUTATION_TOKEN_PATH}.`,
+      );
+    }
+    return parseWikgMutationToken(new TextDecoder().decode(content));
+  } finally {
+    await reader.close();
   }
-  return parseWikgMutationToken(new TextDecoder().decode(content));
 }
 
-function assertCurrentArchive(entries: ReadonlyMap<string, Uint8Array>): void {
-  const manifest = entries.get(WIKG_MANIFEST_PATH);
+async function assertCurrentArchive(
+  reader: HostZipReader,
+  entries: ReadonlyMap<string, string>,
+): Promise<void> {
+  const hostName = entries.get(WIKG_MANIFEST_PATH);
+  const manifest =
+    hostName === undefined ? undefined : await reader.readEntry(hostName);
   if (manifest === undefined) {
     throw new Error(`Missing WIKG manifest: ${WIKG_MANIFEST_PATH}.`);
   }

--- a/packages/core/src/storage/wikg/archive/write.ts
+++ b/packages/core/src/storage/wikg/archive/write.ts
@@ -5,6 +5,7 @@ import {
   type Directory,
   type File,
   type HostZipEntry,
+  type HostZipReader,
 } from "../../../runtime/platform/index.js";
 import {
   LEGACY_SEARCH_INDEX_DATABASE_PATH,
@@ -61,38 +62,94 @@ export async function writeWikgArchiveWithOverlays(
 ): Promise<void> {
   const inputFile = await resolveHostFile(inputFileRef);
   const outputFile = await resolveHostFile(outputFileRef);
-  const entries = new Map<string, Uint8Array>();
-  for (const entry of await getWikiGraphPlatform().zip.read(inputFile)) {
-    const name = normalizeArchivePath(entry.name);
-    if (name !== "" && isWikgArchivePath(name)) entries.set(name, entry.data);
-  }
-  for (const overlay of overlays) {
-    const name = normalizeArchivePath(overlay.entryPath);
-    if (!isWikgArchivePath(name)) continue;
-    if (overlay.kind === "deleted") entries.delete(name);
-    else {
-      const content = await overlay.file.read();
-      entries.set(
-        name,
-        typeof content === "string"
-          ? new TextEncoder().encode(content)
-          : content,
-      );
+  const reader = await getWikiGraphPlatform().zip.open(inputFile);
+  try {
+    const archiveEntries = new Map<string, string>();
+    for (const hostName of await reader.listEntries()) {
+      const name = normalizeArchivePath(hostName);
+      if (name !== "" && isWikgArchivePath(name)) {
+        archiveEntries.set(name, hostName);
+      }
     }
+    const entries = new Map<
+      string,
+      | { readonly kind: "archive"; readonly hostName: string }
+      | WikgArchiveOverlay
+    >(
+      [...archiveEntries].map(([name, hostName]) => [
+        name,
+        { hostName, kind: "archive" },
+      ]),
+    );
+    for (const overlay of overlays) {
+      const name = normalizeArchivePath(overlay.entryPath);
+      if (!isWikgArchivePath(name)) continue;
+      if (overlay.kind === "deleted") entries.delete(name);
+      else entries.set(name, overlay);
+    }
+    entries.delete(LEGACY_SEARCH_INDEX_DATABASE_PATH);
+    const mutationToken =
+      options.preserveMutationToken === true
+        ? await readArchiveEntry(
+            reader,
+            archiveEntries,
+            WIKG_MUTATION_TOKEN_PATH,
+          )
+        : undefined;
+    entries.delete(WIKG_MUTATION_TOKEN_PATH);
+    entries.delete(WIKG_MANIFEST_PATH);
+    const paths = new Set(entries.keys());
+    paths.add(WIKG_MUTATION_TOKEN_PATH);
+    paths.add(WIKG_MANIFEST_PATH);
+
+    await getWikiGraphPlatform().zip.write(
+      outputFile,
+      (async function* (): AsyncGenerator<HostZipEntry> {
+        for (const name of sortArchiveEntryPathsForWrite(paths)) {
+          if (name === WIKG_MUTATION_TOKEN_PATH) {
+            yield {
+              data: mutationToken ?? createWikgMutationTokenContent(),
+              name,
+            };
+            continue;
+          }
+          if (name === WIKG_MANIFEST_PATH) {
+            yield {
+              data: new TextEncoder().encode(WIKG_MANIFEST_CONTENT),
+              name,
+            };
+            continue;
+          }
+          const source = entries.get(name);
+          if (source === undefined || source.kind === "deleted") continue;
+          if (source.kind === "archive") {
+            const data = await reader.readEntry(source.hostName);
+            if (data !== undefined) yield { data, name };
+            continue;
+          }
+          const content = await source.file.read();
+          yield {
+            data:
+              typeof content === "string"
+                ? new TextEncoder().encode(content)
+                : content,
+            name,
+          };
+        }
+      })(),
+    );
+  } finally {
+    await reader.close();
   }
-  entries.delete(LEGACY_SEARCH_INDEX_DATABASE_PATH);
-  entries.set(
-    WIKG_MUTATION_TOKEN_PATH,
-    options.preserveMutationToken === true &&
-      entries.has(WIKG_MUTATION_TOKEN_PATH)
-      ? (entries.get(WIKG_MUTATION_TOKEN_PATH) as Uint8Array)
-      : createWikgMutationTokenContent(),
-  );
-  entries.set(
-    WIKG_MANIFEST_PATH,
-    new TextEncoder().encode(WIKG_MANIFEST_CONTENT),
-  );
-  await writeEntries(outputFile, entries);
+}
+
+async function readArchiveEntry(
+  reader: HostZipReader,
+  entries: ReadonlyMap<string, string>,
+  name: string,
+): Promise<Uint8Array | undefined> {
+  const hostName = entries.get(name);
+  return hostName === undefined ? undefined : await reader.readEntry(hostName);
 }
 
 async function writeEntries(

--- a/packages/core/src/storage/wikg/wikg-coordinator/flusher.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/flusher.ts
@@ -1,0 +1,191 @@
+import {
+  getWikiGraphPlatform,
+  resolveHostFile,
+  type File,
+  type HostZipEntry,
+} from "../../../runtime/platform/index.js";
+import {
+  WIKG_MANIFEST_CONTENT,
+  createWikgMutationTokenBytes,
+} from "../archive/manifest.js";
+import {
+  WIKG_MANIFEST_PATH,
+  WIKG_MUTATION_TOKEN_PATH,
+} from "../archive/constants.js";
+import {
+  isWikgArchivePath,
+  sortArchiveEntryPathsForWrite,
+} from "../archive/paths.js";
+import { WikgArchiveReader } from "../archive/reader.js";
+
+import {
+  DATABASE_ENTRY_PATH,
+  LEGACY_SEARCH_INDEX_DATABASE_ENTRY_PATH,
+  SEARCH_INDEX_DATABASE_ENTRY_PATH,
+} from "./constants.js";
+import {
+  acquireArchiveCommitLock,
+  acquireEntryLock,
+  waitForSqliteLeasesToDrain,
+} from "./locks.js";
+import {
+  deleteCommittedOverlay,
+  listOrphanOverlayPaths,
+  listOverlays,
+  resolveOverlayFile,
+} from "./overlays.js";
+import { cleanupStaleState, withCoordinatorState } from "./state.js";
+import type { CoordinatorOwner, EntryOverlay } from "./types.js";
+
+export async function reapArchive(
+  archiveKey: string,
+  owner: CoordinatorOwner,
+  archive: File,
+): Promise<void> {
+  await withCoordinatorState(async (database) => {
+    await cleanupStaleState(database, archiveKey);
+  });
+  const orphanPaths = await listOrphanOverlayPaths(archiveKey);
+  if (orphanPaths.size > 0) {
+    await flushArchiveOverlays(archiveKey, owner, orphanPaths, archive);
+  }
+}
+
+export async function flushArchiveOverlays(
+  archiveKey: string,
+  owner: CoordinatorOwner,
+  requestedEntryPaths?: ReadonlySet<string>,
+  archiveInput?: File,
+): Promise<Uint8Array | undefined> {
+  const candidates = (await listOverlays(archiveKey)).filter(
+    (overlay) =>
+      requestedEntryPaths === undefined ||
+      requestedEntryPaths.has(overlay.entryPath),
+  );
+  if (candidates.length === 0) return undefined;
+
+  const archive =
+    archiveInput ?? (await resolveHostFile(candidates[0]!.archiveIdentity));
+  const entryPaths = [
+    ...new Set(candidates.map((item) => item.entryPath)),
+  ].sort((left, right) => left.localeCompare(right));
+  const releases: Array<() => Promise<void>> = [];
+  try {
+    for (const entryPath of entryPaths) {
+      releases.push(
+        await acquireEntryLock(archiveKey, entryPath, "write", owner),
+      );
+    }
+    for (const entryPath of entryPaths) {
+      if (isSqliteEntry(entryPath)) {
+        await waitForSqliteLeasesToDrain(archiveKey, entryPath, owner);
+      }
+    }
+
+    const requested = new Set(entryPaths);
+    const overlays = (await listOverlays(archiveKey)).filter((overlay) =>
+      requested.has(overlay.entryPath),
+    );
+    if (overlays.length === 0) return undefined;
+
+    const releaseCommit = await acquireArchiveCommitLock(archiveKey, owner);
+    try {
+      return await commitOverlays(archive, overlays);
+    } finally {
+      await releaseCommit();
+    }
+  } finally {
+    for (const release of releases.reverse()) await release();
+  }
+}
+
+async function commitOverlays(
+  archive: File,
+  overlays: readonly EntryOverlay[],
+): Promise<Uint8Array> {
+  const reader = await WikgArchiveReader.open(archive);
+  const overlayByPath = new Map(overlays.map((item) => [item.entryPath, item]));
+  if (
+    overlayByPath.has(DATABASE_ENTRY_PATH) ||
+    overlayByPath.has(SEARCH_INDEX_DATABASE_ENTRY_PATH)
+  ) {
+    overlayByPath.set(LEGACY_SEARCH_INDEX_DATABASE_ENTRY_PATH, {
+      archiveIdentity: archive.identity,
+      archiveKey: overlays[0]!.archiveKey,
+      entryPath: LEGACY_SEARCH_INDEX_DATABASE_ENTRY_PATH,
+      kind: "deleted",
+      ownerId: overlays[0]!.ownerId,
+      updatedAt: Date.now(),
+    });
+  }
+  const paths = new Set(reader.listEntries());
+  for (const overlay of overlayByPath.values()) {
+    if (overlay.kind === "deleted") paths.delete(overlay.entryPath);
+    else paths.add(overlay.entryPath);
+  }
+  paths.add(WIKG_MANIFEST_PATH);
+  paths.add(WIKG_MUTATION_TOKEN_PATH);
+  const mutationToken = createWikgMutationTokenBytes();
+  try {
+    await getWikiGraphPlatform().zip.write(
+      archive,
+      createArchiveEntries(reader, overlayByPath, paths, mutationToken),
+    );
+  } finally {
+    await reader.close();
+  }
+
+  // The archive is authoritative after its transactional writer commits.
+  // Cleanup failure may leave an idempotent overlay for a later reaper, but
+  // must not turn a successful physical commit into a rollback attempt.
+  for (const overlay of overlays) {
+    await deleteCommittedOverlay(overlay).catch(() => undefined);
+  }
+  return mutationToken;
+}
+
+async function* createArchiveEntries(
+  reader: WikgArchiveReader,
+  overlays: ReadonlyMap<string, EntryOverlay>,
+  paths: ReadonlySet<string>,
+  mutationToken: Uint8Array,
+): AsyncGenerator<HostZipEntry> {
+  for (const path of sortArchiveEntryPathsForWrite(paths)) {
+    if (!isWikgArchivePath(path)) continue;
+    if (path === WIKG_MUTATION_TOKEN_PATH) {
+      yield { data: mutationToken, name: path };
+      continue;
+    }
+    if (path === WIKG_MANIFEST_PATH) {
+      yield {
+        data: new TextEncoder().encode(WIKG_MANIFEST_CONTENT),
+        name: path,
+      };
+      continue;
+    }
+    const overlay = overlays.get(path);
+    if (overlay?.kind === "deleted") continue;
+    if (overlay?.kind === "file") {
+      const file = await resolveOverlayFile(overlay);
+      const content = await file.read();
+      yield {
+        data:
+          typeof content === "string"
+            ? new TextEncoder().encode(content)
+            : content,
+        name: path,
+      };
+      continue;
+    }
+    const content = await reader.readEntry(path);
+    if (content !== undefined) yield { data: content, name: path };
+  }
+}
+
+function isSqliteEntry(entryPath: string): boolean {
+  return (
+    entryPath === DATABASE_ENTRY_PATH ||
+    entryPath === SEARCH_INDEX_DATABASE_ENTRY_PATH ||
+    entryPath === LEGACY_SEARCH_INDEX_DATABASE_ENTRY_PATH
+  );
+}

--- a/packages/core/src/storage/wikg/wikg-coordinator/flusher.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/flusher.ts
@@ -32,6 +32,7 @@ import {
   deleteCommittedOverlay,
   listOrphanOverlayPaths,
   listOverlays,
+  listSettleableOverlays,
   resolveOverlayFile,
 } from "./overlays.js";
 import { cleanupStaleState, withCoordinatorState } from "./state.js";
@@ -83,8 +84,10 @@ export async function flushArchiveOverlays(
     }
 
     const requested = new Set(entryPaths);
-    const overlays = (await listOverlays(archiveKey)).filter((overlay) =>
-      requested.has(overlay.entryPath),
+    const overlays = await listSettleableOverlays(
+      archiveKey,
+      requested,
+      owner.ownerId,
     );
     if (overlays.length === 0) return undefined;
 

--- a/packages/core/src/storage/wikg/wikg-coordinator/host-file-store.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/host-file-store.ts
@@ -3,6 +3,7 @@ import type { DocumentFileStore } from "../../../document/directory/index.js";
 
 import {
   DATABASE_ENTRY_PATH,
+  LEGACY_SEARCH_INDEX_DATABASE_ENTRY_PATH,
   SEARCH_INDEX_DATABASE_ENTRY_PATH,
 } from "./constants.js";
 import { normalizeArchivePath } from "../archive/paths.js";
@@ -15,6 +16,8 @@ export class HostWikgDocumentFileStore implements DocumentFileStore {
   readonly #session: HostWikgArchiveSession;
   #database: File | undefined;
   #searchIndexDatabase: File | undefined;
+  #databaseDirty = false;
+  #searchIndexDatabaseDirty = false;
 
   public constructor(
     session: HostWikgArchiveSession,
@@ -29,8 +32,16 @@ export class HostWikgDocumentFileStore implements DocumentFileStore {
       options.searchIndexWritebackPolicy ?? "cache";
   }
 
-  public close(): Promise<void> {
-    return Promise.resolve();
+  public async close(): Promise<void> {
+    await this.#session.releaseDatabaseLease(DATABASE_ENTRY_PATH);
+    await this.#session.releaseDatabaseLease(SEARCH_INDEX_DATABASE_ENTRY_PATH);
+    if (
+      this.#databaseDirty ||
+      (this.#searchIndexDatabaseDirty &&
+        this.#searchIndexWritebackPolicy === "archive")
+    ) {
+      await this.#session.deleteEntry(LEGACY_SEARCH_INDEX_DATABASE_ENTRY_PATH);
+    }
   }
   public ensureDirectory(): Promise<void> {
     return Promise.resolve();
@@ -51,7 +62,10 @@ export class HostWikgDocumentFileStore implements DocumentFileStore {
   public async resolveDatabasePath(): Promise<File> {
     this.#database ??= await this.#session.materializeDatabase(
       DATABASE_ENTRY_PATH,
-      { createIfMissing: !this.#readonlyDatabase },
+      {
+        createIfMissing: !this.#readonlyDatabase,
+        mode: this.#readonlyDatabase ? "read" : "write",
+      },
     );
     return this.#database;
   }
@@ -64,24 +78,26 @@ export class HostWikgDocumentFileStore implements DocumentFileStore {
           })
         : await this.#session.materializeDatabase(
             SEARCH_INDEX_DATABASE_ENTRY_PATH,
-            { createIfMissing: !this.#readonlyDatabase },
+            {
+              createIfMissing: !this.#readonlyDatabase,
+              mode: this.#readonlyDatabase ? "read" : "write",
+            },
           );
     return this.#searchIndexDatabase;
   }
 
   public markDatabaseDirty(): void {
     if (!this.#readonlyDatabase && this.#database !== undefined) {
-      this.#session.markDatabaseDirty(DATABASE_ENTRY_PATH, this.#database);
+      this.#databaseDirty = true;
+      this.#session.markDatabaseDirty(DATABASE_ENTRY_PATH);
     }
   }
 
   public markSearchIndexDatabaseDirty(): void {
     if (!this.#readonlyDatabase && this.#searchIndexDatabase !== undefined) {
+      this.#searchIndexDatabaseDirty = true;
       if (this.#searchIndexWritebackPolicy === "archive") {
-        this.#session.markDatabaseDirty(
-          SEARCH_INDEX_DATABASE_ENTRY_PATH,
-          this.#searchIndexDatabase,
-        );
+        this.#session.markDatabaseDirty(SEARCH_INDEX_DATABASE_ENTRY_PATH);
       } else {
         this.#session.markSearchIndexCacheDirty(this.#searchIndexDatabase);
       }
@@ -98,13 +114,7 @@ export class HostWikgDocumentFileStore implements DocumentFileStore {
     options: { readonly overwrite?: boolean },
   ): Promise<void> {
     const entryPath = toEntryPath(path);
-    if (
-      options.overwrite !== true &&
-      (await this.#session.readEntry(entryPath)) !== undefined
-    ) {
-      throw new Error(`File already exists: ${path}`);
-    }
-    await this.#session.writeEntry(entryPath, content);
+    await this.#session.writeEntry(entryPath, content, options);
   }
 
   public async deleteFile(path: string): Promise<void> {
@@ -117,15 +127,15 @@ export class HostWikgDocumentFileStore implements DocumentFileStore {
       this.#session.deleteSearchIndexCache();
       return;
     }
-    this.#session.deleteEntry(entryPath);
+    await this.#session.deleteEntry(entryPath);
   }
 
   public async deleteTree(path: string): Promise<void> {
     const root = toEntryPath(path);
     const prefix = root === "" ? "" : `${root}/`;
-    for (const entry of this.#session.listEntries()) {
+    for (const entry of await this.#session.listEntries()) {
       if (entry === root || entry.startsWith(prefix)) {
-        this.#session.deleteEntry(entry);
+        await this.#session.deleteEntry(entry);
       }
     }
   }
@@ -133,8 +143,7 @@ export class HostWikgDocumentFileStore implements DocumentFileStore {
   public async listFiles(path: string): Promise<readonly string[]> {
     const root = toEntryPath(path);
     const prefix = root === "" ? "" : `${root}/`;
-    return this.#session
-      .listEntries()
+    return (await this.#session.listEntries())
       .filter((entry) => entry.startsWith(prefix))
       .map((entry) => entry.slice(prefix.length))
       .filter((entry) => entry !== "" && !entry.includes("/"))

--- a/packages/core/src/storage/wikg/wikg-coordinator/host-session.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/host-session.ts
@@ -1,139 +1,143 @@
-import type {
-  Directory,
-  File,
-  HostZipEntry,
-} from "../../../runtime/platform/index.js";
+import type { File } from "../../../runtime/platform/index.js";
 import {
   ensureRelativeDirectory,
   ensureRelativeFile,
   getRelativeDirectory,
-  getWikiGraphPlatform,
   getWikiGraphStorage,
 } from "../../../runtime/platform/index.js";
 import type { DocumentFileStore } from "../../../document/directory/index.js";
+import { createPortableHash } from "../../../utils/crypto.js";
 
 import {
-  WIKG_MANIFEST_CONTENT,
-  WIKG_SCHEMA_VERSION,
-  createWikgMutationTokenBytes,
-  parseWikgManifest,
-} from "../archive/manifest.js";
-import {
-  WIKG_MANIFEST_PATH,
-  WIKG_MUTATION_TOKEN_PATH,
-} from "../archive/constants.js";
-import {
-  isWikgArchivePath,
-  normalizeArchivePath,
-  sortArchiveEntryPathsForWrite,
-} from "../archive/paths.js";
+  readWikgArchiveMutationToken,
+  WikgArchiveReader,
+} from "../archive/reader.js";
+import { parseWikgMutationToken } from "../archive/manifest.js";
+import { normalizeArchivePath } from "../archive/paths.js";
 import {
   DATABASE_ENTRY_PATH,
   LEGACY_SEARCH_INDEX_DATABASE_ENTRY_PATH,
+  OWNER_HEARTBEAT_INTERVAL_MS,
   SEARCH_INDEX_DATABASE_ENTRY_PATH,
 } from "./constants.js";
+import { flushArchiveOverlays, reapArchive } from "./flusher.js";
 import { HostWikgDocumentFileStore } from "./host-file-store.js";
-import type { WorkspaceWritebackPolicy } from "./types.js";
-import { createPortableHash } from "../../../utils/crypto.js";
+import {
+  acquireSqliteLease,
+  releaseSqliteLease,
+  waitForSqliteLeasesToDrain,
+  withEntryLock,
+} from "./locks.js";
+import {
+  createCoordinatorOwner,
+  heartbeatArchiveOwner,
+  registerArchiveOwner,
+  unregisterArchiveOwner,
+} from "./owners.js";
+import {
+  isDirtyOverlay,
+  deleteCleanOverlayIfUnused,
+  listOverlays,
+  publishDeleteOverlay,
+  publishFileOverlay,
+  readOverlay,
+  resolveOverlayFile,
+  restoreOverlay,
+} from "./overlays.js";
+import type {
+  CoordinatorOwner,
+  EntryOverlay,
+  SqliteLeaseMode,
+  WorkspaceWritebackPolicy,
+} from "./types.js";
+import {
+  createWorkspaceSnapshot,
+  removeWorkspaceSnapshot,
+} from "./workspace.js";
 
-type Overlay =
-  | { readonly kind: "deleted" }
-  | { readonly file: File; readonly kind: "file" };
+interface SessionChange {
+  current: EntryOverlay;
+  readonly previous: EntryOverlay | undefined;
+}
 
-const archiveQueues = new Map<string, Promise<void>>();
-let sessionSequence = 0;
-
-/** Serialize use of one opaque host file without inspecting its implementation. */
+/** Run one archive operation within a durable, host-neutral session. */
 export async function withHostArchiveSession<T>(
   archive: File,
   operation: (session: HostWikgArchiveSession) => Promise<T> | T,
 ): Promise<T> {
-  const previous = archiveQueues.get(archive.identity) ?? Promise.resolve();
-  let release!: () => void;
-  const current = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  const queued = previous.then(() => current);
-  archiveQueues.set(archive.identity, queued);
-  await previous;
-
+  const session = await HostWikgArchiveSession.open(archive);
   try {
-    const session = await HostWikgArchiveSession.open(archive);
-    try {
-      return await operation(session);
-    } catch (error) {
-      session.abort();
-      throw error;
-    } finally {
-      await session.close();
-    }
+    return await operation(session);
+  } catch (error) {
+    await session.abort();
+    throw error;
   } finally {
-    release();
-    if (archiveQueues.get(archive.identity) === queued) {
-      archiveQueues.delete(archive.identity);
-    }
+    await session.close();
   }
 }
 
-/** Host-neutral archive transaction rooted in the injected document store. */
+/** Coordinates logical archive state without observing host locations. */
 export class HostWikgArchiveSession {
   readonly #archive: File;
-  readonly #entries: Map<string, Uint8Array>;
-  readonly #overlays = new Map<string, Overlay>();
-  readonly #workspaceName: string;
-  readonly #workspace: Directory;
+  readonly #archiveKey: string;
+  readonly #owner: CoordinatorOwner;
+  readonly #heartbeat: ReturnType<typeof globalThis.setInterval>;
+  readonly #changes = new Map<string, SessionChange>();
+  readonly #modifiedEntryPaths = new Set<string>();
+  readonly #observedDirtyEntryPaths = new Set<string>();
+  readonly #materializedEntryPaths = new Set<string>();
+  readonly #leasedEntryPaths = new Set<string>();
   readonly #initialSearchCacheKey: string;
   #searchCacheKey: string;
   #searchCacheFile: File | undefined;
+  #searchCacheWorkspacePath: string | undefined;
   #searchCacheDirty = false;
   #searchCacheDelete = false;
   #closed = false;
   #aborted = false;
 
-  public constructor(
-    archive: File,
-    entries: Map<string, Uint8Array>,
-    workspaceName: string,
-    workspace: Directory,
-    searchCacheKey: string,
-  ) {
-    this.#archive = archive;
-    this.#entries = entries;
-    this.#workspaceName = workspaceName;
-    this.#workspace = workspace;
-    this.#initialSearchCacheKey = searchCacheKey;
-    this.#searchCacheKey = searchCacheKey;
+  // eslint-disable-next-line no-restricted-syntax -- constructors cannot use JavaScript #private syntax.
+  private constructor(input: {
+    readonly archive: File;
+    readonly archiveKey: string;
+    readonly initialSearchCacheKey: string;
+    readonly owner: CoordinatorOwner;
+  }) {
+    this.#archive = input.archive;
+    this.#archiveKey = input.archiveKey;
+    this.#initialSearchCacheKey = input.initialSearchCacheKey;
+    this.#searchCacheKey = input.initialSearchCacheKey;
+    this.#owner = input.owner;
+    this.#heartbeat = globalThis.setInterval(() => {
+      void heartbeatArchiveOwner(this.#archiveKey, this.#owner).catch(
+        () => undefined,
+      );
+    }, OWNER_HEARTBEAT_INTERVAL_MS);
   }
 
   public static async open(archive: File): Promise<HostWikgArchiveSession> {
-    const entries = new Map<string, Uint8Array>();
-    for (const entry of await getWikiGraphPlatform().zip.read(archive)) {
-      const path = normalizeArchivePath(entry.name);
-      if (path !== "" && isWikgArchivePath(path)) entries.set(path, entry.data);
+    const validationReader = await WikgArchiveReader.open(archive);
+    await validationReader.close();
+    const archiveKey = createPortableHash("sha256")
+      .update(archive.identity)
+      .digest("hex");
+    const owner = createCoordinatorOwner();
+    await registerArchiveOwner(archiveKey, owner);
+    try {
+      await reapArchive(archiveKey, owner, archive);
+      const mutationToken = await readWikgArchiveMutationToken(archive);
+      return new HostWikgArchiveSession({
+        archive,
+        archiveKey,
+        initialSearchCacheKey: createPortableHash("sha256")
+          .update(mutationToken)
+          .digest("hex"),
+        owner,
+      });
+    } catch (error) {
+      await unregisterArchiveOwner(archiveKey, owner.ownerId);
+      throw error;
     }
-    const manifestContent = entries.get(WIKG_MANIFEST_PATH);
-    if (manifestContent === undefined) {
-      throw new Error(`Missing WIKG manifest: ${WIKG_MANIFEST_PATH}.`);
-    }
-    const manifest = parseWikgManifest(
-      new TextDecoder().decode(manifestContent),
-    );
-    if (manifest.schemaVersion !== WIKG_SCHEMA_VERSION) {
-      throw new Error(
-        `WIKG schema version ${manifest.schemaVersion} requires migration by a host that supports archive migration.`,
-      );
-    }
-
-    const root = getWikiGraphStorage().documentStore;
-    const workspaceName = await createWorkspaceName(root);
-    const workspace = await root.createDirectory(workspaceName);
-    return new HostWikgArchiveSession(
-      archive,
-      entries,
-      workspaceName,
-      workspace,
-      createSearchCacheKey(archive, entries),
-    );
   }
 
   public createFileStore(
@@ -153,63 +157,183 @@ export class HostWikgArchiveSession {
     return `wikg-search-cache:${this.#searchCacheKey}`;
   }
 
-  public listEntries(): readonly string[] {
-    const paths = new Set(this.#entries.keys());
-    for (const [path, overlay] of this.#overlays) {
-      if (overlay.kind === "deleted") paths.delete(path);
-      else paths.add(path);
+  public async listEntries(): Promise<readonly string[]> {
+    const reader = await WikgArchiveReader.open(this.#archive);
+    try {
+      const entries = new Set(reader.listEntries());
+      for (const overlay of await listOverlays(this.#archiveKey)) {
+        if (overlay.kind === "deleted") entries.delete(overlay.entryPath);
+        else entries.add(overlay.entryPath);
+      }
+      return [...entries].sort((left, right) => left.localeCompare(right));
+    } finally {
+      await reader.close();
     }
-    return [...paths].sort((left, right) => left.localeCompare(right));
   }
 
   public async readEntry(path: string): Promise<Uint8Array | undefined> {
     const entryPath = normalizeArchivePath(path);
-    const overlay = this.#overlays.get(entryPath);
-    if (overlay?.kind === "deleted") return undefined;
-    if (overlay?.kind === "file") return await readBytes(overlay.file);
-    return this.#entries.get(entryPath);
+    return await withEntryLock(
+      this.#archiveKey,
+      entryPath,
+      "read",
+      this.#owner,
+      async () => await this.#readEntryUnlocked(entryPath),
+    );
   }
 
   public async writeEntry(
     path: string,
     content: string | Uint8Array,
+    options: { readonly overwrite?: boolean } = {},
   ): Promise<void> {
     const entryPath = normalizeArchivePath(path);
-    const file = await this.#workspaceFile(entryPath);
-    await replaceFile(file, content);
-    this.#overlays.set(entryPath, { file, kind: "file" });
+    await withEntryLock(
+      this.#archiveKey,
+      entryPath,
+      "write",
+      this.#owner,
+      async () => {
+        if (isSqliteEntry(entryPath)) {
+          await waitForSqliteLeasesToDrain(
+            this.#archiveKey,
+            entryPath,
+            this.#owner,
+          );
+        }
+        const previous = await readOverlay(this.#archiveKey, entryPath);
+        if (
+          options.overwrite !== true &&
+          previous?.kind !== "deleted" &&
+          (previous !== undefined ||
+            (await this.#readArchiveEntry(entryPath)) !== undefined)
+        ) {
+          throw new Error(`File already exists: ${path}`);
+        }
+        const snapshot = await createWorkspaceSnapshot(
+          this.#archiveKey,
+          entryPath,
+        );
+        try {
+          await replaceFile(snapshot.file, content);
+          await publishFileOverlay({
+            archiveIdentity: this.#archive.identity,
+            archiveKey: this.#archiveKey,
+            entryPath,
+            owner: this.#owner,
+            workspaceFile: snapshot.file,
+            workspacePath: snapshot.relativePath,
+          });
+        } catch (error) {
+          await removeWorkspaceSnapshot(snapshot.relativePath);
+          throw error;
+        }
+        await this.#recordChange(entryPath, previous);
+        this.#modifiedEntryPaths.add(entryPath);
+      },
+    );
   }
 
-  public deleteEntry(path: string): void {
-    this.#overlays.set(normalizeArchivePath(path), { kind: "deleted" });
+  public async deleteEntry(path: string): Promise<void> {
+    const entryPath = normalizeArchivePath(path);
+    await withEntryLock(
+      this.#archiveKey,
+      entryPath,
+      "write",
+      this.#owner,
+      async () => {
+        if (isSqliteEntry(entryPath)) {
+          await waitForSqliteLeasesToDrain(
+            this.#archiveKey,
+            entryPath,
+            this.#owner,
+          );
+        }
+        const previous = await readOverlay(this.#archiveKey, entryPath);
+        await publishDeleteOverlay({
+          archiveIdentity: this.#archive.identity,
+          archiveKey: this.#archiveKey,
+          entryPath,
+          owner: this.#owner,
+        });
+        await this.#recordChange(entryPath, previous);
+        this.#modifiedEntryPaths.add(entryPath);
+      },
+    );
   }
 
   public async materializeDatabase(
     path: string,
-    options: { readonly createIfMissing: boolean },
+    options: {
+      readonly createIfMissing: boolean;
+      readonly mode: SqliteLeaseMode;
+    },
   ): Promise<File> {
     const entryPath = normalizeArchivePath(path);
-    const existing = this.#overlays.get(entryPath);
-    if (existing?.kind === "file") return existing.file;
+    await acquireSqliteLease({
+      archiveKey: this.#archiveKey,
+      entryPath,
+      mode: options.mode,
+      owner: this.#owner,
+    });
+    this.#leasedEntryPaths.add(entryPath);
+    try {
+      return await withEntryLock(
+        this.#archiveKey,
+        entryPath,
+        "state",
+        this.#owner,
+        async () => {
+          const existing = await readOverlay(this.#archiveKey, entryPath);
+          if (existing?.kind === "file") {
+            if (await isDirtyOverlay(existing)) {
+              this.#observedDirtyEntryPaths.add(entryPath);
+            }
+            this.#materializedEntryPaths.add(entryPath);
+            return await resolveOverlayFile(existing);
+          }
 
-    const content =
-      (await this.readEntry(entryPath)) ??
-      (entryPath === SEARCH_INDEX_DATABASE_ENTRY_PATH
-        ? await this.readEntry(LEGACY_SEARCH_INDEX_DATABASE_ENTRY_PATH)
-        : undefined);
-    if (content === undefined && !options.createIfMissing) {
-      throw new Error(`Archive SQLite entry is missing: ${entryPath}`);
+          const content = await this.#readArchiveEntry(entryPath);
+          if (content === undefined && !options.createIfMissing) {
+            throw new Error(`Archive SQLite entry is missing: ${entryPath}`);
+          }
+          const bytes = content ?? new Uint8Array();
+          const snapshot = await createWorkspaceSnapshot(
+            this.#archiveKey,
+            entryPath,
+          );
+          try {
+            await replaceFile(snapshot.file, bytes);
+            await publishFileOverlay({
+              archiveIdentity: this.#archive.identity,
+              archiveKey: this.#archiveKey,
+              baseDigest: createPortableHash("sha256")
+                .update(bytes)
+                .digest("hex"),
+              entryPath,
+              owner: this.#owner,
+              workspaceFile: snapshot.file,
+              workspacePath: snapshot.relativePath,
+            });
+          } catch (error) {
+            await removeWorkspaceSnapshot(snapshot.relativePath);
+            throw error;
+          }
+          await this.#recordChange(entryPath, existing);
+          this.#materializedEntryPaths.add(entryPath);
+          return snapshot.file;
+        },
+      );
+    } catch (error) {
+      await this.releaseDatabaseLease(entryPath);
+      throw error;
     }
-    const file = await this.#workspaceFile(entryPath);
-    await replaceFile(file, content ?? new Uint8Array());
-    return file;
   }
 
   public async materializeSearchIndexCache(options: {
     readonly createIfMissing: boolean;
   }): Promise<File> {
     if (this.#searchCacheFile !== undefined) return this.#searchCacheFile;
-
     const persistent = this.#searchCacheDelete
       ? undefined
       : await this.#getPersistentSearchIndexCache(
@@ -225,29 +349,21 @@ export class HostWikgArchiveSession {
         `Archive SQLite entry is missing: ${SEARCH_INDEX_DATABASE_ENTRY_PATH}`,
       );
     }
-
-    const file = await this.#workspaceFile(SEARCH_INDEX_DATABASE_ENTRY_PATH);
-    await replaceFile(file, content ?? new Uint8Array());
-    this.#searchCacheFile = file;
-    // Materializing an archive-backed index establishes the durable external
-    // cache even when the caller only reads it.
+    const snapshot = await createWorkspaceSnapshot(
+      this.#archiveKey,
+      SEARCH_INDEX_DATABASE_ENTRY_PATH,
+    );
+    await replaceFile(snapshot.file, content ?? new Uint8Array());
+    this.#searchCacheFile = snapshot.file;
+    this.#searchCacheWorkspacePath = snapshot.relativePath;
     if (persistent === undefined && content !== undefined) {
       this.#searchCacheDirty = true;
     }
-    return file;
+    return snapshot.file;
   }
 
-  public markDatabaseDirty(path: string, file: File): void {
-    const entryPath = normalizeArchivePath(path);
-    this.#overlays.set(entryPath, { file, kind: "file" });
-    if (
-      entryPath === DATABASE_ENTRY_PATH ||
-      entryPath === SEARCH_INDEX_DATABASE_ENTRY_PATH
-    ) {
-      this.#overlays.set(LEGACY_SEARCH_INDEX_DATABASE_ENTRY_PATH, {
-        kind: "deleted",
-      });
-    }
+  public markDatabaseDirty(path: string): void {
+    this.#modifiedEntryPaths.add(normalizeArchivePath(path));
   }
 
   public markSearchIndexCacheDirty(file: File): void {
@@ -257,71 +373,139 @@ export class HostWikgArchiveSession {
   }
 
   public deleteSearchIndexCache(): void {
-    this.#searchCacheFile = undefined;
     this.#searchCacheDirty = false;
     this.#searchCacheDelete = true;
+  }
+
+  public async releaseDatabaseLease(path: string): Promise<void> {
+    const entryPath = normalizeArchivePath(path);
+    if (!this.#leasedEntryPaths.delete(entryPath)) return;
+    await releaseSqliteLease({
+      archiveKey: this.#archiveKey,
+      entryPath,
+      ownerId: this.#owner.ownerId,
+    });
+  }
+
+  public async abort(): Promise<void> {
+    if (this.#aborted) return;
+    this.#aborted = true;
+    await this.#rollbackChanges();
+    await this.#cleanupSearchCacheWorkspace();
   }
 
   public async close(): Promise<void> {
     if (this.#closed) return;
     this.#closed = true;
+    globalThis.clearInterval(this.#heartbeat);
     try {
-      if (!this.#aborted && this.#overlays.size > 0) await this.#commit();
-      if (!this.#aborted) await this.#settleSearchIndexCache();
+      for (const entryPath of [...this.#leasedEntryPaths]) {
+        await this.releaseDatabaseLease(entryPath);
+      }
+      if (!this.#aborted) {
+        for (const entryPath of this.#materializedEntryPaths) {
+          const overlay = await readOverlay(this.#archiveKey, entryPath);
+          if (overlay !== undefined && (await isDirtyOverlay(overlay))) {
+            this.#modifiedEntryPaths.add(entryPath);
+          }
+        }
+        const requested = new Set([
+          ...this.#observedDirtyEntryPaths,
+          ...this.#modifiedEntryPaths,
+        ]);
+        if (requested.size > 0) {
+          const mutationToken = await flushArchiveOverlays(
+            this.#archiveKey,
+            this.#owner,
+            requested,
+            this.#archive,
+          );
+          if (mutationToken !== undefined) {
+            this.#searchCacheKey = createSearchCacheKey(mutationToken);
+          }
+        }
+        await reapArchive(this.#archiveKey, this.#owner, this.#archive);
+        await this.#settleSearchIndexCache();
+        for (const entryPath of this.#materializedEntryPaths) {
+          const overlay = await readOverlay(this.#archiveKey, entryPath);
+          if (overlay !== undefined) {
+            await deleteCleanOverlayIfUnused(overlay);
+          }
+        }
+        await this.#cleanupSupersededSnapshots();
+      }
+    } catch (error) {
+      await this.#rollbackChanges().catch(() => undefined);
+      throw error;
     } finally {
-      await getWikiGraphStorage()
-        .documentStore.remove(this.#workspaceName, { recursive: true })
-        .catch(() => undefined);
+      await this.#cleanupSearchCacheWorkspace();
+      await unregisterArchiveOwner(this.#archiveKey, this.#owner.ownerId);
     }
   }
 
-  public abort(): void {
-    this.#aborted = true;
-  }
-
-  async #workspaceFile(path: string): Promise<File> {
-    const parts = normalizeArchivePath(path).split("/");
-    const name = parts.pop();
-    if (name === undefined || name === "") throw new TypeError("Invalid file");
-    let directory = this.#workspace;
-    for (const part of parts) {
-      directory =
-        (await directory.getDirectory(part)) ??
-        (await directory.createDirectory(part));
+  async #readEntryUnlocked(entryPath: string): Promise<Uint8Array | undefined> {
+    const overlay = await readOverlay(this.#archiveKey, entryPath);
+    if (overlay?.kind === "deleted") {
+      this.#observedDirtyEntryPaths.add(entryPath);
+      return undefined;
     }
-    return (
-      (await directory.getFile(name)) ?? (await directory.createFile(name))
-    );
-  }
-
-  async #commit(): Promise<void> {
-    const paths = new Set(this.#entries.keys());
-    for (const [path, overlay] of this.#overlays) {
-      if (overlay.kind === "deleted") paths.delete(path);
-      else paths.add(path);
-    }
-    paths.add(WIKG_MANIFEST_PATH);
-    paths.add(WIKG_MUTATION_TOKEN_PATH);
-
-    const entries: HostZipEntry[] = [];
-    const mutationToken = createWikgMutationTokenBytes();
-    for (const path of sortArchiveEntryPathsForWrite(paths)) {
-      if (path === WIKG_MUTATION_TOKEN_PATH) {
-        entries.push({ data: mutationToken, name: path });
-        continue;
+    if (overlay?.kind === "file") {
+      if (await isDirtyOverlay(overlay)) {
+        this.#observedDirtyEntryPaths.add(entryPath);
       }
-      if (path === WIKG_MANIFEST_PATH) {
-        entries.push({
-          data: new TextEncoder().encode(WIKG_MANIFEST_CONTENT),
-          name: path,
-        });
-        continue;
-      }
-      const content = await this.readEntry(path);
-      if (content !== undefined) entries.push({ data: content, name: path });
+      return await readBytes(await resolveOverlayFile(overlay));
     }
-    await getWikiGraphPlatform().zip.write(this.#archive, entries);
-    this.#searchCacheKey = createSearchCacheKeyFromToken(mutationToken);
+    return await this.#readArchiveEntry(entryPath);
+  }
+
+  async #readArchiveEntry(entryPath: string): Promise<Uint8Array | undefined> {
+    const reader = await WikgArchiveReader.open(this.#archive);
+    try {
+      return await reader.readEntry(entryPath);
+    } finally {
+      await reader.close();
+    }
+  }
+
+  async #recordChange(
+    entryPath: string,
+    previous: EntryOverlay | undefined,
+  ): Promise<void> {
+    const current = await readOverlay(this.#archiveKey, entryPath);
+    if (current === undefined) {
+      throw new Error(`Could not publish archive entry: ${entryPath}.`);
+    }
+    const existing = this.#changes.get(entryPath);
+    this.#changes.set(entryPath, {
+      current,
+      previous: existing?.previous ?? previous,
+    });
+  }
+
+  async #rollbackChanges(): Promise<void> {
+    for (const change of [...this.#changes.values()].reverse()) {
+      await withEntryLock(
+        this.#archiveKey,
+        change.current.entryPath,
+        "write",
+        this.#owner,
+        async () => {
+          await restoreOverlay(change.current, change.previous);
+        },
+      );
+    }
+    this.#changes.clear();
+    this.#modifiedEntryPaths.clear();
+    this.#observedDirtyEntryPaths.clear();
+  }
+
+  async #cleanupSupersededSnapshots(): Promise<void> {
+    for (const change of this.#changes.values()) {
+      if (change.previous?.workspacePath !== change.current.workspacePath) {
+        await removeWorkspaceSnapshot(change.previous?.workspacePath);
+      }
+    }
+    this.#changes.clear();
   }
 
   async #settleSearchIndexCache(): Promise<void> {
@@ -332,7 +516,6 @@ export class HostWikgArchiveSession {
       await this.#removePersistentSearchIndexCache(this.#initialSearchCacheKey);
     }
     if (!this.#searchCacheDirty || this.#searchCacheFile === undefined) return;
-
     const persistent = await this.#getPersistentSearchIndexCache(
       this.#searchCacheKey,
       true,
@@ -363,29 +546,19 @@ export class HostWikgArchiveSession {
     const archiveCache = await cacheRoot?.getDirectory(key);
     await archiveCache?.remove("index.db").catch(() => undefined);
   }
-}
 
-function createSearchCacheKey(
-  archive: File,
-  entries: ReadonlyMap<string, Uint8Array>,
-): string {
-  const mutationToken = entries.get(WIKG_MUTATION_TOKEN_PATH);
-  return mutationToken === undefined
-    ? createPortableHash("sha256").update(archive.identity).digest("hex")
-    : createSearchCacheKeyFromToken(mutationToken);
-}
-
-function createSearchCacheKeyFromToken(token: Uint8Array): string {
-  return createPortableHash("sha256").update(token).digest("hex");
-}
-
-async function createWorkspaceName(root: Directory): Promise<string> {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
-    sessionSequence += 1;
-    const name = `.wikg-session-${Date.now().toString(36)}-${sessionSequence.toString(36)}`;
-    if ((await root.getDirectory(name)) === undefined) return name;
+  async #cleanupSearchCacheWorkspace(): Promise<void> {
+    await removeWorkspaceSnapshot(this.#searchCacheWorkspacePath);
+    this.#searchCacheWorkspacePath = undefined;
   }
-  throw new Error("Could not allocate a document-store workspace");
+}
+
+function createSearchCacheKey(token: string | Uint8Array): string {
+  const normalized =
+    typeof token === "string"
+      ? token
+      : parseWikgMutationToken(new TextDecoder().decode(token));
+  return createPortableHash("sha256").update(normalized).digest("hex");
 }
 
 async function replaceFile(
@@ -397,7 +570,7 @@ async function replaceFile(
     await writer.write(content);
     await writer.commit();
   } catch (error) {
-    await writer.abort();
+    await writer.abort().catch(() => undefined);
     throw error;
   }
 }
@@ -407,4 +580,12 @@ async function readBytes(file: File): Promise<Uint8Array> {
   return typeof content === "string"
     ? new TextEncoder().encode(content)
     : content;
+}
+
+function isSqliteEntry(entryPath: string): boolean {
+  return (
+    entryPath === DATABASE_ENTRY_PATH ||
+    entryPath === SEARCH_INDEX_DATABASE_ENTRY_PATH ||
+    entryPath === LEGACY_SEARCH_INDEX_DATABASE_ENTRY_PATH
+  );
 }

--- a/packages/core/src/storage/wikg/wikg-coordinator/locks.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/locks.ts
@@ -1,0 +1,246 @@
+import { getNumber, getString } from "../../../document/database.js";
+import { randomUuid } from "../../../utils/crypto.js";
+
+import { LOCK_POLL_INTERVAL_MS, LOCK_STALE_TIMEOUT_MS } from "./constants.js";
+import {
+  cleanupStaleState,
+  mapEntryLock,
+  withCoordinatorState,
+} from "./state.js";
+import type {
+  CoordinatorOwner,
+  EntryLockMode,
+  SqliteLeaseMode,
+} from "./types.js";
+
+export async function acquireArchiveCommitLock(
+  archiveKey: string,
+  owner: CoordinatorOwner,
+): Promise<() => Promise<void>> {
+  while (true) {
+    const acquired = await withCoordinatorState(async (database) => {
+      return await database.transaction(async () => {
+        await cleanupStaleState(database, archiveKey);
+        await database.run(
+          `
+INSERT OR IGNORE INTO archive_commit_locks (
+  archive_key, owner_id, created_at
+) VALUES (?, ?, ?)
+`,
+          [archiveKey, owner.ownerId, Date.now()],
+        );
+        return (
+          (await database.queryOne(
+            "SELECT owner_id FROM archive_commit_locks WHERE archive_key = ?",
+            [archiveKey],
+            (row) => getString(row, "owner_id"),
+          )) === owner.ownerId
+        );
+      });
+    });
+    if (acquired) {
+      return async () => {
+        await withCoordinatorState(async (database) => {
+          await database.run(
+            "DELETE FROM archive_commit_locks WHERE archive_key = ? AND owner_id = ?",
+            [archiveKey, owner.ownerId],
+          );
+        });
+      };
+    }
+    await delay(LOCK_POLL_INTERVAL_MS);
+  }
+}
+
+export async function acquireEntryLock(
+  archiveKey: string,
+  entryPath: string,
+  mode: EntryLockMode,
+  owner: CoordinatorOwner,
+): Promise<() => Promise<void>> {
+  const lockId = randomUuid();
+  while (true) {
+    const acquired = await withCoordinatorState(async (database) => {
+      return await database.transaction(async () => {
+        await cleanupStaleState(database, archiveKey);
+        const locks = await database.queryAll(
+          "SELECT entry_path, mode, owner_id FROM entry_locks WHERE archive_key = ?",
+          [archiveKey],
+          mapEntryLock,
+        );
+        if (
+          locks.some(
+            (lock) =>
+              lock.ownerId !== owner.ownerId &&
+              pathsConflict(entryPath, lock.entryPath) &&
+              locksConflict(mode, lock.mode),
+          )
+        ) {
+          return false;
+        }
+        await database.run(
+          `
+INSERT INTO entry_locks (
+  lock_id, archive_key, entry_path, mode, owner_id, created_at
+) VALUES (?, ?, ?, ?, ?, ?)
+`,
+          [lockId, archiveKey, entryPath, mode, owner.ownerId, Date.now()],
+        );
+        return true;
+      });
+    });
+    if (acquired) {
+      return async () => {
+        await withCoordinatorState(async (database) => {
+          await database.run(
+            `
+DELETE FROM entry_locks
+WHERE lock_id = ? AND owner_id = ?
+`,
+            [lockId, owner.ownerId],
+          );
+        });
+      };
+    }
+    await delay(LOCK_POLL_INTERVAL_MS);
+  }
+}
+
+export async function withEntryLock<T>(
+  archiveKey: string,
+  entryPath: string,
+  mode: EntryLockMode,
+  owner: CoordinatorOwner,
+  operation: () => Promise<T> | T,
+): Promise<T> {
+  const release = await acquireEntryLock(archiveKey, entryPath, mode, owner);
+  try {
+    return await operation();
+  } finally {
+    await release();
+  }
+}
+
+export async function acquireSqliteLease(input: {
+  readonly archiveKey: string;
+  readonly entryPath: string;
+  readonly mode: SqliteLeaseMode;
+  readonly owner: CoordinatorOwner;
+}): Promise<void> {
+  const deadline = Date.now() + LOCK_STALE_TIMEOUT_MS;
+  while (true) {
+    const acquired = await withCoordinatorState(async (database) => {
+      return await database.transaction(async () => {
+        await cleanupStaleState(database, input.archiveKey);
+        const locks = await database.queryAll(
+          `
+SELECT entry_path, mode, owner_id
+FROM entry_locks
+WHERE archive_key = ? AND entry_path = ?
+`,
+          [input.archiveKey, input.entryPath],
+          mapEntryLock,
+        );
+        if (
+          locks.some(
+            (lock) =>
+              lock.ownerId !== input.owner.ownerId && lock.mode === "write",
+          )
+        ) {
+          return false;
+        }
+        await database.run(
+          `
+INSERT INTO entry_sqlite_leases (
+  archive_key, entry_path, mode, owner_id, created_at
+) VALUES (?, ?, ?, ?, ?)
+ON CONFLICT(archive_key, entry_path, owner_id)
+DO UPDATE SET mode = excluded.mode
+`,
+          [
+            input.archiveKey,
+            input.entryPath,
+            input.mode,
+            input.owner.ownerId,
+            Date.now(),
+          ],
+        );
+        return true;
+      });
+    });
+    if (acquired) return;
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Timed out waiting for SQLite ${input.mode} lease: ${input.entryPath}.`,
+      );
+    }
+    await delay(LOCK_POLL_INTERVAL_MS);
+  }
+}
+
+export async function releaseSqliteLease(input: {
+  readonly archiveKey: string;
+  readonly entryPath: string;
+  readonly ownerId: string;
+}): Promise<void> {
+  await withCoordinatorState(async (database) => {
+    await database.run(
+      `
+DELETE FROM entry_sqlite_leases
+WHERE archive_key = ? AND entry_path = ? AND owner_id = ?
+`,
+      [input.archiveKey, input.entryPath, input.ownerId],
+    );
+  });
+}
+
+export async function waitForSqliteLeasesToDrain(
+  archiveKey: string,
+  entryPath: string,
+  owner: CoordinatorOwner,
+): Promise<void> {
+  const deadline = Date.now() + LOCK_STALE_TIMEOUT_MS;
+  while (true) {
+    const count = await withCoordinatorState(async (database) => {
+      await cleanupStaleState(database, archiveKey);
+      return await database.queryOne(
+        `
+SELECT COUNT(*) AS count
+FROM entry_sqlite_leases
+WHERE archive_key = ? AND entry_path = ? AND owner_id <> ?
+`,
+        [archiveKey, entryPath, owner.ownerId],
+        (row) => getNumber(row, "count"),
+      );
+    });
+    if ((count ?? 0) === 0) return;
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for SQLite leases: ${entryPath}.`);
+    }
+    await delay(LOCK_POLL_INTERVAL_MS);
+  }
+}
+
+function locksConflict(
+  requested: EntryLockMode,
+  existing: EntryLockMode,
+): boolean {
+  if (requested === "state" || existing === "state") {
+    return requested === "state" && existing === "state";
+  }
+  return requested !== "read" || existing !== "read";
+}
+
+function pathsConflict(left: string, right: string): boolean {
+  return (
+    left === right ||
+    (left.endsWith("/") && right.startsWith(left)) ||
+    (right.endsWith("/") && left.startsWith(right))
+  );
+}
+
+async function delay(milliseconds: number): Promise<void> {
+  await new Promise<void>((resolve) =>
+    globalThis.setTimeout(resolve, milliseconds),
+  );
+}

--- a/packages/core/src/storage/wikg/wikg-coordinator/overlays.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/overlays.ts
@@ -1,7 +1,11 @@
 import type { File } from "../../../runtime/platform/index.js";
 import { createPortableHash } from "../../../utils/crypto.js";
 
-import { mapEntryOverlay, withCoordinatorState } from "./state.js";
+import {
+  createPlaceholders,
+  mapEntryOverlay,
+  withCoordinatorState,
+} from "./state.js";
 import type { CoordinatorOwner, EntryOverlay } from "./types.js";
 import {
   removeWorkspaceSnapshot,
@@ -33,6 +37,40 @@ WHERE archive_key = ?
 ORDER BY entry_path
 `,
       [archiveKey],
+      mapEntryOverlay,
+    ),
+  );
+}
+
+/**
+ * Returns overlays this owner may commit after the caller has locked their
+ * entries. A foreign live owner can still roll its operation back, so an
+ * observer must leave that overlay for the publishing owner (or a reaper).
+ */
+export async function listSettleableOverlays(
+  archiveKey: string,
+  entryPaths: ReadonlySet<string>,
+  ownerId: string,
+): Promise<readonly EntryOverlay[]> {
+  if (entryPaths.size === 0) return [];
+  const paths = [...entryPaths];
+  return await withCoordinatorState(async (database) =>
+    database.queryAll(
+      `
+SELECT overlay.*
+FROM entry_overlays AS overlay
+LEFT JOIN archive_owners AS publishing_owner
+  ON publishing_owner.archive_key = overlay.archive_key
+ AND publishing_owner.owner_id = overlay.owner_id
+WHERE overlay.archive_key = ?
+  AND overlay.entry_path IN (${createPlaceholders(paths.length)})
+  AND (
+    overlay.owner_id = ?
+    OR publishing_owner.owner_id IS NULL
+  )
+ORDER BY overlay.entry_path
+`,
+      [archiveKey, ...paths, ownerId],
       mapEntryOverlay,
     ),
   );

--- a/packages/core/src/storage/wikg/wikg-coordinator/overlays.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/overlays.ts
@@ -1,0 +1,308 @@
+import type { File } from "../../../runtime/platform/index.js";
+import { createPortableHash } from "../../../utils/crypto.js";
+
+import { mapEntryOverlay, withCoordinatorState } from "./state.js";
+import type { CoordinatorOwner, EntryOverlay } from "./types.js";
+import {
+  removeWorkspaceSnapshot,
+  resolveWorkspaceSnapshot,
+} from "./workspace.js";
+
+export async function readOverlay(
+  archiveKey: string,
+  entryPath: string,
+): Promise<EntryOverlay | undefined> {
+  return await withCoordinatorState(async (database) =>
+    database.queryOne(
+      "SELECT * FROM entry_overlays WHERE archive_key = ? AND entry_path = ?",
+      [archiveKey, entryPath],
+      mapEntryOverlay,
+    ),
+  );
+}
+
+export async function listOverlays(
+  archiveKey: string,
+): Promise<readonly EntryOverlay[]> {
+  return await withCoordinatorState(async (database) =>
+    database.queryAll(
+      `
+SELECT *
+FROM entry_overlays
+WHERE archive_key = ?
+ORDER BY entry_path
+`,
+      [archiveKey],
+      mapEntryOverlay,
+    ),
+  );
+}
+
+export async function listOrphanOverlayPaths(
+  archiveKey: string,
+): Promise<ReadonlySet<string>> {
+  return await withCoordinatorState(async (database) => {
+    const rows = await database.queryAll(
+      `
+SELECT overlay.*
+FROM entry_overlays AS overlay
+LEFT JOIN archive_owners AS owner
+  ON owner.archive_key = overlay.archive_key
+ AND owner.owner_id = overlay.owner_id
+WHERE overlay.archive_key = ? AND owner.owner_id IS NULL
+`,
+      [archiveKey],
+      mapEntryOverlay,
+    );
+    const paths = new Set<string>();
+    for (const overlay of rows) {
+      if (await isDirtyOverlay(overlay)) paths.add(overlay.entryPath);
+    }
+    return paths;
+  });
+}
+
+export async function publishFileOverlay(input: {
+  readonly archiveIdentity: string;
+  readonly archiveKey: string;
+  readonly baseDigest?: string;
+  readonly entryPath: string;
+  readonly owner: CoordinatorOwner;
+  readonly workspaceFile: File;
+  readonly workspacePath: string;
+}): Promise<EntryOverlay | undefined> {
+  return await withCoordinatorState(async (database) => {
+    return await database.transaction(async () => {
+      const previous = await database.queryOne(
+        "SELECT * FROM entry_overlays WHERE archive_key = ? AND entry_path = ?",
+        [input.archiveKey, input.entryPath],
+        mapEntryOverlay,
+      );
+      await database.run(
+        `
+INSERT INTO entry_overlays (
+  archive_key, archive_identity, entry_path, kind, workspace_identity,
+  workspace_path, base_digest, owner_id, updated_at
+) VALUES (?, ?, ?, 'file', ?, ?, ?, ?, ?)
+ON CONFLICT(archive_key, entry_path)
+DO UPDATE SET archive_identity = excluded.archive_identity,
+              kind = excluded.kind,
+              workspace_identity = excluded.workspace_identity,
+              workspace_path = excluded.workspace_path,
+              base_digest = excluded.base_digest,
+              owner_id = excluded.owner_id,
+              updated_at = excluded.updated_at
+`,
+        [
+          input.archiveKey,
+          input.archiveIdentity,
+          input.entryPath,
+          input.workspaceFile.identity,
+          input.workspacePath,
+          input.baseDigest ?? null,
+          input.owner.ownerId,
+          Date.now(),
+        ],
+      );
+      return previous;
+    });
+  });
+}
+
+export async function publishDeleteOverlay(input: {
+  readonly archiveIdentity: string;
+  readonly archiveKey: string;
+  readonly entryPath: string;
+  readonly owner: CoordinatorOwner;
+}): Promise<EntryOverlay | undefined> {
+  return await withCoordinatorState(async (database) => {
+    return await database.transaction(async () => {
+      const previous = await database.queryOne(
+        "SELECT * FROM entry_overlays WHERE archive_key = ? AND entry_path = ?",
+        [input.archiveKey, input.entryPath],
+        mapEntryOverlay,
+      );
+      await database.run(
+        `
+INSERT INTO entry_overlays (
+  archive_key, archive_identity, entry_path, kind, workspace_identity,
+  workspace_path, base_digest, owner_id, updated_at
+) VALUES (?, ?, ?, 'deleted', NULL, NULL, NULL, ?, ?)
+ON CONFLICT(archive_key, entry_path)
+DO UPDATE SET archive_identity = excluded.archive_identity,
+              kind = excluded.kind,
+              workspace_identity = NULL,
+              workspace_path = NULL,
+              base_digest = NULL,
+              owner_id = excluded.owner_id,
+              updated_at = excluded.updated_at
+`,
+        [
+          input.archiveKey,
+          input.archiveIdentity,
+          input.entryPath,
+          input.owner.ownerId,
+          Date.now(),
+        ],
+      );
+      return previous;
+    });
+  });
+}
+
+export async function restoreOverlay(
+  current: EntryOverlay,
+  previous: EntryOverlay | undefined,
+): Promise<boolean> {
+  const restored = await withCoordinatorState(async (database) => {
+    return await database.transaction(async () => {
+      const latest = await database.queryOne(
+        "SELECT * FROM entry_overlays WHERE archive_key = ? AND entry_path = ?",
+        [current.archiveKey, current.entryPath],
+        mapEntryOverlay,
+      );
+      if (!sameOverlay(latest, current)) return false;
+      const otherLeaseCount = await database.queryOne(
+        `
+SELECT COUNT(*) AS count
+FROM entry_sqlite_leases
+WHERE archive_key = ? AND entry_path = ? AND owner_id <> ?
+`,
+        [current.archiveKey, current.entryPath, current.ownerId],
+        (row) => Number(row.count),
+      );
+      if ((otherLeaseCount ?? 0) > 0) return false;
+      if (previous === undefined) {
+        await database.run(
+          "DELETE FROM entry_overlays WHERE archive_key = ? AND entry_path = ?",
+          [current.archiveKey, current.entryPath],
+        );
+      } else {
+        await database.run(
+          `
+UPDATE entry_overlays
+SET archive_identity = ?, kind = ?, workspace_identity = ?,
+    workspace_path = ?, base_digest = ?, owner_id = ?, updated_at = ?
+WHERE archive_key = ? AND entry_path = ?
+`,
+          [
+            previous.archiveIdentity,
+            previous.kind,
+            previous.workspaceIdentity ?? null,
+            previous.workspacePath ?? null,
+            previous.baseDigest ?? null,
+            previous.ownerId,
+            previous.updatedAt,
+            previous.archiveKey,
+            previous.entryPath,
+          ],
+        );
+      }
+      return true;
+    });
+  });
+  if (restored && current.workspacePath !== previous?.workspacePath) {
+    await removeWorkspaceSnapshot(current.workspacePath);
+  }
+  return restored;
+}
+
+export async function deleteCommittedOverlay(
+  overlay: EntryOverlay,
+): Promise<boolean> {
+  const deleted = await withCoordinatorState(async (database) => {
+    const current = await database.queryOne(
+      "SELECT * FROM entry_overlays WHERE archive_key = ? AND entry_path = ?",
+      [overlay.archiveKey, overlay.entryPath],
+      mapEntryOverlay,
+    );
+    if (!sameOverlay(current, overlay)) return false;
+    await database.run(
+      "DELETE FROM entry_overlays WHERE archive_key = ? AND entry_path = ?",
+      [overlay.archiveKey, overlay.entryPath],
+    );
+    return true;
+  });
+  if (deleted) await removeWorkspaceSnapshot(overlay.workspacePath);
+  return deleted;
+}
+
+export async function deleteCleanOverlayIfUnused(
+  overlay: EntryOverlay,
+): Promise<boolean> {
+  if (overlay.baseDigest === undefined || (await isDirtyOverlay(overlay))) {
+    return false;
+  }
+  const deleted = await withCoordinatorState(async (database) => {
+    return await database.transaction(async () => {
+      const leaseCount = await database.queryOne(
+        `
+SELECT COUNT(*) AS count
+FROM entry_sqlite_leases
+WHERE archive_key = ? AND entry_path = ?
+`,
+        [overlay.archiveKey, overlay.entryPath],
+        (row) => Number(row.count),
+      );
+      const current = await database.queryOne(
+        "SELECT * FROM entry_overlays WHERE archive_key = ? AND entry_path = ?",
+        [overlay.archiveKey, overlay.entryPath],
+        mapEntryOverlay,
+      );
+      if ((leaseCount ?? 0) > 0 || !sameOverlay(current, overlay)) {
+        return false;
+      }
+      await database.run(
+        "DELETE FROM entry_overlays WHERE archive_key = ? AND entry_path = ?",
+        [overlay.archiveKey, overlay.entryPath],
+      );
+      return true;
+    });
+  });
+  if (deleted) await removeWorkspaceSnapshot(overlay.workspacePath);
+  return deleted;
+}
+
+export async function resolveOverlayFile(overlay: EntryOverlay): Promise<File> {
+  if (overlay.workspaceIdentity === undefined) {
+    throw new Error(`Missing workspace identity for ${overlay.entryPath}.`);
+  }
+  const file = await resolveWorkspaceSnapshot(overlay.workspaceIdentity);
+  if (file === undefined) {
+    throw new Error(
+      `Published workspace snapshot is unavailable: ${overlay.entryPath}.`,
+    );
+  }
+  return file;
+}
+
+function sameOverlay(
+  left: EntryOverlay | undefined,
+  right: EntryOverlay,
+): boolean {
+  return (
+    left?.archiveKey === right.archiveKey &&
+    left.entryPath === right.entryPath &&
+    left.kind === right.kind &&
+    left.baseDigest === right.baseDigest &&
+    left.workspaceIdentity === right.workspaceIdentity &&
+    left.ownerId === right.ownerId &&
+    left.updatedAt === right.updatedAt
+  );
+}
+
+export async function isDirtyOverlay(overlay: EntryOverlay): Promise<boolean> {
+  if (overlay.kind === "deleted" || overlay.baseDigest === undefined) {
+    return true;
+  }
+  if (overlay.workspaceIdentity === undefined) return false;
+  const file = await resolveWorkspaceSnapshot(overlay.workspaceIdentity);
+  if (file === undefined) return false;
+  const content = await file.read();
+  const bytes =
+    typeof content === "string" ? new TextEncoder().encode(content) : content;
+  return (
+    createPortableHash("sha256").update(bytes).digest("hex") !==
+    overlay.baseDigest
+  );
+}

--- a/packages/core/src/storage/wikg/wikg-coordinator/owners.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/owners.ts
@@ -1,0 +1,74 @@
+import { getWikiGraphPlatform } from "../../../runtime/platform/index.js";
+import { randomUuid } from "../../../utils/crypto.js";
+
+import { cleanupStaleState, withCoordinatorState } from "./state.js";
+import type { CoordinatorOwner } from "./types.js";
+
+export function createCoordinatorOwner(): CoordinatorOwner {
+  return {
+    hostInstanceId: getWikiGraphPlatform().lifecycle.instanceId,
+    ownerId: randomUuid(),
+  };
+}
+
+export async function registerArchiveOwner(
+  archiveKey: string,
+  owner: CoordinatorOwner,
+): Promise<void> {
+  await withCoordinatorState(async (database) => {
+    await database.transaction(async () => {
+      await cleanupStaleState(database, archiveKey);
+      const now = Date.now();
+      await database.run(
+        `
+INSERT INTO archive_owners (
+  archive_key, owner_id, host_instance_id, heartbeat_at, created_at
+) VALUES (?, ?, ?, ?, ?)
+`,
+        [archiveKey, owner.ownerId, owner.hostInstanceId, now, now],
+      );
+    });
+  });
+}
+
+export async function heartbeatArchiveOwner(
+  archiveKey: string,
+  owner: CoordinatorOwner,
+): Promise<void> {
+  await withCoordinatorState(async (database) => {
+    await database.run(
+      `
+UPDATE archive_owners
+SET heartbeat_at = ?, host_instance_id = ?
+WHERE archive_key = ? AND owner_id = ?
+`,
+      [Date.now(), owner.hostInstanceId, archiveKey, owner.ownerId],
+    );
+  });
+}
+
+export async function unregisterArchiveOwner(
+  archiveKey: string,
+  ownerId: string,
+): Promise<void> {
+  await withCoordinatorState(async (database) => {
+    await database.transaction(async () => {
+      await database.run(
+        "DELETE FROM entry_sqlite_leases WHERE archive_key = ? AND owner_id = ?",
+        [archiveKey, ownerId],
+      );
+      await database.run(
+        "DELETE FROM entry_locks WHERE archive_key = ? AND owner_id = ?",
+        [archiveKey, ownerId],
+      );
+      await database.run(
+        "DELETE FROM archive_commit_locks WHERE archive_key = ? AND owner_id = ?",
+        [archiveKey, ownerId],
+      );
+      await database.run(
+        "DELETE FROM archive_owners WHERE archive_key = ? AND owner_id = ?",
+        [archiveKey, ownerId],
+      );
+    });
+  });
+}

--- a/packages/core/src/storage/wikg/wikg-coordinator/state.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/state.ts
@@ -1,0 +1,174 @@
+import {
+  ensureRelativeFile,
+  getWikiGraphPlatform,
+  getWikiGraphStorage,
+} from "../../../runtime/platform/index.js";
+import {
+  Database,
+  getNumber,
+  getOptionalString,
+  getString,
+  type SqlRow,
+} from "../../../document/database.js";
+import { AsyncSemaphore } from "../../../utils/async-semaphore.js";
+
+import { LOCK_STALE_TIMEOUT_MS } from "./constants.js";
+import type { EntryLock, EntryLockMode, EntryOverlay } from "./types.js";
+
+const STATE_SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS archive_owners (
+  archive_key TEXT NOT NULL,
+  owner_id TEXT NOT NULL,
+  host_instance_id TEXT NOT NULL,
+  heartbeat_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (archive_key, owner_id)
+);
+
+CREATE TABLE IF NOT EXISTS entry_overlays (
+  archive_key TEXT NOT NULL,
+  archive_identity TEXT NOT NULL,
+  entry_path TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  base_digest TEXT,
+  workspace_identity TEXT,
+  workspace_path TEXT,
+  owner_id TEXT NOT NULL,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (archive_key, entry_path)
+);
+
+CREATE TABLE IF NOT EXISTS entry_locks (
+  lock_id TEXT PRIMARY KEY,
+  archive_key TEXT NOT NULL,
+  entry_path TEXT NOT NULL,
+  mode TEXT NOT NULL,
+  owner_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS entry_sqlite_leases (
+  archive_key TEXT NOT NULL,
+  entry_path TEXT NOT NULL,
+  mode TEXT NOT NULL,
+  owner_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (archive_key, entry_path, owner_id)
+);
+
+CREATE TABLE IF NOT EXISTS archive_commit_locks (
+  archive_key TEXT PRIMARY KEY,
+  owner_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+`;
+
+const STATE_DATABASE_SEMAPHORE = new AsyncSemaphore(1);
+
+export async function withCoordinatorState<T>(
+  operation: (database: Database) => Promise<T> | T,
+): Promise<T> {
+  return await STATE_DATABASE_SEMAPHORE.use(async () => {
+    const file = await ensureRelativeFile(
+      getWikiGraphStorage().library,
+      "tmp/wikg-coordinator.sqlite",
+    );
+    const database = await Database.open(file, STATE_SCHEMA_SQL);
+    try {
+      return await operation(database);
+    } finally {
+      await database.close();
+    }
+  });
+}
+
+export async function cleanupStaleState(
+  database: Database,
+  archiveKey?: string,
+): Promise<ReadonlySet<string>> {
+  const rows = await database.queryAll(
+    `
+SELECT archive_key, owner_id, host_instance_id, heartbeat_at
+FROM archive_owners
+${archiveKey === undefined ? "" : "WHERE archive_key = ?"}
+`,
+    archiveKey === undefined ? undefined : [archiveKey],
+    (row) => ({
+      archiveKey: getString(row, "archive_key"),
+      heartbeatAt: getNumber(row, "heartbeat_at"),
+      hostInstanceId: getString(row, "host_instance_id"),
+      ownerId: getString(row, "owner_id"),
+    }),
+  );
+  const staleOwnerIds = new Set<string>();
+  const now = Date.now();
+  for (const row of rows) {
+    const alive = await getWikiGraphPlatform().lifecycle.isInstanceAlive(
+      row.hostInstanceId,
+    );
+    if (
+      alive === false ||
+      (alive === undefined && now - row.heartbeatAt >= LOCK_STALE_TIMEOUT_MS)
+    ) {
+      staleOwnerIds.add(row.ownerId);
+    }
+  }
+  if (staleOwnerIds.size === 0) return staleOwnerIds;
+
+  const placeholders = createPlaceholders(staleOwnerIds.size);
+  const values = [...staleOwnerIds];
+  await database.run(
+    `DELETE FROM entry_sqlite_leases WHERE owner_id IN (${placeholders})`,
+    values,
+  );
+  await database.run(
+    `DELETE FROM entry_locks WHERE owner_id IN (${placeholders})`,
+    values,
+  );
+  await database.run(
+    `DELETE FROM archive_commit_locks WHERE owner_id IN (${placeholders})`,
+    values,
+  );
+  await database.run(
+    `DELETE FROM archive_owners WHERE owner_id IN (${placeholders})`,
+    values,
+  );
+  return staleOwnerIds;
+}
+
+export function mapEntryOverlay(row: SqlRow): EntryOverlay {
+  const kind = getString(row, "kind");
+  if (kind !== "deleted" && kind !== "file") {
+    throw new Error(`Unsupported entry overlay kind: ${kind}.`);
+  }
+  const workspaceIdentity = getOptionalString(row, "workspace_identity");
+  const workspacePath = getOptionalString(row, "workspace_path");
+  const baseDigest = getOptionalString(row, "base_digest");
+  return {
+    archiveIdentity: getString(row, "archive_identity"),
+    archiveKey: getString(row, "archive_key"),
+    ...(baseDigest === undefined ? {} : { baseDigest }),
+    entryPath: getString(row, "entry_path"),
+    kind,
+    ownerId: getString(row, "owner_id"),
+    updatedAt: getNumber(row, "updated_at"),
+    ...(workspaceIdentity === undefined ? {} : { workspaceIdentity }),
+    ...(workspacePath === undefined ? {} : { workspacePath }),
+  };
+}
+
+export function mapEntryLock(row: SqlRow): EntryLock {
+  const mode = getString(row, "mode");
+  if (mode !== "read" && mode !== "state" && mode !== "write") {
+    throw new Error(`Unsupported entry lock mode: ${mode}.`);
+  }
+  return {
+    entryPath: getString(row, "entry_path"),
+    mode: mode as EntryLockMode,
+    ownerId: getString(row, "owner_id"),
+  };
+}
+
+export function createPlaceholders(count: number): string {
+  return Array.from({ length: count }, () => "?").join(", ");
+}

--- a/packages/core/src/storage/wikg/wikg-coordinator/types.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/types.ts
@@ -1,1 +1,26 @@
+export type EntryLockMode = "read" | "state" | "write";
+export type SqliteLeaseMode = "read" | "write";
 export type WorkspaceWritebackPolicy = "archive" | "cache";
+
+export interface CoordinatorOwner {
+  readonly hostInstanceId: string;
+  readonly ownerId: string;
+}
+
+export interface EntryOverlay {
+  readonly archiveIdentity: string;
+  readonly archiveKey: string;
+  readonly baseDigest?: string;
+  readonly entryPath: string;
+  readonly kind: "deleted" | "file";
+  readonly ownerId: string;
+  readonly updatedAt: number;
+  readonly workspaceIdentity?: string;
+  readonly workspacePath?: string;
+}
+
+export interface EntryLock {
+  readonly entryPath: string;
+  readonly mode: EntryLockMode;
+  readonly ownerId: string;
+}

--- a/packages/core/src/storage/wikg/wikg-coordinator/workspace.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/workspace.ts
@@ -1,0 +1,66 @@
+import {
+  ensureRelativeDirectory,
+  getRelativeDirectory,
+  getWikiGraphStorage,
+  resolveHostFile,
+  type File,
+} from "../../../runtime/platform/index.js";
+import { createPortableHash, randomUuid } from "../../../utils/crypto.js";
+
+const WORK_ROOT = ".wikg-work";
+
+export async function createWorkspaceSnapshot(
+  archiveKey: string,
+  entryPath: string,
+): Promise<{ readonly file: File; readonly relativePath: string }> {
+  const entryKey = createPortableHash("sha256").update(entryPath).digest("hex");
+  const directoryPath = `${WORK_ROOT}/${archiveKey}/${entryKey}`;
+  const directory = await ensureRelativeDirectory(
+    getWikiGraphStorage().documentStore,
+    directoryPath,
+  );
+  const name = `${randomUuid()}.snapshot`;
+  return {
+    file: await directory.createFile(name),
+    relativePath: `${directoryPath}/${name}`,
+  };
+}
+
+export async function resolveWorkspaceSnapshot(
+  identity: string,
+): Promise<File | undefined> {
+  try {
+    return await resolveHostFile(identity);
+  } catch {
+    return undefined;
+  }
+}
+
+export async function removeWorkspaceSnapshot(
+  relativePath: string | undefined,
+): Promise<void> {
+  if (relativePath === undefined) return;
+  const parts = relativePath.split("/").filter(Boolean);
+  const name = parts.pop();
+  if (name === undefined) return;
+  const root = getWikiGraphStorage().documentStore;
+  const parent = await getRelativeDirectory(root, parts.join("/"));
+  await parent?.remove(name).catch(() => undefined);
+  await removeEmptyParents(parts);
+}
+
+async function removeEmptyParents(parts: string[]): Promise<void> {
+  const root = getWikiGraphStorage().documentStore;
+  for (let index = parts.length; index > 0; index -= 1) {
+    const parentParts = parts.slice(0, index - 1);
+    const name = parts[index - 1];
+    if (name === undefined) continue;
+    const parent =
+      parentParts.length === 0
+        ? root
+        : await getRelativeDirectory(root, parentParts.join("/"));
+    const directory = await parent?.getDirectory(name);
+    if (directory === undefined || (await directory.list()).length > 0) break;
+    await parent?.remove(name, { recursive: true }).catch(() => undefined);
+  }
+}

--- a/packages/core/src/text/source/epub/archive.ts
+++ b/packages/core/src/text/source/epub/archive.ts
@@ -1,23 +1,26 @@
 import {
   getWikiGraphPlatform,
   type File,
-  type HostZipEntry,
+  type HostZipReader,
 } from "../../../runtime/platform/index.js";
 import { createPortableHash as createHash } from "../../../utils/crypto.js";
 
 /** EPUB reader backed only by the host ZIP and File capabilities. */
 export class EpubArchive {
   readonly #file: File;
-  readonly #entries: ReadonlyMap<string, HostZipEntry>;
+  readonly #entries: ReadonlyMap<string, string>;
+  readonly #reader: HostZipReader;
   readonly #digest: string;
 
   // eslint-disable-next-line no-restricted-syntax -- constructors cannot use JavaScript #private syntax.
   private constructor(
     file: File,
-    entries: ReadonlyMap<string, HostZipEntry>,
+    reader: HostZipReader,
+    entries: ReadonlyMap<string, string>,
     digest: string,
   ) {
     this.#file = file;
+    this.#reader = reader;
     this.#entries = entries;
     this.#digest = digest;
   }
@@ -27,16 +30,22 @@ export class EpubArchive {
     const bytes =
       typeof content === "string" ? new TextEncoder().encode(content) : content;
     const digest = createHash("sha256").update(bytes).digest("hex");
-    const entries = new Map<string, HostZipEntry>();
-    for (const entry of await getWikiGraphPlatform().zip.read(file)) {
-      const name = normalizeArchivePath(entry.name);
-      if (name !== "") entries.set(name, entry);
+    const reader = await getWikiGraphPlatform().zip.open(file);
+    try {
+      const entries = new Map<string, string>();
+      for (const hostName of await reader.listEntries()) {
+        const name = normalizeArchivePath(hostName);
+        if (name !== "") entries.set(name, hostName);
+      }
+      return new EpubArchive(file, reader, entries, digest);
+    } catch (error) {
+      await reader.close();
+      throw error;
     }
-    return new EpubArchive(file, entries, digest);
   }
 
   public close(): Promise<void> {
-    return Promise.resolve();
+    return this.#reader.close();
   }
 
   public hasEntry(path: string): boolean {
@@ -52,7 +61,14 @@ export class EpubArchive {
   }
 
   public async readBuffer(path: string): Promise<Uint8Array> {
-    return this.#getEntry(path).data;
+    const hostName = this.#getEntry(path);
+    const data = await this.#reader.readEntry(hostName);
+    if (data === undefined) {
+      throw new Error(
+        `EPUB entry does not exist: ${normalizeArchivePath(path)}`,
+      );
+    }
+    return data;
   }
 
   public resolveRelativePath(basePath: string, href: string): string {
@@ -92,7 +108,7 @@ export class EpubArchive {
     return this.#digest;
   }
 
-  #getEntry(path: string): HostZipEntry {
+  #getEntry(path: string): string {
     const normalizedPath = normalizeArchivePath(path);
     const entry = this.#entries.get(normalizedPath);
     if (entry === undefined) {

--- a/scripts/check-core-portability.mjs
+++ b/scripts/check-core-portability.mjs
@@ -1,4 +1,5 @@
 import { readdir, readFile } from "node:fs/promises";
+import { builtinModules } from "node:module";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
@@ -9,38 +10,10 @@ const target = resolve(
 );
 const artifactMode = process.argv.includes("--artifact");
 const forbidden = new Set([
-  "assert",
-  "async_hooks",
-  "buffer",
-  "child_process",
-  "cluster",
-  "crypto",
-  "events",
-  "fs",
-  "fs/promises",
-  "http",
-  "https",
-  "inspector",
-  "module",
-  "net",
-  "os",
-  "path",
-  "perf_hooks",
-  "readline",
+  ...builtinModules.map((name) => name.replace(/^node:/u, "")),
   "sqlite3",
-  "stream",
-  "stream/promises",
-  "test",
-  "timers",
-  "timers/promises",
-  "url",
-  "util",
-  "v8",
-  "vm",
-  "worker_threads",
   "yauzl",
   "yazl",
-  "zlib",
 ]);
 const violations = [];
 const seenFiles = new Set();
@@ -104,8 +77,8 @@ async function collect(directory, extensions) {
 function report(file, message) {
   violations.push(`${relative(repositoryRoot, file)} ${message}`);
 }
-function moduleName(specifier) {
-  return specifier.startsWith("node:") ? specifier.slice(5) : specifier;
+function isForbiddenModule(specifier) {
+  return specifier.startsWith("node:") || forbidden.has(specifier);
 }
 
 function collectExportTargets(value, targets = new Set()) {
@@ -168,7 +141,7 @@ function inspectSource(
     if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
       const specifier = node.moduleSpecifier;
       if (specifier && ts.isStringLiteral(specifier)) {
-        if (forbidden.has(moduleName(specifier.text)))
+        if (isForbiddenModule(specifier.text))
           report(file, `imports forbidden module ${specifier.text}`);
         else if (specifier.text.startsWith("."))
           relativeImports.add(specifier.text);
@@ -181,7 +154,7 @@ function inspectSource(
         if (
           !argument ||
           !ts.isStringLiteral(argument) ||
-          forbidden.has(moduleName(argument.text))
+          isForbiddenModule(argument.text)
         )
           report(file, "uses a non-literal or forbidden dynamic import");
         else if (argument.text.startsWith("."))
@@ -205,7 +178,7 @@ function inspectSource(
         if (
           !argument ||
           !ts.isStringLiteral(argument) ||
-          forbidden.has(moduleName(argument.text))
+          isForbiddenModule(argument.text)
         )
           report(file, "uses CommonJS require");
         else if (argument.text.startsWith("."))
@@ -468,7 +441,7 @@ async function scanDependency(name, fromDirectory, chain = [], strict = false) {
     ...(manifest.dependencies ?? {}),
     ...(manifest.optionalDependencies ?? {}),
   })) {
-    if (forbidden.has(dependency))
+    if (isForbiddenModule(dependency))
       report(
         join(root, "package.json"),
         `depends on forbidden module ${dependency}`,
@@ -494,7 +467,7 @@ if (!artifactMode) {
   // as non-portable as direct ones.
   const strictDependencyScan = true;
   for (const dependency of Object.keys(manifest.dependencies ?? {})) {
-    if (forbidden.has(dependency))
+    if (isForbiddenModule(dependency))
       report(packageFile, `depends on forbidden module ${dependency}`);
     else
       await scanDependency(

--- a/test/core/runtime/core-portability.test.ts
+++ b/test/core/runtime/core-portability.test.ts
@@ -99,7 +99,11 @@ describe("core portability gate", () => {
         }),
         "node_modules/fixture-dependency/index.js": 'import "node:fs";\n',
       });
-      await expectGateFailure(fixture, false);
+      await expectGateFailure(
+        fixture,
+        false,
+        "node_modules/fixture-dependency/index.js",
+      );
     });
   });
 
@@ -120,7 +124,11 @@ describe("core portability gate", () => {
           "export const portable = true;\n",
         "node_modules/dual-runtime-dependency/node.js": 'import "node:fs";\n',
       });
-      await expectGateFailure(fixture, false);
+      await expectGateFailure(
+        fixture,
+        false,
+        "node_modules/dual-runtime-dependency/node.js",
+      );
     });
   });
 
@@ -144,7 +152,11 @@ describe("core portability gate", () => {
         "node_modules/conditional-runtime-dependency/node-only.cjs":
           'require("node:fs");\n',
       });
-      await expectGateFailure(fixture, false);
+      await expectGateFailure(
+        fixture,
+        false,
+        "node_modules/conditional-runtime-dependency/node-only.cjs",
+      );
     });
   });
 
@@ -165,7 +177,11 @@ describe("core portability gate", () => {
         "node_modules/artifact-runtime-dependency/node.cjs":
           'require("node:fs");\n',
       });
-      await expectGateFailure(fixture, true);
+      await expectGateFailure(
+        fixture,
+        true,
+        "node_modules/artifact-runtime-dependency/node.cjs",
+      );
     });
   });
 });
@@ -176,16 +192,21 @@ async function expectRejected(
 ): Promise<void> {
   await withFixture(async (fixture) => {
     await writeFixture(fixture, files);
-    await expectGateFailure(fixture, artifact);
+    const expectedLocation = Object.keys(files)[0];
+    if (expectedLocation === undefined) {
+      throw new Error("A portability fixture must contain at least one file");
+    }
+    await expectGateFailure(fixture, artifact, expectedLocation);
   });
 }
 
 async function expectGateFailure(
   fixture: string,
   artifact: boolean,
+  expectedLocation: string,
 ): Promise<void> {
-  await expect(
-    execFileAsync(
+  try {
+    await execFileAsync(
       "node",
       [
         "scripts/check-core-portability.mjs",
@@ -193,8 +214,22 @@ async function expectGateFailure(
         ...(artifact ? ["--artifact"] : []),
       ],
       { cwd: process.cwd() },
-    ),
-  ).rejects.toMatchObject({ code: 1 });
+    );
+    throw new Error("Expected the portability gate to reject the fixture");
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === "Expected the portability gate to reject the fixture"
+    ) {
+      throw error;
+    }
+    const failure = error as {
+      readonly code?: unknown;
+      readonly stderr?: unknown;
+    };
+    expect(failure.code).toBe(1);
+    expect(failure.stderr).toEqual(expect.stringContaining(expectedLocation));
+  }
 }
 
 async function withFixture(

--- a/test/core/runtime/core-portability.test.ts
+++ b/test/core/runtime/core-portability.test.ts
@@ -12,6 +12,15 @@ describe("core portability gate", () => {
     await expectRejected({ "forbidden.ts": 'import "node:fs";\n' });
   });
 
+  it.each(["node:dns", "node:diagnostics_channel", "dns/promises"])(
+    "rejects the complete Node builtin surface through %s",
+    async (specifier) => {
+      await expectRejected({
+        "forbidden.ts": `import ${JSON.stringify(specifier)};\n`,
+      });
+    },
+  );
+
   it("rejects a dynamic Node import in isolation", async () => {
     await expectRejected({
       "forbidden.ts": 'export const load = () => import("node:fs");\n',

--- a/test/core/runtime/platform/node-platform.test.ts
+++ b/test/core/runtime/platform/node-platform.test.ts
@@ -73,7 +73,14 @@ describe("Node File/Directory adapter", () => {
         { data: new TextEncoder().encode("alpha"), name: "a.txt" },
         { data: new TextEncoder().encode("beta"), name: "nested/b.txt" },
       ]);
-      const entries = await nodeWikiGraphPlatform.zip.read(zipFile);
+      const reader = await nodeWikiGraphPlatform.zip.open(zipFile);
+      const entries = await Promise.all(
+        (await reader.listEntries()).map(async (name) => ({
+          data: (await reader.readEntry(name)) as Uint8Array,
+          name,
+        })),
+      );
+      await reader.close();
 
       expect(
         entries.map((entry) => [

--- a/test/core/storage/schema-upgrade/index.test.ts
+++ b/test/core/storage/schema-upgrade/index.test.ts
@@ -78,7 +78,7 @@ describe("schema-upgrade", () => {
 
   it("repairs missing chapter keys even when the schema is current", async () => {
     await withFixture(async ({ archive }) => {
-      const entries = await nodeWikiGraphPlatform.zip.read(archive);
+      const entries = await readZipEntries(archive);
       await nodeWikiGraphPlatform.zip.write(
         archive,
         entries.map((entry) =>
@@ -189,7 +189,7 @@ async function rewriteManifest(
   schemaVersion: number,
   addDerivedIndex: boolean,
 ): Promise<void> {
-  const entries = [...(await nodeWikiGraphPlatform.zip.read(archive))]
+  const entries = (await readZipEntries(archive))
     .filter((entry) => entry.name !== WIKG_MANIFEST_PATH)
     .map((entry) => ({ data: entry.data, name: entry.name }));
   entries.push({
@@ -205,4 +205,20 @@ async function rewriteManifest(
     });
   }
   await nodeWikiGraphPlatform.zip.write(archive, entries);
+}
+
+async function readZipEntries(
+  archive: NodeFile,
+): Promise<Array<{ readonly data: Uint8Array; readonly name: string }>> {
+  const reader = await nodeWikiGraphPlatform.zip.open(archive);
+  try {
+    const entries: Array<{ data: Uint8Array; name: string }> = [];
+    for (const name of await reader.listEntries()) {
+      const data = await reader.readEntry(name);
+      if (data !== undefined) entries.push({ data, name });
+    }
+    return entries;
+  } finally {
+    await reader.close();
+  }
 }

--- a/test/core/storage/wikg/archive-coordination.test.ts
+++ b/test/core/storage/wikg/archive-coordination.test.ts
@@ -25,14 +25,12 @@ const workerPath = fileURLToPath(
 const workerErrors = new WeakMap<ChildProcess, string[]>();
 
 describe("wikg cross-process coordination", () => {
-  it("preserves disjoint writes from overlapping processes", async () => {
+  it("preserves disjoint writes when the later process commits last", async () => {
     await withFixture(async ({ archivePath, stateRoot, storage }) => {
       const metadata = spawnWorker(archivePath, stateRoot, "meta");
+      await waitForMessage(metadata, "ready");
       const toc = spawnWorker(archivePath, stateRoot, "toc");
-      await Promise.all([
-        waitForMessage(metadata, "ready"),
-        waitForMessage(toc, "ready"),
-      ]);
+      await waitForMessage(toc, "ready");
 
       metadata.send({ type: "write" });
       toc.send({ type: "write" });
@@ -41,8 +39,9 @@ describe("wikg cross-process coordination", () => {
         waitForMessage(toc, "published"),
       ]);
       metadata.send({ type: "finish" });
+      await waitForExit(metadata);
       toc.send({ type: "finish" });
-      await Promise.all([waitForExit(metadata), waitForExit(toc)]);
+      await waitForExit(toc);
 
       await withWikiGraphStorage(storage, async () => {
         await expect(
@@ -75,6 +74,24 @@ describe("wikg cross-process coordination", () => {
         ).resolves.toMatchObject({
           title: "Written by metadata worker",
         });
+      });
+    });
+  });
+
+  it("does not recover an unpublished staging snapshot after a hard exit", async () => {
+    await withFixture(async ({ archivePath, stateRoot, storage }) => {
+      const writer = spawnWorker(archivePath, stateRoot, "staging");
+      await waitForMessage(writer, "ready");
+      writer.send({ type: "write" });
+      await waitForMessage(writer, "staged");
+      writer.send({ type: "crash" });
+      await waitForExit(writer);
+
+      await withWikiGraphStorage(storage, async () => {
+        await reapThroughCoordinator(archivePath);
+        await expect(
+          readJsonEntry(archivePath, "toc.json"),
+        ).resolves.toMatchObject({ items: [{ title: "Original" }] });
       });
     });
   });
@@ -148,6 +165,53 @@ describe("wikg cross-process coordination", () => {
         await deletion;
         expect(deleted).toBe(true);
       });
+    });
+  });
+
+  it("does not settle a foreign overlay while its owner can still roll back", async () => {
+    await withFixture(async ({ archivePath }) => {
+      const archive = new NodeFile(archivePath);
+      const coordinator = new WikgCoordinator();
+      let markPublished!: () => void;
+      const published = new Promise<void>((resolve) => {
+        markPublished = resolve;
+      });
+      let failWriter!: () => void;
+      const failureGate = new Promise<void>((resolve) => {
+        failWriter = resolve;
+      });
+      const writer = coordinator.withArchiveSession(
+        archive,
+        async (writerSession) => {
+          await writerSession.writeEntry(
+            "toc.json",
+            `${JSON.stringify({ items: [{ children: [], key: "chapter", serialId: 1, title: "Should rollback" }], version: 1 })}\n`,
+            { overwrite: true },
+          );
+          markPublished();
+          await failureGate;
+          throw new Error("rollback writer");
+        },
+      );
+      await published;
+      await coordinator.withArchiveSession(archive, async (readerSession) => {
+        const content = await readerSession.readEntry("toc.json");
+        if (content === undefined) throw new Error("Expected TOC overlay");
+        expect(
+          JSON.parse(new TextDecoder().decode(content)) as {
+            items: Array<{ title: string }>;
+          },
+        ).toMatchObject({ items: [{ title: "Should rollback" }] });
+      });
+      await expect(
+        readJsonEntry(archivePath, "toc.json"),
+      ).resolves.toMatchObject({ items: [{ title: "Original" }] });
+
+      failWriter();
+      await expect(writer).rejects.toThrow("rollback writer");
+      await expect(
+        readJsonEntry(archivePath, "toc.json"),
+      ).resolves.toMatchObject({ items: [{ title: "Original" }] });
     });
   });
 

--- a/test/core/storage/wikg/archive-coordination.test.ts
+++ b/test/core/storage/wikg/archive-coordination.test.ts
@@ -1,0 +1,335 @@
+import { fork, type ChildProcess } from "child_process";
+import { mkdir } from "fs/promises";
+import { join } from "path";
+import { fileURLToPath } from "url";
+import { describe, expect, it } from "vitest";
+
+import { DirectoryDocument } from "../../../../packages/core/src/document/index.js";
+import { withWikiGraphStorage } from "../../../../packages/core/src/runtime/platform/index.js";
+import {
+  readWikgArchiveEntry,
+  writeWikgArchive,
+} from "../../../../packages/core/src/storage/wikg/archive/index.js";
+import { WikgCoordinator } from "../../../../packages/core/src/storage/wikg/coordinator.js";
+import { WikiGraphArchiveFile } from "../../../../packages/core/src/storage/wikg/wiki-graph-archive-file.js";
+import {
+  createNodeWikiGraphStorage,
+  NodeDirectory,
+  NodeFile,
+} from "../../../../packages/cli/src/runtime/node-platform.js";
+import { withTempDir } from "../../../helpers/temp.js";
+
+const workerPath = fileURLToPath(
+  new URL("../../../helpers/archive-coordination-worker.ts", import.meta.url),
+);
+const workerErrors = new WeakMap<ChildProcess, string[]>();
+
+describe("wikg cross-process coordination", () => {
+  it("preserves disjoint writes from overlapping processes", async () => {
+    await withFixture(async ({ archivePath, stateRoot, storage }) => {
+      const metadata = spawnWorker(archivePath, stateRoot, "meta");
+      const toc = spawnWorker(archivePath, stateRoot, "toc");
+      await Promise.all([
+        waitForMessage(metadata, "ready"),
+        waitForMessage(toc, "ready"),
+      ]);
+
+      metadata.send({ type: "write" });
+      toc.send({ type: "write" });
+      await Promise.all([
+        waitForMessage(metadata, "published"),
+        waitForMessage(toc, "published"),
+      ]);
+      metadata.send({ type: "finish" });
+      toc.send({ type: "finish" });
+      await Promise.all([waitForExit(metadata), waitForExit(toc)]);
+
+      await withWikiGraphStorage(storage, async () => {
+        await expect(
+          readJsonEntry(archivePath, "cover/info.json"),
+        ).resolves.toMatchObject({
+          title: "Written by metadata worker",
+        });
+        await expect(
+          readJsonEntry(archivePath, "toc.json"),
+        ).resolves.toMatchObject({
+          items: [{ title: "Written by TOC worker" }],
+        });
+      });
+    });
+  });
+
+  it("reaps a published write after its process exits abruptly", async () => {
+    await withFixture(async ({ archivePath, stateRoot, storage }) => {
+      const writer = spawnWorker(archivePath, stateRoot, "meta");
+      await waitForMessage(writer, "ready");
+      writer.send({ type: "write" });
+      await waitForMessage(writer, "published");
+      writer.send({ type: "crash" });
+      await waitForExit(writer);
+
+      await withWikiGraphStorage(storage, async () => {
+        await reapThroughCoordinator(archivePath);
+        await expect(
+          readJsonEntry(archivePath, "cover/info.json"),
+        ).resolves.toMatchObject({
+          title: "Written by metadata worker",
+        });
+      });
+    });
+  });
+
+  it("reaps a published delete without resurrecting the entry", async () => {
+    await withFixture(async ({ archivePath, stateRoot, storage }) => {
+      const writer = spawnWorker(archivePath, stateRoot, "delete-summary");
+      await waitForMessage(writer, "ready");
+      writer.send({ type: "write" });
+      await waitForMessage(writer, "published");
+      writer.send({ type: "crash" });
+      await waitForExit(writer);
+
+      await withWikiGraphStorage(storage, async () => {
+        await reapThroughCoordinator(archivePath);
+        await expect(
+          readWikgArchiveEntry(
+            new NodeFile(archivePath),
+            "texts/summary/1.txt",
+          ),
+        ).resolves.toBeUndefined();
+      });
+    });
+  });
+
+  it("recovers a committed SQLite change and stale lease after a hard exit", async () => {
+    await withFixture(async ({ archivePath, stateRoot }) => {
+      const writer = spawnWorker(archivePath, stateRoot, "database");
+      await waitForMessage(writer, "ready");
+      writer.send({ type: "write" });
+      await expect(waitForMessage(writer, "published")).resolves.toMatchObject({
+        serialId: 2,
+      });
+      writer.send({ type: "crash" });
+      await waitForExit(writer);
+
+      await expect(
+        new WikiGraphArchiveFile(new NodeFile(archivePath)).readDocument(
+          async (document) => await document.serials.getById(2),
+        ),
+      ).resolves.toMatchObject({ id: 2 });
+    });
+  });
+
+  it("does not replace a SQLite entry while another session is using it", async () => {
+    await withFixture(async ({ archivePath }) => {
+      const archive = new NodeFile(archivePath);
+      const coordinator = new WikgCoordinator();
+      await coordinator.withArchiveSession(archive, async (readerSession) => {
+        const document = await DirectoryDocument.openFileStore(
+          readerSession.createFileStore({ readonlyDatabase: true }),
+        );
+        let startDelete!: () => void;
+        const deleteStarted = new Promise<void>((resolve) => {
+          startDelete = resolve;
+        });
+        let deleted = false;
+        const deletion = coordinator.withArchiveSession(
+          archive,
+          async (writerSession) => {
+            startDelete();
+            await writerSession.deleteEntry("database.db");
+            deleted = true;
+          },
+        );
+
+        await deleteStarted;
+        await new Promise((resolve) => globalThis.setTimeout(resolve, 100));
+        expect(deleted).toBe(false);
+        await document.release();
+        await deletion;
+        expect(deleted).toBe(true);
+      });
+    });
+  });
+
+  it("settles dirty state observed before the writer dies", async () => {
+    await withFixture(async ({ archivePath, stateRoot, storage }) => {
+      const writer = spawnWorker(archivePath, stateRoot, "meta");
+      await waitForMessage(writer, "ready");
+      writer.send({ type: "write" });
+      await waitForMessage(writer, "published");
+
+      const reader = spawnWorker(archivePath, stateRoot, "observe-meta");
+      await expect(waitForMessage(reader, "observed")).resolves.toMatchObject({
+        title: "Written by metadata worker",
+      });
+      writer.send({ type: "crash" });
+      await waitForExit(writer);
+      reader.send({ type: "finish" });
+      await waitForExit(reader);
+
+      await withWikiGraphStorage(storage, async () => {
+        await expect(
+          readJsonEntry(archivePath, "cover/info.json"),
+        ).resolves.toMatchObject({
+          title: "Written by metadata worker",
+        });
+      });
+    });
+  });
+});
+
+async function withFixture(
+  operation: (input: {
+    readonly archivePath: string;
+    readonly stateRoot: string;
+    readonly storage: ReturnType<typeof createNodeWikiGraphStorage>;
+  }) => Promise<void>,
+): Promise<void> {
+  await withTempDir("wikigraph-coordination-", async (root) => {
+    const stateRoot = join(root, "state");
+    const documentPath = join(root, "document");
+    await mkdir(documentPath, { recursive: true });
+    const storage = createNodeWikiGraphStorage(stateRoot);
+    await withWikiGraphStorage(storage, async () => {
+      const directory = new NodeDirectory(documentPath);
+      const document = await DirectoryDocument.open(directory);
+      try {
+        await document.openSession(async (opened) => {
+          await opened.createSerial();
+          await opened.writeBookMeta(createMeta("Before"));
+          await opened.writeSummary(1, "Summary before deletion");
+          await opened.writeToc({
+            items: [
+              {
+                children: [],
+                key: "chapter",
+                serialId: 1,
+                title: "Original",
+              },
+            ],
+            version: 1,
+          });
+        });
+      } finally {
+        await document.release();
+      }
+      const archivePath = join(root, "book.wikg");
+      await writeWikgArchive(directory, new NodeFile(archivePath));
+      await operation({ archivePath, stateRoot, storage });
+    });
+  });
+}
+
+function spawnWorker(
+  archivePath: string,
+  stateRoot: string,
+  action: string,
+): ChildProcess {
+  const child = fork(workerPath, [archivePath, stateRoot, action], {
+    execArgv: ["--import", "tsx"],
+    silent: true,
+  });
+  const errors: string[] = [];
+  child.stderr?.on("data", (chunk) => errors.push(String(chunk)));
+  workerErrors.set(child, errors);
+  return child;
+}
+
+async function waitForMessage(
+  child: ChildProcess,
+  type: string,
+): Promise<Record<string, unknown>> {
+  return await new Promise((resolve, reject) => {
+    const timeout = globalThis.setTimeout(() => {
+      cleanup();
+      reject(
+        new Error(
+          `Timed out waiting for ${type}: ${workerErrors.get(child)?.join("") ?? ""}`,
+        ),
+      );
+    }, 5_000);
+    const onMessage = (message: unknown) => {
+      if (
+        typeof message !== "object" ||
+        message === null ||
+        !("type" in message) ||
+        message.type !== type
+      ) {
+        return;
+      }
+      cleanup();
+      resolve(message as Record<string, unknown>);
+    };
+    const onExit = (code: number | null) => {
+      cleanup();
+      reject(
+        new Error(
+          `Archive coordination worker exited with ${String(code)} before ${type}: ${workerErrors.get(child)?.join("") ?? ""}`,
+        ),
+      );
+    };
+    const cleanup = () => {
+      globalThis.clearTimeout(timeout);
+      child.off("message", onMessage);
+      child.off("exit", onExit);
+    };
+    child.on("message", onMessage);
+    child.on("exit", onExit);
+  });
+}
+
+async function waitForExit(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null) {
+    expect(child.exitCode).toBe(0);
+    return;
+  }
+  await new Promise<void>((resolve, reject) => {
+    const timeout = globalThis.setTimeout(() => {
+      reject(
+        new Error(
+          `Timed out waiting for worker exit: ${workerErrors.get(child)?.join("") ?? ""}`,
+        ),
+      );
+    }, 5_000);
+    child.once("exit", (code) => {
+      globalThis.clearTimeout(timeout);
+      if (code === 0) resolve();
+      else
+        reject(new Error(`Archive coordination worker exited with ${code}.`));
+    });
+  });
+}
+
+function createMeta(title: string) {
+  return {
+    authors: [],
+    description: null,
+    identifier: null,
+    language: null,
+    publishedAt: null,
+    publisher: null,
+    sourceFormat: "txt" as const,
+    title,
+    version: 1 as const,
+  };
+}
+
+async function readJsonEntry(
+  archivePath: string,
+  entryPath: string,
+): Promise<unknown> {
+  const content = await readWikgArchiveEntry(
+    new NodeFile(archivePath),
+    entryPath,
+  );
+  return content === undefined
+    ? undefined
+    : JSON.parse(new TextDecoder().decode(content));
+}
+
+async function reapThroughCoordinator(archivePath: string): Promise<void> {
+  await new WikgCoordinator().withArchiveSession(
+    new NodeFile(archivePath),
+    () => Promise.resolve(),
+  );
+}

--- a/test/core/storage/wikg/opaque-file-adapter.test.ts
+++ b/test/core/storage/wikg/opaque-file-adapter.test.ts
@@ -10,7 +10,6 @@ import {
   type Directory,
   type File,
   type HostDatabaseConnection,
-  type HostZipEntry,
   type WikiGraphPlatform,
   withWikiGraphStorage,
 } from "../../../../packages/core/src/runtime/platform/index.js";
@@ -269,6 +268,7 @@ const opaqueNodePlatform: WikiGraphPlatform = {
     open: async (file, options): Promise<HostDatabaseConnection> =>
       await nodeWikiGraphPlatform.database.open(unwrapFile(file), options),
   },
+  lifecycle: nodeWikiGraphPlatform.lifecycle,
   resources: {
     getDirectory: async (identity) => {
       const directory =
@@ -284,8 +284,8 @@ const opaqueNodePlatform: WikiGraphPlatform = {
   },
   templates: nodeWikiGraphPlatform.templates,
   zip: {
-    read: async (file): Promise<readonly HostZipEntry[]> =>
-      await nodeWikiGraphPlatform.zip.read(unwrapFile(file)),
+    open: async (file) =>
+      await nodeWikiGraphPlatform.zip.open(unwrapFile(file)),
     write: async (file, entries) =>
       await nodeWikiGraphPlatform.zip.write(unwrapFile(file), entries),
   },

--- a/test/core/storage/wikg/wiki-graph-archive-file.test.ts
+++ b/test/core/storage/wikg/wiki-graph-archive-file.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, rename } from "fs/promises";
 import { join } from "path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { DirectoryDocument } from "../../../../packages/core/src/document/index.js";
 import { WikiGraphArchiveFile } from "../../../../packages/core/src/storage/wikg/wiki-graph-archive-file.js";
@@ -13,13 +13,22 @@ import {
   isArchiveSearchIndexCurrent,
   rebuildArchiveSearchIndex,
 } from "../../../../packages/core/src/retrieval/query/index.js";
-import { withWikiGraphStorage } from "../../../../packages/core/src/runtime/platform/index.js";
+import {
+  installWikiGraphPlatform,
+  withWikiGraphStorage,
+} from "../../../../packages/core/src/runtime/platform/index.js";
 import {
   createNodeWikiGraphStorage,
+  installNodeWikiGraphPlatform,
   NodeDirectory,
   NodeFile,
+  nodeWikiGraphPlatform,
 } from "../../../../packages/cli/src/runtime/node-platform.js";
 import { withTempDir } from "../../../helpers/temp.js";
+
+afterEach(() => {
+  installNodeWikiGraphPlatform();
+});
 
 describe("wikg/wiki-graph-archive-file", () => {
   it("reads and writes an archive through opaque File capabilities", async () => {
@@ -45,6 +54,46 @@ describe("wikg/wiki-graph-archive-file", () => {
       ).resolves.toMatchObject({
         items: [{ serialId: 1, title: "Updated" }],
       });
+    });
+  });
+
+  it("does not materialize unrelated ZIP entries during an ordinary read", async () => {
+    await withArchiveFixture(async ({ archive }) => {
+      const initialReader = await nodeWikiGraphPlatform.zip.open(archive);
+      const sentinel = (await initialReader.listEntries()).find((entry) =>
+        entry.startsWith("texts/"),
+      );
+      await initialReader.close();
+      expect(sentinel).toBeDefined();
+
+      const readEntries: string[] = [];
+      installWikiGraphPlatform({
+        ...nodeWikiGraphPlatform,
+        zip: {
+          ...nodeWikiGraphPlatform.zip,
+          open: async (file) => {
+            const reader = await nodeWikiGraphPlatform.zip.open(file);
+            return {
+              close: async () => await reader.close(),
+              listEntries: async () => await reader.listEntries(),
+              readEntry: async (name) => {
+                readEntries.push(name);
+                if (name === sentinel) {
+                  throw new Error(`Unrelated ZIP entry was read: ${name}`);
+                }
+                return await reader.readEntry(name);
+              },
+            };
+          },
+        },
+      });
+
+      await expect(
+        new WikiGraphArchiveFile(archive).read(
+          async (digest) => await digest.readToc(),
+        ),
+      ).resolves.toMatchObject({ items: [{ title: "Original" }] });
+      expect(readEntries).not.toContain(sentinel);
     });
   });
 

--- a/test/helpers/archive-coordination-worker.ts
+++ b/test/helpers/archive-coordination-worker.ts
@@ -2,6 +2,8 @@ import process from "process";
 
 import { DirectoryDocument } from "../../packages/core/src/document/index.js";
 import { WikgCoordinator } from "../../packages/core/src/storage/wikg/coordinator.js";
+import { createWorkspaceSnapshot } from "../../packages/core/src/storage/wikg/wikg-coordinator/workspace.js";
+import { createPortableHash } from "../../packages/core/src/utils/crypto.js";
 import {
   installNodeWikiGraphPlatform,
   NodeFile,
@@ -23,6 +25,24 @@ const coordinator = new WikgCoordinator();
 await run();
 
 async function run(): Promise<void> {
+  if (action === "staging") {
+    await coordinator.withArchiveSession(archive, async () => {
+      send({ type: "ready" });
+      await waitFor("write");
+      const archiveKey = createPortableHash("sha256")
+        .update(archive.identity)
+        .digest("hex");
+      const snapshot = await createWorkspaceSnapshot(archiveKey, "toc.json");
+      const writer = await snapshot.file.openWriter();
+      await writer.write(`${JSON.stringify({ items: [], version: 1 })}\n`);
+      await writer.commit();
+      send({ type: "staged" });
+      await waitFor("crash");
+      process.exit(0);
+    });
+    return;
+  }
+
   if (action === "database") {
     await coordinator.withArchiveSession(archive, async (session) => {
       const document = await DirectoryDocument.openFileStore(

--- a/test/helpers/archive-coordination-worker.ts
+++ b/test/helpers/archive-coordination-worker.ts
@@ -1,0 +1,109 @@
+import process from "process";
+
+import { DirectoryDocument } from "../../packages/core/src/document/index.js";
+import { WikgCoordinator } from "../../packages/core/src/storage/wikg/coordinator.js";
+import {
+  installNodeWikiGraphPlatform,
+  NodeFile,
+} from "../../packages/cli/src/runtime/node-platform.js";
+
+const [archivePath, stateRoot, action] = process.argv.slice(2);
+if (
+  archivePath === undefined ||
+  stateRoot === undefined ||
+  action === undefined
+) {
+  throw new Error("Expected archive path, state root, and worker action");
+}
+
+installNodeWikiGraphPlatform(stateRoot);
+const archive = new NodeFile(archivePath);
+const coordinator = new WikgCoordinator();
+
+await run();
+
+async function run(): Promise<void> {
+  if (action === "database") {
+    await coordinator.withArchiveSession(archive, async (session) => {
+      const document = await DirectoryDocument.openFileStore(
+        session.createFileStore(),
+      );
+      send({ type: "ready" });
+      await waitFor("write");
+      const serialId = await document.createSerial();
+      send({ serialId, type: "published" });
+      const command = await waitFor("finish", "crash");
+      if (command === "crash") process.exit(0);
+      await document.release();
+    });
+    send({ type: "done" });
+    return;
+  }
+
+  if (action === "observe-meta") {
+    await coordinator.withArchiveSession(archive, async (session) => {
+      const content = await session.readEntry("cover/info.json");
+      const title =
+        content === undefined
+          ? undefined
+          : (
+              JSON.parse(new TextDecoder().decode(content)) as {
+                title?: string;
+              }
+            ).title;
+      send({ title, type: "observed" });
+      await waitFor("finish");
+    });
+    send({ type: "done" });
+    return;
+  }
+
+  await coordinator.withArchiveSession(archive, async (session) => {
+    send({ type: "ready" });
+    await waitFor("write");
+    if (action === "meta") {
+      await session.writeEntry(
+        "cover/info.json",
+        `${JSON.stringify({ title: "Written by metadata worker" })}\n`,
+        { overwrite: true },
+      );
+    } else if (action === "toc") {
+      await session.writeEntry(
+        "toc.json",
+        `${JSON.stringify({ items: [{ children: [], key: "chapter", serialId: 1, title: "Written by TOC worker" }], version: 1 })}\n`,
+        { overwrite: true },
+      );
+    } else if (action === "delete-summary") {
+      await session.deleteEntry("texts/summary/1.txt");
+    } else {
+      throw new Error(`Unsupported worker action: ${action}`);
+    }
+    send({ type: "published" });
+    const command = await waitFor("finish", "crash");
+    if (command === "crash") process.exit(0);
+  });
+  send({ type: "done" });
+}
+
+function send(message: Readonly<Record<string, unknown>>): void {
+  process.send?.(message);
+}
+
+async function waitFor(...expected: readonly string[]): Promise<string> {
+  return await new Promise((resolve) => {
+    const listener = (message: unknown) => {
+      if (
+        typeof message !== "object" ||
+        message === null ||
+        !("type" in message) ||
+        typeof message.type !== "string" ||
+        !expected.includes(message.type)
+      ) {
+        return;
+      }
+      process.off("message", listener);
+      resolve(message.type);
+    };
+    process.on("message", listener);
+  });
+}


### PR DESCRIPTION
## Summary

- 恢复基于宿主 File/Directory 抽象的 Archive 跨进程协调、锁、lease、overlay、settlement、reaper 与失败恢复语义
- 将 ZIP 读取改为按需访问，并增强 Core 的 Node 运行时依赖拦截
- 恢复并补充跨进程、硬退出、回滚竞态、懒读取及 portability 回归测试

## Verification

- `pnpm verify`
- `pnpm test:run`（151 files / 961 tests）
- `pnpm build`