### PR TITLE
修复旧版 HOME 的显式升级恢复路径

### DIFF
--- a/docs/schema-upgrade.md
+++ b/docs/schema-upgrade.md
@@ -106,7 +106,9 @@ overlays/workspaces for `index.db` or legacy `fts.db`, and orphaned SQLite
 materialization cache overlays whose archive file no longer exists. The v2 -> v3
 home upgrader uses the same cleanup boundary because the index-cache semantics
 changed. A home upgrader must block before cleanup when library/state/GC locks,
-build jobs, worker leases, or coordinator owners are still active. Orphaned
+a build worker lease, or coordinator owners are still active. Queued, paused,
+or otherwise unfinished job rows without a live worker are inactive derived
+state and do not block migration. Orphaned
 cross-version overlays are rollback state, not a reason to replay a partially
 completed operation against an archive.
 
@@ -125,7 +127,7 @@ Hosts that need to accept a v3 home implement the resource adapter's
 normal file and directory operations.
 
 Before changing the registry or deleting derived state, the upgrader rejects
-fresh library/state/GC locks, active build jobs or worker leases, and live
+fresh library/state/GC locks, an active build worker lease, and live
 legacy or current coordinator owners. Once those checks pass, cross-version
 coordinator state is rolled back: legacy/current coordinator databases and
 their workspaces are discarded, including non-derived overlays, so the last
@@ -154,7 +156,10 @@ and legacy sdpub inputs. Internal SQLite files such as search sessions, job
 state, staging state, and library `index.db` are implementation details of the
 home or library target and must not become CLI targets.
 
-- `wg maintenance upgrade ~/.wikigraph` explicitly upgrades home state. Real CLI
+- `wg maintenance upgrade home` explicitly upgrades home state. This command
+  bypasses the ordinary home preflight so an old schema can enter its own
+  upgrade flow; `~/.wikigraph` and its shell-expanded configured path are also
+  accepted as aliases. Real CLI
   commands also run a centralized home preflight before touching local state;
   `wg --version`, `wg --help`, `wg help ...`, and other pure help rendering paths
   remain rescue paths and do not create or upgrade home.

--- a/packages/cli/src/app/dispatch.ts
+++ b/packages/cli/src/app/dispatch.ts
@@ -17,6 +17,7 @@ import {
 } from "../commands/index.js";
 import { formatCLIJSON, formatCLIJSONLine } from "../support/index.js";
 import { readCLIVersion } from "../support/index.js";
