### PR TITLE
fix: 完善 home schema v3 到 v4 迁移安全

### DIFF
--- a/docs/schema-upgrade.md
+++ b/docs/schema-upgrade.md
@@ -60,7 +60,10 @@ the resulting database is written back only by the explicit archive upgrader.
 
 Archive upgraders must refuse active coordinator state for the target archive
 and non-search-index overlays, because those can represent uncommitted important
-data.
+data. This check uses the current host-neutral coordinator state in
+`tmp/wikg-coordinator.sqlite`; an in-process upgrade queue is not a substitute
+for the durable check. Derived `index.db` / `fts.db` overlays may be discarded
+after the archive rewrite commits.
 
 ## Home Gate
 
@@ -85,13 +88,16 @@ code and tests when adding new home SQLite files:
   - build jobs and build worker lease state.
 - `~/.wikigraph/tmp/gc.sqlite`
   - GC locks.
+- `~/.wikigraph/tmp/wikg-coordinator.sqlite`
+  - current host-neutral coordinator overlays, entry locks, owners, sqlite
+    leases, and commit locks.
 - `~/.wikigraph/staging/staging.sqlite`
-  - coordinator overlays, entry locks, owners, sqlite leases, and commit locks.
+  - legacy v3 coordinator state, inspected only by the home upgrader.
 - `~/.wikigraph/staging/library/<library-id>/index/index.db`
   - library aggregate search index SQLite.
-- `~/.wikigraph/staging/work/<archiveKey>/index.db`
-  - archive coordinator external search index cache workspace referenced by
-    `entry_overlays(entry_path = 'index.db')`.
+- the host-provided document store
+  - `.wikg-work` coordinator snapshots, `.wikg-cache` search caches, and
+    abandoned `.wikg-session-*` / `.wikg-upgrade-*` workspaces.
 
 For home schema upgrades, derived home data is deleted or invalidated:
 query/search caches, external cache, GC state, build queue SQLite/cache when
@@ -99,12 +105,34 @@ safe, library aggregate indexes, external archive search index
 overlays/workspaces for `index.db` or legacy `fts.db`, and orphaned SQLite
 materialization cache overlays whose archive file no longer exists. The v2 -> v3
 home upgrader uses the same cleanup boundary because the index-cache semantics
-changed. The upgrader must block when active GC, build job, worker lease,
-coordinator owner/lock/sqlite lease/commit lock, or remaining non-derived
-overlay state is present.
+changed. A home upgrader must block before cleanup when library/state/GC locks,
+build jobs, worker leases, or coordinator owners are still active. Orphaned
+cross-version overlays are rollback state, not a reason to replay a partially
+completed operation against an archive.
 
 Pure information commands such as `wg --version` and help rendering must not open
 home SQLite and must not trigger schema upgrade.
+
+The v3 -> v4 home upgrader is the persistence boundary for the host-neutral
+runtime refactor. It renames `libraries.folder_path` to
+`libraries.folder_identity` and asks the host resource adapter to resolve every
+legacy stored directory reference, then persists only each resulting opaque
+`Directory.identity`. Config sections, library ids/default status, library
+metadata, and `library_archives` membership rows remain unchanged. The archive
+schema remains v4 and no `.wikg` is rewritten by this home migration.
+Hosts that need to accept a v3 home implement the resource adapter's
+`resolveLegacyDirectory` hook; this keeps legacy location syntax outside Core's
+normal file and directory operations.
+
+Before changing the registry or deleting derived state, the upgrader rejects
+fresh library/state/GC locks, active build jobs or worker leases, and live
+legacy or current coordinator owners. Once those checks pass, cross-version
+coordinator state is rolled back: legacy/current coordinator databases and
+their workspaces are discarded, including non-derived overlays, so the last
+atomic `.wikg` commit stays authoritative. Search/cache/index state and inactive
+job queue/work/cache state are likewise invalidated. The v4 marker is written
+last; a failure retains the prior marker and the migration can be retried. A
+second successful run is a no-op.
 
 Search index caches also carry their own `search_index_state.version`. Opening a
 cache whose version is missing, unreadable, or different from the current search

--- a/packages/cli/src/bin/cli.ts
+++ b/packages/cli/src/bin/cli.ts
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
 
-import { installNodeWikiGraphPlatform } from "../runtime/node-platform.js";
-
-installNodeWikiGraphPlatform();
 const { main } = await import("../app/index.js");
 
 void main();

--- a/packages/cli/src/bin/dev-cli.ts
+++ b/packages/cli/src/bin/dev-cli.ts
@@ -1,6 +1,3 @@
-import { installNodeWikiGraphPlatform } from "../runtime/node-platform.js";
-
-installNodeWikiGraphPlatform();
 const { main } = await import("../app/index.js");
 import {
   resolveDevProjectRootPath,

--- a/packages/cli/src/runtime/node-platform.ts
+++ b/packages/cli/src/runtime/node-platform.ts
@@ -572,6 +572,12 @@ export const nodeWikiGraphPlatform: WikiGraphPlatform = {
         path === undefined ? undefined : new NodeFile(path),
       );
     },
