### PR TITLE
为原文片段补充 Artifact Locator 映射

### DIFF
--- a/docs/en/wikg-standard.md
+++ b/docs/en/wikg-standard.md
@@ -258,16 +258,25 @@ The file layout is small, but the archive carries several semantic layers:
 
 - Source layer: `texts/source/*.txt`, chapter serials, and source sentence
   records.
-- Source provenance: source artifacts and format-specific locators are stored
-  in `database.db`; source text map ranges connect normalized source text
-  character offsets to those locators. Original PDF/EPUB files are never
-  stored in the archive.
+- Source provenance: a source artifact identifies an imported PDF or EPUB by
+  its file SHA-256 and has the archive-root URI `wikg://artifact/<digest>`.
+  A fragment selects a stored location in that artifact: `#epubcfi(...)` for
+  EPUB, or `#page=<page>&bbox=<left>,<bottom>,<right>,<top>` for PDF. PDF pages
+  are 1-based and bounding-box coordinates use the normalized `[0,1]`
+  lower-left coordinate space. The artifact metadata and locator records live
+  in `database.db`; original source files are not stored in the archive.
+- Source locator maps: source passages expose a compact `locators` map from
+  1-based inclusive Unicode-character ranges in the returned text to artifact
+  locator URIs. These character ranges are distinct from the sentence ranges
+  in source URIs such as `source#4..8`; gaps mean that no locator is stored for
+  those characters.
 - Reading Graph: chunks, reading edges, snakes, and sentence groups in
   `database.db`.
 - Knowledge Graph: mentions, mention links, entity projections, triple
   projections, and evidence references in `database.db`.
 - Summary layer: `texts/summary/*.txt` plus summary sentence records.
-- Search artifact layer: chapter index artifacts in `database.db`.
+- Search artifact layer: chapter index artifacts in `database.db`. These are
+  generated search data, distinct from imported source artifacts.
 - Metadata layer: archive, chapter, chunk, entity, and triple metadata in
   `database.db`, plus optional cover files.
 

--- a/docs/schema-upgrade.md
+++ b/docs/schema-upgrade.md
@@ -54,9 +54,11 @@ never stored them as important data.
 
 The v3 -> v4 archive upgrader adds the source provenance schema to
 `database.db`: `source_artifacts`, `source_locators`, `source_text_maps`, and
-their indexes. It preserves existing source/summary text and structured archive
-data; provenance tables are initialized in the extracted upgrade workspace and
-the resulting database is written back only by the explicit archive upgrader.
+their indexes. Locator fragments are persisted canonically and are unique
+within each source artifact. It preserves existing source/summary text and
+structured archive data; provenance tables are initialized in the extracted
+upgrade workspace and the resulting database is written back only by the
+explicit archive upgrader.
 
 Archive upgraders must refuse active coordinator state for the target archive
 and non-search-index overlays, because those can represent uncommitted important

--- a/docs/zh-CN/wikg-standard.md
+++ b/docs/zh-CN/wikg-standard.md
@@ -217,11 +217,12 @@ database.db-shm
 文件布局很小，但归档承载多个语义层：
 
 - Source layer：`texts/source/*.txt`、chapter serials 和 source sentence records。
-- Source provenance：source artifact 和格式专属 locator 存在 `database.db` 中；source text map 用映射范围把规范化 source text 的字符 offset 连接到这些 locator。原始 PDF/EPUB 文件不会存进归档。
+- Source provenance：source artifact 通过文件 SHA-256 标识导入的 PDF 或 EPUB，其归档根级 URI 为 `wikg://artifact/<digest>`。fragment 在 artifact 内选择已存位置：EPUB 使用 `#epubcfi(...)`，PDF 使用 `#page=<page>&bbox=<left>,<bottom>,<right>,<top>`。PDF 页码从 1 开始，bbox 使用左下角为原点的 `[0,1]` 归一化坐标。artifact 元数据与 locator 记录存放在 `database.db` 中；原始源文件不会存进归档。
+- Source locator map：原文片段通过紧凑的 `locators` map，把返回文本内从 1 开始、闭区间的 Unicode 字符范围映射到 artifact locator URI。这种字符范围不同于 `source#4..8` 里的句子范围；未覆盖区间表示没有保存 locator。
 - Reading Graph：`database.db` 中的 chunks、reading edges、snakes 和 sentence groups。
 - Knowledge Graph：`database.db` 中的 mentions、mention links、entity projections、triple projections 和 evidence references。
 - Summary layer：`texts/summary/*.txt` 加上 summary sentence records。
-- Search artifact layer：`database.db` 中的 chapter index artifacts。
+- Search artifact layer：`database.db` 中的 chapter index artifacts。这些是生成的搜索数据，与导入的 source artifact 不同。
 - Metadata layer：`database.db` 中的 archive、chapter、chunk、entity 和 triple metadata，以及可选 cover files。
 
 Reading Graph objects 和 Knowledge Graph objects 是不同层。Chunks 是阅读单元；entities 和 triples 是知识对象。Source text 是两者共同的 grounding layer。