+import { isWikiGraphHomeTarget } from "../runtime/home-target.js";
 import {
   ensureWikiGraphHomeSchemaCurrent,
   formatError,
@@ -56,7 +57,12 @@ export async function dispatchWikiGraphCLI(
         return { exitCode: 0 };
     }
 
-    await ensureWikiGraphHomeSchemaCurrent();
+    if (
+      parsed.kind !== "maintenance-command" ||
+      !isWikiGraphHomeTarget(parsed.args.target)
+    ) {
+      await ensureWikiGraphHomeSchemaCurrent();
+    }
 
     switch (parsed.kind) {
       case "convert":

--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -8,6 +8,7 @@ import {
   renderLibraryPredicateHelpText,
   renderLibraryUriHelpText,
   renderMainHelpText,
+  renderMaintenanceCommandHelpText,
   renderUriHelpText,
   renderUriPredicateHelpText,
   renderTransformHelpText,
@@ -215,6 +216,12 @@ describe("cli/args/help", () => {
         "wikg://book.wikg/chapter/part/title",
       ),
     ).toContain("does not delete the chapter");
+  });
+
+  it("shows the explicit home schema recovery command", () => {
+    expect(renderMaintenanceCommandHelpText("upgrade")).toContain(
+      "wg maintenance upgrade home",
+    );
   });
 
   it("prints help topic pages", () => {

--- a/packages/cli/src/commands/maintenance.ts
+++ b/packages/cli/src/commands/maintenance.ts
@@ -5,6 +5,7 @@ import {
 } from "wiki-graph-core";
 
 import type { CLIMaintenanceArguments } from "../args/index.js";
+import { isWikiGraphHomeTarget } from "../runtime/home-target.js";
 import { formatCLIJSON, writeTextToStdout } from "../support/index.js";
 import { NodeFile } from "../runtime/node-platform.js";
 import { resolve } from "path";
@@ -55,7 +56,7 @@ function formatMaintenanceUpgradeResult(
 }
 
 function parseMaintenanceTarget(target: string) {
-  if (target === "home" || target === "~/.wikigraph") {
+  if (isWikiGraphHomeTarget(target)) {
     return { kind: "home" as const };
   }
   if (target.startsWith("wikg://lib")) {

--- a/packages/cli/src/runtime/home-target.ts
+++ b/packages/cli/src/runtime/home-target.ts
@@ -1,0 +1,13 @@
+import { homedir } from "os";
+import { join, resolve } from "path";
+
+import { getCLICwd, getCLIStateDir } from "./context.js";
+
+export function isWikiGraphHomeTarget(target: string): boolean {
+  if (target === "home" || target === "~/.wikigraph") return true;
+
+  const configuredHome = resolve(
+    getCLIStateDir() ?? join(homedir(), ".wikigraph"),
+  );
+  return resolve(getCLICwd(), target) === configuredHome;
+}

--- a/packages/core/data/help/commands/maintenance.jinja
+++ b/packages/core/data/help/commands/maintenance.jinja
@@ -11,7 +11,7 @@ Commands:
   upgrade    Upgrade home state, a .wikg archive, a library, or migrate .sdpub.
 
 Upgrade targets:
-  {{ commandName }} maintenance upgrade ~/.wikigraph
+  {{ commandName }} maintenance upgrade home
   {{ commandName }} maintenance upgrade ./book.wikg
   {{ commandName }} maintenance upgrade wikg://book.wikg
   {{ commandName }} maintenance upgrade ./book.sdpub [--output ./book.wikg]

--- a/packages/core/data/help/commands/maintenance/upgrade.jinja
+++ b/packages/core/data/help/commands/maintenance/upgrade.jinja
@@ -9,7 +9,7 @@ Usage:
   {{ commandName }} maintenance upgrade <path.sdpub> [--output <path.wikg>] [--json]
 
 Targets:
-  - Home state: ~/.wikigraph
+  - Home state: home (or ~/.wikigraph)
   - Standalone archive: ./book.wikg, /path/to/book.wikg, wikg://book.wikg, wikg:///path/to/book.wikg
   - Legacy sdpub: ./book.sdpub, optionally with --output
   - Library: wikg://lib or wikg://lib/<lib-id>
@@ -23,7 +23,7 @@ Notes:
   - Library upgrade covers the registry and managed archive members for that library.
 
 Examples:
-  {{ commandName }} maintenance upgrade ~/.wikigraph
+  {{ commandName }} maintenance upgrade home
   {{ commandName }} maintenance upgrade ./book.wikg
   {{ commandName }} maintenance upgrade wikg://lib
   {{ commandName }} maintenance upgrade ./book.sdpub --output ./book.wikg

--- a/packages/core/src/document/home-schema-upgrade.ts
+++ b/packages/core/src/document/home-schema-upgrade.ts
@@ -12,6 +12,8 @@ import { getNumber, getString, Database } from "./database.js";
 
 const CURRENT_HOME_SCHEMA_VERSION = 4;
 const LOCK_STALE_TIMEOUT_MS = 5 * 60 * 1000;
+const HOME_UPGRADE_RECOVERY =
+  "Stop the active operation, then run `wg maintenance upgrade home`. See: `wg maintenance upgrade --help`.";
 const HOME_SCHEMA_SQL = `
   CREATE TABLE IF NOT EXISTS schema_versions (
     scope TEXT PRIMARY KEY,
@@ -277,16 +279,6 @@ async function assertBuildQueueSafe(file: File | undefined): Promise<void> {
   if (file === undefined || (await isEmpty(file))) return;
   const database = await Database.open(file, "", { readonly: true });
   try {
-    if (await tableExists(database, "build_jobs")) {
-      const active = await database.queryOne(
-        "SELECT 1 AS active FROM build_jobs WHERE state IN ('queued', 'running', 'canceling', 'paused') LIMIT 1",
-        undefined,
-        () => true,
-      );
-      if (active === true) {
-        throw new Error("Cannot upgrade home with active build jobs.");
-      }
-    }
     if (await tableExists(database, "build_worker_lease")) {
       const columns = await readTableColumns(database, "build_worker_lease");
       const ownerColumns = ["owner_id", "owner_pid"].filter((name) =>
@@ -305,7 +297,9 @@ async function assertBuildQueueSafe(file: File | undefined): Promise<void> {
         () => true,
       );
       if (active === true) {
-        throw new Error("Cannot upgrade home with an active build worker.");
+        throw homeUpgradeBlocked(
+          "Cannot upgrade home with an active build worker.",
+        );
       }
     }
   } finally {
@@ -337,7 +331,9 @@ async function assertCoordinatorInactive(
       for (const owner of owners) {
         if (owner.hostInstanceId === undefined) {
           if (isFresh(owner.heartbeatAt)) {
-            throw new Error(`Cannot upgrade home with active ${label} state.`);
+            throw homeUpgradeBlocked(
+              `Cannot upgrade home with active ${label} state.`,
+            );
           }
           continue;
         }
@@ -348,7 +344,9 @@ async function assertCoordinatorInactive(
           alive === true ||
           (alive === undefined && isFresh(owner.heartbeatAt))
         ) {
-          throw new Error(`Cannot upgrade home with active ${label} state.`);
+          throw homeUpgradeBlocked(
+            `Cannot upgrade home with active ${label} state.`,
+          );
         }
       }
     }
@@ -367,7 +365,9 @@ async function assertCoordinatorInactive(
         () => true,
       );
       if (active === true) {
-        throw new Error(`Cannot upgrade home with active ${label} state.`);
+        throw homeUpgradeBlocked(
+          `Cannot upgrade home with active ${label} state.`,
+        );
       }
     }
   } finally {
@@ -389,11 +389,15 @@ async function assertNoFreshRows(
         [Date.now() - LOCK_STALE_TIMEOUT_MS],
         () => true,
       );
-      if (active === true) throw new Error(message);
+      if (active === true) throw homeUpgradeBlocked(message);
     }
   } finally {
     await database.close();
   }
+}
+
+function homeUpgradeBlocked(message: string): Error {
+  return new Error(`${message} ${HOME_UPGRADE_RECOVERY}`);
 }
 
 function isFresh(heartbeat: number | undefined): boolean {

--- a/test/cli/main.test.ts
+++ b/test/cli/main.test.ts
@@ -21,6 +21,7 @@ const mainMockState = vi.hoisted(() => ({
   archiveCoverRunCalls: [] as unknown[],
   archiveMetaRunCalls: [] as unknown[],
   legacyRunCalls: [] as unknown[],
+  maintenanceRunCalls: [] as unknown[],
   archiveRunError: undefined as Error | undefined,
   archiveIndexRunError: undefined as Error | undefined,
   convertRunError: undefined as Error | undefined,
@@ -30,6 +31,7 @@ const mainMockState = vi.hoisted(() => ({
   archiveCoverRunError: undefined as Error | undefined,
   archiveMetaRunError: undefined as Error | undefined,
   legacyRunError: undefined as Error | undefined,
+  maintenanceRunError: undefined as Error | undefined,
 }));
 
 vi.mock("../../packages/cli/src/args/index.js", () => ({
@@ -124,6 +126,15 @@ vi.mock("../../packages/cli/src/commands/index.js", () => ({
 
     return Promise.resolve();
   }),
+  runMaintenanceCommand: vi.fn((args: unknown) => {
+    mainMockState.maintenanceRunCalls.push(args);
+
+    if (mainMockState.maintenanceRunError !== undefined) {
+      return Promise.reject(mainMockState.maintenanceRunError);
+    }
+
+    return Promise.resolve();
+  }),
 }));
 
 vi.mock("wiki-graph-core", async (importOriginal) => {
@@ -137,6 +148,7 @@ vi.mock("wiki-graph-core", async (importOriginal) => {
 import { main } from "../../packages/cli/src/app/index.js";
 import { renderMainHelpText } from "../../packages/cli/src/args/help.js";
 import { LLMPaymentRequiredError } from "../../packages/core/src/external/llm/index.js";
+import { ensureWikiGraphHomeSchemaCurrent } from "wiki-graph-core";
 
 describe("cli/main", () => {
   const originalExitCode = process.exitCode;
@@ -166,6 +178,7 @@ describe("cli/main", () => {
     mainMockState.archiveCoverRunCalls.length = 0;
     mainMockState.archiveMetaRunCalls.length = 0;
     mainMockState.legacyRunCalls.length = 0;
+    mainMockState.maintenanceRunCalls.length = 0;
     mainMockState.archiveRunError = undefined;
     mainMockState.archiveIndexRunError = undefined;
     mainMockState.convertRunError = undefined;
@@ -175,6 +188,8 @@ describe("cli/main", () => {
     mainMockState.archiveCoverRunError = undefined;
     mainMockState.archiveMetaRunError = undefined;
     mainMockState.legacyRunError = undefined;
+    mainMockState.maintenanceRunError = undefined;
+    vi.mocked(ensureWikiGraphHomeSchemaCurrent).mockClear();
     process.exitCode = 0;
     process.argv = ["node", "wg"];
     setStdinTTY(false);
@@ -252,7 +267,54 @@ describe("cli/main", () => {
     ]);
     expect(mainMockState.archiveMetaRunCalls).toHaveLength(0);
     expect(mainMockState.localConfigRunCalls).toHaveLength(0);
+    expect(ensureWikiGraphHomeSchemaCurrent).toHaveBeenCalledOnce();
     expect(stdoutChunks).toStrictEqual([]);
+    expect(stderrChunks).toStrictEqual([]);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("lets an explicit home upgrade bypass the ordinary home gate", async () => {
+    mainMockState.argsResult = {
+      args: {
+        action: "upgrade",
+        target: "home",
+      },
+      help: false,
+      kind: "maintenance-command",
+    };
+
+    await main();
+
+    expect(ensureWikiGraphHomeSchemaCurrent).not.toHaveBeenCalled();
+    expect(mainMockState.maintenanceRunCalls).toStrictEqual([
+      {
+        action: "upgrade",
+        target: "home",
+      },
+    ]);
+    expect(stderrChunks).toStrictEqual([]);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("keeps the ordinary home gate for non-home maintenance targets", async () => {
+    mainMockState.argsResult = {
+      args: {
+        action: "upgrade",
+        target: "/tmp/book.wikg",
+      },
+      help: false,
+      kind: "maintenance-command",
+    };
+
+    await main();
+
+    expect(ensureWikiGraphHomeSchemaCurrent).toHaveBeenCalledOnce();
+    expect(mainMockState.maintenanceRunCalls).toStrictEqual([
+      {
+        action: "upgrade",
+        target: "/tmp/book.wikg",
+      },
+    ]);
     expect(stderrChunks).toStrictEqual([]);
     expect(process.exitCode).toBe(0);
   });

--- a/test/cli/maintenance-upgrade.test.ts
+++ b/test/cli/maintenance-upgrade.test.ts
@@ -1,0 +1,84 @@
+import { access, mkdir } from "fs/promises";
+import { join } from "path";
+
+import { describe, expect, it } from "vitest";
+
+import { runWikiGraphCLICaptured } from "../../packages/cli/src/index.js";
+import { Database } from "../../packages/core/src/document/index.js";
+import { NodeFile } from "../../packages/cli/src/runtime/node-platform.js";
+import { withTempDir } from "../helpers/temp.js";
+
+describe("cli/maintenance upgrade", () => {
+  it("upgrades an old home through its shell-expanded path despite stale jobs", async () => {
+    await withTempDir("wikigraph-cli-home-upgrade-", async (stateDir) => {
+      await createV3HomeWithStaleJob(stateDir);
+
+      const result = await runWikiGraphCLICaptured({
+        argv: ["maintenance", "upgrade", stateDir],
+        stateDir,
+      });
+
+      expect(result).toStrictEqual({
+        exitCode: 0,
+        stderr: "",
+        stdout: "Home upgraded (schema v3 -> v4)\n",
+      });
+      await expect(readHomeSchemaVersion(stateDir)).resolves.toBe(4);
+      await expect(access(join(stateDir, "jobs/job.sqlite"))).rejects.toThrow();
+    });
+  });
+});
+
+async function createV3HomeWithStaleJob(stateDir: string): Promise<void> {
+  await mkdir(join(stateDir, "jobs"), { recursive: true });
+  const core = await Database.open(new NodeFile(join(stateDir, "core.sqlite")));
+  try {
+    await core.execute(`
+      CREATE TABLE schema_versions (
+        scope TEXT PRIMARY KEY,
+        version INTEGER NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+    `);
+    await core.run("INSERT INTO schema_versions VALUES ('home', 3, 'fixture')");
+  } finally {
+    await core.close();
+  }
+
+  const jobs = await Database.open(
+    new NodeFile(join(stateDir, "jobs/job.sqlite")),
+  );
+  try {
+    await jobs.execute(`
+      CREATE TABLE build_jobs (state TEXT NOT NULL);
+      CREATE TABLE build_worker_lease (
+        id INTEGER PRIMARY KEY,
+        owner_id TEXT,
+        owner_pid INTEGER,
+        heartbeat_at INTEGER
+      );
+    `);
+    await jobs.run("INSERT INTO build_jobs VALUES ('queued')");
+  } finally {
+    await jobs.close();
+  }
+}
+
+async function readHomeSchemaVersion(stateDir: string): Promise<number> {
+  const database = await Database.open(
+    new NodeFile(join(stateDir, "core.sqlite")),
+    "",
+    { readonly: true },
+  );
+  try {
+    return await database
+      .queryOne(
+        "SELECT version FROM schema_versions WHERE scope = 'home'",
+        undefined,
+        (row) => Number(row.version),
+      )
+      .then((version) => version ?? 0);
+  } finally {
+    await database.close();
+  }
+}

--- a/test/core/storage/schema-upgrade/index.test.ts
+++ b/test/core/storage/schema-upgrade/index.test.ts
@@ -459,8 +459,8 @@ describe("schema-upgrade", () => {
     });
   });
 
-  it("blocks v3 home migration before cleanup when a build job is queued", async () => {
-    await withTempDir("wikigraph-home-build-active-", async (root) => {
+  it("discards unfinished build jobs when no worker lease is active", async () => {
+    await withTempDir("wikigraph-home-build-inactive-", async (root) => {
       const statePath = join(root, "state");
       const libraryPath = join(root, "library");
       await mkdir(libraryPath, { recursive: true });
@@ -492,8 +492,56 @@ describe("schema-upgrade", () => {
       await withWikiGraphStorage(
         createNodeWikiGraphStorage(statePath),
         async () => {
+          await expect(
+            ensureWikiGraphHomeSchemaCurrent(),
+          ).resolves.toBeUndefined();
+          await expect(readWikiGraphHomeSchemaVersion()).resolves.toBe(4);
+          await expectPathMissing(join(statePath, "cache/cache.sqlite"));
+          await expectPathMissing(join(statePath, "jobs/job.sqlite"));
+        },
+      );
+    });
+  });
+
+  it("blocks v3 home migration while a build worker lease is active", async () => {
+    await withTempDir("wikigraph-home-build-active-", async (root) => {
+      const statePath = join(root, "state");
+      const libraryPath = join(root, "library");
+      await mkdir(libraryPath, { recursive: true });
+      await createV3Home(statePath, libraryPath);
+      await mkdir(join(statePath, "cache"), { recursive: true });
+      await writeFile(
+        join(statePath, "cache/cache.sqlite"),
+        "keep-before-gate",
+      );
+      await mkdir(join(statePath, "jobs"), { recursive: true });
+      const jobs = await Database.open(
+        new NodeFile(join(statePath, "jobs/job.sqlite")),
+      );
+      try {
+        await jobs.execute(`
+          CREATE TABLE build_jobs (state TEXT NOT NULL);
+          CREATE TABLE build_worker_lease (
+            id INTEGER PRIMARY KEY,
+            owner_id TEXT,
+            owner_pid INTEGER,
+            heartbeat_at INTEGER
+          );
+        `);
+        await jobs.run("INSERT INTO build_jobs VALUES ('running')");
+        await jobs.run(
+          "INSERT INTO build_worker_lease VALUES (1, 'worker', 1234, ?)",
+          [Date.now()],
+        );
+      } finally {
+        await jobs.close();
+      }
+
+      await withWikiGraphStorage(
+        createNodeWikiGraphStorage(statePath),
+        async () => {
           await expect(ensureWikiGraphHomeSchemaCurrent()).rejects.toThrow(
-            "active build jobs",
+            "Cannot upgrade home with an active build worker. Stop the active operation, then run `wg maintenance upgrade home`. See: `wg maintenance upgrade --help`.",
           );
           await expect(readWikiGraphHomeSchemaVersion()).resolves.toBe(3);
           await expect(


### PR DESCRIPTION
## Summary

- let explicit HOME maintenance upgrades bypass the ordinary schema preflight
- discard inactive legacy job state while preserving active worker and lock safety gates
- expose an actionable recovery command and keep CLI help/schema documentation aligned
- cover canonical and shell-expanded HOME targets with CLI and migration regressions

## Verification

- `pnpm test:run` (153 files, 987 tests)
- `pnpm verify`
- `pnpm build`
- `pnpm dev maintenance upgrade --help`