### PR TITLE
补齐章节写入后的 CLI 可验证闭环

### DIFF
--- a/packages/cli/src/args/archive.test.ts
+++ b/packages/cli/src/args/archive.test.ts
@@ -1387,9 +1387,7 @@ describe("cli/args/archive", () => {
         "--input-format",
         "txt",
       ]),
-    ).toThrow(
-      "The `chapter set-source` action does not support --input-format.",
-    );
+    ).toThrow("`--input-format` for chapter source set only accepts `jsonl`.");
     expect(
       parseCLIArguments([
         "wikg://book.wikg/chapter",

--- a/packages/cli/src/args/helper/chapter/normalize.ts
+++ b/packages/cli/src/args/helper/chapter/normalize.ts
@@ -280,11 +280,11 @@ export function normalizeArchiveChapterArguments(
         values["input-format"] !== undefined &&
         values["input-format"] !== "jsonl"
       ) {
-        rejectActionFlag(
-          values["input-format"],
-          "--input-format",
-          action,
-          helpRoute,
+        throw new Error(
+          withHelpRoute(
+            "`--input-format` for chapter source set only accepts `jsonl`.",
+            helpRoute,
+          ),
         );
       }
       rejectActionFlag(values.parent, "--parent", action, helpRoute);

--- a/packages/cli/src/commands/archive-command/chapter.ts
+++ b/packages/cli/src/commands/archive-command/chapter.ts
@@ -8,6 +8,7 @@ import {
   applyChapterTree,
   assertNoActiveBuildJobConflicts,
   assertNoActiveBuildJobs,
+  formatLocatedChapterUri,
   getChapterTree,
   listChapters,
   moveChapter,
@@ -19,6 +20,7 @@ import {
   setChapterSummary,
   setChapterTitle,
   parseSourceTextJsonl,
+  WikiGraphArchiveFile,
   type BuildJobTarget,
   type ChapterTree,
   type ChapterTreeApplyResult,
@@ -27,11 +29,11 @@ import {
   type IndexArtifactKind,
 } from "wiki-graph-core";
 import { NodeFile } from "../../runtime/node-platform.js";
-import { WikiGraphArchiveFile } from "wiki-graph-core";
 
 import type { CLIArchiveChapterArguments } from "../../args/index.js";
 import type { RenderTreeNode } from "../../support/index.js";
 import {
+  parseLocatedWikiGraphUri,
   renderTreeText,
   readTextStreamFromStdin,
   writeTextToStdout,
@@ -70,7 +72,9 @@ export async function runArchiveChapterCommand(
           );
         }
 
-        await writeChapterDetails(details, args.json ?? false);
+        await writeChapterDetails(details, args.json ?? false, {
+          locatedUri: formatChapterCommandUri(args.path, details.path),
+        });
       });
       return;
     case "list":
@@ -472,7 +476,7 @@ async function readRequiredSourceText(
 
   if (content.trim() === "") {
     throw new Error(
-      "Source input is empty. Pass non-empty text with --input <path> or --input -.",
+      "Source input is empty. Pass non-empty positional text, use --input <path>, or use --input - for stdin.",
     );
   }
 
@@ -482,6 +486,7 @@ async function readRequiredSourceText(
 async function writeChapterDetails(
   details: ChapterDetails,
   json: boolean,
+  options: { readonly locatedUri?: string } = {},
 ): Promise<void> {
   if (json) {
     await writeTextToStdout(
@@ -489,6 +494,9 @@ async function writeChapterDetails(
         childCount: details.childCount,
         graphReady: details.graphReady,
         hasSummary: details.hasSummary,
+        ...(options.locatedUri === undefined
+          ? {}
+          : { locatedUri: options.locatedUri }),
         sourceUnits: details.fragmentCount,
         stage: formatStage(details.stage),
         title: details.title,
@@ -500,6 +508,9 @@ async function writeChapterDetails(
 
   const lines = [
     `Chapter: ${details.uri}`,
+    ...(options.locatedUri === undefined
+      ? []
+      : [`Located URI: ${options.locatedUri}`]),
     `Title: ${details.title ?? "[untitled]"}`,
     `Stage: ${formatStage(details.stage)}`,
     `Source Units: ${details.fragmentCount}`,
@@ -509,6 +520,24 @@ async function writeChapterDetails(
   ];
 
   await writeTextToStdout(`${lines.join("\n")}\n`);
+}
+
+function formatChapterCommandUri(
+  archiveLocator: string,
+  chapterPath: string,
+): string {
+  if (archiveLocator.startsWith("wikg://lib/")) {
+    return `${archiveLocator.replace(/\/+$/u, "")}/chapter/${chapterPath}`;
+  }
+  if (archiveLocator.startsWith("wikg://")) {
+    const parsed = parseLocatedWikiGraphUri(archiveLocator);
+
+    if (parsed.archivePath !== undefined) {
+      return formatLocatedChapterUri(parsed.archivePath, chapterPath);
+    }
+  }
+
+  return formatLocatedChapterUri(archiveLocator, chapterPath);
 }
 
 async function writeChapterList(

--- a/packages/cli/src/commands/archive-output/object/objects.ts
+++ b/packages/cli/src/commands/archive-output/object/objects.ts
@@ -306,6 +306,9 @@ export async function createPageObject(
           ...(backlinks === undefined
             ? {}
             : { backlinks: await createBacklinksObject(backlinks, context) }),
+          ...(page.provenance === undefined
+            ? {}
+            : { provenance: page.provenance }),
           text: page.fragment.text,
           uri: toWikiGraphUri(page.id),
         };

--- a/packages/cli/src/commands/archive-output/object/types.ts
+++ b/packages/cli/src/commands/archive-output/object/types.ts
@@ -1,4 +1,4 @@
-import type { QueryIndexScope } from "wiki-graph-core";
+import type { QueryIndexScope, SourceTextMapRecord } from "wiki-graph-core";
 import type { CLIArchiveArguments } from "../../../args/index.js";
 
 export type ResultFormat = "json" | "jsonl" | "text";
@@ -26,6 +26,7 @@ export interface ArchiveOutputObject {
   readonly libraryArchiveUri?: string;
   readonly objectLabel?: string;
   readonly predicate?: string;
+  readonly provenance?: readonly SourceTextMapRecord[];
   readonly publisher?: string;
   readonly score?: number;
   readonly state?: Record<string, string>;

--- a/packages/core/src/document/text-streams/serial.ts
+++ b/packages/core/src/document/text-streams/serial.ts
@@ -18,6 +18,7 @@ import {
   TEXT_STREAM_KIND,
   type ReadonlySerialTextStream,
   type TextSentenceLocation,
+  type TextStreamRangeRead,
   type TextStreamDraftState,
   type TextStreamFileAccess,
   type TextStreamName,
@@ -134,8 +135,20 @@ export class SerialTextStream implements ReadonlySerialTextStream {
     startSentenceIndex: number,
     endSentenceIndex: number,
   ): Promise<string | undefined> {
+    return (
+      await this.readTextInRangeWithOffsets(
+        startSentenceIndex,
+        endSentenceIndex,
+      )
+    )?.text;
+  }
+
+  public async readTextInRangeWithOffsets(
+    startSentenceIndex: number,
+    endSentenceIndex: number,
+  ): Promise<TextStreamRangeRead | undefined> {
     if (endSentenceIndex < startSentenceIndex) {
-      return "";
+      return { sourceEnd: 0, sourceStart: 0, text: "" };
     }
 
     const rows = await this.#database.queryAll(
@@ -162,10 +175,18 @@ export class SerialTextStream implements ReadonlySerialTextStream {
     }
 
     const content = await this.#readContent();
-
-    return new TextDecoder().decode(
+    const text = new TextDecoder().decode(
       content.subarray(first.byteOffset, last.byteOffset + last.byteLength),
     );
+    const sourceStart = Array.from(
+      new TextDecoder().decode(content.subarray(0, first.byteOffset)),
+    ).length;
+
+    return {
+      sourceEnd: sourceStart + Array.from(text).length,
+      sourceStart,
+      text,
+    };
   }
 
   async #getSentenceLocation(

--- a/packages/core/src/document/text-streams/types.ts
+++ b/packages/core/src/document/text-streams/types.ts
@@ -63,6 +63,16 @@ export interface ReadonlySerialTextStream {
     startSentenceIndex: number,
     endSentenceIndex: number,
   ): Promise<string | undefined>;
+  readTextInRangeWithOffsets?(
+    startSentenceIndex: number,
+    endSentenceIndex: number,
+  ): Promise<TextStreamRangeRead | undefined>;
   readonly path: string;
   readonly serialId: number;
+}
+
+export interface TextStreamRangeRead {
+  readonly sourceEnd: number;
+  readonly sourceStart: number;
+  readonly text: string;
 }

--- a/packages/core/src/retrieval/query/archive-view/pages.ts
+++ b/packages/core/src/retrieval/query/archive-view/pages.ts
@@ -1,4 +1,7 @@
-import type { ReadonlyDocument } from "../../../document/index.js";
+import type {
+  ReadonlyDocument,
+  SourceTextMapRecord,
+} from "../../../document/index.js";
 import { parseWikiGraphUriSyntax } from "../../../runtime/common/wiki-graph/uri.js";
 import {
   getChapterTree,
@@ -408,7 +411,18 @@ async function readWikiGraphPage(
       );
     }
     case "text-stream": {
-      const fragment = await createTextStreamRangeFragment(document, reference);
+      const { fragment, sourceEnd, sourceStart } =
+        await createTextStreamRangeFragment(document, reference);
+      const provenance =
+        reference.stream === "source"
+          ? await listSourceRangeProvenance(
+              document,
+              reference.chapterId,
+              sourceStart,
+              sourceEnd,
+              !Number.isFinite(reference.endSentenceIndex),
+            )
+          : undefined;
       return {
         ...(options.backlinks === true
           ? { backlinks: await createTextStreamBacklinks(document, reference) }
@@ -418,9 +432,38 @@ async function readWikiGraphPage(
         nextFragmentId: undefined,
         nodes: [],
         previousFragmentId: undefined,
+        ...(provenance === undefined ? {} : { provenance }),
         title: displayUri,
         type: "fragment",
       };
     }
   }
+}
+
+async function listSourceRangeProvenance(
+  document: ReadonlyDocument,
+  chapterId: number,
+  sourceStart: number | undefined,
+  sourceEnd: number | undefined,
+  wholeSource: boolean,
+): Promise<readonly SourceTextMapRecord[]> {
+  const [mappings, sourceRevision] = await Promise.all([
+    document.sourceProvenance.listMap(chapterId),
+    document.serials.getRevision(chapterId),
+  ]);
+  const currentMappings = mappings.filter(
+    (mapping) => mapping.sourceRevision === sourceRevision,
+  );
+
+  if (wholeSource) {
+    return currentMappings;
+  }
+  if (sourceStart === undefined || sourceEnd === undefined) {
+    return [];
+  }
+
+  return currentMappings.filter(
+    (mapping) =>
+      mapping.sourceStart < sourceEnd && mapping.sourceEnd > sourceStart,
+  );
 }

--- a/packages/core/src/retrieval/query/archive-view/text-streams.ts
+++ b/packages/core/src/retrieval/query/archive-view/text-streams.ts
@@ -56,7 +56,11 @@ export async function readSourceFragment(
 export async function createTextStreamRangeFragment(
   document: ReadonlyDocument,
   reference: Extract<WikiGraphReference, { readonly type: "text-stream" }>,
-): Promise<ArchiveSourceFragment> {
+): Promise<{
+  readonly fragment: ArchiveSourceFragment;
+  readonly sourceEnd?: number;
+  readonly sourceStart?: number;
+}> {
   const range = await readTextStreamRange(
     document,
     reference.chapterId,
@@ -66,12 +70,18 @@ export async function createTextStreamRangeFragment(
   );
 
   return {
-    fragmentId: range.startSentenceIndex,
-    id: range.id,
-    preview: createSnippet(range.text),
-    sentenceCount: range.endSentenceIndex - range.startSentenceIndex + 1,
-    text: range.text,
-    wordsCount: countWords(range.text),
+    fragment: {
+      fragmentId: range.startSentenceIndex,
+      id: range.id,
+      preview: createSnippet(range.text),
+      sentenceCount: range.endSentenceIndex - range.startSentenceIndex + 1,
+      text: range.text,
+      wordsCount: countWords(range.text),
+    },
+    ...(range.sourceEnd === undefined ? {} : { sourceEnd: range.sourceEnd }),
+    ...(range.sourceStart === undefined
+      ? {}
+      : { sourceStart: range.sourceStart }),
   };
 }
 
@@ -85,6 +95,8 @@ export async function readTextStreamRange(
 ): Promise<{
   readonly endSentenceIndex: number;
   readonly id: string;
+  readonly sourceEnd?: number;
+  readonly sourceStart?: number;
   readonly startSentenceIndex: number;
   readonly text: string;
 }> {
@@ -105,14 +117,26 @@ export async function readTextStreamRange(
   const start = clampInteger(startSentenceIndex, 0, lastSentenceIndex);
   const end = clampInteger(endSentenceIndex, start, lastSentenceIndex);
   const sentences = index.sentences.slice(start, end + 1);
+  const rawRange = await readTextStreamRawRange(
+    document,
+    chapterId,
+    stream,
+    start,
+    end,
+  );
   const text =
-    normalizeRenderedTextStreamRange(
-      await readTextStreamRawRange(document, chapterId, stream, start, end),
-    ) ?? joinTextStreamSentences(sentences);
+    normalizeRenderedTextStreamRange(rawRange?.text) ??
+    joinTextStreamSentences(sentences);
 
   return {
     endSentenceIndex: end,
     id: formatTextStreamRangeUri(chapterId, stream, start, end),
+    ...(rawRange?.sourceEnd === undefined
+      ? {}
+      : { sourceEnd: rawRange.sourceEnd }),
+    ...(rawRange?.sourceStart === undefined
+      ? {}
+      : { sourceStart: rawRange.sourceStart }),
     startSentenceIndex: start,
     text,
   };
@@ -141,10 +165,30 @@ async function readTextStreamRawRange(
   stream: ArchiveTextStreamKind,
   startSentenceIndex: number,
   endSentenceIndex: number,
-): Promise<string | undefined> {
+): Promise<
+  | {
+      readonly sourceEnd?: number;
+      readonly sourceStart?: number;
+      readonly text: string;
+    }
+  | undefined
+> {
   const serial = getTextStreamSerial(document, chapterId, stream);
+  const range = await serial.readTextInRangeWithOffsets?.(
+    startSentenceIndex,
+    endSentenceIndex,
+  );
 
-  return await serial.readTextInRange?.(startSentenceIndex, endSentenceIndex);
+  if (range !== undefined) {
+    return range;
+  }
+
+  const text = await serial.readTextInRange?.(
+    startSentenceIndex,
+    endSentenceIndex,
+  );
+
+  return text === undefined ? undefined : { text };
 }
 
 function getTextStreamSerial(

--- a/packages/core/src/retrieval/query/archive-view/types.ts
+++ b/packages/core/src/retrieval/query/archive-view/types.ts
@@ -1,6 +1,7 @@
 import type {
   MentionLinkRecord,
   MentionRecord,
+  SourceTextMapRecord,
 } from "../../../document/index.js";
 import type { BookMeta } from "../../../text/source/index.js";
 import type { GraphNeighbor } from "../../../graph/reading.js";
@@ -302,6 +303,7 @@ export type ArchivePage = ArchiveLibrarySourceFields &
         readonly nextFragmentId: string | undefined;
         readonly nodes: readonly ArchiveNodeLabel[];
         readonly previousFragmentId: string | undefined;
+        readonly provenance?: readonly SourceTextMapRecord[];
         readonly title: string;
         readonly type: "fragment";
       }

--- a/test/cli/archive/chapter.test.ts
+++ b/test/cli/archive/chapter.test.ts
@@ -401,6 +401,9 @@ describe("cli/archive-chapter", () => {
     expect(chapterMockState.textWrites[0]).toContain(
       "Chapter: wikg://chapter/c3d4e5f6a1b2\n",
     );
+    expect(chapterMockState.textWrites[0]).toContain(
+      "Located URI: wikg:///tmp/book.wikg/chapter/c3d4e5f6a1b2\n",
+    );
   });
 
   it("adds a chapter and prints JSON when requested", async () => {
@@ -415,6 +418,7 @@ describe("cli/archive-chapter", () => {
       childCount: 0,
       graphReady: false,
       hasSummary: false,
+      locatedUri: "wikg:///tmp/book.wikg/chapter/c3d4e5f6a1b2",
       sourceUnits: 2,
       stage: "planned",
       title: "New Chapter",
@@ -545,6 +549,21 @@ describe("cli/archive-chapter", () => {
       }),
     ).rejects.toThrow(
       "Missing input. Pass a positional value, use --input <path>, or use --input - for stdin.",
+    );
+
+    expect(chapterMockState.setSourceCalls).toStrictEqual([]);
+  });
+
+  it("explains every supported source input when source text is empty", async () => {
+    await expect(
+      runArchiveChapterCommand({
+        action: "set-source",
+        chapterPath: "a1b2c3d4e5f6/b2c3d4e5f6a1",
+        inputValue: "  \n",
+        path: "/tmp/book.wikg",
+      }),
+    ).rejects.toThrow(
+      "Source input is empty. Pass non-empty positional text, use --input <path>, or use --input - for stdin.",
     );
 
     expect(chapterMockState.setSourceCalls).toStrictEqual([]);

--- a/test/cli/archive/source-ingestion.test.ts
+++ b/test/cli/archive/source-ingestion.test.ts
@@ -49,6 +49,123 @@ interface TocItemLike {
 }
 
 describe("cli/archive/source-ingestion", () => {
+  it("returns a reusable chapter URI and exposes source provenance", async () => {
+    const digest = "a".repeat(64);
+    const firstText = "😀 First source sentence. ";
+    const secondText = "Second source sentence.";
+    const secondStart = Array.from(firstText).length;
+    const jsonl = [
+      JSON.stringify({
+        digest,
+        mediaType: "application/pdf",
+        name: "two-pages.pdf",
+        type: "artifact",
+      }),
+      JSON.stringify({
+        locator: { bbox: [0, 0, 0.5, 0.5], pageIndex: 1 },
+        text: firstText,
+        type: "text",
+      }),
+      JSON.stringify({
+        locator: { bbox: [0.5, 0.5, 1, 1], pageIndex: 2 },
+        text: secondText,
+        type: "text",
+      }),
+    ].join("\n");
+
+    await withTempDir("wikigraph-cli-source-provenance-", async (path) => {
+      const stateDir = resolve(path, "state");
+      const archivePath = resolve(path, "provenance.wikg");
+      const archiveUri = formatWikiGraphCommandUri(archivePath);
+
+      await runJsonCLI(stateDir, [archiveUri, "create", "--json"]);
+      const chapter = await runJsonCLI(stateDir, [
+        `${archiveUri}/chapter`,
+        "add",
+        "--title",
+        "Provenance",
+        "--json",
+      ]);
+      expect(chapter.uri).toMatch(/^wikg:\/\/chapter\//u);
+      const locatedChapterUri = requireString(chapter, "locatedUri");
+      expect(locatedChapterUri).toBe(
+        `${archiveUri}/chapter/${requireChapterPath(chapter)}`,
+      );
+
+      const sourceUri = `${locatedChapterUri}/source`;
+      await runJsonCLI(
+        stateDir,
+        [sourceUri, "set", "--input", "-", "--input-format", "jsonl", "--json"],
+        jsonl,
+      );
+
+      const wholeSource = await runJsonCLI(stateDir, [sourceUri, "--json"]);
+      expect(
+        requireProvenance(wholeSource).map((mapping) => ({
+          digest: mapping.artifact.digest,
+          locator: mapping.locator,
+          sourceEnd: mapping.sourceEnd,
+          sourceStart: mapping.sourceStart,
+        })),
+      ).toStrictEqual([
+        {
+          digest,
+          locator: { bbox: [0, 0, 0.5, 0.5], pageIndex: 1 },
+          sourceEnd: secondStart,
+          sourceStart: 0,
+        },
+        {
+          digest,
+          locator: { bbox: [0.5, 0.5, 1, 1], pageIndex: 2 },
+          sourceEnd: secondStart + Array.from(secondText).length,
+          sourceStart: secondStart,
+        },
+      ]);
+
+      const firstRange = await runJsonCLI(stateDir, [
+        `${sourceUri}#1`,
+        "--json",
+      ]);
+      expect(
+        requireProvenance(firstRange).map((mapping) => ({
+          digest: mapping.artifact.digest,
+          locator: mapping.locator,
+        })),
+      ).toStrictEqual([
+        {
+          digest,
+          locator: { bbox: [0, 0, 0.5, 0.5], pageIndex: 1 },
+        },
+      ]);
+      const secondRange = await runJsonCLI(stateDir, [
+        `${sourceUri}#2`,
+        "--json",
+      ]);
+      expect(
+        requireProvenance(secondRange).map((mapping) => ({
+          digest: mapping.artifact.digest,
+          locator: mapping.locator,
+        })),
+      ).toStrictEqual([
+        {
+          digest,
+          locator: { bbox: [0.5, 0.5, 1, 1], pageIndex: 2 },
+        },
+      ]);
+
+      await runJsonCLI(stateDir, [
+        locatedChapterUri,
+        "reset",
+        "--to",
+        "planned",
+        "--json",
+      ]);
+      await runJsonCLI(stateDir, [sourceUri, "set", "Plain source.", "--json"]);
+      const plainSource = await runJsonCLI(stateDir, [sourceUri, "--json"]);
+      expect(requireProvenance(plainSource)).toStrictEqual([]);
+    });
+  });
+
   it("sets a PDF source from JSONL through real CLI stdin", async () => {
     const jsonl = await readFile(NEWTON_JSONL_PATH, "utf8");
     const records = parseJsonl(jsonl);
@@ -315,4 +432,25 @@ function requireChapterPath(
     throw new Error("CLI chapter output did not contain a URI.");
   }
   return uri.replace(/^wikg:\/\/chapter\//u, "");
+}
+
+function requireString(
+  object: Readonly<Record<string, unknown>>,
+  key: string,
+): string {
+  const value = object[key];
+  if (typeof value !== "string") {
+    throw new Error(`CLI output did not contain string field ${key}.`);
+  }
+  return value;
+}
+
+function requireProvenance(
+  object: Readonly<Record<string, unknown>>,
+): readonly SourceTextMapRecord[] {
+  const value = object.provenance;
+  if (!Array.isArray(value)) {
+    throw new Error("CLI output did not contain a provenance array.");
+  }
+  return value as readonly SourceTextMapRecord[];
 }

--- a/test/cli/archive/source-ingestion.test.ts
+++ b/test/cli/archive/source-ingestion.test.ts
@@ -353,7 +353,7 @@ describe("cli/archive/source-ingestion", () => {
         ),
       ).toBe(true);
     });
-  });
+  }, 20_000);
 });
 
 async function runJsonCLI(


### PR DESCRIPTION
## 内容

- `chapter add` 同时返回短 URI 与可直接执行的 located URI
- source/source range 的结构化输出暴露当前 provenance 映射
- 修正空 source 与非法 `--input-format` 的错误提示
- 增加真实 CLI JSONL、范围读取与普通文本覆盖回归

## 验证

- `pnpm verify`
- `pnpm build`
- `pnpm test:run`（153 个测试文件，991 项测试）