--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -304,7 +304,7 @@ describe("cli/args/help", () => {
 
   it("rejects invalid help usage", () => {
     expect(() => parseCLIArguments(["help", "unknown"])).toThrow(
-      "Invalid help topic: unknown. Expected one of format, file-import, config, runtime, uri, recipe, readiness, library.\nSee: wg --help",
+      "Invalid help topic: unknown. Expected one of format, file-import, source-locators, config, runtime, uri, recipe, readiness, library.\nSee: wg --help",
     );
     expect(() =>
       parseCLIArguments(["help", "object", "entity", "extra"]),
@@ -375,9 +375,9 @@ describe("cli/args/help", () => {
     expect(fileImportHelpText).toContain("SHA-256 of source file bytes");
     expect(fileImportHelpText).toContain("`chapter add --json`");
     expect(fileImportHelpText).toContain(
-      "a ranged source read includes only mappings that overlap",
+      "The response includes a `locators` map for the returned text",
     );
-    expect(sourceHelpText).toContain("`uri`, `text`, and source `provenance`");
+    expect(sourceHelpText).toContain("`uri`, `text`, and a compact `locators`");
     expect(fileImportHelpText).toContain(
       "evidence cannot point back to a PDF page or EPUB CFI",
     );
@@ -398,10 +398,38 @@ describe("cli/args/help", () => {
     expect(rootHelpText).toContain("wg help readiness");
     expect(rootHelpText).toContain("wg help library");
     expect(rootHelpText).not.toContain("wg help file-import");
+    expect(rootHelpText).not.toContain("wg help source-locators");
     expect(fileImportHelpText).toContain("Source Files and Provenance");
     expect(fileImportHelpText).toContain("source-text map");
     expect(fileImportHelpText).toContain("OCR, layout analysis");
     expect(archiveCreateHelpText).toContain("wg help file-import");
+    const locatorHelpText = renderHelpTopicText("source-locators");
+    expect(locatorHelpText).toContain("wikg://artifact/<digest>");
+    expect(locatorHelpText).toContain("3..13 -> <artifact-locator-uri>");
+    expect(locatorHelpText).toContain("Unicode characters");
+    expect(
+      renderUriHelpText(
+        "artifact-object",
+        `wikg://book.wikg/artifact/${"a".repeat(64)}`,
+      ),
+    ).toContain("Source artifact object");
+    expect(
+      renderUriPredicateHelpText(
+        "entity-object",
+        "evidence",
+        "wikg://book.wikg/entity/Q1",
+      ),
+    ).toContain("wg help source-locators");
+    const libraryArtifactHelp = renderUriHelpText(
+      "artifact-object",
+      `wikg://lib/arc/archive123/artifact/${"a".repeat(64)}`,
+    );
+    expect(libraryArtifactHelp).toContain(
+      "wikg://lib/arc/<archive-id>/artifact/<digest>",
+    );
+    expect(libraryArtifactHelp).not.toContain(
+      "wikg://lib/arc/<archive-id>/entity",
+    );
     expect(rootHelpText).toContain("Core concepts:");
     expect(rootHelpText).toContain("knowledge-base archives");
     expect(rootHelpText).toContain("Do not edit archive internals:");
@@ -539,7 +567,7 @@ describe("cli/args/help", () => {
       "Use `--json` when an Agent or script needs one stable machine-readable response.",
     );
     expect(renderHelpTopicText("format")).toContain(
-      "Whole `source` and `summary` objects print plain text by default; with `--json`, source also returns `provenance`",
+      "Whole `source` and `summary` objects print plain text by default; with `--json`, source also returns `locators`",
     );
     expect(renderHelpTopicText("format")).toContain(
       "Ranged fragments such as `/source#20..30` and `/summary#20..30` use the same output choices and retain the requested range in `uri`.",
@@ -749,7 +777,7 @@ describe("cli/args/help", () => {
       "Use `--json` when you want stable Agent-readable fields",
     );
     expect(renderHelpTopicText("recipe")).toContain(
-      "Whole and ranged `source` reads return `uri`, `text`, and `provenance`",
+      "Whole and ranged `source` reads return `uri`, `text`, and `locators`",
     );
     expect(uriHelpText).toContain(
       "Ranged fragments such as `/source#4..8` and `/summary#4..8` are structured range objects.",
@@ -760,7 +788,7 @@ describe("cli/args/help", () => {
         "wikg://book.wikg/chapter/part/source",
       ),
     ).toContain(
-      "Whole and ranged source reads print text by default. With `--json`, they return one object containing `uri`, `text`, and source `provenance` mappings.",
+      "Whole and ranged source reads print text by default. With `--json`, they return one object containing `uri`, `text`, and a compact `locators` map.",
     );
     expect(
       renderUriHelpText(

--- a/packages/cli/src/args/help.ts
+++ b/packages/cli/src/args/help.ts
@@ -21,6 +21,7 @@ import { parseChapterTarget } from "./uri/chapter/target.js";
 export const HELP_TOPICS = [
   "format",
   "file-import",
+  "source-locators",
   "config",
   "runtime",
   "uri",
@@ -33,6 +34,7 @@ export type HelpTopic = (typeof HELP_TOPICS)[number];
 
 export type UriHelpTargetName =
   | "archive-scope"
+  | "artifact-object"
   | "chapter-collection-scope"
   | "chapter-scope"
   | "chapter-source-range-object"
@@ -97,6 +99,7 @@ const URI_HELP_TARGETS: readonly UriHelpTarget[] = [
     name: "archive-scope",
     predicates: ["create", "export", "inspect"],
   },
+  { name: "artifact-object", predicates: [] },
   {
     name: "chapter-collection-scope",
     predicates: ["add"],
@@ -187,6 +190,11 @@ const HELP_TOPIC_METADATA: readonly {
     summary: "Advanced source-file import and source-text provenance behavior.",
   },
   {
+    name: "source-locators",
+    rootVisible: false,
+    summary: "Source artifact URIs and source-text locator mappings.",
+  },
+  {
     name: "config",
     summary: "Configuration overview, precedence, and when each layer applies.",
   },
@@ -235,6 +243,7 @@ const ARCHIVE_MAINTENANCE_COMMAND_METADATA: readonly {
 const HELP_TOPIC_TEMPLATE_NAMES: Readonly<Record<HelpTopic, string>> = {
   format: "help/topics/format",
   "file-import": "help/topics/file-import",
+  "source-locators": "help/topics/source-locators",
   config: "help/topics/config",
   runtime: "help/topics/runtime",
   uri: "help/topics/uri",

--- a/packages/cli/src/args/uri/entry.ts
+++ b/packages/cli/src/args/uri/entry.ts
@@ -206,6 +206,9 @@ function classifyArchiveUriHelpTarget(uri: string): UriHelpTargetName {
   if (path === "index") {
     return "index-object";
   }
+  if (/^artifact\/[0-9a-f]{64}(?:#.+)?$/iu.test(path)) {
+    return "artifact-object";
+  }
   const chapterTarget = parseChapterTarget(objectUri);
   if (chapterTarget !== undefined) {
     switch (chapterTarget.kind) {

--- a/packages/cli/src/commands/archive-output/object/objects.ts
+++ b/packages/cli/src/commands/archive-output/object/objects.ts
@@ -161,6 +161,7 @@ export async function createFindObject(
           }),
         }),
     label: hit.title,
+    ...(hit.type === "source" ? { locators: hit.locators ?? {} } : {}),
     ...(isTextStreamOutputType(hit.type)
       ? { text: hit.snippet }
       : { type: hit.type === "node" ? "chunk" : hit.type }),
@@ -192,6 +193,7 @@ export function createSourceObject(
   return {
     ...createLibrarySourceObject(item),
     ...(item.score === undefined ? {} : { score: item.score }),
+    locators: item.locators ?? {},
     text: item.source,
     uri: item.id,
   };
@@ -232,6 +234,11 @@ export async function createPageObject(
   const librarySource = createLibrarySourceObject(page);
 
   switch (page.type) {
+    case "artifact": {
+      const { id: _id, type: _type, ...rest } = page;
+
+      return { ...librarySource, ...rest, uri: page.id };
+    }
     case "entity-wikipage":
       return {
         ...librarySource,
@@ -306,9 +313,9 @@ export async function createPageObject(
           ...(backlinks === undefined
             ? {}
             : { backlinks: await createBacklinksObject(backlinks, context) }),
-          ...(page.provenance === undefined
-            ? {}
-            : { provenance: page.provenance }),
+          ...(textStreamType === "source"
+            ? { locators: page.locators ?? {} }
+            : {}),
           text: page.fragment.text,
           uri: toWikiGraphUri(page.id),
         };

--- a/packages/cli/src/commands/archive-output/object/types.ts
+++ b/packages/cli/src/commands/archive-output/object/types.ts
@@ -1,4 +1,4 @@
-import type { QueryIndexScope, SourceTextMapRecord } from "wiki-graph-core";
+import type { QueryIndexScope } from "wiki-graph-core";
 import type { CLIArchiveArguments } from "../../../args/index.js";
 
 export type ResultFormat = "json" | "jsonl" | "text";
@@ -6,6 +6,11 @@ export type ResultFormat = "json" | "jsonl" | "text";
 export const DEFAULT_GET_EVIDENCE_LIMIT = 3;
 export const PLAIN_OBJECT_KEY_PRIORITY = [
   "uri",
+  "digest",
+  "mediaType",
+  "name",
+  "identifier",
+  "locator",
   "title",
   "label",
   "labels",
@@ -21,12 +26,17 @@ export interface ArchiveOutputObject {
   readonly authors?: readonly string[];
   readonly backlinks?: ArchiveOutputBacklinks;
   readonly description?: string;
+  readonly digest?: string;
   readonly evidence?: ArchiveOutputEvidencePreview;
   readonly label?: string;
+  readonly identifier?: string;
   readonly libraryArchiveUri?: string;
+  readonly locators?: Readonly<Record<string, string>>;
+  readonly locator?: Readonly<Record<string, unknown>>;
+  readonly mediaType?: string;
+  readonly name?: string;
   readonly objectLabel?: string;
   readonly predicate?: string;
-  readonly provenance?: readonly SourceTextMapRecord[];
   readonly publisher?: string;
   readonly score?: number;
   readonly state?: Record<string, string>;
@@ -72,6 +82,7 @@ export interface ArchiveOutputEvidencePreview {
 export interface ArchiveOutputSource {
   readonly archiveId?: number;
   readonly libraryArchiveUri?: string;
+  readonly locators: Readonly<Record<string, string>>;
   readonly score?: number;
   readonly text: string;
   readonly uri: string;

--- a/packages/cli/src/commands/archive-output/text/evidence.ts
+++ b/packages/cli/src/commands/archive-output/text/evidence.ts
@@ -14,7 +14,7 @@ export function formatEvidenceNextCursor(nextCursor: string | null): string {
 export function formatEvidenceItem(item: ArchiveEvidenceItem): string {
   return formatScoredLines(
     item.score,
-    formatSourceCitationBlock(item.id, item.source).split("\n"),
+    formatSourceCitationBlock(item.id, item.source, item.locators).split("\n"),
   ).join("\n");
 }
 

--- a/packages/cli/src/commands/archive-output/text/object.ts
+++ b/packages/cli/src/commands/archive-output/text/object.ts
@@ -99,6 +99,7 @@ function formatObjectSummaryLines(object: ArchiveOutputObject): string[] {
   ) {
     return [
       ...formatSourceObject({
+        locators: object.locators ?? {},
         text: object.text,
         uri: object.uri,
       }).split("\n"),

--- a/packages/cli/src/commands/archive-output/text/page.ts
+++ b/packages/cli/src/commands/archive-output/text/page.ts
@@ -160,6 +160,8 @@ export async function formatPackAnchor(
   context: ArchiveOutputContext,
 ): Promise<string> {
   switch (anchor.type) {
+    case "artifact":
+      return formatPlainObject(await createPageObject(anchor, context));
     case "chapter-title":
     case "chapter":
       return formatPlainObject(await createPageObject(anchor, context));

--- a/packages/cli/src/commands/archive-output/text/source.ts
+++ b/packages/cli/src/commands/archive-output/text/source.ts
@@ -1,37 +1,40 @@
 import type { ArchiveOutputSource } from "../object/types.js";
 
 export function formatSourceObject(source: ArchiveOutputSource): string {
-  return formatSourceCitationBlock(source.uri, source.text);
+  return formatSourceCitationBlock(source.uri, source.text, source.locators);
 }
 
-export function formatSourceCitationBlock(uri: string, text: string): string {
-  return [`@@ ${uri} @@`, normalizeSourceText(text)].join("\n");
+export function formatSourceCitationBlock(
+  uri: string,
+  text: string,
+  locators: Readonly<Record<string, string>> = {},
+): string {
+  const locatorLines = Object.entries(locators).map(
+    ([range, locator]) => `${range} -> ${locator}`,
+  );
+  // Locator ranges address the exact text below. Legacy whitespace cleanup is
+  // safe only when there is no map to invalidate.
+  const renderedText =
+    locatorLines.length === 0 ? normalizeUnmappedSourceText(text) : text;
+
+  return [
+    `@@ ${uri} @@`,
+    ...locatorLines,
+    ...(locatorLines.length === 0 ? [] : [""]),
+    renderedText,
+  ].join("\n");
 }
 
-function normalizeSourceText(text: string): string {
-  const lines = text.replace(/\r\n?/g, "\n").split("\n");
+function normalizeUnmappedSourceText(text: string): string {
+  const lines = text.replace(/\r\n?/gu, "\n").split("\n");
 
-  while (lines.length > 0 && lines[0]?.trim() === "") {
-    lines.shift();
-  }
-  while (lines.length > 0 && lines.at(-1)?.trim() === "") {
-    lines.pop();
-  }
+  while (lines.length > 0 && lines[0]?.trim() === "") lines.shift();
+  while (lines.length > 0 && lines.at(-1)?.trim() === "") lines.pop();
 
   const normalizedLines: string[] = [];
-  let previousLineWasBlank = false;
-
   for (const line of lines) {
-    if (line.trim() === "") {
-      if (!previousLineWasBlank) {
-        normalizedLines.push("");
-      }
-      previousLineWasBlank = true;
-      continue;
-    }
-
-    normalizedLines.push(line);
-    previousLineWasBlank = false;
+    if (line.trim() === "" && normalizedLines.at(-1) === "") continue;
+    normalizedLines.push(line.trim() === "" ? "" : line);
   }
 
   return normalizedLines.join("\n");

--- a/packages/cli/src/commands/archive-output/write/page.ts
+++ b/packages/cli/src/commands/archive-output/write/page.ts
@@ -39,6 +39,11 @@ export async function writePage(
   }
 
   switch (page.type) {
+    case "artifact":
+      await writeTextToStdout(
+        `${formatPlainObject(await createPageObject(page, context))}\n`,
+      );
+      return;
     case "chapter-title":
       await writeTextToStdout(
         `${formatPlainObject(await createPageObject(page, context))}\n`,

--- a/packages/core/data/help/commands/predicate.jinja
+++ b/packages/core/data/help/commands/predicate.jinja
@@ -37,6 +37,7 @@ Notes:
   - Add `--skip-unindexed` only with `--query` when you intentionally want to search indexed chapters and ignore uncovered chapters.
   - Without `--query`, `--reverse` reads Document Flow order backward. See `{{ commandName }} help uri`.
   - Evidence previews include nearby source context by default; use `--context 0` for exact cited ranges.
+  - When a source passage includes locator map lines or a JSON `locators` field, read `{{ commandName }} help source-locators`.
   - Source and scope URIs are not evidence targets.
 {% elif predicate == "pack" %}
 Purpose:

--- a/packages/core/data/help/commands/uri.jinja
+++ b/packages/core/data/help/commands/uri.jinja
@@ -111,6 +111,17 @@ Use when:
 {% if libraryContext.isLibraryWide %}
   - Open returned triple object URIs for `evidence`; expand related context through the subject or object entity.
 {% endif %}
+{% elif target.name == "artifact-object" %}
+URI type:
+  Source artifact object
+
+Default behavior:
+  - `{{ commandName }} {{ uri }}` reads the imported file identity and available metadata.
+  - An artifact fragment selects one stored PDF page box or EPUB CFI; it is not a separate object.
+
+Use when:
+  - A source passage returns an artifact locator URI and you need to inspect its source location.
+  - Read `{{ commandName }} help source-locators` for the mapping syntax.
 {% elif target.name == "chapter-source-object" %}
 URI type:
   Chapter source object
@@ -120,10 +131,11 @@ Default behavior:
   - Source range fragments such as `#4..8` read sentence numbers 4 through 8, inclusive.
   - Range fragments are read-only; `set` writes the complete source object.
   - Range sentence numbers are 1-based. `#1` is the first sentence; `#1..2` is the first two sentences.
-  - Whole and ranged source reads print text by default. With `--json`, they return one object containing `uri`, `text`, and source `provenance` mappings.
+  - Whole and ranged source reads print text by default. With `--json`, they return one object containing `uri`, `text`, and a compact `locators` map.
 
 Use when:
   - You need continuous original wording from a selected chapter.
+  - Read `{{ commandName }} help source-locators` when locator map lines are present.
 {% elif target.name == "chapter-source-range-object" %}
 URI type:
   Chapter source range object
@@ -131,10 +143,11 @@ URI type:
 Default behavior:
   - `{{ commandName }} {{ uri }}` reads a structured source sentence range.
   - Range sentence numbers are 1-based. `#1` is the first sentence; `#1..2` is the first two sentences.
-  - Source range fragments support `--json`; the result includes provenance mappings that overlap the selected text.
+  - Source range fragments support `--json`; the result includes a `locators` map clipped to the selected text.
 
 Use when:
   - You need bounded original wording with machine-readable range metadata.
+  - Read `{{ commandName }} help source-locators` when locator map lines are present.
 {% elif target.name == "chapter-summary-object" or target.name == "summary-object" %}
 URI type:
   Summary object
@@ -342,6 +355,8 @@ Library context:
 {% endif %}
   - Library archive shortcuts such as `wikg://lib/arc/<archive-id>/chapter` query or maintain one managed archive through its membership id.
   - Use a standalone archive URI or library archive shortcut for chapter maintenance writes.
+{% elif target.name == "artifact-object" %}
+  - A source artifact belongs to one archive. Use a library archive shortcut such as `wikg://lib/arc/<archive-id>/artifact/<digest>` to open it through library membership.
 {% elif target.name == "triple-scope" or target.name == "triple-object" %}
 {% if libraryContext.isLibraryWide %}
   - Library-wide scopes such as `wikg://lib/triple` use the aggregate library index.

--- a/packages/core/data/help/topics/file-import.jinja
+++ b/packages/core/data/help/topics/file-import.jinja
@@ -32,7 +32,7 @@ Minimal PDF example:
 
 Verification:
   {{ commandName }} <chapter-uri>/source --json
-  - The response includes stored provenance; a ranged source read includes only mappings that overlap the selected text.
+  - The response includes a `locators` map for the returned text. Read `{{ commandName }} help source-locators` for its compact range syntax.
 
 Boundaries:
   - OCR, layout analysis, and format-specific extraction belong to the importer; WG consumes the contract above.
@@ -45,3 +45,4 @@ See also:
   - {{ commandName }} wikg://book.wikg create --help
   - {{ commandName }} wikg://book.wikg/chapter/part/source set --help
   - {{ commandName }} help format
+  - {{ commandName }} help source-locators

--- a/packages/core/data/help/topics/format.jinja
+++ b/packages/core/data/help/topics/format.jinja
@@ -32,7 +32,7 @@ Command output shapes:
   - Default text output is for direct human reading and quick inspection.
   - Use `--json` when an Agent or script needs one stable machine-readable response.
   - Use `--jsonl` when a command returns many records, streams progress, or feeds a Unix pipeline.
-  - Whole `source` and `summary` objects print plain text by default; with `--json`, source also returns `provenance`, while summary returns `uri` and `text`.
+  - Whole `source` and `summary` objects print plain text by default; with `--json`, source also returns `locators`, while summary returns `uri` and `text`.
   - Ranged fragments such as `/source#20..30` and `/summary#20..30` use the same output choices and retain the requested range in `uri`.
   - Source and summary range numbers are 1-based and inclusive.
   - Commands that do not support `--json` or `--jsonl` say so in their command help or error message.

--- a/packages/core/data/help/topics/recipe.jinja
+++ b/packages/core/data/help/topics/recipe.jinja
@@ -10,7 +10,7 @@ Purpose:
 Operating rules:
   - Never unzip a `.wikg` archive, rewrite internal files, or bypass this CLI. Use CLI commands for archive edits.
   - Use Wiki Graph URIs as stable object handles.
-  - Use `--json` when you want stable Agent-readable fields instead of human text. Whole and ranged `source` reads return `uri`, `text`, and `provenance`; `summary` reads return `uri` and `text`.
+  - Use `--json` when you want stable Agent-readable fields instead of human text. Whole and ranged `source` reads return `uri`, `text`, and `locators`; `summary` reads return `uri` and `text`.
   - If you have a URI and need valid operations, run `{{ commandName }} <uri> --help`.
   - If you need concrete predicate usage for that URI type, run `{{ commandName }} <uri> <predicate> --help`.
   - Never pass a bare filesystem path to URI-targeted commands.

--- a/packages/core/data/help/topics/source-locators.jinja
+++ b/packages/core/data/help/topics/source-locators.jinja
@@ -1,0 +1,35 @@
+Help Type: topic
+Topic: source-locators
+
+Source Artifacts and Locator Maps
+
+Purpose:
+  Trace a returned source passage back to the imported file location that
+  produced it.
+
+Artifact URIs:
+  - A source artifact identifies an imported PDF or EPUB by the SHA-256 digest
+    of its file bytes: `wikg://artifact/<digest>`.
+  - It belongs to the archive, not to one chapter. Add the archive locator when
+    opening a returned short URI.
+  - A fragment selects a location inside that artifact. PDF uses
+    `#page=21&bbox=left,bottom,right,top`; EPUB uses `#epubcfi(...)`.
+  - PDF pages are 1-based. Bounding boxes use normalized `[0,1]` coordinates
+    in left,bottom,right,top order with a lower-left origin.
+
+Passage maps:
+  - Plain source passages print locator map lines between the `@@ source-uri @@`
+    header and the text: `3..13 -> <artifact-locator-uri>`.
+  - JSON and JSONL passages expose the same information as a `locators` object.
+  - Source URI fragments such as `source#4..8` count sentences. Locator map keys
+    count Unicode characters within the returned `text`; both are 1-based and
+    inclusive.
+  - Missing ranges mean those characters have no stored source locator.
+
+Reading details:
+  {{ commandName }} wikg://book.wikg/artifact/<digest>
+  {{ commandName }} 'wikg://book.wikg/artifact/<digest>#page=21&bbox=0.1,0.2,0.9,0.35'
+
+See also:
+  - {{ commandName }} help file-import
+  - {{ commandName }} help uri

--- a/packages/core/data/help/topics/uri.jinja
+++ b/packages/core/data/help/topics/uri.jinja
@@ -31,6 +31,7 @@ Library locators:
     wikg://lib/arc/<archive-id>/chapter
     wikg://lib/arc/<archive-id>/entity
     wikg://lib/arc/<archive-id>/triple
+    wikg://lib/arc/<archive-id>/artifact/<sha256-digest>
   - Library-wide scopes such as `wikg://lib/entity` query the aggregate library index.
   - Read `{{ commandName }} help library` before managing registry, membership, path binding, or library index lifecycle.
 
@@ -38,6 +39,7 @@ Short and located URIs:
   Commands may return short object URIs without local file paths:
     wikg://chapter/part/title
     wikg://chapter/part/source#4..8
+    wikg://artifact/<sha256-digest>#epubcfi(...)
     wikg://chunk/12
     wikg://entity/Q8018
     wikg://triple/Q8018/discusses/Q123
@@ -106,6 +108,7 @@ Object URIs:
     wikg://book.wikg/chapter/part/source#4..8
     wikg://book.wikg/chapter/part/summary
     wikg://book.wikg/chapter/part/summary#4..8
+    wikg://book.wikg/artifact/<sha256-digest>
     wikg://book.wikg/chapter/part/chunk/12
     wikg://book.wikg/chapter/part/entity/Q8018
     wikg://book.wikg/chapter/part/triple/Q8018/discusses/Q123

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -166,6 +166,7 @@ export type {
   ArchiveLibrarySource,
   ArchivePack,
   ArchivePage,
+  SourceLocatorMap,
   ArchiveRelatedResult,
   ArchiveTriplePattern,
 } from "../retrieval/query/index.js";

--- a/packages/core/src/document/index.ts
+++ b/packages/core/src/document/index.ts
@@ -25,6 +25,13 @@ export type {
 } from "./directory/index.js";
 export { SCHEMA_SQL } from "./schema.js";
 export {
+  formatSourceArtifactUri,
+  formatSourceLocatorFragment,
+  normalizeSourceArtifactDigest,
+  parseSourceLocatorFragment,
+} from "./source-locator.js";
+export type { ParsedSourceLocatorFragment } from "./source-locator.js";
+export {
   ChunkStore,
   FragmentGroupStore,
   GraphBuildParameterStore,
@@ -83,6 +90,7 @@ export type {
   SerialRecord,
   SourceArtifactInput,
   SourceArtifactRecord,
+  SourceLocatorRecord,
   SourceTextMapRecord,
   SourceTextMappingInput,
   SourceTextProvenanceInput,

--- a/packages/core/src/document/schema.ts
+++ b/packages/core/src/document/schema.ts
@@ -304,7 +304,9 @@ export const SCHEMA_SQL = `
   CREATE TABLE IF NOT EXISTS source_locators (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     artifact_id INTEGER NOT NULL,
+    fragment TEXT NOT NULL,
     value_json TEXT NOT NULL,
+    UNIQUE(artifact_id, fragment),
     FOREIGN KEY (artifact_id) REFERENCES source_artifacts(id)
   );
 

--- a/packages/core/src/document/source-locator.ts
+++ b/packages/core/src/document/source-locator.ts
@@ -1,0 +1,160 @@
+const SOURCE_ARTIFACT_DIGEST_PATTERN = /^[0-9a-f]{64}$/iu;
+
+export interface ParsedSourceLocatorFragment {
+  readonly fragment: string;
+  readonly locator: Readonly<Record<string, unknown>>;
+  readonly mediaType: "application/epub+zip" | "application/pdf";
+}
+
+export function normalizeSourceArtifactDigest(value: string): string {
+  if (!SOURCE_ARTIFACT_DIGEST_PATTERN.test(value)) {
+    throw new Error(
+      "Source artifact digest must be exactly 64 hex characters.",
+    );
+  }
+
+  return value.toLowerCase();
+}
+
+export function formatSourceArtifactUri(
+  digest: string,
+  fragment?: string,
+): string {
+  const normalizedDigest = normalizeSourceArtifactDigest(digest);
+
+  return `wikg://artifact/${normalizedDigest}${
+    fragment === undefined ? "" : `#${fragment}`
+  }`;
+}
+
+export function formatSourceLocatorFragment(
+  mediaType: string,
+  locator: Readonly<Record<string, unknown>>,
+): string {
+  if (mediaType === "application/pdf") {
+    return formatPdfLocatorFragment(locator);
+  }
+  if (mediaType === "application/epub+zip") {
+    return formatEpubLocatorFragment(locator);
+  }
+
+  throw new Error(`Unsupported source artifact mediaType ${mediaType}.`);
+}
+
+export function parseSourceLocatorFragment(
+  value: string,
+): ParsedSourceLocatorFragment {
+  if (isSyntacticallyValidCfi(value)) {
+    return {
+      fragment: value,
+      locator: { cfi: value },
+      mediaType: "application/epub+zip",
+    };
+  }
+
+  const match =
+    /^page=([1-9][0-9]*)&bbox=([^,]+),([^,]+),([^,]+),([^,]+)$/u.exec(value);
+  if (match === null) {
+    throw new Error(`Invalid source artifact locator fragment: ${value}`);
+  }
+
+  const pageIndex = Number(match[1]);
+  const bbox = match.slice(2).map(Number);
+  const locator = { bbox, pageIndex };
+
+  return {
+    fragment: formatPdfLocatorFragment(locator),
+    locator,
+    mediaType: "application/pdf",
+  };
+}
+
+function formatPdfLocatorFragment(
+  locator: Readonly<Record<string, unknown>>,
+): string {
+  const pageIndex = locator.pageIndex;
+  const bbox = locator.bbox;
+  if (!Number.isInteger(pageIndex) || (pageIndex as number) < 1) {
+    throw new Error("PDF locator pageIndex must be a 1-based integer.");
+  }
+  if (
+    !Array.isArray(bbox) ||
+    bbox.length !== 4 ||
+    !bbox.every(
+      (coordinate) =>
+        typeof coordinate === "number" &&
+        Number.isFinite(coordinate) &&
+        coordinate >= 0 &&
+        coordinate <= 1,
+    )
+  ) {
+    throw new Error(
+      "PDF locator bbox must contain four finite numbers in [0, 1].",
+    );
+  }
+  const [left, bottom, right, top] = bbox as [number, number, number, number];
+  if (left > right || bottom > top) {
+    throw new Error("PDF locator bbox must be [left, bottom, right, top].");
+  }
+
+  return `page=${String(pageIndex)}&bbox=${bbox
+    .map((coordinate) => String(Object.is(coordinate, -0) ? 0 : coordinate))
+    .join(",")}`;
+}
+
+function formatEpubLocatorFragment(
+  locator: Readonly<Record<string, unknown>>,
+): string {
+  if (
+    typeof locator.cfi !== "string" ||
+    !isSyntacticallyValidCfi(locator.cfi)
+  ) {
+    throw new Error(
+      "EPUB locator cfi must be a syntactically valid epubcfi(...).",
+    );
+  }
+
+  return locator.cfi;
+}
+
+function isSyntacticallyValidCfi(value: string): boolean {
+  if (!value.startsWith("epubcfi(") || !value.endsWith(")")) return false;
+  const body = value.slice("epubcfi(".length, -1);
+  if (!body.startsWith("/")) return false;
+
+  const step = /\/\d+(?:\[[^\r\n]*\])?/gu;
+  let cursor = 0;
+  while (cursor < body.length) {
+    if (body[cursor] === "/") {
+      step.lastIndex = cursor;
+      const match = step.exec(body);
+      if (match === null || match.index !== cursor) return false;
+      cursor = step.lastIndex;
+      continue;
+    }
+    if (body[cursor] === "!") {
+      cursor += 1;
+      continue;
+    }
+    if (body[cursor] === ":" || body[cursor] === "@" || body[cursor] === "~") {
+      const match = /^(?::\d+|@\d+(?::\d+)?|~\d+(?:@\d+(?::\d+)?)?)/u.exec(
+        body.slice(cursor),
+      );
+      if (match === null) return false;
+      cursor += match[0].length;
+      if (body[cursor] === "[") {
+        const assertionEnd = body.indexOf("]", cursor + 1);
+        if (assertionEnd < 0) return false;
+        cursor = assertionEnd + 1;
+      }
+      continue;
+    }
+    if (body[cursor] === ",") {
+      cursor += 1;
+      continue;
+    }
+    return false;
+  }
+
+  return cursor > 0;
+}

--- a/packages/core/src/document/stores/source-provenance.ts
+++ b/packages/core/src/document/stores/source-provenance.ts
@@ -1,8 +1,13 @@
 import { bytesToHex, hexToBytes } from "../../utils/bytes.js";
 import { getNumber, getOptionalString, getString } from "../database.js";
-import type { Database } from "../database.js";
+import type { Database, SqlRow } from "../database.js";
+import {
+  formatSourceLocatorFragment,
+  normalizeSourceArtifactDigest,
+} from "../source-locator.js";
 import type {
   SourceArtifactRecord,
+  SourceLocatorRecord,
   SourceTextMapRecord,
   SourceTextProvenanceInput,
 } from "../types.js";
@@ -15,6 +20,51 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
     this.#database = database;
   }
 
+  public async getArtifact(
+    digestValue: string,
+  ): Promise<SourceArtifactRecord | undefined> {
+    const digest = normalizeSourceArtifactDigest(digestValue);
+
+    return await this.#database.queryOne(
+      `
+        SELECT id, digest, media_type, name, identifier
+        FROM source_artifacts
+        WHERE digest = ?
+      `,
+      [hexToBytes(digest)],
+      mapArtifactRecord,
+    );
+  }
+
+  public async getLocator(
+    digestValue: string,
+    fragment: string,
+  ): Promise<SourceLocatorRecord | undefined> {
+    const digest = normalizeSourceArtifactDigest(digestValue);
+
+    return await this.#database.queryOne(
+      `
+        SELECT
+          source_artifacts.digest AS digest,
+          source_artifacts.media_type AS media_type,
+          source_artifacts.name AS name,
+          source_artifacts.identifier AS identifier,
+          source_locators.fragment AS fragment,
+          source_locators.value_json AS value_json
+        FROM source_locators
+        JOIN source_artifacts
+          ON source_artifacts.id = source_locators.artifact_id
+        WHERE source_artifacts.digest = ? AND source_locators.fragment = ?
+      `,
+      [hexToBytes(digest), fragment],
+      (row) => ({
+        artifact: mapArtifactRecordWithoutId(row),
+        fragment: getString(row, "fragment"),
+        locator: parseLocator(getString(row, "value_json")),
+      }),
+    );
+  }
+
   public async listArtifacts(): Promise<SourceArtifactRecord[]> {
     return await this.#database.queryAll(
       `
@@ -23,17 +73,7 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
         ORDER BY id
       `,
       undefined,
-      (row) => {
-        const identifier = getOptionalString(row, "identifier");
-        const name = getOptionalString(row, "name");
-        return {
-          digest: readDigest(row.digest),
-          id: getNumber(row, "id"),
-          ...(identifier === undefined ? {} : { identifier }),
-          mediaType: getString(row, "media_type"),
-          ...(name === undefined ? {} : { name }),
-        };
-      },
+      mapArtifactRecord,
     );
   }
 
@@ -48,6 +88,7 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
           source_artifacts.media_type AS media_type,
           source_artifacts.name AS name,
           source_artifacts.identifier AS identifier,
+          source_locators.fragment AS fragment,
           source_locators.value_json AS value_json
         FROM source_text_maps
         JOIN source_locators
@@ -68,6 +109,7 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
             mediaType: getString(row, "media_type"),
             ...(name === undefined ? {} : { name }),
           },
+          fragment: getString(row, "fragment"),
           locator: parseLocator(getString(row, "value_json")),
           sourceEnd: getNumber(row, "source_end"),
           sourceRevision: getNumber(row, "source_revision"),
@@ -90,7 +132,7 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
         const artifactIds = new Map<string, number>();
 
         for (const artifact of input.artifacts) {
-          const digest = normalizeDigest(artifact.digest);
+          const digest = normalizeSourceArtifactDigest(artifact.digest);
           const existing = await this.#database.queryOne(
             `
               SELECT id, media_type
@@ -169,7 +211,7 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
               "Source text map offsets must be non-negative integer ranges.",
             );
           }
-          const digest = normalizeDigest(mapping.artifactDigest);
+          const digest = normalizeSourceArtifactDigest(mapping.artifactDigest);
           const artifactId = artifactIds.get(digest);
 
           if (artifactId === undefined) {
@@ -178,14 +220,40 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
             );
           }
 
+          const artifact = input.artifacts.find(
+            (candidate) =>
+              normalizeSourceArtifactDigest(candidate.digest) === digest,
+          );
+          if (artifact === undefined) {
+            throw new Error(
+              `Source mapping references undeclared artifact ${digest}.`,
+            );
+          }
+          const fragment = formatSourceLocatorFragment(
+            artifact.mediaType,
+            mapping.locator,
+          );
+
           await this.#database.run(
             `
-              INSERT INTO source_locators (artifact_id, value_json)
-              VALUES (?, ?)
+              INSERT INTO source_locators (artifact_id, fragment, value_json)
+              VALUES (?, ?, ?)
+              ON CONFLICT(artifact_id, fragment) DO NOTHING
             `,
-            [artifactId, JSON.stringify(mapping.locator)],
+            [artifactId, fragment, JSON.stringify(mapping.locator)],
           );
-          const locatorId = await this.#database.getLastInsertRowId();
+          const locatorId = await this.#database.queryOne(
+            `
+              SELECT id
+              FROM source_locators
+              WHERE artifact_id = ? AND fragment = ?
+            `,
+            [artifactId, fragment],
+            (row) => getNumber(row, "id"),
+          );
+          if (locatorId === undefined) {
+            throw new Error("Failed to persist source locator.");
+          }
 
           await this.#database.run(
             `
@@ -226,7 +294,7 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
     const seen = new Map<string, string>();
     const declared = new Set<string>();
     for (const artifact of input.artifacts) {
-      const digest = normalizeDigest(artifact.digest);
+      const digest = normalizeSourceArtifactDigest(artifact.digest);
       if (artifact.mediaType.length === 0) {
         throw new Error("Source artifact mediaType must not be empty.");
       }
@@ -246,6 +314,11 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
         );
       }
       seen.set(digest, artifact.mediaType);
+      for (const mapping of input.mappings) {
+        if (normalizeSourceArtifactDigest(mapping.artifactDigest) === digest) {
+          formatSourceLocatorFragment(artifact.mediaType, mapping.locator);
+        }
+      }
       const existing = await this.#database.queryOne(
         `SELECT media_type FROM source_artifacts WHERE digest = ?`,
         [hexToBytes(digest)],
@@ -277,35 +350,38 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
           "Source text map offsets must be non-negative character ranges within source text.",
         );
       }
-      if (!declared.has(normalizeDigest(mapping.artifactDigest))) {
+      if (
+        !declared.has(normalizeSourceArtifactDigest(mapping.artifactDigest))
+      ) {
         throw new Error(
           `Source mapping references undeclared artifact ${mapping.artifactDigest}.`,
         );
       }
     }
+
+    const orderedMappings = input.mappings
+      .filter((mapping) => mapping.sourceEnd > mapping.sourceStart)
+      .slice()
+      .sort(
+        (left, right) =>
+          left.sourceStart - right.sourceStart ||
+          left.sourceEnd - right.sourceEnd,
+      );
+    for (let index = 1; index < orderedMappings.length; index += 1) {
+      if (
+        orderedMappings[index]!.sourceStart <
+        orderedMappings[index - 1]!.sourceEnd
+      ) {
+        throw new Error("Source text map ranges must not overlap.");
+      }
+    }
   }
 
   async #deleteSerialRecords(serialId: number): Promise<void> {
-    const locatorIds = await this.#database.queryAll(
-      `
-        SELECT locator_id
-        FROM source_text_maps
-        WHERE serial_id = ?
-      `,
-      [serialId],
-      (row) => getNumber(row, "locator_id"),
-    );
-
     await this.#database.run(
       `DELETE FROM source_text_maps WHERE serial_id = ?`,
       [serialId],
     );
-
-    for (const locatorId of locatorIds) {
-      await this.#database.run(`DELETE FROM source_locators WHERE id = ?`, [
-        locatorId,
-      ]);
-    }
   }
 
   async #deleteUnreferenced(): Promise<void> {
@@ -332,21 +408,32 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
   }
 }
 
-function normalizeDigest(value: string): string {
-  if (!/^[0-9a-f]{64}$/iu.test(value)) {
-    throw new Error(
-      "Source artifact digest must be exactly 64 hex characters.",
-    );
-  }
-
-  return value.toLowerCase();
-}
-
 function readDigest(value: unknown): string {
   if (value instanceof Uint8Array) {
     return bytesToHex(value);
   }
   throw new TypeError("Expected source artifact digest to be binary");
+}
+
+function mapArtifactRecord(row: SqlRow): SourceArtifactRecord {
+  return {
+    ...mapArtifactRecordWithoutId(row),
+    id: getNumber(row, "id"),
+  };
+}
+
+function mapArtifactRecordWithoutId(
+  row: SqlRow,
+): Omit<SourceArtifactRecord, "id"> {
+  const identifier = getOptionalString(row, "identifier");
+  const name = getOptionalString(row, "name");
+
+  return {
+    digest: readDigest(row.digest),
+    ...(identifier === undefined ? {} : { identifier }),
+    mediaType: getString(row, "media_type"),
+    ...(name === undefined ? {} : { name }),
+  };
 }
 
 function parseLocator(value: string): Readonly<Record<string, unknown>> {

--- a/packages/core/src/document/stores/types.ts
+++ b/packages/core/src/document/stores/types.ts
@@ -15,10 +15,16 @@ import type {
   SnakeEdgeRecord,
   SnakeRecord,
   SourceArtifactRecord,
+  SourceLocatorRecord,
   SourceTextMapRecord,
 } from "../types.js";
 
 export interface ReadonlySourceProvenanceStore {
+  getArtifact(digest: string): Promise<SourceArtifactRecord | undefined>;
+  getLocator(
+    digest: string,
+    fragment: string,
+  ): Promise<SourceLocatorRecord | undefined>;
   listArtifacts(): Promise<SourceArtifactRecord[]>;
   listMap(serialId: number): Promise<SourceTextMapRecord[]>;
 }

--- a/packages/core/src/document/types.ts
+++ b/packages/core/src/document/types.ts
@@ -101,10 +101,17 @@ export interface SourceTextProvenanceInput {
 
 export interface SourceTextMapRecord {
   readonly artifact: Omit<SourceArtifactRecord, "id">;
+  readonly fragment: string;
   readonly locator: Readonly<Record<string, unknown>>;
   readonly sourceEnd: number;
   readonly sourceRevision: number;
   readonly sourceStart: number;
+}
+
+export interface SourceLocatorRecord {
+  readonly artifact: Omit<SourceArtifactRecord, "id">;
+  readonly fragment: string;
+  readonly locator: Readonly<Record<string, unknown>>;
 }
 
 export interface GraphBuildParameterRecord {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -209,7 +209,11 @@ export type {
 } from "./storage/wikg/index.js";
 export {
   DirectoryDocument,
+  formatSourceArtifactUri,
+  formatSourceLocatorFragment,
+  normalizeSourceArtifactDigest,
   openSharedStateDatabase,
+  parseSourceLocatorFragment,
 } from "./document/index.js";
 export type {
   Database,
@@ -217,6 +221,7 @@ export type {
   ReadonlyDocument,
   SourceArtifactInput,
   SourceArtifactRecord,
+  SourceLocatorRecord,
   SourceTextMapRecord,
   SourceTextMappingInput,
   SourceTextProvenanceInput,
@@ -326,6 +331,7 @@ export type {
   ArchiveObjectType,
   ArchivePack,
   ArchivePage,
+  SourceLocatorMap,
   ArchiveRelatedResult,
   ArchiveTriplePattern,
   ContinuationCursor,

--- a/packages/core/src/library/registry.ts
+++ b/packages/core/src/library/registry.ts
@@ -292,6 +292,7 @@ function formatWikiGraphUriFragment(
   fragment:
     | number
     | { readonly begin: number; readonly end: number }
+    | { readonly raw: string }
     | undefined,
 ): string | undefined {
   if (fragment === undefined) {
@@ -299,6 +300,9 @@ function formatWikiGraphUriFragment(
   }
   if (typeof fragment === "number") {
     return String(fragment);
+  }
+  if ("raw" in fragment) {
+    return fragment.raw;
   }
 
   return `${fragment.begin}..${fragment.end}`;

--- a/packages/core/src/retrieval/query/archive-view/evidence-hydration.ts
+++ b/packages/core/src/retrieval/query/archive-view/evidence-hydration.ts
@@ -161,7 +161,7 @@ async function hydrateTextStreamHitContext(
   sourceContext: number,
   context: EvidenceReadContext,
 ): Promise<ArchiveFindHit> {
-  if (sourceContext <= 0 || (hit.type !== "source" && hit.type !== "summary")) {
+  if (hit.type !== "source" && hit.type !== "summary") {
     return hit;
   }
   if (hit.matchCount === undefined && hit.matchedTerms === undefined) {
@@ -186,6 +186,7 @@ async function hydrateTextStreamHitContext(
   return {
     ...hit,
     id: range.id,
+    locators: range.locators,
     snippet: range.text,
   };
 }
@@ -339,6 +340,7 @@ async function mergeTextStreamHitRangeGroup(
     hit: {
       ...representative.hit,
       id: text.id,
+      locators: text.locators,
       matchCount: Math.max(...hits.map((hit) => hit.matchCount ?? 0)),
       matchedTerms: mergeStringLists(
         hits.flatMap((hit) => hit.matchedTerms ?? []),

--- a/packages/core/src/retrieval/query/archive-view/evidence-hydration.ts
+++ b/packages/core/src/retrieval/query/archive-view/evidence-hydration.ts
@@ -33,6 +33,7 @@ export async function hydrateFindHitEvidence(
   document: ReadonlyDocument,
   hits: readonly ArchiveFindHit[],
   options: {
+    readonly coalesceTextStreams?: boolean;
     readonly evidenceLimit?: number;
     readonly order?: ArchiveFindOrder;
     readonly sessionId?: string;
@@ -116,7 +117,9 @@ export async function hydrateFindHitEvidence(
     }),
   );
 
-  return await coalesceTextStreamFindHits(document, hydrated, evidenceContext);
+  return options.coalesceTextStreams === false
+    ? hydrated
+    : await coalesceTextStreamFindHits(document, hydrated, evidenceContext);
 }
 
 async function hydrateEntityDisplayHit(

--- a/packages/core/src/retrieval/query/archive-view/evidence.ts
+++ b/packages/core/src/retrieval/query/archive-view/evidence.ts
@@ -40,6 +40,7 @@ export async function listArchiveEvidence(
   }
 
   switch (reference.type) {
+    case "artifact":
     case "chapter":
     case "chapter-title":
     case "chapter-state":

--- a/packages/core/src/retrieval/query/archive-view/index.ts
+++ b/packages/core/src/retrieval/query/archive-view/index.ts
@@ -69,5 +69,6 @@ export type {
   ArchiveRelatedResult,
   ArchiveRelatedRole,
   ArchiveSourceFragment,
+  SourceLocatorMap,
   ArchiveTriplePattern,
 } from "./types.js";

--- a/packages/core/src/retrieval/query/archive-view/pages.ts
+++ b/packages/core/src/retrieval/query/archive-view/pages.ts
@@ -1,6 +1,7 @@
-import type {
-  ReadonlyDocument,
-  SourceTextMapRecord,
+import {
+  formatSourceArtifactUri,
+  parseSourceLocatorFragment,
+  type ReadonlyDocument,
 } from "../../../document/index.js";
 import { parseWikiGraphUriSyntax } from "../../../runtime/common/wiki-graph/uri.js";
 import {
@@ -255,6 +256,7 @@ function formatParsedUriFragment(
   fragment:
     | number
     | { readonly begin: number; readonly end: number }
+    | { readonly raw: string }
     | undefined,
 ): string | undefined {
   if (fragment === undefined) {
@@ -262,6 +264,9 @@ function formatParsedUriFragment(
   }
   if (typeof fragment === "number") {
     return String(fragment);
+  }
+  if ("raw" in fragment) {
+    return fragment.raw;
   }
 
   return `${fragment.begin}..${fragment.end}`;
@@ -278,6 +283,57 @@ async function readWikiGraphPage(
   const reference = parseWikiGraphReference(uri);
 
   switch (reference.type) {
+    case "artifact": {
+      const artifact = await document.sourceProvenance.getArtifact(
+        reference.digest,
+      );
+      if (artifact === undefined) {
+        throw new Error(
+          `Source artifact ${formatSourceArtifactUri(reference.digest)} was not found in this archive.`,
+        );
+      }
+
+      if (reference.fragment === undefined) {
+        return {
+          digest: artifact.digest,
+          id: formatSourceArtifactUri(artifact.digest),
+          ...(artifact.identifier === undefined
+            ? {}
+            : { identifier: artifact.identifier }),
+          mediaType: artifact.mediaType,
+          ...(artifact.name === undefined ? {} : { name: artifact.name }),
+          type: "artifact",
+        };
+      }
+
+      const parsedLocator = parseSourceLocatorFragment(reference.fragment);
+      if (parsedLocator.mediaType !== artifact.mediaType) {
+        throw new Error(
+          `Source locator ${reference.fragment} does not match artifact mediaType ${artifact.mediaType}.`,
+        );
+      }
+      const locator = await document.sourceProvenance.getLocator(
+        artifact.digest,
+        parsedLocator.fragment,
+      );
+      if (locator === undefined) {
+        throw new Error(
+          `Source locator ${formatSourceArtifactUri(artifact.digest, parsedLocator.fragment)} was not found in this archive.`,
+        );
+      }
+
+      return {
+        digest: artifact.digest,
+        id: formatSourceArtifactUri(artifact.digest, parsedLocator.fragment),
+        ...(artifact.identifier === undefined
+          ? {}
+          : { identifier: artifact.identifier }),
+        locator: locator.locator,
+        mediaType: artifact.mediaType,
+        ...(artifact.name === undefined ? {} : { name: artifact.name }),
+        type: "artifact",
+      };
+    }
     case "meta":
       return await readArchivePage(document, ARCHIVE_ROOT_ID, options);
     case "chapter":
@@ -411,18 +467,10 @@ async function readWikiGraphPage(
       );
     }
     case "text-stream": {
-      const { fragment, sourceEnd, sourceStart } =
-        await createTextStreamRangeFragment(document, reference);
-      const provenance =
-        reference.stream === "source"
-          ? await listSourceRangeProvenance(
-              document,
-              reference.chapterId,
-              sourceStart,
-              sourceEnd,
-              !Number.isFinite(reference.endSentenceIndex),
-            )
-          : undefined;
+      const { fragment, locators } = await createTextStreamRangeFragment(
+        document,
+        reference,
+      );
       return {
         ...(options.backlinks === true
           ? { backlinks: await createTextStreamBacklinks(document, reference) }
@@ -432,38 +480,10 @@ async function readWikiGraphPage(
         nextFragmentId: undefined,
         nodes: [],
         previousFragmentId: undefined,
-        ...(provenance === undefined ? {} : { provenance }),
+        ...(reference.stream === "source" ? { locators } : {}),
         title: displayUri,
         type: "fragment",
       };
     }
   }
-}
-
-async function listSourceRangeProvenance(
-  document: ReadonlyDocument,
-  chapterId: number,
-  sourceStart: number | undefined,
-  sourceEnd: number | undefined,
-  wholeSource: boolean,
-): Promise<readonly SourceTextMapRecord[]> {
-  const [mappings, sourceRevision] = await Promise.all([
-    document.sourceProvenance.listMap(chapterId),
-    document.serials.getRevision(chapterId),
-  ]);
-  const currentMappings = mappings.filter(
-    (mapping) => mapping.sourceRevision === sourceRevision,
-  );
-
-  if (wholeSource) {
-    return currentMappings;
-  }
-  if (sourceStart === undefined || sourceEnd === undefined) {
-    return [];
-  }
-
-  return currentMappings.filter(
-    (mapping) =>
-      mapping.sourceStart < sourceEnd && mapping.sourceEnd > sourceStart,
-  );
 }

--- a/packages/core/src/retrieval/query/archive-view/references.ts
+++ b/packages/core/src/retrieval/query/archive-view/references.ts
@@ -53,6 +53,11 @@ export function formatTextStreamRangeUri(
 
 export type WikiGraphReference =
   | {
+      readonly digest: string;
+      readonly fragment?: string;
+      readonly type: "artifact";
+    }
+  | {
       readonly type: "meta";
     }
   | {
@@ -147,6 +152,18 @@ export function parseWikiGraphReference(uri: string): WikiGraphReference {
   }
 
   switch (pathParts[0]) {
+    case "artifact":
+      if (pathParts.length === 2) {
+        const digest = pathParts[1];
+        if (digest !== undefined && /^[0-9a-f]{64}$/iu.test(digest)) {
+          return {
+            digest: digest.toLowerCase(),
+            ...(hash === "" ? {} : { fragment: hash }),
+            type: "artifact",
+          };
+        }
+      }
+      break;
     case "chapter":
       if (pathParts.length === 2) {
         return {
@@ -333,6 +350,9 @@ function formatParsedFragment(
   }
   if (typeof fragment === "number") {
     return String(fragment);
+  }
+  if ("raw" in fragment) {
+    return fragment.raw;
   }
 
   return `${fragment.begin}..${fragment.end}`;

--- a/packages/core/src/retrieval/query/archive-view/related/core.ts
+++ b/packages/core/src/retrieval/query/archive-view/related/core.ts
@@ -131,6 +131,7 @@ async function listRelatedWikiGraphObjects(
   const reference = parseWikiGraphReference(uri);
 
   switch (reference.type) {
+    case "artifact":
     case "chapter": {
       throw new Error(`Related is not available for scope URI: ${uri}`);
     }

--- a/packages/core/src/retrieval/query/archive-view/search/core.ts
+++ b/packages/core/src/retrieval/query/archive-view/search/core.ts
@@ -392,13 +392,21 @@ async function findTextOnlyArchiveObjectsIndexed(
 ): Promise<ArchiveFindResult> {
   const indexed = await findArchiveObjectsIndexed(document, query, options);
   const hits = indexed?.hits ?? [];
-
-  return createFindResult(
+  const result = createFindResult(
     query,
     filterLexicalHitsByMatch(hits, search, options.match ?? "any"),
     options,
     indexed?.result.terms ?? search.terms,
   );
+
+  return {
+    ...result,
+    items: await hydrateFindHitEvidence(document, result.items, {
+      ...createFindEvidenceHydrationOptions(options),
+      coalesceTextStreams: false,
+      sourceContext: 0,
+    }),
+  };
 }
 
 async function createSearchRevisionScope(

--- a/packages/core/src/retrieval/query/archive-view/search/hydration.ts
+++ b/packages/core/src/retrieval/query/archive-view/search/hydration.ts
@@ -304,6 +304,7 @@ export async function hydrateSearchTextHit(
     hit.sentenceIndex,
     hit.sentenceIndex,
     context,
+    { includeLocators: false },
   );
 
   return {

--- a/packages/core/src/retrieval/query/archive-view/source-evidence/read.ts
+++ b/packages/core/src/retrieval/query/archive-view/source-evidence/read.ts
@@ -34,6 +34,7 @@ export async function createSourceEvidenceItem(
       range.startSentenceIndex,
       range.endSentenceIndex,
     ),
+    locators: range.locators,
     ...(score === undefined ? {} : { score }),
     source: range.text,
     startSentenceIndex: range.startSentenceIndex,

--- a/packages/core/src/retrieval/query/archive-view/source-locators.ts
+++ b/packages/core/src/retrieval/query/archive-view/source-locators.ts
@@ -1,0 +1,66 @@
+import {
+  formatSourceArtifactUri,
+  type ReadonlyDocument,
+} from "../../../document/index.js";
+
+import type { SourceLocatorMap } from "./types.js";
+
+interface LocalLocatorRange {
+  end: number;
+  readonly uri: string;
+  readonly start: number;
+}
+
+export async function createSourceLocatorMap(
+  document: ReadonlyDocument,
+  chapterId: number,
+  sourceStart: number | undefined,
+  sourceEnd: number | undefined,
+): Promise<SourceLocatorMap> {
+  if (
+    sourceStart === undefined ||
+    sourceEnd === undefined ||
+    sourceEnd <= sourceStart
+  ) {
+    return {};
+  }
+
+  const [mappings, sourceRevision] = await Promise.all([
+    document.sourceProvenance.listMap(chapterId),
+    document.serials.getRevision(chapterId),
+  ]);
+  const ranges: LocalLocatorRange[] = [];
+
+  for (const mapping of mappings) {
+    if (
+      mapping.sourceRevision !== sourceRevision ||
+      mapping.sourceStart >= sourceEnd ||
+      mapping.sourceEnd <= sourceStart
+    ) {
+      continue;
+    }
+
+    const start = Math.max(mapping.sourceStart, sourceStart) - sourceStart;
+    const end = Math.min(mapping.sourceEnd, sourceEnd) - sourceStart;
+    if (end <= start) continue;
+
+    const uri = formatSourceArtifactUri(
+      mapping.artifact.digest,
+      mapping.fragment,
+    );
+    const previous = ranges.at(-1);
+    if (
+      previous !== undefined &&
+      previous.uri === uri &&
+      previous.end === start
+    ) {
+      previous.end = end;
+    } else {
+      ranges.push({ end, start, uri });
+    }
+  }
+
+  return Object.fromEntries(
+    ranges.map((range) => [`${range.start + 1}..${range.end}`, range.uri]),
+  );
+}

--- a/packages/core/src/retrieval/query/archive-view/text-streams.ts
+++ b/packages/core/src/retrieval/query/archive-view/text-streams.ts
@@ -17,7 +17,9 @@ import type {
   ArchiveTextStreamKind,
   ArchiveTextStreamSentence,
   EvidenceReadContext,
+  SourceLocatorMap,
 } from "./types.js";
+import { createSourceLocatorMap } from "./source-locators.js";
 
 function createTextStreamReadContext(): EvidenceReadContext {
   return {
@@ -58,8 +60,7 @@ export async function createTextStreamRangeFragment(
   reference: Extract<WikiGraphReference, { readonly type: "text-stream" }>,
 ): Promise<{
   readonly fragment: ArchiveSourceFragment;
-  readonly sourceEnd?: number;
-  readonly sourceStart?: number;
+  readonly locators: SourceLocatorMap;
 }> {
   const range = await readTextStreamRange(
     document,
@@ -78,10 +79,7 @@ export async function createTextStreamRangeFragment(
       text: range.text,
       wordsCount: countWords(range.text),
     },
-    ...(range.sourceEnd === undefined ? {} : { sourceEnd: range.sourceEnd }),
-    ...(range.sourceStart === undefined
-      ? {}
-      : { sourceStart: range.sourceStart }),
+    locators: range.locators,
   };
 }
 
@@ -95,6 +93,7 @@ export async function readTextStreamRange(
 ): Promise<{
   readonly endSentenceIndex: number;
   readonly id: string;
+  readonly locators: SourceLocatorMap;
   readonly sourceEnd?: number;
   readonly sourceStart?: number;
   readonly startSentenceIndex: number;
@@ -124,19 +123,32 @@ export async function readTextStreamRange(
     start,
     end,
   );
-  const text =
-    normalizeRenderedTextStreamRange(rawRange?.text) ??
-    joinTextStreamSentences(sentences);
+  const normalizedRange = normalizeRenderedTextStreamRange(rawRange?.text);
+  const text = normalizedRange?.text ?? joinTextStreamSentences(sentences);
+  const sourceStart =
+    rawRange?.sourceStart === undefined
+      ? undefined
+      : rawRange.sourceStart + (normalizedRange?.removedStart ?? 0);
+  const sourceEnd =
+    sourceStart === undefined
+      ? undefined
+      : sourceStart + Array.from(text).length;
+  const locators =
+    stream === "source"
+      ? await createSourceLocatorMap(
+          document,
+          chapterId,
+          sourceStart,
+          sourceEnd,
+        )
+      : {};
 
   return {
     endSentenceIndex: end,
     id: formatTextStreamRangeUri(chapterId, stream, start, end),
-    ...(rawRange?.sourceEnd === undefined
-      ? {}
-      : { sourceEnd: rawRange.sourceEnd }),
-    ...(rawRange?.sourceStart === undefined
-      ? {}
-      : { sourceStart: rawRange.sourceStart }),
+    locators,
+    ...(sourceEnd === undefined ? {} : { sourceEnd }),
+    ...(sourceStart === undefined ? {} : { sourceStart }),
     startSentenceIndex: start,
     text,
   };
@@ -209,10 +221,18 @@ function joinTextStreamSentences(
 
 function normalizeRenderedTextStreamRange(
   text: string | undefined,
-): string | undefined {
-  return text
-    ?.replace(/^(?:[^\S\r\n]*(?:\r\n|\n|\r))+/u, "")
-    .replace(/(?:(?:\r\n|\n|\r)[^\S\r\n]*)+$/u, "");
+): { readonly removedStart: number; readonly text: string } | undefined {
+  if (text === undefined) return undefined;
+
+  const leading = /^(?:[^\S\r\n]*(?:\r\n|\n|\r))+/u.exec(text)?.[0] ?? "";
+  const withoutLeading = text.slice(leading.length);
+  const trailing =
+    /(?:(?:\r\n|\n|\r)[^\S\r\n]*)+$/u.exec(withoutLeading)?.[0] ?? "";
+
+  return {
+    removedStart: Array.from(leading).length,
+    text: withoutLeading.slice(0, withoutLeading.length - trailing.length),
+  };
 }
 
 export async function getTextStreamIndex(

--- a/packages/core/src/retrieval/query/archive-view/text-streams.ts
+++ b/packages/core/src/retrieval/query/archive-view/text-streams.ts
@@ -90,6 +90,7 @@ export async function readTextStreamRange(
   startSentenceIndex: number,
   endSentenceIndex: number,
   context: EvidenceReadContext = createTextStreamReadContext(),
+  options: { readonly includeLocators?: boolean } = {},
 ): Promise<{
   readonly endSentenceIndex: number;
   readonly id: string;
@@ -134,7 +135,7 @@ export async function readTextStreamRange(
       ? undefined
       : sourceStart + Array.from(text).length;
   const locators =
-    stream === "source"
+    stream === "source" && options.includeLocators !== false
       ? await createSourceLocatorMap(
           document,
           chapterId,

--- a/packages/core/src/retrieval/query/archive-view/types.ts
+++ b/packages/core/src/retrieval/query/archive-view/types.ts
@@ -1,7 +1,6 @@
 import type {
   MentionLinkRecord,
   MentionRecord,
-  SourceTextMapRecord,
 } from "../../../document/index.js";
 import type { BookMeta } from "../../../text/source/index.js";
 import type { GraphNeighbor } from "../../../graph/reading.js";
@@ -12,6 +11,7 @@ import type {
 import type { SearchIndexEmbeddingProvider } from "../../search-index/index.js";
 
 export type ArchiveObjectType =
+  | "artifact"
   | "chapter"
   | "chapter-title"
   | "chapter-tree"
@@ -93,6 +93,7 @@ export interface ArchiveFindHit extends ArchiveLibrarySourceFields {
   readonly evidenceMentions?: readonly EntityEvidenceMention[];
   readonly field: ArchiveFindField;
   readonly id: string;
+  readonly locators?: SourceLocatorMap;
   readonly matchCount?: number;
   readonly matchedTerms?: readonly string[];
   readonly missingTerms?: readonly string[];
@@ -248,7 +249,7 @@ export type ArchiveListItem = ArchiveLibrarySourceFields &
         readonly score?: number;
         readonly state?: ChapterState;
         readonly summary: string;
-        readonly type: Exclude<ArchiveObjectType, "triple">;
+        readonly type: Exclude<ArchiveObjectType, "artifact" | "triple">;
       }
     | {
         readonly evidence?: ArchiveFindEvidencePreview;
@@ -268,6 +269,15 @@ export type ArchiveListItem = ArchiveLibrarySourceFields &
 
 export type ArchivePage = ArchiveLibrarySourceFields &
   (
+    | {
+        readonly digest: string;
+        readonly id: string;
+        readonly identifier?: string;
+        readonly locator?: Readonly<Record<string, unknown>>;
+        readonly mediaType: string;
+        readonly name?: string;
+        readonly type: "artifact";
+      }
     | {
         readonly id: string;
         readonly state: ChapterState;
@@ -303,7 +313,7 @@ export type ArchivePage = ArchiveLibrarySourceFields &
         readonly nextFragmentId: string | undefined;
         readonly nodes: readonly ArchiveNodeLabel[];
         readonly previousFragmentId: string | undefined;
-        readonly provenance?: readonly SourceTextMapRecord[];
+        readonly locators?: SourceLocatorMap;
         readonly title: string;
         readonly type: "fragment";
       }
@@ -400,6 +410,7 @@ export interface ArchiveEvidenceItem extends ArchiveLibrarySourceFields {
   readonly endSentenceIndex: number;
   readonly fragmentId?: number;
   readonly id: string;
+  readonly locators?: SourceLocatorMap;
   readonly score?: number;
   readonly source: string;
   readonly startSentenceIndex: number;
@@ -425,6 +436,8 @@ export interface ArchiveSourceFragment {
   readonly text: string;
   readonly wordsCount: number;
 }
+
+export type SourceLocatorMap = Readonly<Record<string, string>>;
 
 export type ArchiveTextStreamKind = "source" | "summary";
 export type SourceEvidenceRange = {

--- a/packages/core/src/retrieval/query/index.ts
+++ b/packages/core/src/retrieval/query/index.ts
@@ -51,6 +51,7 @@ export type {
   ArchiveObjectType,
   ArchivePack,
   ArchivePage,
+  SourceLocatorMap,
   ArchiveRelatedResult,
   ArchiveTriplePattern,
 } from "./view.js";

--- a/packages/core/src/runtime/common/wiki-graph/uri.ts
+++ b/packages/core/src/runtime/common/wiki-graph/uri.ts
@@ -7,7 +7,10 @@ export const WIKI_GRAPH_ARCHIVE_EXTENSION = ".wikg";
 export interface ParsedWikiGraphUri {
   readonly protocol: string;
   readonly path: readonly string[];
-  readonly fragment?: number | { readonly begin: number; readonly end: number };
+  readonly fragment?:
+    | number
+    | { readonly begin: number; readonly end: number }
+    | { readonly raw: string };
 }
 
 export interface LocatedWikiGraphUri {
@@ -89,11 +92,12 @@ export function parseWikiGraphUriSyntax(uri: string): ParsedWikiGraphUri {
     throw new Error(`Invalid Wiki Graph URI fragment: ${uri}`);
   }
 
-  return {
-    protocol,
-    path: parseWikiGraphUriPath(rawPath, uri),
-    ...optionalWikiGraphUriFragment(rawFragment, uri),
-  };
+  const path = parseWikiGraphUriPath(rawPath, uri);
+
+  const parsedFragment = optionalWikiGraphUriFragment(rawFragment, uri, path);
+  return parsedFragment === undefined
+    ? { protocol, path }
+    : { fragment: parsedFragment, protocol, path };
 }
 
 function parseWikiGraphUriPath(path: string, uri: string): readonly string[] {
@@ -131,11 +135,10 @@ function rejectEmptyUriSegments(
 function optionalWikiGraphUriFragment(
   fragment: string | undefined,
   uri: string,
-): {
-  readonly fragment?: number | { readonly begin: number; readonly end: number };
-} {
+  path: readonly string[],
+): NonNullable<ParsedWikiGraphUri["fragment"]> | undefined {
   if (fragment === undefined) {
-    return {};
+    return undefined;
   }
   if (fragment === "") {
     throw new Error(`Invalid Wiki Graph URI fragment: ${uri}`);
@@ -145,11 +148,18 @@ function optionalWikiGraphUriFragment(
   if (range?.groups !== undefined) {
     const begin = Number(range.groups.begin);
     const end = Number(range.groups.end);
-    return { fragment: { begin, end } };
+    return { begin, end };
   }
 
   if (/^[0-9]+$/u.test(fragment)) {
-    return { fragment: Number(fragment) };
+    return Number(fragment);
+  }
+
+  if (
+    path.at(-2) === "artifact" &&
+    /^[0-9a-f]{64}$/iu.test(path.at(-1) ?? "")
+  ) {
+    return { raw: fragment };
   }
 
   throw new Error(`Invalid Wiki Graph URI fragment: ${uri}`);
@@ -211,6 +221,9 @@ function formatWikiGraphUriFragment(
   }
   if (typeof fragment === "number") {
     return String(fragment);
+  }
+  if ("raw" in fragment) {
+    return fragment.raw;
   }
 
   return `${fragment.begin}..${fragment.end}`;

--- a/packages/core/src/text/source/provenance.ts
+++ b/packages/core/src/text/source/provenance.ts
@@ -4,6 +4,7 @@ import type {
   SourceArtifactInput,
   SourceTextProvenanceInput,
 } from "../../document/types.js";
+import { formatSourceLocatorFragment } from "../../document/source-locator.js";
 
 const artifactRecordSchema = z.object({
   type: z.literal("artifact"),
@@ -147,111 +148,16 @@ function validateLocator(
   locator: Readonly<Record<string, unknown>>,
   lineNumber: number,
 ): void {
-  if (mediaType === "application/pdf") {
-    validatePdfLocator(locator, lineNumber);
-    return;
-  }
-  if (mediaType === "application/epub+zip") {
-    validateEpubLocator(locator, lineNumber);
-    return;
-  }
-  throw new Error(
-    `Unsupported source artifact mediaType ${mediaType} at line ${lineNumber}.`,
-  );
-}
-
-function validatePdfLocator(
-  locator: Readonly<Record<string, unknown>>,
-  lineNumber: number,
-): void {
-  const pageIndex = locator.pageIndex;
-  const bbox = locator.bbox;
-  if (!Number.isInteger(pageIndex) || (pageIndex as number) < 1) {
-    throw new Error(
-      `PDF locator pageIndex at line ${lineNumber} must be a 1-based integer.`,
-    );
-  }
-  if (
-    !Array.isArray(bbox) ||
-    bbox.length !== 4 ||
-    !bbox.every(
-      (coordinate) =>
-        typeof coordinate === "number" &&
-        Number.isFinite(coordinate) &&
-        coordinate >= 0 &&
-        coordinate <= 1,
-    )
-  ) {
-    throw new Error(
-      `PDF locator bbox at line ${lineNumber} must contain four finite numbers in [0, 1].`,
-    );
-  }
-  const [left, bottom, right, top] = bbox as [number, number, number, number];
-  if (left > right || bottom > top) {
-    throw new Error(
-      `PDF locator bbox at line ${lineNumber} must be [left, bottom, right, top].`,
-    );
-  }
-}
-
-function validateEpubLocator(
-  locator: Readonly<Record<string, unknown>>,
-  lineNumber: number,
-): void {
-  if (
-    typeof locator.cfi !== "string" ||
-    !isSyntacticallyValidCfi(locator.cfi)
-  ) {
-    throw new Error(
-      `EPUB locator cfi at line ${lineNumber} must be a syntactically valid epubcfi(...).`,
-    );
+  try {
+    formatSourceLocatorFragment(mediaType, locator);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`${message.replace(/\.$/u, "")} at line ${lineNumber}.`, {
+      cause: error,
+    });
   }
 }
 
 function countCharacters(text: string): number {
   return Array.from(text).length;
-}
-
-function isSyntacticallyValidCfi(value: string): boolean {
-  if (!value.startsWith("epubcfi(") || !value.endsWith(")")) return false;
-  const body = value.slice("epubcfi(".length, -1);
-  if (!body.startsWith("/")) return false;
-
-  // Validate the structural shape without interpreting CFI assertions.
-  // Assertions may contain escaped characters; the locator remains opaque.
-  const step = /\/\d+(?:\[[^\r\n]*\])?/gu;
-  let cursor = 0;
-  while (cursor < body.length) {
-    if (body[cursor] === "/") {
-      step.lastIndex = cursor;
-      const match = step.exec(body);
-      if (match === null || match.index !== cursor) return false;
-      cursor = step.lastIndex;
-      continue;
-    }
-    if (body[cursor] === "!") {
-      cursor += 1;
-      continue;
-    }
-    if (body[cursor] === ":" || body[cursor] === "@" || body[cursor] === "~") {
-      const match = /^(?::\d+|@\d+(?::\d+)?|~\d+(?:@\d+(?::\d+)?)?)/u.exec(
-        body.slice(cursor),
-      );
-      if (match === null) return false;
-      cursor += match[0].length;
-      if (body[cursor] === "[") {
-        const assertionEnd = body.indexOf("]", cursor + 1);
-        if (assertionEnd < 0) return false;
-        cursor = assertionEnd + 1;
-      }
-      continue;
-    }
-    if (body[cursor] === ",") {
-      cursor += 1;
-      continue;
-    }
-    return false;
-  }
-
-  return cursor > 0;
 }

--- a/packages/core/src/text/summary-build/snapshot/empty-stores.ts
+++ b/packages/core/src/text/summary-build/snapshot/empty-stores.ts
@@ -118,6 +118,14 @@ export class EmptySnapshotGraphBuildParameterStore implements ReadonlyGraphBuild
 }
 
 export class EmptySnapshotSourceProvenanceStore implements ReadonlySourceProvenanceStore {
+  public getArtifact(_digest: string): Promise<undefined> {
+    return Promise.resolve(undefined);
+  }
+
+  public getLocator(_digest: string, _fragment: string): Promise<undefined> {
+    return Promise.resolve(undefined);
+  }
+
   public listArtifacts(): Promise<never[]> {
     return Promise.resolve([]);
   }

--- a/test/cli/archive/object.test.ts
+++ b/test/cli/archive/object.test.ts
@@ -579,6 +579,7 @@ describe("cli/archive/object", () => {
         shown: 1,
         sources: [
           {
+            locators: {},
             uri: "wikg://chapter/2/source#1..2",
             text: "RAG original source fragment.",
           },
@@ -778,10 +779,12 @@ describe("cli/archive/object", () => {
         shown: 2,
         sources: [
           {
+            locators: {},
             text: "\n\t\nRAG original source fragment.\n   \n\t\nSecond paragraph.\n\n",
             uri: "wikg://chapter/2/source#1..2",
           },
           {
+            locators: {},
             text: "Follow-up source fragment.",
             uri: "wikg://chapter/2/source#4",
           },

--- a/test/cli/archive/query.test.ts
+++ b/test/cli/archive/query.test.ts
@@ -484,6 +484,7 @@ describe("cli/archive/query", () => {
             shown: 1,
             sources: [
               {
+                locators: {},
                 text: "RAG original source fragment.",
                 uri: "wikg://chapter/2/source#1..2",
               },
@@ -615,6 +616,7 @@ describe("cli/archive/query", () => {
             shown: 1,
             sources: [
               {
+                locators: {},
                 text: "RAG original source fragment.",
                 uri: "wikg://chapter/2/source#1..2",
               },
@@ -705,6 +707,7 @@ describe("cli/archive/query", () => {
             shown: 1,
             sources: [
               {
+                locators: {},
                 text: "RAG original source fragment.",
                 uri: "wikg://chapter/2/source#1..2",
               },

--- a/test/cli/archive/source-ingestion.test.ts
+++ b/test/cli/archive/source-ingestion.test.ts
@@ -49,7 +49,7 @@ interface TocItemLike {
 }
 
 describe("cli/archive/source-ingestion", () => {
-  it("returns a reusable chapter URI and exposes source provenance", async () => {
+  it("returns source locator maps and opens their artifact URIs", async () => {
     const digest = "a".repeat(64);
     const firstText = "😀 First source sentence. ";
     const secondText = "Second source sentence.";
@@ -100,58 +100,71 @@ describe("cli/archive/source-ingestion", () => {
       );
 
       const wholeSource = await runJsonCLI(stateDir, [sourceUri, "--json"]);
-      expect(
-        requireProvenance(wholeSource).map((mapping) => ({
-          digest: mapping.artifact.digest,
-          locator: mapping.locator,
-          sourceEnd: mapping.sourceEnd,
-          sourceStart: mapping.sourceStart,
-        })),
-      ).toStrictEqual([
-        {
-          digest,
-          locator: { bbox: [0, 0, 0.5, 0.5], pageIndex: 1 },
-          sourceEnd: secondStart,
-          sourceStart: 0,
-        },
-        {
-          digest,
-          locator: { bbox: [0.5, 0.5, 1, 1], pageIndex: 2 },
-          sourceEnd: secondStart + Array.from(secondText).length,
-          sourceStart: secondStart,
-        },
-      ]);
+      const firstLocator = `wikg://artifact/${digest}#page=1&bbox=0,0,0.5,0.5`;
+      const secondLocator = `wikg://artifact/${digest}#page=2&bbox=0.5,0.5,1,1`;
+      expect(requireLocatorMap(wholeSource)).toStrictEqual({
+        [`1..${secondStart}`]: firstLocator,
+        [`${secondStart + 1}..${secondStart + Array.from(secondText).length}`]:
+          secondLocator,
+      });
+      const wholePlain = await runWikiGraphCLICaptured({
+        argv: [sourceUri],
+        stateDir,
+      });
+      expect(wholePlain.exitCode, wholePlain.stderr).toBe(0);
+      expect(wholePlain.stdout).toBe(`${firstText}${secondText}\n`);
 
       const firstRange = await runJsonCLI(stateDir, [
         `${sourceUri}#1`,
         "--json",
       ]);
-      expect(
-        requireProvenance(firstRange).map((mapping) => ({
-          digest: mapping.artifact.digest,
-          locator: mapping.locator,
-        })),
-      ).toStrictEqual([
-        {
-          digest,
-          locator: { bbox: [0, 0, 0.5, 0.5], pageIndex: 1 },
-        },
-      ]);
+      expect(requireLocatorMap(firstRange)).toStrictEqual({
+        [`1..${secondStart}`]: firstLocator,
+      });
       const secondRange = await runJsonCLI(stateDir, [
         `${sourceUri}#2`,
         "--json",
       ]);
-      expect(
-        requireProvenance(secondRange).map((mapping) => ({
-          digest: mapping.artifact.digest,
-          locator: mapping.locator,
-        })),
-      ).toStrictEqual([
-        {
-          digest,
-          locator: { bbox: [0.5, 0.5, 1, 1], pageIndex: 2 },
-        },
+      expect(requireLocatorMap(secondRange)).toStrictEqual({
+        [`1..${Array.from(secondText).length}`]: secondLocator,
+      });
+
+      const artifact = await runJsonCLI(stateDir, [
+        `${archiveUri}/artifact/${digest}`,
+        "--json",
       ]);
+      expect(artifact).toMatchObject({
+        digest,
+        mediaType: "application/pdf",
+        name: "two-pages.pdf",
+        uri: `wikg://artifact/${digest}`,
+      });
+      const locator = await runJsonCLI(stateDir, [
+        `${archiveUri}/artifact/${digest}#page=1&bbox=0,0,0.5,0.5`,
+        "--json",
+      ]);
+      expect(locator).toMatchObject({
+        locator: { bbox: [0, 0, 0.5, 0.5], pageIndex: 1 },
+        uri: firstLocator,
+      });
+
+      const plain = await runWikiGraphCLICaptured({
+        argv: [`${sourceUri}#2`],
+        stateDir,
+      });
+      expect(plain.exitCode, plain.stderr).toBe(0);
+      expect(plain.stdout).toBe(
+        `@@ ${requireString(wholeSource, "uri")}#2 @@\n1..${Array.from(secondText).length} -> ${secondLocator}\n\n${secondText}\n`,
+      );
+      const jsonlResult = await runWikiGraphCLICaptured({
+        argv: [`${sourceUri}#1`, "--jsonl"],
+        stateDir,
+      });
+      expect(jsonlResult.exitCode, jsonlResult.stderr).toBe(0);
+      expect(JSON.parse(jsonlResult.stdout)).toMatchObject({
+        locators: { [`1..${secondStart}`]: firstLocator },
+        text: firstText,
+      });
 
       await runJsonCLI(stateDir, [
         locatedChapterUri,
@@ -162,7 +175,7 @@ describe("cli/archive/source-ingestion", () => {
       ]);
       await runJsonCLI(stateDir, [sourceUri, "set", "Plain source.", "--json"]);
       const plainSource = await runJsonCLI(stateDir, [sourceUri, "--json"]);
-      expect(requireProvenance(plainSource)).toStrictEqual([]);
+      expect(requireLocatorMap(plainSource)).toStrictEqual({});
     });
   });
 
@@ -445,12 +458,12 @@ function requireString(
   return value;
 }
 
-function requireProvenance(
+function requireLocatorMap(
   object: Readonly<Record<string, unknown>>,
-): readonly SourceTextMapRecord[] {
-  const value = object.provenance;
-  if (!Array.isArray(value)) {
-    throw new Error("CLI output did not contain a provenance array.");
+): Readonly<Record<string, string>> {
+  const value = object.locators;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("CLI output did not contain a locators object.");
   }
-  return value as readonly SourceTextMapRecord[];
+  return value as Readonly<Record<string, string>>;
 }

--- a/test/core/api/source-provenance.test.ts
+++ b/test/core/api/source-provenance.test.ts
@@ -59,11 +59,27 @@ describe("source provenance workflow", () => {
               identifier: "fixture:sample-observatory-guide",
               mediaType: "application/epub+zip",
             },
+            fragment: "epubcfi(/6/2[body]!/4/2/1:0)",
             locator: { cfi: "epubcfi(/6/2[body]!/4/2/1:0)" },
             sourceStart: 0,
             sourceEnd: sourceText.length,
           },
         ]);
+        expect(
+          await document.sourceProvenance.getArtifact(digest),
+        ).toMatchObject({
+          digest,
+          mediaType: "application/epub+zip",
+        });
+        expect(
+          await document.sourceProvenance.getLocator(
+            digest,
+            "epubcfi(/6/2[body]!/4/2/1:0)",
+          ),
+        ).toMatchObject({
+          fragment: "epubcfi(/6/2[body]!/4/2/1:0)",
+          locator: { cfi: "epubcfi(/6/2[body]!/4/2/1:0)" },
+        });
       } finally {
         await document.release();
       }

--- a/test/core/document/source-locator.test.ts
+++ b/test/core/document/source-locator.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatSourceArtifactUri,
+  formatSourceLocatorFragment,
+  parseSourceLocatorFragment,
+} from "../../../packages/core/src/document/index.js";
+
+describe("source locator URI", () => {
+  it("canonicalizes artifact digests and PDF fragments", () => {
+    const digest = "A".repeat(64);
+    const fragment = formatSourceLocatorFragment("application/pdf", {
+      bbox: [-0, 0.25, 1, 1],
+      pageIndex: 21,
+    });
+
+    expect(fragment).toBe("page=21&bbox=0,0.25,1,1");
+    expect(formatSourceArtifactUri(digest, fragment)).toBe(
+      `wikg://artifact/${digest.toLowerCase()}#${fragment}`,
+    );
+    expect(parseSourceLocatorFragment(fragment)).toStrictEqual({
+      fragment,
+      locator: { bbox: [0, 0.25, 1, 1], pageIndex: 21 },
+      mediaType: "application/pdf",
+    });
+  });
+
+  it("round-trips EPUB CFI fragments", () => {
+    const fragment = "epubcfi(/6/2[body]!/4/2/1:0)";
+
+    expect(
+      formatSourceLocatorFragment("application/epub+zip", { cfi: fragment }),
+    ).toBe(fragment);
+    expect(parseSourceLocatorFragment(fragment)).toStrictEqual({
+      fragment,
+      locator: { cfi: fragment },
+      mediaType: "application/epub+zip",
+    });
+  });
+
+  it("rejects non-canonical or out-of-bounds PDF locations", () => {
+    expect(() => parseSourceLocatorFragment("page=0&bbox=0,0,1,1")).toThrow(
+      "Invalid source artifact locator fragment",
+    );
+    expect(() =>
+      formatSourceLocatorFragment("application/pdf", {
+        bbox: [0, 0, 1.1, 1],
+        pageIndex: 1,
+      }),
+    ).toThrow("in [0, 1]");
+    expect(() =>
+      formatSourceLocatorFragment("application/pdf", {
+        bbox: [0.8, 0, 0.2, 1],
+        pageIndex: 1,
+      }),
+    ).toThrow("left, bottom, right, top");
+  });
+});

--- a/test/core/library/registry.test.ts
+++ b/test/core/library/registry.test.ts
@@ -112,6 +112,16 @@ describe("wiki graph library registry", () => {
       kind: "scope",
       objectUri: "wikg://entity/Q42",
     });
+    expect(
+      parseWikiGraphLibraryUri(
+        `wikg://lib/arc/archive123/artifact/${"c".repeat(64)}#epubcfi(/6/2!/4/2)`,
+      ),
+    ).toStrictEqual({
+      archivePublicId: "archive123",
+      isDefault: true,
+      kind: "archive",
+      objectUri: `wikg://artifact/${"c".repeat(64)}#epubcfi(/6/2!/4/2)`,
+    });
     const parsed = parseLocatedWikiGraphUri(
       "wikg://tmp/lib/book.wikg/entity/Q42",
     );

--- a/test/core/retrieval/query/archive-view/evidence.test.ts
+++ b/test/core/retrieval/query/archive-view/evidence.test.ts
@@ -18,6 +18,42 @@ beforeEach(setupArchiveViewTestState);
 afterEach(teardownArchiveViewTestState);
 
 describe("archive/query/archive-view/evidence", () => {
+  it("returns the same locator map with source evidence", async () => {
+    await withTempDir("wikigraph-archive-view-", async (path) => {
+      const document = await DirectoryDocument.open(`${path}/document`);
+
+      try {
+        await seedSourcedDocument(document);
+        const sourceText =
+          (await document.getSerialFragments(1).readText()) ?? "";
+        const digest = "b".repeat(64);
+        await document.sourceProvenance.replace(
+          1,
+          await document.serials.getRevision(1),
+          {
+            artifacts: [{ digest, mediaType: "application/pdf" }],
+            mappings: [
+              {
+                artifactDigest: digest,
+                locator: { bbox: [0, 0, 1, 1], pageIndex: 3 },
+                sourceEnd: Array.from(sourceText).length,
+                sourceStart: 0,
+              },
+            ],
+          },
+        );
+
+        const result = await listArchiveEvidence(document, "wikg://chunk/100");
+        const [source] = result.items;
+        expect(source?.locators).toStrictEqual({
+          [`1..${Array.from(source?.source ?? "").length}`]: `wikg://artifact/${digest}#page=3&bbox=0,0,1,1`,
+        });
+      } finally {
+        await document.release();
+      }
+    });
+  });
+
   it("applies evidence limits when reading entity pages", async () => {
     await withTempDir("wikigraph-archive-view-", async (path) => {
       const document = await DirectoryDocument.open(`${path}/document`);

--- a/test/core/retrieval/query/archive-view/text-search.test.ts
+++ b/test/core/retrieval/query/archive-view/text-search.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DirectoryDocument,
   SEARCH_INDEX_FTS_HIT_LIMIT,
@@ -80,6 +80,19 @@ describe("archive/query/archive-view/text search", () => {
         expect(sourceHit?.locators).toStrictEqual({
           [`1..${Array.from(sourceHit?.snippet ?? "").length}`]: `wikg://artifact/${"a".repeat(64)}#epubcfi(/6/2!/4/2)`,
         });
+
+        const listMap = vi.spyOn(document.sourceProvenance, "listMap");
+        const sourceOnly = await findArchiveObjects(document, "Wiki", {
+          limit: 1,
+          types: ["source"],
+        });
+        const typedSourceHit = sourceOnly.items[0];
+
+        expect(typedSourceHit?.type).toBe("source");
+        expect(typedSourceHit?.locators).toStrictEqual({
+          [`1..${Array.from(typedSourceHit?.snippet ?? "").length}`]: `wikg://artifact/${"a".repeat(64)}#epubcfi(/6/2!/4/2)`,
+        });
+        expect(listMap).toHaveBeenCalledTimes(1);
       } finally {
         await document.release();
       }

--- a/test/core/retrieval/query/archive-view/text-search.test.ts
+++ b/test/core/retrieval/query/archive-view/text-search.test.ts
@@ -31,6 +31,28 @@ describe("archive/query/archive-view/text search", () => {
 
       try {
         await seedSourcedDocument(document);
+        const sourceText =
+          (await document.getSerialFragments(1).readText()) ?? "";
+        await document.sourceProvenance.replace(
+          1,
+          await document.serials.getRevision(1),
+          {
+            artifacts: [
+              {
+                digest: "a".repeat(64),
+                mediaType: "application/epub+zip",
+              },
+            ],
+            mappings: [
+              {
+                artifactDigest: "a".repeat(64),
+                locator: { cfi: "epubcfi(/6/2!/4/2)" },
+                sourceEnd: Array.from(sourceText).length,
+                sourceStart: 0,
+              },
+            ],
+          },
+        );
 
         const result = await findArchiveObjects(document, "Wiki");
 
@@ -54,6 +76,10 @@ describe("archive/query/archive-view/text search", () => {
             type: "source",
           }),
         );
+        const sourceHit = result.items.find((item) => item.type === "source");
+        expect(sourceHit?.locators).toStrictEqual({
+          [`1..${Array.from(sourceHit?.snippet ?? "").length}`]: `wikg://artifact/${"a".repeat(64)}#epubcfi(/6/2!/4/2)`,
+        });
       } finally {
         await document.release();
       }

--- a/test/core/retrieval/source-locators.test.ts
+++ b/test/core/retrieval/source-locators.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import type { ReadonlyDocument } from "../../../packages/core/src/document/index.js";
+import { createSourceLocatorMap } from "../../../packages/core/src/retrieval/query/archive-view/source-locators.js";
+
+describe("source passage locator maps", () => {
+  it("clips, rebases, merges adjacent locators, and preserves gaps", async () => {
+    const digest = "a".repeat(64);
+    const first = {
+      artifact: { digest, mediaType: "application/pdf" },
+      fragment: "page=1&bbox=0,0,1,1",
+      locator: { bbox: [0, 0, 1, 1], pageIndex: 1 },
+      sourceRevision: 3,
+    } as const;
+    const document = {
+      serials: { getRevision: () => Promise.resolve(3) },
+      sourceProvenance: {
+        listMap: () =>
+          Promise.resolve([
+            { ...first, sourceEnd: 2, sourceStart: 0 },
+            { ...first, sourceEnd: 4, sourceStart: 2 },
+            {
+              ...first,
+              fragment: "page=2&bbox=0.1,0.2,0.9,1",
+              locator: { bbox: [0.1, 0.2, 0.9, 1], pageIndex: 2 },
+              sourceEnd: 8,
+              sourceStart: 5,
+            },
+            { ...first, sourceEnd: 20, sourceRevision: 2, sourceStart: 10 },
+          ]),
+      },
+    } as unknown as ReadonlyDocument;
+
+    await expect(createSourceLocatorMap(document, 7, 1, 7)).resolves.toEqual({
+      "1..3": `wikg://artifact/${digest}#page=1&bbox=0,0,1,1`,
+      "5..6": `wikg://artifact/${digest}#page=2&bbox=0.1,0.2,0.9,1`,
+    });
+  });
+
+  it("omits empty intersections", async () => {
+    const document = {
+      serials: { getRevision: () => Promise.resolve(1) },
+      sourceProvenance: { listMap: () => Promise.resolve([]) },
+    } as unknown as ReadonlyDocument;
+
+    await expect(createSourceLocatorMap(document, 1, 4, 4)).resolves.toEqual(
+      {},
+    );
+  });
+});

--- a/test/core/runtime/common/wiki-graph-uri.test.ts
+++ b/test/core/runtime/common/wiki-graph-uri.test.ts
@@ -86,6 +86,15 @@ describe("wiki graph URI helpers", () => {
       protocol: "wikg",
       path: ["/", "file", "path", "to.wikg", "entity", "Q1"],
     });
+    expect(
+      parseWikiGraphUriSyntax(
+        `wikg://artifact/${"a".repeat(64)}#epubcfi(/6/2!/4/2)`,
+      ),
+    ).toStrictEqual({
+      fragment: { raw: "epubcfi(/6/2!/4/2)" },
+      protocol: "wikg",
+      path: ["artifact", "a".repeat(64)],
+    });
     expect(() => parseWikiGraphUriSyntax("wikg://lib//arc")).toThrow(
       "empty path segment",
     );
@@ -111,6 +120,14 @@ describe("wiki graph URI helpers", () => {
     ).toStrictEqual({
       archivePath: "wikg://lib/arc/archive123",
       objectUri: "wikg://chapter/part/source#1..5",
+    });
+    expect(
+      parseLocatedWikiGraphUri(
+        `wikg:///file/book.wikg/artifact/${"b".repeat(64)}#page=2&bbox=0,0,1,1`,
+      ),
+    ).toStrictEqual({
+      archivePath: "/file/book.wikg",
+      objectUri: `wikg://artifact/${"b".repeat(64)}#page=2&bbox=0,0,1,1`,
     });
   });
 });

--- a/test/core/storage/schema-upgrade/index.test.ts
+++ b/test/core/storage/schema-upgrade/index.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, readFile, writeFile } from "fs/promises";
+import { access, copyFile, mkdir, readFile, writeFile } from "fs/promises";
 import { join } from "path";
 import { describe, expect, it } from "vitest";
 
@@ -24,6 +24,7 @@ import { createPortableHash } from "../../../../packages/core/src/utils/crypto.j
 import {
   readWikgArchiveEntry,
   readWikgArchiveMutationToken,
+  WikiGraphArchiveFile,
   writeWikgArchive,
 } from "../../../../packages/core/src/storage/wikg/index.js";
 import {
@@ -44,30 +45,40 @@ import {
 import { withTempDir } from "../../../helpers/temp.js";
 
 describe("schema-upgrade", () => {
-  it("upgrades a v3 archive in place and preserves its mutation token", async () => {
+  it("upgrades a copied v3 archive and supports source provenance", async () => {
     await withFixture(async ({ archive, root }) => {
       await removeV4SourceProvenanceSchema(archive, root);
       await rewriteManifest(archive, 3, true);
-      const before = await readWikgArchiveMutationToken(archive);
+      const sourceBytes = await readFile(archive.path);
+      const sourceToken = await readWikgArchiveMutationToken(archive);
+      const upgradedArchive = new NodeFile(join(root, "upgraded.wikg"));
+      await copyFile(archive.path, upgradedArchive.path);
       await expect(
-        ensureWikiGraphArchiveSchemaCurrent(archive),
+        ensureWikiGraphArchiveSchemaCurrent(upgradedArchive),
       ).rejects.toThrow("must be upgraded");
 
       await expect(
-        upgradeWikiGraphArchiveSchema(archive),
+        upgradeWikiGraphArchiveSchema(upgradedArchive),
       ).resolves.toMatchObject({
         changed: true,
         schemaChanged: true,
       });
-      await expect(readWikiGraphArchiveSchemaVersion(archive)).resolves.toBe(4);
-      await expect(readWikgArchiveMutationToken(archive)).resolves.toBe(before);
       await expect(
-        readWikgArchiveEntry(archive, SEARCH_INDEX_DATABASE_PATH),
+        readWikiGraphArchiveSchemaVersion(upgradedArchive),
+      ).resolves.toBe(4);
+      await expect(readWikgArchiveMutationToken(upgradedArchive)).resolves.toBe(
+        sourceToken,
+      );
+      await expect(
+        readWikgArchiveEntry(upgradedArchive, SEARCH_INDEX_DATABASE_PATH),
       ).resolves.toBeUndefined();
 
       const extracted = new NodeDirectory(join(root, "extracted"));
       await mkdir(extracted.path, { recursive: true });
-      const databaseBytes = await readWikgArchiveEntry(archive, "database.db");
+      const databaseBytes = await readWikgArchiveEntry(
+        upgradedArchive,
+        "database.db",
+      );
       expect(databaseBytes).toBeDefined();
       const databaseFile = await extracted.createFile("database.db");
       const writer = await databaseFile.openWriter();
@@ -95,6 +106,52 @@ describe("schema-upgrade", () => {
       } finally {
         await database.close();
       }
+
+      const digest = "c".repeat(64);
+      const fragment = "epubcfi(/6/2!/4/2)";
+      const upgraded = new WikiGraphArchiveFile(upgradedArchive);
+      await upgraded.write(async (document) => {
+        await document.sourceProvenance.replace(
+          1,
+          await document.serials.getRevision(1),
+          {
+            artifacts: [
+              { digest, mediaType: "application/epub+zip", name: "book.epub" },
+            ],
+            mappings: [
+              {
+                artifactDigest: digest,
+                locator: { cfi: fragment },
+                sourceEnd: 7,
+                sourceStart: 0,
+              },
+            ],
+          },
+        );
+      });
+      await upgraded.readDocument(async (document) => {
+        await expect(
+          document.sourceProvenance.getArtifact(digest),
+        ).resolves.toMatchObject({ digest, mediaType: "application/epub+zip" });
+        await expect(
+          document.sourceProvenance.getLocator(digest, fragment),
+        ).resolves.toMatchObject({ fragment, locator: { cfi: fragment } });
+        await expect(
+          document.sourceProvenance.listMap(1),
+        ).resolves.toMatchObject([
+          {
+            artifact: { digest, mediaType: "application/epub+zip" },
+            fragment,
+            sourceEnd: 7,
+            sourceStart: 0,
+          },
+        ]);
+      });
+
+      expect(await readFile(archive.path)).toEqual(sourceBytes);
+      await expect(readWikgArchiveMutationToken(archive)).resolves.toBe(
+        sourceToken,
+      );
     });
   });
 
@@ -688,6 +745,7 @@ async function withFixture(
         const directory = new NodeDirectory(documentPath);
         const document = await DirectoryDocument.open(directory);
         try {
+          await document.createSerial();
           await document.writeToc({
             items: [
               { children: [], key: "chapter", serialId: 1, title: "Chapter" },

--- a/test/core/storage/schema-upgrade/index.test.ts
+++ b/test/core/storage/schema-upgrade/index.test.ts
@@ -46,6 +46,7 @@ import { withTempDir } from "../../../helpers/temp.js";
 describe("schema-upgrade", () => {
   it("upgrades a v3 archive in place and preserves its mutation token", async () => {
     await withFixture(async ({ archive, root }) => {
+      await removeV4SourceProvenanceSchema(archive, root);
       await rewriteManifest(archive, 3, true);
       const before = await readWikgArchiveMutationToken(archive);
       await expect(
@@ -76,12 +77,21 @@ describe("schema-upgrade", () => {
         readonly: true,
       });
       try {
-        const provenanceTable = await database.queryOne(
-          "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'source_artifacts'",
+        const locatorColumns = await database.queryAll(
+          "PRAGMA table_info(source_locators)",
           undefined,
-          () => true,
+          (row) => String(row.name),
         );
-        expect(provenanceTable).toBe(true);
+        expect(locatorColumns).toContain("fragment");
+        const locatorIndexes = await database.queryAll(
+          "PRAGMA index_list(source_locators)",
+          undefined,
+          (row) => ({ name: String(row.name), unique: Number(row.unique) }),
+        );
+        expect(locatorIndexes).toContainEqual({
+          name: "sqlite_autoindex_source_locators_1",
+          unique: 1,
+        });
       } finally {
         await database.close();
       }
@@ -716,6 +726,39 @@ async function rewriteManifest(
     });
   }
   await nodeWikiGraphPlatform.zip.write(archive, entries);
+}
+
+async function removeV4SourceProvenanceSchema(
+  archive: NodeFile,
+  root: string,
+): Promise<void> {
+  const entries = await readZipEntries(archive);
+  const databaseEntry = entries.find((entry) => entry.name === "database.db");
+  if (databaseEntry === undefined) {
+    throw new Error("Fixture archive has no database.db entry.");
+  }
+
+  const databasePath = join(root, "v3-database.db");
+  await writeFile(databasePath, databaseEntry.data);
+  const database = await Database.open(new NodeFile(databasePath));
+  try {
+    await database.execute(`
+      DROP TABLE source_text_maps;
+      DROP TABLE source_locators;
+      DROP TABLE source_artifacts;
+    `);
+  } finally {
+    await database.close();
+  }
+  const databaseBytes = await readFile(databasePath);
+  await nodeWikiGraphPlatform.zip.write(
+    archive,
+    entries.map((entry) =>
+      entry.name === "database.db"
+        ? { data: databaseBytes, name: entry.name }
+        : entry,
+    ),
+  );
 }
 
 async function readZipEntries(


### PR DESCRIPTION
## 概要

- 增加 archive 级 artifact URI 与 EPUB/PDF locator fragment 协议
- 为 source range、搜索结果和 evidence 输出紧凑 locator 映射
- 将 locator fragment 唯一约束纳入 Archive Schema V4 迁移
- 补充分层 CLI help、公开文档和 URI/输出/迁移回归测试
- 确保 typed source 搜索仅在分页后读取 locator

## 验证

- `pnpm verify`
- `pnpm test:run`（155 files / 997 tests）
- `pnpm build`