### PR TITLE
校正章节 source 帮助契约

### DIFF
--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -55,10 +55,11 @@ $ wg wikg://quickstart.wikg/chapter/tree
 └─ Second note  wikg://chapter/second-note
 ```
 
-开启并构建 FTS 全文索引（开启后才可使用 `--query` 进行全文搜索）：
+构建 FTS 索引产物，再同步本地索引缓存。完成后即可使用 `--query` 进行全文搜索：
 
 ```bash
-$ wg wikg://quickstart.wikg/index enable
+$ wg wikg://local/job add --input wikg://quickstart.wikg --task index-fts --accept-cost
+$ wg wikg://quickstart.wikg/index sync
 ```
 
 把内容搜出来：

--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -347,6 +347,9 @@ describe("cli/args/help", () => {
     expect(sourceSetHelpText).toContain("must be `planned`");
     expect(sourceSetHelpText).toContain("Plain text writes source without");
     expect(sourceSetHelpText).toContain("File extensions are not inferred");
+    expect(sourceSetHelpText).toContain(
+      "`sourceUnits` is the number of stored source processing fragments",
+    );
     expect(sourceSetHelpText).toContain("<chapter-uri>/state --help");
     expect(sourceSetHelpText).toContain("<chapter-uri> reset --help");
     expect(sourceSetHelpText).toContain("[--json]");
@@ -520,10 +523,10 @@ describe("cli/args/help", () => {
       "Use `--json` when an Agent or script needs one stable machine-readable response.",
     );
     expect(renderHelpTopicText("format")).toContain(
-      "Whole `source` and `summary` text objects are plain text streams and do not support `--json`.",
+      "Whole `source` and `summary` objects print plain text by default; with `--json`, they return one object containing `uri` and `text`.",
     );
     expect(renderHelpTopicText("format")).toContain(
-      "Ranged fragments such as `/source#20..30` and `/summary#20..30` are structured range objects and support `--json`.",
+      "Ranged fragments such as `/source#20..30` and `/summary#20..30` use the same output choices and retain the requested range in `uri`.",
     );
     expect(renderHelpTopicText("format")).toContain(
       "JSONL may contain both object records and control records.",
@@ -730,7 +733,7 @@ describe("cli/args/help", () => {
       "Use `--json` when you want stable Agent-readable fields",
     );
     expect(renderHelpTopicText("recipe")).toContain(
-      "ranged fragments such as `/source#20..30` support `--json`",
+      "Whole and ranged `source` or `summary` reads return `uri` and `text`",
     );
     expect(uriHelpText).toContain(
       "Ranged fragments such as `/source#4..8` and `/summary#4..8` are structured range objects.",
@@ -741,7 +744,15 @@ describe("cli/args/help", () => {
         "wikg://book.wikg/chapter/part/source",
       ),
     ).toContain(
-      "Whole source reads are plain text streams and do not support `--json`; source range fragments are structured range objects and support `--json`.",
+      "Whole and ranged source reads print text by default. With `--json`, they return one object containing `uri` and `text`.",
+    );
+    expect(
+      renderUriHelpText(
+        "chapter-summary-object",
+        "wikg://book.wikg/chapter/part/summary",
+      ),
+    ).toContain(
+      "Whole and ranged summary reads print text by default. With `--json`, they return one object containing `uri` and `text`.",
     );
     expect(renderHelpTopicText("recipe")).toContain(
       "wg wikg://book.wikg/chapter/part/entity --all --jsonl",

--- a/packages/core/data/help/commands/maintenance/chapter/set-source.jinja
+++ b/packages/core/data/help/commands/maintenance/chapter/set-source.jinja
@@ -1,28 +1,8 @@
 Help Type: command
 Command: {{ commandName }} <chapter-uri>/source set
 
-Purpose:
-  Fill a planned chapter with its complete source text.
-
-Usage:
-  {{ commandName }} <chapter-uri>/source set (<text>|--input <path|->) [--input-format jsonl] [--llm <json>] [--json] [--help|-h]
-
-Input:
-  - Supply exactly one positional value or `--input`; files and stdin are UTF-8 plain text unless `--input-format jsonl` is set. File extensions are not inferred.
-  - Plain text writes source without a source-text map.
-  - `--input-format jsonl` writes source and provenance supplied by an external extractor. Read `{{ commandName }} help file-import` for the record contract.
-
-Preconditions:
-  - The chapter must be `planned`.
-  - Read the chapter state and reset help before discarding data from a later-stage chapter.
-
-Behavior:
-  - Writes the complete source text.
-  - Moves the chapter to `source`.
-  - Does not generate Reading Graph data.
-  - Does not generate or modify a summary.
-  - Does not call an LLM provider.
-  - With `--json`, prints the updated chapter status as one JSON object.
+{% set uri = "<chapter-uri>/source" %}
+{% include "help/commands/shared/chapter-source-set.jinja" %}
 
 Typical next step:
   {{ commandName }} wikg://local/job add --input <archive-uri|chapter-uri> --task reading-graph --accept-cost

--- a/packages/core/data/help/commands/predicate.jinja
+++ b/packages/core/data/help/commands/predicate.jinja
@@ -213,18 +213,7 @@ Notes:
   - Use `--input -` to read the tree JSON from stdin.
   - This rewires chapter hierarchy and order; it does not rewrite chapter source text or generated graph content.
 {% elif target.name == "chapter-source-object" %}
-Purpose:
-  Fill a planned chapter with its complete source text.
-
-Usage:
-  {{ commandName }} {{ uri }} set (<text>|--input <path|->) [--input-format jsonl] [--json]
-
-Notes:
-  - Supply exactly one positional value or `--input`; files and stdin are UTF-8 plain text unless `--input-format jsonl` is set. File extensions are not inferred.
-  - `--input-format jsonl` records source provenance supplied by an external extractor. Read `{{ commandName }} help file-import` for the record contract.
-  - The chapter must be `planned`. Read the chapter state and reset help before discarding data from a later-stage chapter.
-  - Plain text writes source without a source-text map. JSONL writes both source and its map.
-  - On success, the chapter moves to `source` and the updated status is printed; `--json` prints one JSON object.
+{% include "help/commands/shared/chapter-source-set.jinja" %}
 {% elif target.name == "chapter-summary-object" %}
 Purpose:
   Replace this chapter summary text.

--- a/packages/core/data/help/commands/shared/chapter-source-set.jinja
+++ b/packages/core/data/help/commands/shared/chapter-source-set.jinja
@@ -1,0 +1,19 @@
+Purpose:
+  Fill a planned chapter with its complete source text.
+
+Usage:
+  {{ commandName }} {{ uri }} set (<text>|--input <path|->) [--input-format jsonl] [--json]
+
+Input:
+  - Supply exactly one positional value or `--input`; files and stdin are UTF-8 plain text unless `--input-format jsonl` is set. File extensions are not inferred.
+  - Plain text writes source without a source-text map.
+  - `--input-format jsonl` writes source and provenance supplied by an external extractor. Read `{{ commandName }} help file-import` for the record contract.
+
+Preconditions:
+  - The chapter must be `planned`.
+  - Read the chapter state and reset help before discarding data from a later-stage chapter.
+
+Behavior:
+  - Writes the complete source text and moves the chapter to `source`.
+  - Does not generate Reading Graph data or a summary, and does not call an LLM provider.
+  - With `--json`, prints the updated chapter status as one JSON object. `sourceUnits` is the number of stored source processing fragments, not the number of sentences.

--- a/packages/core/data/help/commands/uri.jinja
+++ b/packages/core/data/help/commands/uri.jinja
@@ -120,7 +120,7 @@ Default behavior:
   - Source range fragments such as `#4..8` read sentence numbers 4 through 8, inclusive.
   - Range fragments are read-only; `set` writes the complete source object.
   - Range sentence numbers are 1-based. `#1` is the first sentence; `#1..2` is the first two sentences.
-  - Whole source reads are plain text streams and do not support `--json`; source range fragments are structured range objects and support `--json`.
+  - Whole and ranged source reads print text by default. With `--json`, they return one object containing `uri` and `text`.
 
 Use when:
   - You need continuous original wording from a selected chapter.
@@ -143,7 +143,7 @@ Default behavior:
   - `{{ commandName }} {{ uri }}` reads summary text.
   - Summary range fragments such as `#4..8` read sentence numbers 4 through 8, inclusive.
   - Range sentence numbers are 1-based. `#1` is the first sentence; `#1..2` is the first two sentences.
-  - Whole summary reads are plain text streams and do not support `--json`; summary range fragments are structured range objects and support `--json`.
+  - Whole and ranged summary reads print text by default. With `--json`, they return one object containing `uri` and `text`.
   - Summary readiness means a summary object exists and is current for the chapter source. It does not guarantee the prose answers every question about the chapter.
 
 Use when:

--- a/packages/core/data/help/topics/format.jinja
+++ b/packages/core/data/help/topics/format.jinja
@@ -32,8 +32,8 @@ Command output shapes:
   - Default text output is for direct human reading and quick inspection.
   - Use `--json` when an Agent or script needs one stable machine-readable response.
   - Use `--jsonl` when a command returns many records, streams progress, or feeds a Unix pipeline.
-  - Whole `source` and `summary` text objects are plain text streams and do not support `--json`.
-  - Ranged fragments such as `/source#20..30` and `/summary#20..30` are structured range objects and support `--json`.
+  - Whole `source` and `summary` objects print plain text by default; with `--json`, they return one object containing `uri` and `text`.
+  - Ranged fragments such as `/source#20..30` and `/summary#20..30` use the same output choices and retain the requested range in `uri`.
   - Source and summary range numbers are 1-based and inclusive.
   - Commands that do not support `--json` or `--jsonl` say so in their command help or error message.
 

--- a/packages/core/data/help/topics/recipe.jinja
+++ b/packages/core/data/help/topics/recipe.jinja
@@ -10,7 +10,7 @@ Purpose:
 Operating rules:
   - Never unzip a `.wikg` archive, rewrite internal files, or bypass this CLI. Use CLI commands for archive edits.
   - Use Wiki Graph URIs as stable object handles.
-  - Use `--json` when you want stable Agent-readable fields instead of human text. Whole `source` and `summary` objects are text streams, while ranged fragments such as `/source#20..30` support `--json`.
+  - Use `--json` when you want stable Agent-readable fields instead of human text. Whole and ranged `source` or `summary` reads return `uri` and `text` in that form.
   - If you have a URI and need valid operations, run `{{ commandName }} <uri> --help`.
   - If you need concrete predicate usage for that URI type, run `{{ commandName }} <uri> <predicate> --help`.
   - Never pass a bare filesystem path to URI-targeted commands.


### PR DESCRIPTION
修正完整 source/summary 读取的 JSON 输出说明，统一 source set 帮助正文，并同步中文 Quick Start 的索引流程。\n\n验证：\n- pnpm exec vitest run packages/cli/src/args/help.test.ts\n- pnpm run typecheck\n- pnpm run build\n- pnpm exec prettier --check README_zh-CN.md packages/cli/src/args/help.test.ts\n- git diff --check