### PR TITLE
恢复 Node ZIP 流式写入

### DIFF
--- a/packages/cli/src/runtime/node-platform.ts
+++ b/packages/cli/src/runtime/node-platform.ts
@@ -428,19 +428,27 @@ async function writeNodeZip(
   const writer = await file.openWriter();
   const outputStream = zipFile.outputStream as Readable;
   const outputDone = writeNodeStream(outputStream, writer);
-  // Observe sink failures immediately while entry production may still be running.
-  void outputDone.catch(() => undefined);
+  const entryState = { cancelled: false, complete: false };
+  let iterator:
+    | Iterator<HostZipEntry>
+    | AsyncIterator<HostZipEntry>
+    | undefined;
 
   try {
-    for await (const entry of entries) {
-      zipFile.addBuffer(Buffer.from(entry.data), entry.name, {
-        compress: false,
-      });
+    iterator = getNodeZipEntryIterator(entries);
+    const entriesDone = addNodeZipEntries(zipFile, iterator, entryState);
+    await Promise.race([entriesDone, outputDone]);
+    if (!entryState.complete) {
+      throw new Error("ZIP output ended before entry production completed");
     }
     zipFile.end();
     await outputDone;
     await writer.commit();
   } catch (error) {
+    entryState.cancelled = true;
+    if (!entryState.complete && iterator !== undefined) {
+      closeNodeZipEntryIterator(iterator);
+    }
     if (!outputStream.destroyed) {
       outputStream.destroy(
         error instanceof Error ? error : new Error("Cannot write ZIP archive"),
@@ -449,6 +457,46 @@ async function writeNodeZip(
     await outputDone.catch(() => undefined);
     await writer.abort().catch(() => undefined);
     throw error;
+  }
+}
+
+async function addNodeZipEntries(
+  zipFile: yazl.ZipFile,
+  iterator: Iterator<HostZipEntry> | AsyncIterator<HostZipEntry>,
+  state: { cancelled: boolean; complete: boolean },
+): Promise<void> {
+  while (!state.cancelled) {
+    const result = await iterator.next();
+    if (state.cancelled) return;
+    if (result.done) {
+      state.complete = true;
+      return;
+    }
+    zipFile.addBuffer(Buffer.from(result.value.data), result.value.name, {
+      compress: false,
+    });
+  }
+}
+
+function getNodeZipEntryIterator(
+  entries: Iterable<HostZipEntry> | AsyncIterable<HostZipEntry>,
+): Iterator<HostZipEntry> | AsyncIterator<HostZipEntry> {
+  const asyncIterator = (entries as AsyncIterable<HostZipEntry>)[
+    Symbol.asyncIterator
+  ];
+  return asyncIterator === undefined
+    ? (entries as Iterable<HostZipEntry>)[Symbol.iterator]()
+    : asyncIterator.call(entries);
+}
+
+function closeNodeZipEntryIterator(
+  iterator: Iterator<HostZipEntry> | AsyncIterator<HostZipEntry>,
+): void {
+  if (iterator.return === undefined) return;
+  try {
+    void Promise.resolve(iterator.return()).catch(() => undefined);
+  } catch {
+    // Preserve the failure that caused iteration to stop.
   }
 }
 

--- a/packages/cli/src/runtime/node-platform.ts
+++ b/packages/cli/src/runtime/node-platform.ts
@@ -6,6 +6,8 @@ import * as fsPromises from "node:fs/promises";
 import * as os from "node:os";
 import * as pathModule from "node:path";
 import * as process from "node:process";
+import { type Readable, Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 import * as sqlite3 from "sqlite3";
 import * as yauzl from "yauzl";
 import * as yazl from "yazl";
@@ -423,20 +425,53 @@ async function writeNodeZip(
   entries: Iterable<HostZipEntry> | AsyncIterable<HostZipEntry>,
 ): Promise<void> {
   const zipFile = new yazl.ZipFile();
-  const output = collectNodeStream(zipFile.outputStream);
-  for await (const entry of entries) {
-    zipFile.addBuffer(Buffer.from(entry.data), entry.name, { compress: false });
-  }
-  zipFile.end();
-
   const writer = await file.openWriter();
+  const outputStream = zipFile.outputStream as Readable;
+  const outputDone = writeNodeStream(outputStream, writer);
+  // Observe sink failures immediately while entry production may still be running.
+  void outputDone.catch(() => undefined);
+
   try {
-    await writer.write(await output);
+    for await (const entry of entries) {
+      zipFile.addBuffer(Buffer.from(entry.data), entry.name, {
+        compress: false,
+      });
+    }
+    zipFile.end();
+    await outputDone;
     await writer.commit();
   } catch (error) {
-    await writer.abort();
+    if (!outputStream.destroyed) {
+      outputStream.destroy(
+        error instanceof Error ? error : new Error("Cannot write ZIP archive"),
+      );
+    }
+    await outputDone.catch(() => undefined);
+    await writer.abort().catch(() => undefined);
     throw error;
   }
+}
+
+async function writeNodeStream(
+  input: NodeJS.ReadableStream,
+  writer: FileWriter,
+): Promise<void> {
+  await pipeline(
+    input,
+    new Writable({
+      write: (chunk: Buffer, _encoding, callback) => {
+        void writer.write(chunk).then(
+          () => callback(),
+          (error: unknown) =>
+            callback(
+              error instanceof Error
+                ? error
+                : new Error("Cannot stream ZIP archive"),
+            ),
+        );
+      },
+    }),
+  );
 }
 
 async function collectNodeStream(

--- a/test/core/runtime/platform/node-platform.test.ts
+++ b/test/core/runtime/platform/node-platform.test.ts
@@ -5,6 +5,11 @@ import {
   nodeWikiGraphPlatform,
 } from "../../../../packages/cli/src/runtime/node-platform.js";
 import { DirectoryFileStore } from "../../../../packages/core/src/document/directory/directory-file-store.js";
+import type {
+  File,
+  FileWriter,
+  HostZipEntry,
+} from "../../../../packages/core/src/runtime/platform/index.js";
 import { withTempDir } from "../../../helpers/temp.js";
 
 describe("Node File/Directory adapter", () => {
@@ -94,6 +99,75 @@ describe("Node File/Directory adapter", () => {
     });
   });
 
+  it("streams ZIP output through sequential FileWriter chunks", async () => {
+    const probe = createWriterProbe({ writeDelayMs: 1 });
+
+    await nodeWikiGraphPlatform.zip.write(probe.file, createLargeZipEntries());
+
+    expect(probe.writeCalls).toBeGreaterThan(1);
+    expect(probe.maxConcurrentWrites).toBe(1);
+    expect(probe.commitCalls).toBe(1);
+    expect(probe.commitAtWriteCount).toBe(probe.writeCalls);
+    expect(probe.abortCalls).toBe(0);
+  });
+
+  it("aborts a streaming ZIP write when a chunk fails", async () => {
+    const probe = createWriterProbe({ failWriteAt: 2 });
+
+    await expect(
+      nodeWikiGraphPlatform.zip.write(probe.file, createLargeZipEntries()),
+    ).rejects.toThrow("stream write failed");
+
+    expect(probe.writeCalls).toBe(2);
+    expect(probe.commitCalls).toBe(0);
+    expect(probe.abortCalls).toBe(1);
+  });
+
+  it("aborts a streaming ZIP write when entry production fails", async () => {
+    const probe = createWriterProbe();
+    const entries = (function* (): Generator<HostZipEntry> {
+      yield {
+        data: new TextEncoder().encode("first"),
+        name: "first.txt",
+      };
+      throw new Error("entry production failed");
+    })();
+
+    await expect(
+      nodeWikiGraphPlatform.zip.write(probe.file, entries),
+    ).rejects.toThrow("entry production failed");
+
+    expect(probe.commitCalls).toBe(0);
+    expect(probe.abortCalls).toBe(1);
+  });
+
+  it("aborts a streaming ZIP write when ZIP entry creation fails", async () => {
+    const probe = createWriterProbe();
+
+    await expect(
+      nodeWikiGraphPlatform.zip.write(probe.file, [
+        {
+          data: new TextEncoder().encode("invalid"),
+          name: "../invalid.txt",
+        },
+      ]),
+    ).rejects.toThrow();
+
+    expect(probe.commitCalls).toBe(0);
+    expect(probe.abortCalls).toBe(1);
+  });
+
+  it("aborts a streaming ZIP write when commit fails", async () => {
+    const probe = createWriterProbe({ failCommit: true });
+
+    await expect(
+      nodeWikiGraphPlatform.zip.write(probe.file, createLargeZipEntries()),
+    ).rejects.toThrow("commit failed");
+
+    expect(probe.commitCalls).toBe(1);
+    expect(probe.abortCalls).toBe(1);
+  });
+
   it("restores persisted opaque capabilities without exposing a path to Core", async () => {
     await withTempDir("wikigraph-host-resources-", async (path) => {
       const directory = new NodeDirectory(path);
@@ -112,3 +186,87 @@ describe("Node File/Directory adapter", () => {
     });
   });
 });
+
+function createLargeZipEntries(): HostZipEntry[] {
+  return Array.from({ length: 4 }, (_, index) => ({
+    data: new Uint8Array(256 * 1024).fill(index + 1),
+    name: `entry-${index}.bin`,
+  }));
+}
+
+function createWriterProbe(
+  options: {
+    readonly failCommit?: boolean;
+    readonly failWriteAt?: number;
+    readonly writeDelayMs?: number;
+  } = {},
+): {
+  readonly file: File;
+  readonly abortCalls: number;
+  readonly commitAtWriteCount: number | undefined;
+  readonly commitCalls: number;
+  readonly maxConcurrentWrites: number;
+  readonly writeCalls: number;
+} {
+  let abortCalls = 0;
+  let activeWrites = 0;
+  let commitAtWriteCount: number | undefined;
+  let commitCalls = 0;
+  let maxConcurrentWrites = 0;
+  let writeCalls = 0;
+  const writer: FileWriter = {
+    abort: () => {
+      abortCalls += 1;
+      return Promise.resolve();
+    },
+    commit: () => {
+      commitCalls += 1;
+      commitAtWriteCount = writeCalls;
+      if (options.failCommit === true) {
+        return Promise.reject(new Error("commit failed"));
+      }
+      return Promise.resolve();
+    },
+    write: async () => {
+      writeCalls += 1;
+      activeWrites += 1;
+      maxConcurrentWrites = Math.max(maxConcurrentWrites, activeWrites);
+      try {
+        if (writeCalls === options.failWriteAt) {
+          throw new Error("stream write failed");
+        }
+        if ((options.writeDelayMs ?? 0) > 0) {
+          await new Promise<void>((resolve) => {
+            globalThis.setTimeout(resolve, options.writeDelayMs);
+          });
+        }
+      } finally {
+        activeWrites -= 1;
+      }
+    },
+  };
+  const file: File = {
+    identity: "writer-probe",
+    name: "probe.zip",
+    openWriter: () => Promise.resolve(writer),
+    read: () => Promise.resolve(new Uint8Array()),
+  };
+  return {
+    get abortCalls() {
+      return abortCalls;
+    },
+    get commitAtWriteCount() {
+      return commitAtWriteCount;
+    },
+    get commitCalls() {
+      return commitCalls;
+    },
+    file,
+    get maxConcurrentWrites() {
+      return maxConcurrentWrites;
+    },
+    get writeCalls() {
+      return writeCalls;
+    },
+  };
+}

--- a/test/core/runtime/platform/node-platform.test.ts
+++ b/test/core/runtime/platform/node-platform.test.ts
@@ -123,6 +123,54 @@ describe("Node File/Directory adapter", () => {
     expect(probe.abortCalls).toBe(1);
   });
 
+  it("rejects promptly when the sink fails while an async producer waits", async () => {
+    const probe = createWriterProbe({ failWriteAt: 1 });
+    let releaseProducer: (() => void) | undefined;
+    let signalProducerWaiting: (() => void) | undefined;
+    const producerWaiting = new Promise<void>((resolve) => {
+      signalProducerWaiting = resolve;
+    });
+    const producerRelease = new Promise<void>((resolve) => {
+      releaseProducer = resolve;
+    });
+    const entries = (async function* (): AsyncGenerator<HostZipEntry> {
+      yield {
+        data: new Uint8Array(256 * 1024).fill(1),
+        name: "first.bin",
+      };
+      signalProducerWaiting?.();
+      await producerRelease;
+      yield {
+        data: new Uint8Array(256 * 1024).fill(2),
+        name: "second.bin",
+      };
+    })();
+    const writing = nodeWikiGraphPlatform.zip.write(probe.file, entries);
+
+    await producerWaiting;
+    let timeout: ReturnType<typeof globalThis.setTimeout> | undefined;
+    try {
+      await expect(
+        Promise.race([
+          writing,
+          new Promise<never>((_resolve, reject) => {
+            timeout = globalThis.setTimeout(
+              () => reject(new Error("stream failure was not propagated")),
+              100,
+            );
+          }),
+        ]),
+      ).rejects.toThrow("stream write failed");
+    } finally {
+      if (timeout !== undefined) globalThis.clearTimeout(timeout);
+      releaseProducer?.();
+      await entries.return(undefined);
+    }
+
+    expect(probe.commitCalls).toBe(0);
+    expect(probe.abortCalls).toBe(1);
+  });
+
   it("aborts a streaming ZIP write when entry production fails", async () => {
     const probe = createWriterProbe();
     const entries = (function* (): Generator<HostZipEntry> {


### PR DESCRIPTION
## 变更

- 将 `yazl.outputStream` 按块、带背压地写入 `FileWriter`，避免聚合完整 ZIP Buffer
- 输出失败时及时中止异步 entry producer，并保持 commit/abort 原子语义
- 补充流式写入、失败传播与清理路径测试

## 验证

- `pnpm verify`
- `pnpm build`
- `pnpm test:run`（151 个测试文件，967 项测试）