+    resolveLegacyDirectory: (reference) => {
+      const path = decodeNodeResourceIdentity(reference, "directory");
+      return Promise.resolve(
+        path === undefined ? undefined : new NodeDirectory(path),
+      );
+    },
   },
   templates: {
     createEnvironment: (options) =>

--- a/packages/cli/src/runtime/node-platform.ts
+++ b/packages/cli/src/runtime/node-platform.ts
@@ -624,7 +624,6 @@ function resolveNodeDataDirectory(): string {
 export function createNodeWikiGraphStorage(
   stateRoot = pathModule.join(os.homedir(), ".wikigraph"),
 ): WikiGraphStorage {
-  fs.mkdirSync(pathModule.join(stateRoot, "documents"), { recursive: true });
   return {
     library: new NodeDirectory(stateRoot),
     documentStore: new NodeDirectory(pathModule.join(stateRoot, "documents")),

--- a/packages/core/src/document/home-schema-upgrade.ts
+++ b/packages/core/src/document/home-schema-upgrade.ts
@@ -1,12 +1,15 @@
 import {
   ensureRelativeFile,
   getRelativeFile,
+  getWikiGraphPlatform,
   getWikiGraphStorage,
+  isDirectory,
+  type Directory,
   type File,
 } from "../runtime/platform/index.js";
-import { Database } from "./database.js";
+import { getNumber, getString, Database } from "./database.js";
 
-const CURRENT_HOME_SCHEMA_VERSION = 3;
+const CURRENT_HOME_SCHEMA_VERSION = 4;
 const LOCK_STALE_TIMEOUT_MS = 5 * 60 * 1000;
 const HOME_SCHEMA_SQL = `
   CREATE TABLE IF NOT EXISTS schema_versions (
@@ -26,22 +29,8 @@ export async function ensureWikiGraphHomeSchemaCurrent(): Promise<void> {
     return;
   }
 
-  const upgrade = (async () => {
-    const version = await readWikiGraphHomeSchemaVersion();
-    if (version > CURRENT_HOME_SCHEMA_VERSION) {
-      throw new Error(
-        `Unsupported Wiki Graph home schema version: ${version}.`,
-      );
-    }
-    if (version < CURRENT_HOME_SCHEMA_VERSION && version > 0) {
-      await assertHomeUpgradeSafe();
-      await cleanupHomeDerivedData();
-    }
-    const file = await ensureRelativeFile(root, "core.sqlite");
-    await writeHomeSchemaVersion(file, CURRENT_HOME_SCHEMA_VERSION);
-  })();
+  const upgrade = upgradeHomeSchema(root);
   homeSchemaUpgradesInFlight.set(root.identity, upgrade);
-
   try {
     await upgrade;
   } finally {
@@ -64,9 +53,117 @@ export async function readWikiGraphHomeSchemaVersion(): Promise<number> {
       (await database.queryOne(
         "SELECT version FROM schema_versions WHERE scope = ?",
         ["home"],
-        (row) => Number(row.version),
+        (row) => getNumber(row, "version"),
       )) ?? 1
     );
+  } finally {
+    await database.close();
+  }
+}
+
+async function upgradeHomeSchema(root: Directory): Promise<void> {
+  let version = await readWikiGraphHomeSchemaVersion();
+  if (version > CURRENT_HOME_SCHEMA_VERSION) {
+    throw new Error(`Unsupported Wiki Graph home schema version: ${version}.`);
+  }
+
+  const file = await ensureRelativeFile(root, "core.sqlite");
+  if (version === 0) {
+    await writeHomeSchemaVersion(file, CURRENT_HOME_SCHEMA_VERSION);
+    return;
+  }
+
+  while (version < CURRENT_HOME_SCHEMA_VERSION) {
+    switch (version) {
+      case 1:
+        await upgradeLegacyHomeSchema(root);
+        await writeHomeSchemaVersion(file, 2);
+        version = 2;
+        break;
+      case 2:
+        await upgradeLegacyHomeSchema(root);
+        await writeHomeSchemaVersion(file, 3);
+        version = 3;
+        break;
+      case 3:
+        await upgradeHomeSchemaFromV3ToV4(file);
+        await writeHomeSchemaVersion(file, 4);
+        version = 4;
+        break;
+      default:
+        throw new Error(
+          `Unsupported Wiki Graph home schema version: ${version}.`,
+        );
+    }
+  }
+}
+
+async function upgradeLegacyHomeSchema(root: Directory): Promise<void> {
+  await assertHomeUpgradeSafe(root);
+  await cleanupHomeDerivedData(root);
+}
+
+/** The only v3 -> v4 migration. Keep all v3 interpretation inside this gate. */
+async function upgradeHomeSchemaFromV3ToV4(file: File): Promise<void> {
+  const root = getWikiGraphStorage().library;
+  await assertHomeUpgradeSafe(root);
+  await migrateLibraryDirectoryIdentities(file);
+  await cleanupHomeDerivedData(root);
+}
+
+async function migrateLibraryDirectoryIdentities(file: File): Promise<void> {
+  const database = await Database.open(file);
+  try {
+    if (!(await tableExists(database, "libraries"))) return;
+    const columns = await readTableColumns(database, "libraries");
+    const sourceColumn = columns.has("folder_identity")
+      ? "folder_identity"
+      : columns.has("folder_path")
+        ? "folder_path"
+        : undefined;
+    if (sourceColumn === undefined) {
+      throw new Error(
+        "Cannot migrate library registry without a folder reference.",
+      );
+    }
+
+    const rows = await database.queryAll(
+      `SELECT id, ${sourceColumn} AS folder_reference FROM libraries ORDER BY id`,
+      undefined,
+      (row) => ({
+        id: getNumber(row, "id"),
+        reference: getString(row, "folder_reference"),
+      }),
+    );
+    const migrated: Array<{ readonly id: number; readonly identity: string }> =
+      [];
+    for (const row of rows) {
+      const resources = getWikiGraphPlatform().resources;
+      const directory =
+        resources.resolveLegacyDirectory === undefined
+          ? await resources.getDirectory(row.reference)
+          : await resources.resolveLegacyDirectory(row.reference);
+      if (directory === undefined) {
+        throw new Error(
+          `Cannot migrate unavailable library Directory for registry id ${row.id}.`,
+        );
+      }
+      migrated.push({ id: row.id, identity: directory.identity });
+    }
+
+    await database.transaction(async () => {
+      if (!columns.has("folder_identity")) {
+        await database.run(
+          "ALTER TABLE libraries RENAME COLUMN folder_path TO folder_identity",
+        );
+      }
+      for (const row of migrated) {
+        await database.run(
+          "UPDATE libraries SET folder_identity = ? WHERE id = ?",
+          [row.identity, row.id],
+        );
+      }
+    });
   } finally {
     await database.close();
   }
@@ -92,33 +189,63 @@ async function writeHomeSchemaVersion(
   }
 }
 
-async function cleanupHomeDerivedData(): Promise<void> {
-  const root = getWikiGraphStorage().library;
-  const cache = await root.getDirectory("cache");
-  if (cache !== undefined) {
-    await cache.remove("search-sessions.sqlite").catch(() => undefined);
-    await cache.remove("continuation-cursors.sqlite").catch(() => undefined);
-    await cache.remove("cache.sqlite").catch(() => undefined);
-  }
+async function cleanupHomeDerivedData(root: Directory): Promise<void> {
+  await removeKnownChildren(await root.getDirectory("cache"), [
+    "search-sessions.sqlite",
+    "continuation-cursors.sqlite",
+    "cache.sqlite",
+  ]);
+
   const staging = await root.getDirectory("staging");
-  if (staging !== undefined) {
-    await staging.remove("library", { recursive: true }).catch(() => undefined);
-    await staging.remove("staging.sqlite").catch(() => undefined);
-  }
+  await removeKnownChildren(staging, ["library", "work"]);
+  await removeSqlite(staging, "staging.sqlite");
+
   const temporary = await root.getDirectory("tmp");
-  if (temporary !== undefined) {
-    await temporary.remove("gc.sqlite").catch(() => undefined);
-    await temporary.remove("gc.last-run").catch(() => undefined);
-  }
+  await removeSqlite(temporary, "gc.sqlite");
+  await removeSqlite(temporary, "wikg-coordinator.sqlite");
+  await removeKnownChildren(temporary, ["gc.last-run"]);
+
   const jobs = await root.getDirectory("jobs");
-  if (jobs !== undefined) {
-    await jobs.remove("cache", { recursive: true }).catch(() => undefined);
-    await jobs.remove("job.sqlite").catch(() => undefined);
+  await removeKnownChildren(jobs, ["cache", "work"]);
+  await removeSqlite(jobs, "job.sqlite");
+
+  const documentStore = getWikiGraphStorage().documentStore;
+  for (const entry of await documentStore.list()) {
+    if (
+      entry.name === ".wikg-work" ||
+      entry.name === ".wikg-cache" ||
+      entry.name.startsWith(".wikg-session-") ||
+      entry.name.startsWith(".wikg-upgrade-")
+    ) {
+      await documentStore.remove(entry.name, { recursive: isDirectory(entry) });
+    }
   }
 }
 
-async function assertHomeUpgradeSafe(): Promise<void> {
-  const root = getWikiGraphStorage().library;
+async function removeSqlite(
+  directory: Directory | undefined,
+  name: string,
+): Promise<void> {
+  await removeKnownChildren(directory, [name, `${name}-wal`, `${name}-shm`]);
+}
+
+async function removeKnownChildren(
+  directory: Directory | undefined,
+  names: readonly string[],
+): Promise<void> {
+  if (directory === undefined) return;
+  const entries = new Map(
+    (await directory.list()).map((entry) => [entry.name, entry]),
+  );
+  for (const name of names) {
+    const entry = entries.get(name);
+    if (entry !== undefined) {
+      await directory.remove(name, { recursive: isDirectory(entry) });
+    }
+  }
+}
+
+async function assertHomeUpgradeSafe(root: Directory): Promise<void> {
   await assertNoFreshRows(await getRelativeFile(root, "core.sqlite"), [
     ["library_locks", "Cannot upgrade home with active library locks."],
     ["state_locks", "Cannot upgrade home with active state locks."],
@@ -126,34 +253,116 @@ async function assertHomeUpgradeSafe(): Promise<void> {
   await assertNoFreshRows(await getRelativeFile(root, "tmp/gc.sqlite"), [
     ["gc_locks", "Cannot upgrade home with an active GC lock."],
   ]);
+  await assertBuildQueueSafe(await getRelativeFile(root, "jobs/job.sqlite"));
+  await assertCoordinatorInactive(
+    await getRelativeFile(root, "staging/staging.sqlite"),
+    "legacy coordinator",
+  );
+  await assertCoordinatorInactive(
+    await getRelativeFile(root, "tmp/wikg-coordinator.sqlite"),
+    "coordinator",
+  );
+}
 
-  const jobsFile = await getRelativeFile(root, "jobs/job.sqlite");
-  if (jobsFile !== undefined && !(await isEmpty(jobsFile))) {
-    const database = await Database.open(jobsFile, "", { readonly: true });
-    try {
-      if (await tableExists(database, "build_jobs")) {
-        const active = await database.queryOne(
-          "SELECT 1 AS active FROM build_jobs WHERE state IN ('queued', 'running', 'canceling', 'paused') LIMIT 1",
-          undefined,
-          () => true,
-        );
-        if (active === true) {
-          throw new Error("Cannot upgrade home with active build jobs.");
-        }
+async function assertBuildQueueSafe(file: File | undefined): Promise<void> {
+  if (file === undefined || (await isEmpty(file))) return;
+  const database = await Database.open(file, "", { readonly: true });
+  try {
+    if (await tableExists(database, "build_jobs")) {
+      const active = await database.queryOne(
+        "SELECT 1 AS active FROM build_jobs WHERE state IN ('queued', 'running', 'canceling', 'paused') LIMIT 1",
+        undefined,
+        () => true,
+      );
+      if (active === true) {
+        throw new Error("Cannot upgrade home with active build jobs.");
       }
-      if (await tableExists(database, "build_worker_lease")) {
-        const heartbeat = await database.queryOne(
-          "SELECT heartbeat_at FROM build_worker_lease WHERE id = 1",
-          undefined,
-          (row) => Number(row.heartbeat_at),
-        );
-        if (isFresh(heartbeat)) {
-          throw new Error("Cannot upgrade home with an active build worker.");
-        }
-      }
-    } finally {
-      await database.close();
     }
+    if (await tableExists(database, "build_worker_lease")) {
+      const columns = await readTableColumns(database, "build_worker_lease");
+      const ownerColumns = ["owner_id", "owner_pid"].filter((name) =>
+        columns.has(name),
+      );
+      const ownerPredicate = ownerColumns
+        .map((name) => `${name} IS NOT NULL`)
+        .join(" OR ");
+      const active = await database.queryOne(
+        `SELECT 1 AS active FROM build_worker_lease
+         WHERE heartbeat_at IS NOT NULL
+           AND heartbeat_at >= ?
+           ${ownerPredicate === "" ? "" : `AND (${ownerPredicate})`}
+         LIMIT 1`,
+        [Date.now() - LOCK_STALE_TIMEOUT_MS],
+        () => true,
+      );
+      if (active === true) {
+        throw new Error("Cannot upgrade home with an active build worker.");
+      }
+    }
+  } finally {
+    await database.close();
+  }
+}
+
+async function assertCoordinatorInactive(
+  file: File | undefined,
+  label: string,
+): Promise<void> {
+  if (file === undefined || (await isEmpty(file))) return;
+  const database = await Database.open(file, "", { readonly: true });
+  try {
+    if (await tableExists(database, "archive_owners")) {
+      const columns = await readTableColumns(database, "archive_owners");
+      const owners = await database.queryAll(
+        `SELECT heartbeat_at${columns.has("host_instance_id") ? ", host_instance_id" : ""}
+         FROM archive_owners`,
+        undefined,
+        (row) => ({
+          heartbeatAt: getNumber(row, "heartbeat_at"),
+          hostInstanceId:
+            typeof row.host_instance_id === "string"
+              ? row.host_instance_id
+              : undefined,
+        }),
+      );
+      for (const owner of owners) {
+        if (owner.hostInstanceId === undefined) {
+          if (isFresh(owner.heartbeatAt)) {
+            throw new Error(`Cannot upgrade home with active ${label} state.`);
+          }
+          continue;
+        }
+        const alive = await getWikiGraphPlatform().lifecycle.isInstanceAlive(
+          owner.hostInstanceId,
+        );
+        if (
+          alive === true ||
+          (alive === undefined && isFresh(owner.heartbeatAt))
+        ) {
+          throw new Error(`Cannot upgrade home with active ${label} state.`);
+        }
+      }
+    }
+
+    for (const table of [
+      "entry_locks",
+      "entry_sqlite_leases",
+      "archive_commit_locks",
+    ]) {
+      if (!(await tableExists(database, table))) continue;
+      const columns = await readTableColumns(database, table);
+      if (!columns.has("heartbeat_at")) continue;
+      const active = await database.queryOne(
+        `SELECT 1 AS active FROM ${table} WHERE heartbeat_at >= ? LIMIT 1`,
+        [Date.now() - LOCK_STALE_TIMEOUT_MS],
+        () => true,
+      );
+      if (active === true) {
+        throw new Error(`Cannot upgrade home with active ${label} state.`);
+      }
+    }
+  } finally {
+    await database.close();
   }
 }
 
@@ -166,12 +375,12 @@ async function assertNoFreshRows(
   try {
     for (const [table, message] of tables) {
       if (!(await tableExists(database, table))) continue;
-      const heartbeat = await database.queryOne(
-        `SELECT heartbeat_at FROM ${table} ORDER BY heartbeat_at DESC LIMIT 1`,
-        undefined,
-        (row) => Number(row.heartbeat_at),
+      const active = await database.queryOne(
+        `SELECT 1 AS active FROM ${table} WHERE heartbeat_at >= ? LIMIT 1`,
+        [Date.now() - LOCK_STALE_TIMEOUT_MS],
+        () => true,
       );
-      if (isFresh(heartbeat)) throw new Error(message);
+      if (active === true) throw new Error(message);
     }
   } finally {
     await database.close();
@@ -191,6 +400,17 @@ async function isEmpty(file: File): Promise<boolean> {
   return typeof content === "string"
     ? content.length === 0
     : content.byteLength === 0;
+}
+
+async function readTableColumns(
+  database: Database,
+  name: string,
+): Promise<ReadonlySet<string>> {
+  return new Set(
+    await database.queryAll(`PRAGMA table_info(${name})`, undefined, (row) =>
+      getString(row, "name"),
+    ),
+  );
 }
 
 async function tableExists(database: Database, name: string): Promise<boolean> {

--- a/packages/core/src/document/home-schema-upgrade.ts
+++ b/packages/core/src/document/home-schema-upgrade.ts
@@ -7,6 +7,7 @@ import {
   type Directory,
   type File,
 } from "../runtime/platform/index.js";
+import { isHostError } from "../utils/host-error.js";
 import { getNumber, getString, Database } from "./database.js";
 
 const CURRENT_HOME_SCHEMA_VERSION = 4;
@@ -210,7 +211,14 @@ async function cleanupHomeDerivedData(root: Directory): Promise<void> {
   await removeSqlite(jobs, "job.sqlite");
 
   const documentStore = getWikiGraphStorage().documentStore;
-  for (const entry of await documentStore.list()) {
+  let documentStoreEntries: ReadonlyArray<File | Directory>;
+  try {
+    documentStoreEntries = await documentStore.list();
+  } catch (error) {
+    if (isHostError(error) && error.code === "ENOENT") return;
+    throw error;
+  }
+  for (const entry of documentStoreEntries) {
     if (
       entry.name === ".wikg-work" ||
       entry.name === ".wikg-cache" ||

--- a/packages/core/src/library/registry.ts
+++ b/packages/core/src/library/registry.ts
@@ -31,6 +31,8 @@ const RESERVED_METADATA_KEYS = new Set([
   "publicId",
   "folder_path",
   "folderPath",
+  "folder_identity",
+  "folderIdentity",
   "is_default",
   "isDefault",
   "staging_path",
@@ -48,7 +50,7 @@ const LIBRARY_REGISTRY_SCHEMA_SQL = `
   CREATE TABLE IF NOT EXISTS libraries (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     public_id TEXT NOT NULL UNIQUE,
-    folder_path TEXT NOT NULL UNIQUE,
+    folder_identity TEXT NOT NULL UNIQUE,
     is_default INTEGER NOT NULL DEFAULT 0 CHECK (is_default IN (0, 1)),
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
@@ -336,7 +338,7 @@ export async function ensureDefaultWikiGraphLibrary(): Promise<WikiGraphLibraryR
 
       await database.run(
         `
-          INSERT INTO libraries (public_id, folder_path, is_default, created_at, updated_at)
+          INSERT INTO libraries (public_id, folder_identity, is_default, created_at, updated_at)
           VALUES (?, ?, 1, ?, ?)
         `,
         [publicId, folder.identity, now, now],
@@ -359,7 +361,7 @@ export async function createWikiGraphLibrary(input: {
 
       await database.run(
         `
-          INSERT INTO libraries (public_id, folder_path, is_default, created_at, updated_at)
+          INSERT INTO libraries (public_id, folder_identity, is_default, created_at, updated_at)
           VALUES (?, ?, 0, ?, ?)
         `,
         [publicId, input.folder.identity, now, now],
@@ -377,7 +379,7 @@ export async function listWikiGraphLibraries(): Promise<
   return await withLibraryRegistryDatabase(async (database) => {
     const rows = await database.queryAll(
       `
-          SELECT id, public_id, folder_path, is_default, created_at, updated_at
+          SELECT id, public_id, folder_identity, is_default, created_at, updated_at
           FROM libraries
           ORDER BY is_default DESC, public_id
         `,
@@ -464,7 +466,7 @@ export async function updateWikiGraphLibraryFolderForRebind(
   return await withLibraryRegistryDatabase(async (database) => {
     return await database.transaction(async () => {
       const existing = await database.queryOne(
-        "SELECT id FROM libraries WHERE folder_path = ?",
+        "SELECT id FROM libraries WHERE folder_identity = ?",
         [folder.identity],
         (row) => getNumber(row, "id"),
       );
@@ -475,7 +477,7 @@ export async function updateWikiGraphLibraryFolderForRebind(
       }
 
       await database.run(
-        "UPDATE libraries SET folder_path = ?, updated_at = ? WHERE id = ?",
+        "UPDATE libraries SET folder_identity = ?, updated_at = ? WHERE id = ?",
         [folder.identity, new Date().toISOString(), library.id],
       );
       return await requireLibraryRecordById(database, library.id);
@@ -584,7 +586,7 @@ async function readDefaultLibraryRecord(
 ): Promise<WikiGraphLibraryRecord | undefined> {
   const row = await database.queryOne(
     `
-      SELECT id, public_id, folder_path, is_default, created_at, updated_at
+      SELECT id, public_id, folder_identity, is_default, created_at, updated_at
       FROM libraries
       WHERE is_default = 1
     `,
@@ -610,7 +612,7 @@ async function requireLibraryRecordByPublicId(
 ): Promise<WikiGraphLibraryRecord> {
   const row = await database.queryOne(
     `
-      SELECT id, public_id, folder_path, is_default, created_at, updated_at
+      SELECT id, public_id, folder_identity, is_default, created_at, updated_at
       FROM libraries
       WHERE public_id = ?
     `,
@@ -630,7 +632,7 @@ async function requireLibraryRecordById(
 ): Promise<WikiGraphLibraryRecord> {
   const row = await database.queryOne(
     `
-      SELECT id, public_id, folder_path, is_default, created_at, updated_at
+      SELECT id, public_id, folder_identity, is_default, created_at, updated_at
       FROM libraries
       WHERE id = ?
     `,
@@ -648,7 +650,7 @@ async function requireLibraryRecordById(
 async function mapLibraryRecord(row: SqlRow): Promise<WikiGraphLibraryRecord> {
   const id = getNumber(row, "id");
   const publicId = getString(row, "public_id");
-  const folderIdentity = getString(row, "folder_path");
+  const folderIdentity = getString(row, "folder_identity");
   const folder =
     await getWikiGraphPlatform().resources.getDirectory(folderIdentity);
   if (folder === undefined) {

--- a/packages/core/src/maintenance/upgrade.ts
+++ b/packages/core/src/maintenance/upgrade.ts
@@ -120,9 +120,11 @@ export async function assertWikiGraphLibrarySchemaCurrent(
     const schemaVersion = await readWikiGraphArchiveSchemaVersion(
       requireArchiveFile(archive),
     );
-    if (schemaVersion < CURRENT_ARCHIVE_SCHEMA_VERSION) {
+    if (schemaVersion !== CURRENT_ARCHIVE_SCHEMA_VERSION) {
       throw new Error(
-        `This Wiki Graph library must be upgraded before use: ${library.uri}.`,
+        schemaVersion > CURRENT_ARCHIVE_SCHEMA_VERSION
+          ? `This Wiki Graph library contains an unsupported future archive schema v${schemaVersion}: ${library.uri}.`
+          : `This Wiki Graph library must be upgraded before use: ${library.uri}.`,
       );
     }
   }

--- a/packages/core/src/runtime/platform/types.ts
+++ b/packages/core/src/runtime/platform/types.ts
@@ -45,6 +45,8 @@ export interface Directory {
 export interface HostResourceProvider {
   getDirectory(identity: string): Promise<Directory | undefined>;
   getFile(identity: string): Promise<File | undefined>;
+  /** Resolves a pre-v4 persisted directory reference during home migration. */
+  resolveLegacyDirectory?(reference: string): Promise<Directory | undefined>;
 }
 
 /** Host storage roots. Their backing locations are never visible to Core. */

--- a/packages/core/src/storage/schema-upgrade/index.ts
+++ b/packages/core/src/storage/schema-upgrade/index.ts
@@ -30,6 +30,10 @@ import {
   normalizeArchivePath,
   sortArchiveEntryPathsForWrite,
 } from "../wikg/archive/paths.js";
+import {
+  assertArchiveUpgradeCoordinatorSafe,
+  clearArchiveUpgradeDerivedOverlays,
+} from "../wikg/wikg-coordinator/index.js";
 
 export {
   ensureWikiGraphHomeSchemaCurrent,
@@ -96,6 +100,8 @@ export async function upgradeWikiGraphArchiveSchema(
       );
     }
 
+    await assertArchiveUpgradeCoordinatorSafe(archive);
+
     const root = getWikiGraphStorage().documentStore;
     const workspaceName = await createWorkspaceName(root);
     const workspace = await root.createDirectory(workspaceName);
@@ -137,6 +143,7 @@ export async function upgradeWikiGraphArchiveSchema(
           name,
         })),
       );
+      await clearArchiveUpgradeDerivedOverlays(archive);
       await cleanupArchiveDerivedData();
 
       return {

--- a/packages/core/src/storage/wikg/wikg-coordinator/gc.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/gc.ts
@@ -5,6 +5,7 @@ import {
   readHostEntrySize,
 } from "../../../runtime/platform/index.js";
 import type { GcContext, GcJobResult } from "../../../runtime/gc/index.js";
+import { isHostError } from "../../../utils/host-error.js";
 
 const ABANDONED_SESSION_TTL_MS = 60 * 60 * 1000;
 
@@ -16,7 +17,16 @@ export async function runWikgCoordinatorGc(
   let scanned = 0;
   let removed = 0;
   let freedBytes = 0;
-  for (const entry of await root.list()) {
+  let entries: ReadonlyArray<Awaited<ReturnType<typeof root.list>>[number]>;
+  try {
+    entries = await root.list();
+  } catch (error) {
+    if (isHostError(error) && error.code === "ENOENT") {
+      return { freedBytes, removed, scanned };
+    }
+    throw error;
+  }
+  for (const entry of entries) {
     if (!isDirectory(entry) || !entry.name.startsWith(".wikg-session-")) {
       continue;
     }

--- a/packages/core/src/storage/wikg/wikg-coordinator/index.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/index.ts
@@ -1,3 +1,7 @@
 export { WikgCoordinator } from "./facade.js";
 export { HostWikgArchiveSession as WikgArchiveSession } from "./host-session.js";
 export { runWikgCoordinatorGc } from "./gc.js";
+export {
+  assertArchiveUpgradeCoordinatorSafe,
+  clearArchiveUpgradeDerivedOverlays,
+} from "./maintenance.js";

--- a/packages/core/src/storage/wikg/wikg-coordinator/maintenance.ts
+++ b/packages/core/src/storage/wikg/wikg-coordinator/maintenance.ts
@@ -1,0 +1,144 @@
+import { Database, getNumber, getString } from "../../../document/database.js";
+import {
+  getRelativeFile,
+  getWikiGraphPlatform,
+  getWikiGraphStorage,
+  type File,
+} from "../../../runtime/platform/index.js";
+import { createPortableHash } from "../../../utils/crypto.js";
+
+import {
+  LEGACY_SEARCH_INDEX_DATABASE_ENTRY_PATH,
+  LOCK_STALE_TIMEOUT_MS,
+  SEARCH_INDEX_DATABASE_ENTRY_PATH,
+} from "./constants.js";
+import { removeWorkspaceSnapshot } from "./workspace.js";
+
+export async function assertArchiveUpgradeCoordinatorSafe(
+  archive: File,
+): Promise<void> {
+  const state = await getRelativeFile(
+    getWikiGraphStorage().library,
+    "tmp/wikg-coordinator.sqlite",
+  );
+  if (state === undefined || (await isEmpty(state))) return;
+
+  const archiveKey = createArchiveKey(archive);
+  const database = await Database.open(state, "", { readonly: true });
+  try {
+    if (await tableExists(database, "archive_owners")) {
+      const owners = await database.queryAll(
+        `SELECT host_instance_id, heartbeat_at
+         FROM archive_owners
+         WHERE archive_key = ?`,
+        [archiveKey],
+        (row) => ({
+          heartbeatAt: getNumber(row, "heartbeat_at"),
+          hostInstanceId: getString(row, "host_instance_id"),
+        }),
+      );
+      for (const owner of owners) {
+        const alive = await getWikiGraphPlatform().lifecycle.isInstanceAlive(
+          owner.hostInstanceId,
+        );
+        if (
+          alive === true ||
+          (alive === undefined &&
+            Date.now() - owner.heartbeatAt <= LOCK_STALE_TIMEOUT_MS)
+        ) {
+          throw new Error(
+            `Cannot upgrade archive with active coordinator state: ${archive.identity}.`,
+          );
+        }
+      }
+    }
+
+    if (await tableExists(database, "entry_overlays")) {
+      const nonDerived = await database.queryOne(
+        `SELECT entry_path
+         FROM entry_overlays
+         WHERE archive_key = ?
+           AND entry_path NOT IN (?, ?)
+         LIMIT 1`,
+        [
+          archiveKey,
+          SEARCH_INDEX_DATABASE_ENTRY_PATH,
+          LEGACY_SEARCH_INDEX_DATABASE_ENTRY_PATH,
+        ],
+        (row) => getString(row, "entry_path"),
+      );
+      if (nonDerived !== undefined) {
+        throw new Error(
+          `Cannot upgrade archive with non-derived overlay state: ${archive.identity}.`,
+        );
+      }
+    }
+  } finally {
+    await database.close();
+  }
+}
+
+export async function clearArchiveUpgradeDerivedOverlays(
+  archive: File,
+): Promise<void> {
+  const state = await getRelativeFile(
+    getWikiGraphStorage().library,
+    "tmp/wikg-coordinator.sqlite",
+  );
+  if (state === undefined || (await isEmpty(state))) return;
+
+  const archiveKey = createArchiveKey(archive);
+  const database = await Database.open(state);
+  try {
+    if (!(await tableExists(database, "entry_overlays"))) return;
+    const overlays = await database.queryAll(
+      `SELECT workspace_path
+       FROM entry_overlays
+       WHERE archive_key = ? AND entry_path IN (?, ?)`,
+      [
+        archiveKey,
+        SEARCH_INDEX_DATABASE_ENTRY_PATH,
+        LEGACY_SEARCH_INDEX_DATABASE_ENTRY_PATH,
+      ],
+      (row) =>
+        typeof row.workspace_path === "string" ? row.workspace_path : undefined,
+    );
+    await database.run(
+      `DELETE FROM entry_overlays
+       WHERE archive_key = ? AND entry_path IN (?, ?)`,
+      [
+        archiveKey,
+        SEARCH_INDEX_DATABASE_ENTRY_PATH,
+        LEGACY_SEARCH_INDEX_DATABASE_ENTRY_PATH,
+      ],
+    );
+    for (const workspacePath of overlays) {
+      await removeWorkspaceSnapshot(workspacePath);
+    }
+  } finally {
+    await database.close();
+  }
+}
+
+function createArchiveKey(archive: File): string {
+  return createPortableHash("sha256").update(archive.identity).digest("hex");
+}
+
+async function isEmpty(file: File): Promise<boolean> {
+  if (file.getSize !== undefined) return (await file.getSize()) === 0;
+  if (file.size !== undefined) return file.size === 0;
+  const content = await file.read();
+  return typeof content === "string"
+    ? content.length === 0
+    : content.byteLength === 0;
+}
+
+async function tableExists(database: Database, name: string): Promise<boolean> {
+  return (
+    (await database.queryOne(
+      "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ?",
+      [name],
+      () => true,
+    )) === true
+  );
+}

--- a/test/cli/informational-home.test.ts
+++ b/test/cli/informational-home.test.ts
@@ -1,0 +1,77 @@
+import { access, mkdir, mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { Writable } from "stream";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { main } from "../../packages/cli/src/app/main.js";
+import { installNodeWikiGraphPlatform } from "../../packages/cli/src/runtime/node-platform.js";
+
+describe("CLI informational home isolation", () => {
+  const originalExitCode = process.exitCode;
+  const originalHome = process.env.HOME;
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    installNodeWikiGraphPlatform();
+  });
+
+  it.each([
+    ["version", ["--version"]],
+    ["root help", ["--help"]],
+    ["help command", ["help"]],
+  ] as const)("does not create ~/.wikigraph for %s", async (_name, argv) => {
+    const root = await mkdtemp(join(tmpdir(), "wikigraph-info-home-"));
+    const home = join(root, "home");
+    await mkdir(home);
+    process.env.HOME = home;
+    process.exitCode = 0;
+    const stdout = createCaptureStream();
+    const stderr = createCaptureStream();
+
+    try {
+      await main({
+        argv,
+        env: {
+          ...process.env,
+          WIKIGRAPH_DEV: undefined,
+          WIKIGRAPH_ENV_POLICY: undefined,
+          WIKIGRAPH_QUEUE_DISABLE_AUTOSTART: undefined,
+          WIKIGRAPH_STATE_DIR: undefined,
+        },
+        stderr: stderr.stream,
+        stdin: "",
+        stdinIsTTY: false,
+        stdout: stdout.stream,
+      });
+
+      expect(process.exitCode).toBe(0);
+      expect(stderr.text).toBe("");
+      expect(stdout.text.length).toBeGreaterThan(0);
+      await expect(access(join(home, ".wikigraph"))).rejects.toThrow();
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});
+
+function createCaptureStream(): {
+  readonly stream: Writable;
+  readonly text: string;
+} {
+  const chunks: string[] = [];
+  return {
+    stream: new Writable({
+      write(chunk: Buffer | string, _encoding, callback) {
+        chunks.push(String(chunk));
+        callback();
+      },
+    }),
+    get text() {
+      return chunks.join("");
+    },
+  };
+}

--- a/test/core/runtime/gc/gc.test.ts
+++ b/test/core/runtime/gc/gc.test.ts
@@ -152,6 +152,25 @@ describe("gc", () => {
     });
   });
 
+  it("treats a missing document store as empty", async () => {
+    await withTempDir("wikigraph-gc-", async (path) => {
+      setWikiGraphStateDirectoryPathForTesting(join(path, "state"));
+
+      const report = await tryRunWikiGraphGc({ dryRun: true });
+      const coordinatorJob = report.jobs.find(
+        (item) => item.name === "wikg-coordinator",
+      );
+
+      expect(report.skipped).toBe(false);
+      expect(coordinatorJob).toStrictEqual({
+        freedBytes: 0,
+        name: "wikg-coordinator",
+        removed: 0,
+        scanned: 0,
+      });
+    });
+  });
+
   it("removes orphan library index staging while preserving valid and locked libraries", async () => {
     await withTempDir("wikigraph-gc-", async (path) => {
       setWikiGraphStateDirectoryPathForTesting(join(path, "state"));

--- a/test/core/runtime/platform/node-platform.test.ts
+++ b/test/core/runtime/platform/node-platform.test.ts
@@ -1,6 +1,9 @@
+import { access } from "fs/promises";
+import { join } from "path";
 import { describe, expect, it } from "vitest";
 
 import {
+  createNodeWikiGraphStorage,
   NodeDirectory,
   nodeWikiGraphPlatform,
 } from "../../../../packages/cli/src/runtime/node-platform.js";
@@ -13,6 +16,21 @@ import type {
 import { withTempDir } from "../../../helpers/temp.js";
 
 describe("Node File/Directory adapter", () => {
+  it("constructs storage capabilities without creating the home directory", async () => {
+    await withTempDir("wikigraph-platform-storage-", async (path) => {
+      const stateRoot = join(path, "not-created");
+      const storage = createNodeWikiGraphStorage(stateRoot);
+
+      expect(storage.library.identity).toBe(
+        new NodeDirectory(stateRoot).identity,
+      );
+      expect(storage.documentStore.identity).toBe(
+        new NodeDirectory(join(stateRoot, "documents")).identity,
+      );
+      await expect(access(stateRoot)).rejects.toThrow();
+    });
+  });
+
   it("performs relative child operations and transactional file writes", async () => {
     await withTempDir("wikigraph-platform-", async (path) => {
       const root = new NodeDirectory(path);

--- a/test/core/storage/schema-upgrade/index.test.ts
+++ b/test/core/storage/schema-upgrade/index.test.ts
@@ -1,4 +1,4 @@
-import { mkdir } from "fs/promises";
+import { access, mkdir, readFile, writeFile } from "fs/promises";
 import { join } from "path";
 import { describe, expect, it } from "vitest";
 
@@ -13,6 +13,13 @@ import {
   readWikiGraphHomeSchemaVersion,
   upgradeWikiGraphArchiveSchema,
 } from "../../../../packages/core/src/storage/schema-upgrade/index.js";
+import { assertWikiGraphLibrarySchemaCurrent } from "../../../../packages/core/src/maintenance/upgrade.js";
+import {
+  createWikiGraphLibrary,
+  parseWikiGraphLibraryUri,
+  scanWikiGraphLibrary,
+} from "../../../../packages/core/src/library/index.js";
+import { createPortableHash } from "../../../../packages/core/src/utils/crypto.js";
 import {
   readWikgArchiveEntry,
   readWikgArchiveMutationToken,
@@ -125,7 +132,7 @@ describe("schema-upgrade", () => {
         async () => {
           await expect(readWikiGraphHomeSchemaVersion()).resolves.toBe(0);
           await ensureWikiGraphHomeSchemaCurrent();
-          await expect(readWikiGraphHomeSchemaVersion()).resolves.toBe(3);
+          await expect(readWikiGraphHomeSchemaVersion()).resolves.toBe(4);
         },
       );
     });
@@ -143,11 +150,333 @@ describe("schema-upgrade", () => {
             async (storage) =>
               await withWikiGraphStorage(storage, async () => {
                 await ensureWikiGraphHomeSchemaCurrent();
-                await expect(readWikiGraphHomeSchemaVersion()).resolves.toBe(3);
+                await expect(readWikiGraphHomeSchemaVersion()).resolves.toBe(4);
               }),
           ),
         );
       });
+    });
+  });
+
+  it("migrates a v3 home atomically while preserving important registry data", async () => {
+    await withTempDir("wikigraph-home-v3-", async (root) => {
+      const statePath = join(root, "state");
+      const libraryPath = join(root, "library");
+      await mkdir(libraryPath, { recursive: true });
+      await createV3Home(statePath, libraryPath);
+      const archivePath = join(libraryPath, "book.wikg");
+      await writeFile(archivePath, "archive-v4-is-untouched");
+      await createDerivedHomeState(statePath);
+
+      await withWikiGraphStorage(
+        createNodeWikiGraphStorage(statePath),
+        async () => {
+          await ensureWikiGraphHomeSchemaCurrent();
+          await expect(readWikiGraphHomeSchemaVersion()).resolves.toBe(4);
+
+          const database = await Database.open(
+            new NodeFile(join(statePath, "core.sqlite")),
+            "",
+            { readonly: true },
+          );
+          try {
+            const columns = await database.queryAll(
+              "PRAGMA table_info(libraries)",
+              undefined,
+              (row) => String(row.name),
+            );
+            expect(columns).toContain("folder_identity");
+            expect(columns).not.toContain("folder_path");
+            await expect(
+              database.queryOne(
+                "SELECT folder_identity FROM libraries WHERE id = 7",
+                undefined,
+                (row) => String(row.folder_identity),
+              ),
+            ).resolves.toBe(new NodeDirectory(libraryPath).identity);
+            await expect(
+              database.queryOne(
+                "SELECT folder_identity FROM libraries WHERE id = 8",
+                undefined,
+                (row) => String(row.folder_identity),
+              ),
+            ).resolves.toBe(
+              new NodeDirectory(join(statePath, "default-library")).identity,
+            );
+            await expect(
+              database.queryOne(
+                "SELECT value_json FROM config_sections WHERE section = 'llm'",
+                undefined,
+                (row) => String(row.value_json),
+              ),
+            ).resolves.toBe('{"model":"test"}');
+            await expect(
+              database.queryOne(
+                "SELECT value_json FROM library_metadata WHERE library_id = 7 AND key = 'label'",
+                undefined,
+                (row) => String(row.value_json),
+              ),
+            ).resolves.toBe('"Fixture"');
+            await expect(
+              database.queryOne(
+                "SELECT relative_path FROM library_archives WHERE library_id = 7",
+                undefined,
+                (row) => String(row.relative_path),
+              ),
+            ).resolves.toBe("book.wikg");
+          } finally {
+            await database.close();
+          }
+
+          await expect(readFile(archivePath, "utf8")).resolves.toBe(
+            "archive-v4-is-untouched",
+          );
+          await expectPathMissing(join(statePath, "cache/cache.sqlite"));
+          await expectPathMissing(join(statePath, "jobs/job.sqlite"));
+          await expectPathMissing(join(statePath, "staging/staging.sqlite"));
+          await expectPathMissing(
+            join(statePath, "tmp/wikg-coordinator.sqlite"),
+          );
+          await expectPathMissing(join(statePath, "documents/.wikg-work"));
+
+          await ensureWikiGraphHomeSchemaCurrent();
+          await expect(readWikiGraphHomeSchemaVersion()).resolves.toBe(4);
+        },
+      );
+    });
+  });
+
+  it("keeps the v3 marker and important data when migration fails, then retries", async () => {
+    await withTempDir("wikigraph-home-retry-", async (root) => {
+      const statePath = join(root, "state");
+      const libraryPath = join(root, "library");
+      await mkdir(libraryPath, { recursive: true });
+      await createV3Home(statePath, "relative-path-cannot-be-resolved");
+
+      await withWikiGraphStorage(
+        createNodeWikiGraphStorage(statePath),
+        async () => {
+          await expect(ensureWikiGraphHomeSchemaCurrent()).rejects.toThrow(
+            "Cannot migrate unavailable library Directory",
+          );
+          await expect(readWikiGraphHomeSchemaVersion()).resolves.toBe(3);
+
+          const file = new NodeFile(join(statePath, "core.sqlite"));
+          const database = await Database.open(file);
+          try {
+            await expect(
+              database.queryOne(
+                "SELECT value_json FROM config_sections WHERE section = 'llm'",
+                undefined,
+                (row) => String(row.value_json),
+              ),
+            ).resolves.toBe('{"model":"test"}');
+            await database.run(
+              "UPDATE libraries SET folder_path = ? WHERE id = 7",
+              [libraryPath],
+            );
+          } finally {
+            await database.close();
+          }
+
+          await ensureWikiGraphHomeSchemaCurrent();
+          await expect(readWikiGraphHomeSchemaVersion()).resolves.toBe(4);
+        },
+      );
+    });
+  });
+
+  it("blocks v3 home migration before writes when coordinator state is active", async () => {
+    await withTempDir("wikigraph-home-active-", async (root) => {
+      const statePath = join(root, "state");
+      const libraryPath = join(root, "library");
+      await mkdir(libraryPath, { recursive: true });
+      await createV3Home(statePath, libraryPath);
+      await seedCurrentCoordinator(statePath, {
+        archiveIdentity: new NodeFile(join(root, "book.wikg")).identity,
+        entryPath: "database.db",
+        withActiveOwner: true,
+      });
+
+      await withWikiGraphStorage(
+        createNodeWikiGraphStorage(statePath),
+        async () => {
+          await expect(ensureWikiGraphHomeSchemaCurrent()).rejects.toThrow(
+            "active coordinator state",
+          );
+          await expect(readWikiGraphHomeSchemaVersion()).resolves.toBe(3);
+          const database = await Database.open(
+            new NodeFile(join(statePath, "core.sqlite")),
+            "",
+            { readonly: true },
+          );
+          try {
+            const columns = await database.queryAll(
+              "PRAGMA table_info(libraries)",
+              undefined,
+              (row) => String(row.name),
+            );
+            expect(columns).toContain("folder_path");
+          } finally {
+            await database.close();
+          }
+        },
+      );
+    });
+  });
+
+  it("blocks v3 home migration before cleanup when a build job is queued", async () => {
+    await withTempDir("wikigraph-home-build-active-", async (root) => {
+      const statePath = join(root, "state");
+      const libraryPath = join(root, "library");
+      await mkdir(libraryPath, { recursive: true });
+      await createV3Home(statePath, libraryPath);
+      await mkdir(join(statePath, "cache"), { recursive: true });
+      await writeFile(
+        join(statePath, "cache/cache.sqlite"),
+        "keep-before-gate",
+      );
+      await mkdir(join(statePath, "jobs"), { recursive: true });
+      const jobs = await Database.open(
+        new NodeFile(join(statePath, "jobs/job.sqlite")),
+      );
+      try {
+        await jobs.execute(`
+          CREATE TABLE build_jobs (state TEXT NOT NULL);
+          CREATE TABLE build_worker_lease (
+            id INTEGER PRIMARY KEY,
+            owner_id TEXT,
+            owner_pid INTEGER,
+            heartbeat_at INTEGER
+          );
+        `);
+        await jobs.run("INSERT INTO build_jobs VALUES ('queued')");
+      } finally {
+        await jobs.close();
+      }
+
+      await withWikiGraphStorage(
+        createNodeWikiGraphStorage(statePath),
+        async () => {
+          await expect(ensureWikiGraphHomeSchemaCurrent()).rejects.toThrow(
+            "active build jobs",
+          );
+          await expect(readWikiGraphHomeSchemaVersion()).resolves.toBe(3);
+          await expect(
+            readFile(join(statePath, "cache/cache.sqlite"), "utf8"),
+          ).resolves.toBe("keep-before-gate");
+        },
+      );
+    });
+  });
+
+  it("rejects future home schema versions without rewriting their marker", async () => {
+    await withTempDir("wikigraph-home-future-", async (root) => {
+      const statePath = join(root, "state");
+      await mkdir(statePath, { recursive: true });
+      const database = await Database.open(
+        new NodeFile(join(statePath, "core.sqlite")),
+      );
+      try {
+        await database.execute(`
+          CREATE TABLE schema_versions (
+            scope TEXT PRIMARY KEY,
+            version INTEGER NOT NULL,
+            updated_at TEXT NOT NULL
+          );
+        `);
+        await database.run(
+          "INSERT INTO schema_versions VALUES ('home', 99, 'future')",
+        );
+      } finally {
+        await database.close();
+      }
+
+      await withWikiGraphStorage(
+        createNodeWikiGraphStorage(statePath),
+        async () => {
+          await expect(ensureWikiGraphHomeSchemaCurrent()).rejects.toThrow(
+            "Unsupported Wiki Graph home schema version: 99",
+          );
+          await expect(readWikiGraphHomeSchemaVersion()).resolves.toBe(99);
+        },
+      );
+    });
+  });
+
+  it("blocks archive maintenance for active coordinator and non-derived overlays", async () => {
+    await withFixture(async ({ archive, root }) => {
+      await rewriteManifest(archive, 3, false);
+      const statePath = join(root, "state");
+      await seedCurrentCoordinator(statePath, {
+        archiveIdentity: archive.identity,
+        entryPath: "database.db",
+        withActiveOwner: true,
+      });
+      await expect(upgradeWikiGraphArchiveSchema(archive)).rejects.toThrow(
+        "active coordinator state",
+      );
+      await expect(readWikiGraphArchiveSchemaVersion(archive)).resolves.toBe(3);
+    });
+
+    await withFixture(async ({ archive, root }) => {
+      await rewriteManifest(archive, 3, false);
+      await seedCurrentCoordinator(join(root, "state"), {
+        archiveIdentity: archive.identity,
+        entryPath: "database.db",
+        withActiveOwner: false,
+      });
+      await expect(upgradeWikiGraphArchiveSchema(archive)).rejects.toThrow(
+        "non-derived overlay state",
+      );
+      await expect(readWikiGraphArchiveSchemaVersion(archive)).resolves.toBe(3);
+    });
+  });
+
+  it("discards orphaned derived overlays after archive maintenance commits", async () => {
+    await withFixture(async ({ archive, root }) => {
+      await rewriteManifest(archive, 3, false);
+      const statePath = join(root, "state");
+      await seedCurrentCoordinator(statePath, {
+        archiveIdentity: archive.identity,
+        entryPath: "index.db",
+        withActiveOwner: false,
+      });
+
+      await expect(
+        upgradeWikiGraphArchiveSchema(archive),
+      ).resolves.toMatchObject({ changed: true, schemaChanged: true });
+      const coordinator = await Database.open(
+        new NodeFile(join(statePath, "tmp/wikg-coordinator.sqlite")),
+        "",
+        { readonly: true },
+      );
+      try {
+        await expect(
+          coordinator.queryOne(
+            "SELECT 1 AS present FROM entry_overlays LIMIT 1",
+            undefined,
+            () => true,
+          ),
+        ).resolves.toBeUndefined();
+      } finally {
+        await coordinator.close();
+      }
+    });
+  });
+
+  it("rejects a future archive during library preflight", async () => {
+    await withFixture(async ({ archive, root }) => {
+      const library = await createWikiGraphLibrary({
+        folder: new NodeDirectory(root),
+      });
+      const target = parseWikiGraphLibraryUri(library.uri);
+      expect(target).toBeDefined();
+      await scanWikiGraphLibrary(target!);
+      await rewriteManifest(archive, 99, false);
+      await expect(
+        assertWikiGraphLibrarySchemaCurrent(target!),
+      ).rejects.toThrow("unsupported future archive schema v99");
     });
   });
 });
@@ -221,4 +550,212 @@ async function readZipEntries(
   } finally {
     await reader.close();
   }
+}
+
+async function createV3Home(
+  statePath: string,
+  libraryReference: string,
+): Promise<void> {
+  await mkdir(statePath, { recursive: true });
+  const database = await Database.open(
+    new NodeFile(join(statePath, "core.sqlite")),
+  );
+  try {
+    await database.execute(`
+      CREATE TABLE schema_versions (
+        scope TEXT PRIMARY KEY,
+        version INTEGER NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE TABLE config_sections (
+        section TEXT PRIMARY KEY,
+        value_json TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE TABLE libraries (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        public_id TEXT NOT NULL UNIQUE,
+        folder_path TEXT NOT NULL UNIQUE,
+        is_default INTEGER NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE TABLE library_metadata (
+        library_id INTEGER NOT NULL,
+        key TEXT NOT NULL,
+        value_json TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (library_id, key)
+      );
+      CREATE TABLE library_archives (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        library_id INTEGER NOT NULL,
+        public_id TEXT NOT NULL,
+        relative_path TEXT NOT NULL,
+        status TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+    `);
+    await database.run("INSERT INTO schema_versions VALUES ('home', 3, 'v3')");
+    await database.run(
+      `INSERT INTO config_sections VALUES ('llm', '{"model":"test"}', 'v3')`,
+    );
+    await database.run(
+      "INSERT INTO libraries VALUES (7, 'fixture-lib', ?, 0, 'created', 'updated')",
+      [libraryReference],
+    );
+    await database.run(
+      "INSERT INTO libraries VALUES (8, 'opaque-lib', ?, 1, 'created', 'updated')",
+      [new NodeDirectory(join(statePath, "default-library")).identity],
+    );
+    await database.run(
+      `INSERT INTO library_metadata VALUES (7, 'label', '"Fixture"', 'v3')`,
+    );
+    await database.run(
+      "INSERT INTO library_archives VALUES (11, 7, 'fixture-archive', 'book.wikg', 'present', 'created', 'updated')",
+    );
+  } finally {
+    await database.close();
+  }
+}
+
+async function createDerivedHomeState(statePath: string): Promise<void> {
+  for (const path of [
+    "cache/cache.sqlite",
+    "cache/search-sessions.sqlite",
+    "staging/library/7/index/index.db",
+    "documents/.wikg-work/orphan/snapshot",
+  ]) {
+    const filePath = join(statePath, path);
+    await mkdir(join(filePath, ".."), { recursive: true });
+    await writeFile(filePath, "derived");
+  }
+
+  await mkdir(join(statePath, "jobs"), { recursive: true });
+  const jobs = await Database.open(
+    new NodeFile(join(statePath, "jobs/job.sqlite")),
+  );
+  try {
+    await jobs.execute(`
+      CREATE TABLE build_jobs (state TEXT NOT NULL);
+      CREATE TABLE build_worker_lease (
+        id INTEGER PRIMARY KEY,
+        owner_id TEXT,
+        owner_pid INTEGER,
+        heartbeat_at INTEGER
+      );
+    `);
+    await jobs.run("INSERT INTO build_jobs VALUES ('completed')");
+  } finally {
+    await jobs.close();
+  }
+
+  await mkdir(join(statePath, "staging"), { recursive: true });
+  const legacy = await Database.open(
+    new NodeFile(join(statePath, "staging/staging.sqlite")),
+  );
+  try {
+    await legacy.execute(`
+      CREATE TABLE archive_owners (
+        owner_id TEXT PRIMARY KEY,
+        heartbeat_at INTEGER NOT NULL
+      );
+      CREATE TABLE entry_overlays (entry_path TEXT NOT NULL);
+    `);
+    await legacy.run("INSERT INTO entry_overlays VALUES ('database.db')");
+  } finally {
+    await legacy.close();
+  }
+
+  await seedCurrentCoordinator(statePath, {
+    archiveIdentity: "node-file:b3JwaGFu",
+    entryPath: "database.db",
+    withActiveOwner: false,
+  });
+}
+
+async function seedCurrentCoordinator(
+  statePath: string,
+  input: {
+    readonly archiveIdentity: string;
+    readonly entryPath: string;
+    readonly withActiveOwner: boolean;
+  },
+): Promise<void> {
+  await mkdir(join(statePath, "tmp"), { recursive: true });
+  const database = await Database.open(
+    new NodeFile(join(statePath, "tmp/wikg-coordinator.sqlite")),
+  );
+  const archiveKey = createPortableHash("sha256")
+    .update(input.archiveIdentity)
+    .digest("hex");
+  try {
+    await database.execute(`
+      CREATE TABLE IF NOT EXISTS archive_owners (
+        archive_key TEXT NOT NULL,
+        owner_id TEXT NOT NULL,
+        host_instance_id TEXT NOT NULL,
+        heartbeat_at INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        PRIMARY KEY (archive_key, owner_id)
+      );
+      CREATE TABLE IF NOT EXISTS entry_overlays (
+        archive_key TEXT NOT NULL,
+        archive_identity TEXT NOT NULL,
+        entry_path TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        base_digest TEXT,
+        workspace_identity TEXT,
+        workspace_path TEXT,
+        owner_id TEXT NOT NULL,
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (archive_key, entry_path)
+      );
+      CREATE TABLE IF NOT EXISTS entry_locks (
+        lock_id TEXT PRIMARY KEY,
+        archive_key TEXT NOT NULL,
+        entry_path TEXT NOT NULL,
+        mode TEXT NOT NULL,
+        owner_id TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS entry_sqlite_leases (
+        archive_key TEXT NOT NULL,
+        entry_path TEXT NOT NULL,
+        mode TEXT NOT NULL,
+        owner_id TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        PRIMARY KEY (archive_key, entry_path, owner_id)
+      );
+      CREATE TABLE IF NOT EXISTS archive_commit_locks (
+        archive_key TEXT PRIMARY KEY,
+        owner_id TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+    `);
+    if (input.withActiveOwner) {
+      await database.run(
+        "INSERT INTO archive_owners VALUES (?, 'owner', ?, ?, ?)",
+        [
+          archiveKey,
+          nodeWikiGraphPlatform.lifecycle.instanceId,
+          Date.now(),
+          Date.now(),
+        ],
+      );
+    }
+    await database.run(
+      `INSERT INTO entry_overlays (
+         archive_key, archive_identity, entry_path, kind, owner_id, updated_at
+       ) VALUES (?, ?, ?, 'deleted', 'owner', ?)`,
+      [archiveKey, input.archiveIdentity, input.entryPath, Date.now()],
+    );
+  } finally {
+    await database.close();
+  }
+}
+
+async function expectPathMissing(path: string): Promise<void> {
+  await expect(access(path)).rejects.toThrow();
 }


### PR DESCRIPTION
## 摘要
- 完善 home schema v3→v4 迁移与派生状态清理
- 纯信息命令不创建 home；缺失 document store 的 GC 按空目录处理
- 增加迁移、CLI 信息命令与 GC 回归测试

## 验证
- pnpm verify
- pnpm build
- pnpm test:run（152 files / 980 tests）
- 构建产物隔离 HOME 实跑 wg gc --dry-run、wg --version、wg --help、wg help