### PR TITLE
fix: clarify chapter source and query readiness help

### DIFF
--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -404,6 +404,10 @@ describe("cli/args/help", () => {
     expect(renderHelpTopicText("recipe")).toContain(
       'wikg://book.wikg/chapter add --title "Part" --input ./chapter.txt',
     );
+    expect(renderHelpTopicText("recipe")).toContain(
+      "wikg://local/job add --input <archive-uri> --task index-fts",
+    );
+    expect(renderHelpTopicText("recipe")).not.toContain("<chapter-id>");
   });
 
   it("documents the layered help contract", () => {
@@ -875,6 +879,16 @@ describe("cli/args/help", () => {
         "wikg://local/job",
       ),
     ).toContain("require a current FTS artifact");
+    expect(
+      renderUriPredicateHelpText(
+        "job-collection-scope",
+        "add",
+        "wikg://local/job",
+      ),
+    ).toContain("re-run archive `inspect` to verify coverage");
+    expect(renderHelpTopicText("readiness")).toContain(
+      "wikg://local/job add --input <archive-uri|chapter-uri> --task index-fts",
+    );
     expect(renderHelpTopicText("runtime")).toContain("Local state map:");
     expect(renderHelpTopicText("runtime")).toContain(
       "~/.wikigraph/cache/continuation-cursors.sqlite",

--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -174,6 +174,15 @@ describe("cli/args/help", () => {
         "wikg://book.wikg/chapter/part",
       ),
     ).toContain("not supported reset targets");
+    const resetHelpText = renderUriPredicateHelpText(
+      "chapter-scope",
+      "reset",
+      "wikg://book.wikg/chapter/part",
+    );
+    expect(resetHelpText).toContain("source text and provenance");
+    expect(resetHelpText).toContain("Knowledge Graph");
+    expect(resetHelpText).toContain("all chapter index artifacts");
+    expect(resetHelpText).toContain("source embedding artifact");
     const libraryChapterHelp = parseCLIArguments([
       "wikg://lib/chapter",
       "--help",
@@ -346,6 +355,9 @@ describe("cli/args/help", () => {
     );
     expect(chapterAddHelpText).toContain("Located URI");
     expect(chapterAddHelpText).toContain("`uri` and `locatedUri`");
+    expect(chapterAddHelpText).toContain("non-empty UTF-8 plain text");
+    expect(chapterAddHelpText).toContain("does not create a source-text map");
+    expect(chapterAddHelpText).toContain("does not infer a");
     expect(chapterHelpText).toContain(
       "wikg://book.wikg/chapter/part/state --help",
     );
@@ -356,6 +368,7 @@ describe("cli/args/help", () => {
       "Supply exactly one positional value or `--input`",
     );
     expect(sourceSetHelpText).toContain("must be `planned`");
+    expect(sourceSetHelpText).toContain("Source input must not be empty");
     expect(sourceSetHelpText).toContain("Plain text writes source without");
     expect(sourceSetHelpText).toContain("File extensions are not inferred");
     expect(sourceSetHelpText).toContain(
@@ -373,13 +386,23 @@ describe("cli/args/help", () => {
     expect(fileImportHelpText).toContain('"cfi":"epubcfi(...)"');
     expect(fileImportHelpText).toContain("offsets are not input fields");
     expect(fileImportHelpText).toContain("SHA-256 of source file bytes");
-    expect(fileImportHelpText).toContain("`chapter add --json`");
+    expect(fileImportHelpText).toContain(
+      'wikg://book.wikg/chapter add --title "Part" --json',
+    );
+    expect(fileImportHelpText).toContain("<locatedUri>/source set");
+    expect(fileImportHelpText).toContain("not title-derived slugs");
+    expect(fileImportHelpText).not.toContain(
+      "wikg://book.wikg/chapter/part/source set --input",
+    );
     expect(fileImportHelpText).toContain(
       "The response includes a `locators` map for the returned text",
     );
     expect(sourceHelpText).toContain("`uri`, `text`, and a compact `locators`");
     expect(fileImportHelpText).toContain(
       "evidence cannot point back to a PDF page or EPUB CFI",
+    );
+    expect(renderHelpTopicText("recipe")).toContain(
+      'wikg://book.wikg/chapter add --title "Part" --input ./chapter.txt',
     );
   });
 

--- a/packages/core/data/help/commands/predicate.jinja
+++ b/packages/core/data/help/commands/predicate.jinja
@@ -158,6 +158,7 @@ Notes:
   - Reading Graph and Knowledge Graph jobs require a current FTS artifact for the chapter.
   - Summary embedding jobs require an existing non-empty summary.
   - Archive input adds jobs for all eligible chapters; chapter input expands to the chapter subtree by default.
+  - For archive-wide indexing, use `{{ commandName }} wikg://local/job --json` to inspect the jobs and re-run archive `inspect` to verify coverage.
   - Use `--depth <N>` with archive or chapter input to limit affected chapters. For archive input, depth is measured from the archive's root chapters; for chapter input, it is measured from the specified chapter. `--depth 0` means only the relevant root chapters or specified chapter.
   - `--llm <json>` stores a job-local LLM object; it does not update `wikg://local/config/llm`.
 {% elif predicate == "move" %}

--- a/packages/core/data/help/commands/predicate.jinja
+++ b/packages/core/data/help/commands/predicate.jinja
@@ -136,9 +136,10 @@ Usage:
 
 Notes:
   - Without `--input`, creates an empty planned chapter placeholder.
-  - With `--input <path>`, creates a chapter and fills source text.
-  - Use `--input -` to read source text from stdin.
-  - Source input must not be empty when `--input` is used.
+  - With `--input <path|->`, reads non-empty UTF-8 plain text, does not infer a
+    format from the file name, and creates the chapter in the `source` stage.
+  - This plain-text path does not create a source-text map or call an LLM
+    provider. Read `{{ commandName }} help file-import` for source locators.
 
 Output:
   - Text output includes `Chapter`, the archive-relative handle, and `Located URI`, the complete target for later commands.
@@ -200,9 +201,13 @@ Usage:
   {{ commandName }} {{ uri }} reset --to planned|source|reading-graph [--json]
 
 Notes:
-  - `planned` deletes source text, Reading Graph data, and summary.
-  - `source` keeps source text and deletes Reading Graph data and summary.
-  - `reading-graph` keeps source text and Reading Graph data, and deletes summary.
+  - `planned` deletes source text and provenance, Reading Graph, Knowledge Graph,
+    summary, and all chapter index artifacts.
+  - `source` keeps source text and provenance, and deletes Reading Graph,
+    Knowledge Graph, summary, and all chapter index artifacts.
+  - `reading-graph` keeps source text and provenance, Reading Graph, Knowledge
+    Graph, and the source embedding artifact. It deletes summary, FTS, and the
+    summary embedding artifact.
   - `reading-summary` and `knowledge-graph` are not supported reset targets.
   - Reset is destructive and may discard generated work.
 {% elif predicate == "set" %}

--- a/packages/core/data/help/commands/shared/chapter-source-set.jinja
+++ b/packages/core/data/help/commands/shared/chapter-source-set.jinja
@@ -6,6 +6,7 @@ Usage:
 
 Input:
   - Supply exactly one positional value or `--input`; files and stdin are UTF-8 plain text unless `--input-format jsonl` is set. File extensions are not inferred.
+  - Source input must not be empty.
   - Plain text writes source without a source-text map.
   - `--input-format jsonl` writes source and provenance supplied by an external extractor. Read `{{ commandName }} help file-import` for the record contract.
 

--- a/packages/core/data/help/topics/file-import.jinja
+++ b/packages/core/data/help/topics/file-import.jinja
@@ -13,10 +13,11 @@ Built-in EPUB import:
     source text, and source-text map.
 
 External extractor input:
-  {{ commandName }} wikg://book.wikg/chapter add --title "Part"
-  {{ commandName }} wikg://book.wikg/chapter/part/source set --input ./source.jsonl --input-format jsonl
+  {{ commandName }} wikg://book.wikg/chapter add --title "Part" --json
+  {{ commandName }} <locatedUri>/source set --input ./source.jsonl --input-format jsonl
   - Use this path for PDF, or when another extractor handles EPUB.
-  - The selected chapter must be `planned`; use `Located URI` from text output or `locatedUri` from `chapter add --json`.
+  - Chapter paths are returned handles, not title-derived slugs. Reuse `locatedUri`
+    from the first command; the selected chapter must be `planned`.
 
 JSONL contract:
   - Each non-empty line is one `artifact` or `text` object. At least one of each is required.
@@ -43,6 +44,6 @@ Boundaries:
 
 See also:
   - {{ commandName }} wikg://book.wikg create --help
-  - {{ commandName }} wikg://book.wikg/chapter/part/source set --help
+  - {{ commandName }} <chapter-uri>/source set --help
   - {{ commandName }} help format
   - {{ commandName }} help source-locators

--- a/packages/core/data/help/topics/readiness.jinja
+++ b/packages/core/data/help/topics/readiness.jinja
@@ -21,10 +21,12 @@ Archive index readiness:
 
   Artifact behavior:
     Chapter artifacts are stored inside the `.wikg` archive.
-    Build FTS artifacts with the chapter index URI or queue target `index-fts`.
+    Build FTS artifacts locally for an archive or chapter, without provider calls:
+      {{ commandName }} wikg://local/job add --input <archive-uri|chapter-uri> --task index-fts
     Build source embedding artifacts with the chapter index URI or queue target `index-embedding-source`.
     Build summary embedding artifacts with the chapter index URI or queue target `index-embedding-summary`.
     Building embedding artifacts requires `wikg://local/config/embeddings` and may call the configured provider.
+    Archive input creates one job per eligible chapter. Re-run inspect after the jobs finish to verify query readiness.
 
   Cache behavior:
     `{{ commandName }} <archive-uri>/index sync` builds or repairs local `index.db` cache from artifacts.

--- a/packages/core/data/help/topics/recipe.jinja
+++ b/packages/core/data/help/topics/recipe.jinja
@@ -32,10 +32,11 @@ Choose your starting point:
       {{ commandName }} help library
 
   - User gave you source content and needs a reusable knowledge-base archive:
-    Create an empty `.wikg` archive, or create one while importing a source file.
+    Create an empty archive and add UTF-8 chapter text, or create one while importing EPUB.
       {{ commandName }} wikg://book.wikg create
+      {{ commandName }} wikg://book.wikg/chapter add --title "Part" --input ./chapter.txt
       {{ commandName }} wikg://book.wikg create --import ./book.epub
-    Read `{{ commandName }} help file-import` when the source is a file.
+    Read `{{ commandName }} help file-import` for EPUB or source-locator JSONL.
 
   - User needs one-shot conversion without keeping an archive:
     Use transform. Source input usually requires LLM configuration.

--- a/packages/core/data/help/topics/recipe.jinja
+++ b/packages/core/data/help/topics/recipe.jinja
@@ -52,14 +52,12 @@ After inspect:
     {{ commandName }} wikg:///Users/me/book.wikg --query "attention memory"
     {{ commandName }} wikg:///Users/me/book.wikg/chapter/part --query "attention"
 
-  - If inspect reports missing index artifacts or cache, inspect the index targets before syncing cache.
-    {{ commandName }} <archive-uri>/index --help
-    {{ commandName }} <archive-uri>/chapter/<chapter-id>/index/fts --help
-    {{ commandName }} <archive-uri>/chapter/<chapter-id>/index/embedding/source --help
-    {{ commandName }} <archive-uri>/chapter/<chapter-id>/index/embedding/summary --help
-    {{ commandName }} <archive-uri>/index sync --help
-    Read readiness before deciding whether artifacts or cache are missing:
-      {{ commandName }} help readiness
+  - If inspect reports query blockers, build the free local FTS artifacts, then inspect again.
+    {{ commandName }} wikg://local/job add --input <archive-uri> --task index-fts
+    {{ commandName }} <archive-uri> inspect
+    If artifacts are ready but only the local cache is missing or outdated, sync it:
+      {{ commandName }} <archive-uri>/index sync
+    Read `{{ commandName }} help readiness` for artifact and cache alternatives.
 
   - If library-wide query reports a missing, stale, or not-ready index cache, inspect the library index target and sync it when appropriate.
     {{ commandName }} wikg://lib/index --help


### PR DESCRIPTION
## Summary

- make chapter source import examples reuse the opaque `locatedUri` returned by chapter creation
- clarify plain-text chapter input, reset effects, and non-empty source requirements
- document the shortest FTS artifact-to-cache recovery path without promoting advanced topics to root help

## Verification

- `pnpm exec vitest run packages/cli/src/args/help.test.ts`
- `pnpm verify`
- `pnpm run lint:fix`