### PR TITLE
修复 Archive 并发互斥测试的时序抖动

### DIFF
--- a/packages/core/src/storage/wikg/wiki-graph-archive-file.ts
+++ b/packages/core/src/storage/wikg/wiki-graph-archive-file.ts
@@ -5,6 +5,11 @@ import { WikiGraphArchive } from "../../api/wiki-graph-archive.js";
 import { deleteArchiveSearchSessions } from "../../retrieval/query/index.js";
 
 import { WikgCoordinator } from "./coordinator.js";
+import type { HostWikgArchiveSession } from "./wikg-coordinator/host-session.js";
+
+// Keep high-level callbacks exclusive in this realm; the coordinator retains
+// its finer-grained entry and cross-process concurrency underneath.
+const archiveFileQueues = new Map<string, Promise<void>>();
 
 /** A .wikg archive exposed to Core as an opaque host File capability. */
 export class WikiGraphArchiveFile {
@@ -30,8 +35,9 @@ export class WikiGraphArchiveFile {
     operation: (document: DirectoryDocument) => Promise<T> | T,
     options: { readonly searchIndexWritebackPolicy?: "archive" | "cache" } = {},
   ): Promise<T> {
-    return await this.#coordinator.withArchiveSession(
+    return await withSerializedArchiveFileSession(
       this.#file,
+      this.#coordinator,
       async (session) => {
         const fileStore = session.createFileStore({
           readonlyDatabase: true,
@@ -55,8 +61,9 @@ export class WikiGraphArchiveFile {
     operation: (document: DirectoryDocument) => Promise<T> | T,
     options: { readonly searchIndexWritebackPolicy?: "archive" | "cache" } = {},
   ): Promise<T> {
-    return await this.#coordinator.withArchiveSession(
+    return await withSerializedArchiveFileSession(
       this.#file,
+      this.#coordinator,
       async (session) => {
         const fileStore = session.createFileStore({
           ...(options.searchIndexWritebackPolicy === undefined
@@ -77,5 +84,40 @@ export class WikiGraphArchiveFile {
         }
       },
     );
+  }
+}
+
+async function withSerializedArchiveFileSession<T>(
+  file: File,
+  coordinator: WikgCoordinator,
+  operation: (session: HostWikgArchiveSession) => Promise<T> | T,
+): Promise<T> {
+  return await withSerializedArchiveFileAccess(
+    file,
+    async () => await coordinator.withArchiveSession(file, operation),
+  );
+}
+
+async function withSerializedArchiveFileAccess<T>(
+  file: File,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const identity = file.identity;
+  const previous = archiveFileQueues.get(identity) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queued = previous.then(() => current);
+  archiveFileQueues.set(identity, queued);
+  await previous;
+
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (archiveFileQueues.get(identity) === queued) {
+      archiveFileQueues.delete(identity);
+    }
   }
 }

--- a/test/core/storage/wikg/wiki-graph-archive-file.test.ts
+++ b/test/core/storage/wikg/wiki-graph-archive-file.test.ts
@@ -116,23 +116,88 @@ describe("wikg/wiki-graph-archive-file", () => {
 
   it("serializes concurrent access by opaque file identity", async () => {
     await withArchiveFixture(async ({ archive }) => {
-      const file = new WikiGraphArchiveFile(archive);
+      let watchSecondAccess = false;
+      let secondTouchedBackingFile = false;
+      let markSecondQueued!: () => void;
+      let rejectSecondQueued!: (error: Error) => void;
+      const secondQueued = new Promise<void>((resolve, reject) => {
+        markSecondQueued = resolve;
+        rejectSecondQueued = reject;
+      });
+      // Identity is read at the queue boundary, before the backing file opens.
+      // This makes the second caller's arrival observable without a timer.
+      const observedArchive = new Proxy(archive, {
+        get: (target, property, receiver) => {
+          if (watchSecondAccess && property === "path") {
+            secondTouchedBackingFile = true;
+          }
+          if (watchSecondAccess && property === "identity") {
+            watchSecondAccess = false;
+            if (secondTouchedBackingFile) {
+              rejectSecondQueued(
+                new Error(
+                  "Second archive access touched the backing file before reaching the identity queue.",
+                ),
+              );
+            } else {
+              markSecondQueued();
+            }
+          }
+          return Reflect.get(target, property, receiver) as unknown;
+        },
+      });
+      const firstFile = new WikiGraphArchiveFile(archive);
+      const secondFile = new WikiGraphArchiveFile(observedArchive);
       const order: string[] = [];
-      let release!: () => void;
-      const gate = new Promise<void>((resolve) => {
-        release = resolve;
+      let activeSessions = 0;
+      let maxConcurrentSessions = 0;
+      let markFirstEntered!: () => void;
+      const firstEntered = new Promise<void>((resolve) => {
+        markFirstEntered = resolve;
       });
-      const first = file.write(async () => {
+      let releaseFirst!: () => void;
+      const firstGate = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      const first = firstFile.write(async () => {
+        activeSessions += 1;
+        maxConcurrentSessions = Math.max(maxConcurrentSessions, activeSessions);
         order.push("first-start");
-        await gate;
-        order.push("first-end");
+        markFirstEntered();
+        try {
+          await firstGate;
+          order.push("first-end");
+        } finally {
+          activeSessions -= 1;
+        }
       });
-      const second = file.read(() => {
-        order.push("second");
+
+      await firstEntered;
+      watchSecondAccess = true;
+      const second = secondFile.read(() => {
+        activeSessions += 1;
+        maxConcurrentSessions = Math.max(maxConcurrentSessions, activeSessions);
+        try {
+          order.push("second");
+        } finally {
+          activeSessions -= 1;
+        }
       });
-      await Promise.resolve();
-      release();
+      let queueError: Error | undefined;
+      try {
+        await secondQueued;
+      } catch (error) {
+        queueError = error instanceof Error ? error : new Error(String(error));
+      } finally {
+        releaseFirst();
+      }
+      if (queueError !== undefined) {
+        await Promise.allSettled([first, second]);
+        throw queueError;
+      }
       await Promise.all([first, second]);
+
+      expect(maxConcurrentSessions).toBe(1);
       expect(order).toStrictEqual(["first-start", "first-end", "second"]);
     });
   });


### PR DESCRIPTION
## Summary

- serialize high-level WikiGraphArchiveFile callbacks by opaque file identity within one JavaScript realm
- retain the coordinator's finer-grained entry and cross-process concurrency
- replace the scheduling-dependent assertion with a deterministic queue-arrival signal and overlap check

## Verification

- target test file repeated 20 times
- archive coordination test group repeated 5 times
- pnpm typecheck
- wiki-graph-core portability build
- pnpm test:run (151 files, 967 tests)