### PR TITLE
统一 Home URI 子路径解析与动态帮助引用

### DIFF
--- a/packages/cli/src/app/dispatch.ts
+++ b/packages/cli/src/app/dispatch.ts
@@ -15,7 +15,11 @@ import {
   runObjectMetadataCommand,
   runQueueCommand,
 } from "../commands/index.js";
-import { formatCLIJSON, formatCLIJSONLine } from "../support/index.js";
+import {
+  formatCLIJSON,
+  formatCLIJSONLine,
+  getRelativeArchiveUriResolution,
+} from "../support/index.js";
 import { readCLIVersion } from "../support/index.js";
 import { isWikiGraphHomeTarget } from "../runtime/home-target.js";
 import {
@@ -107,14 +111,18 @@ export async function dispatchWikiGraphCLI(
     }
   } catch (error) {
     if (shouldWriteJSONError(input.argv)) {
-      input.stdout.write(formatCLIJSON(createCLIErrorObject(error)));
+      input.stdout.write(
+        formatCLIJSON(createCLIErrorObject(error, input.argv)),
+      );
       return { exitCode: 1 };
     }
     if (shouldWriteJSONLError(input.argv)) {
-      input.stdout.write(formatCLIJSONLine(createCLIErrorObject(error)));
+      input.stdout.write(
+        formatCLIJSONLine(createCLIErrorObject(error, input.argv)),
+      );
       return { exitCode: 1 };
     }
-    input.stderr.write(`${formatCLIError(error)}\n`);
+    input.stderr.write(`${formatCLIError(error, input.argv)}\n`);
     return { exitCode: 1 };
   }
 }
@@ -126,15 +134,26 @@ function shouldPrintDefaultHelp(
   return argv.length === 0 && stdinIsTTY === true;
 }
 
-function formatCLIError(error: unknown): string {
+function formatCLIError(error: unknown, argv: readonly string[]): string {
   if (error instanceof LLMPaymentRequiredError) {
     return "LLM payment required. Check your provider billing status or account balance.";
   }
 
-  return formatError(error);
+  const message = formatError(error);
+  const relativeResolution = hasErrorCode(error, "ENOENT")
+    ? getRelativeArchiveUriResolution(argv[0] ?? "")
+    : undefined;
+  if (relativeResolution === undefined) {
+    return message;
+  }
+
+  return `${message}\nArchive URI \`${relativeResolution.inputUri}\` is relative to the current working directory:\n  ${relativeResolution.workingDirectory}\nResolved archive path:\n  ${relativeResolution.resolvedArchivePath}\nSee: wg help uri`;
 }
 
-function createCLIErrorObject(error: unknown): {
+function createCLIErrorObject(
+  error: unknown,
+  argv: readonly string[],
+): {
   readonly error: {
     readonly message: string;
     readonly type: string;
@@ -142,13 +161,32 @@ function createCLIErrorObject(error: unknown): {
 } {
   return {
     error: {
-      message: formatCLIError(error),
+      message: formatCLIError(error, argv),
       type:
         error instanceof LLMPaymentRequiredError
           ? "llm_payment_required"
           : "error",
     },
   };
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  const visited = new Set<unknown>();
+  let current: unknown = error;
+
+  while (current !== undefined && !visited.has(current)) {
+    visited.add(current);
+    if (
+      current instanceof Error &&
+      "code" in current &&
+      (current as Error & { readonly code?: unknown }).code === code
+    ) {
+      return true;
+    }
+    current = current instanceof Error ? current.cause : undefined;
+  }
+
+  return false;
 }
 
 function shouldWriteJSONError(argv: readonly string[]): boolean {

--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -18,6 +18,31 @@ describe("cli/args/help", () => {
   const wikispineRuntimeGuideUrl =
     "https://raw.githubusercontent.com/oomol-lab/wiki-graph/refs/heads/main/docs/wikispine-runtime.md";
 
+  it("shell-quotes actual URIs in dynamic help commands", () => {
+    const archiveUri = "wikg://~/Library's Books/The little prince.wikg";
+    const sourceUri = `${archiveUri}/chapter/part/source`;
+    const archiveHelp = renderUriHelpText("archive-scope", archiveUri);
+    const sourceSetHelp = renderUriPredicateHelpText(
+      "chapter-source-object",
+      "set",
+      sourceUri,
+    );
+
+    expect(archiveHelp).toContain(`Target:\n  ${archiveUri}`);
+    expect(archiveHelp).toContain(
+      "wg 'wikg://~/Library'\\''s Books/The little prince.wikg'",
+    );
+    expect(archiveHelp).toContain(
+      "wg 'wikg://~/Library'\\''s Books/The little prince.wikg'/chapter --help",
+    );
+    expect(archiveHelp).not.toContain(`wg ${archiveUri}`);
+    expect(sourceSetHelp).toContain(`Target:\n  ${sourceUri}`);
+    expect(sourceSetHelp).toContain(
+      "wg 'wikg://~/Library'\\''s Books/The little prince.wikg/chapter/part/source' set",
+    );
+    expect(sourceSetHelp).not.toContain(`wg ${sourceUri}`);
+  });
+
   it("prints archive maintenance help pages", () => {
     expect(parseCLIArguments(["meta", "--help"])).toStrictEqual({
       help: true,

--- a/packages/cli/src/args/help.ts
+++ b/packages/cli/src/args/help.ts
@@ -9,7 +9,7 @@ import { CLI_FULL_COMMAND, CLI_PRIMARY_COMMAND } from "wiki-graph-core";
 import type { ParsedWikiGraphLibraryUri } from "wiki-graph-core";
 import { CLI_FORMATS, parseLocatedWikiGraphUri } from "../support/index.js";
 import { CLI_HELP_ROUTES, withHelpRoute } from "../support/index.js";
-import { formatCliCommand } from "../support/index.js";
+import { formatCliCommand, formatShellArgument } from "../support/index.js";
 import type {
   CLIArchiveAction,
   CLIArchiveChapterAction,
@@ -295,10 +295,11 @@ export function renderUriHelpText(
   uri: string,
 ): string {
   return renderHelpTemplate("help/commands/uri", {
+    displayUri: uri,
     libraryContext: getLibraryHelpContext(uri),
     target: requireUriHelpTarget(targetName),
     uriContext: getUriHelpContext(uri),
-    uri,
+    uri: formatHelpCommandUri(uri),
   });
 }
 
@@ -319,11 +320,12 @@ export function renderUriPredicateHelpText(
   }
 
   return renderHelpTemplate("help/commands/predicate", {
+    displayUri: uri,
     libraryContext: getLibraryHelpContext(uri),
     predicate,
     target,
     uriContext: getUriHelpContext(uri),
-    uri,
+    uri: formatHelpCommandUri(uri),
   });
 }
 
@@ -331,9 +333,10 @@ export function renderLibraryUriHelpText(
   uri: string,
   target: ParsedWikiGraphLibraryUri,
 ): string {
+  const helpUri = formatLibraryHelpUri(uri, target);
   return renderHelpTemplate("help/commands/library", {
     target,
-    uri: formatLibraryHelpUri(uri, target),
+    uri: formatHelpCommandUri(helpUri),
   });
 }
 
@@ -342,11 +345,17 @@ export function renderLibraryPredicateHelpText(
   target: ParsedWikiGraphLibraryUri,
   predicate: LibraryHelpPredicateName,
 ): string {
+  const helpUri = formatLibraryHelpUri(uri, target);
   return renderHelpTemplate("help/commands/library-predicate", {
+    displayUri: helpUri,
     predicate,
     target,
-    uri: formatLibraryHelpUri(uri, target),
+    uri: formatHelpCommandUri(helpUri),
   });
+}
+
+function formatHelpCommandUri(uri: string): string {
+  return formatShellArgument(uri);
 }
 
 function formatLibraryHelpUri(

--- a/packages/cli/src/commands/archive-command/run/uri.test.ts
+++ b/packages/cli/src/commands/archive-command/run/uri.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "crypto";
 import { mkdtemp, rm } from "fs/promises";
-import { tmpdir } from "os";
+import { homedir, tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -21,6 +21,9 @@ import {
 import { readWikgArchiveEntry } from "../../../../../core/src/storage/wikg/archive/index.js";
 import { runArchiveChapterCommand } from "../chapter.js";
 import {
+  getArchivePath,
+  getObjectUri,
+  isArchiveRootGet,
   resolveArchiveCommandRuntimeArguments,
   resolveArchiveRuntimeLocation,
 } from "./uri.js";
@@ -46,6 +49,44 @@ afterEach(async () => {
 });
 
 describe("archive-command URI runtime resolution", () => {
+  it("expands home archive locators consistently for root and child URIs", () => {
+    const archivePath = join(
+      process.env.HOME?.trim() || homedir(),
+      "Books",
+      "The little prince.wikg",
+    );
+    const cases = [
+      ["wikg://~/Books/The little prince.wikg", "wikg://"],
+      ["wikg://~/Books/The little prince.wikg/chapter", "wikg://chapter"],
+      [
+        "wikg://~/Books/The little prince.wikg/chapter/part/source",
+        "wikg://chapter/part/source",
+      ],
+      ["wikg://~/Books/The little prince.wikg/index", "wikg://index"],
+      ["wikg://~/Books/The little prince.wikg/entity/Q42", "wikg://entity/Q42"],
+    ] as const;
+
+    for (const [uri, objectUri] of cases) {
+      expect(getArchivePath(uri)).toBe(archivePath);
+      expect(getObjectUri(uri)).toBe(objectUri);
+    }
+
+    expect(
+      isArchiveRootGet({
+        action: "get",
+        archivePath: cases[0][0],
+        objectId: cases[0][0],
+      }),
+    ).toBe(true);
+    expect(
+      isArchiveRootGet({
+        action: "get",
+        archivePath: cases[1][0],
+        objectId: cases[1][0],
+      }),
+    ).toBe(false);
+  });
+
   it("resolves library archive object URIs before running archive commands", async () => {
     const target = await createTestLibraryTarget();
     const source = join(tempDir, "book.wikg");

--- a/packages/cli/src/commands/archive-command/run/uri.ts
+++ b/packages/cli/src/commands/archive-command/run/uri.ts
@@ -1,7 +1,6 @@
 import {
   formatLocatedWikiGraphUri,
   parseWikiGraphLibraryUri,
-  requireLocatedObjectOrArchiveUri,
   resolveWikiGraphLibraryArchiveFile,
   type ParsedWikiGraphLibraryUri,
   type QueryIndexScope,
@@ -104,7 +103,11 @@ export function getArchivePath(uri: string): string {
     return uri;
   }
 
-  return requireLocatedObjectOrArchiveUri(uri).archivePath;
+  const archivePath = parseLocatedWikiGraphUri(uri).archivePath;
+  if (archivePath === undefined) {
+    throw new Error(`Missing archive locator in URI: ${uri}`);
+  }
+  return archivePath;
 }
 
 export function getArchiveIndexScope(uri: string): QueryIndexScope {
@@ -125,7 +128,7 @@ export function getObjectUri(uri: string): string {
     return libraryTarget.objectUri;
   }
 
-  const parsed = requireLocatedObjectOrArchiveUri(uri);
+  const parsed = parseLocatedWikiGraphUri(uri);
 
   return parsed.objectUri ?? "wikg://";
 }
@@ -133,7 +136,7 @@ export function getObjectUri(uri: string): string {
 export function isArchiveRootGet(args: CLIArchiveArguments): boolean {
   return (
     args.objectId !== undefined &&
-    requireLocatedObjectOrArchiveUri(args.objectId).objectUri === undefined
+    parseLocatedWikiGraphUri(args.objectId).objectUri === undefined
   );
 }
 

--- a/packages/cli/src/support/uri.ts
+++ b/packages/cli/src/support/uri.ts
@@ -7,6 +7,14 @@ import {
   type LocatedWikiGraphUri,
 } from "wiki-graph-core";
 
+import { getCLICwd, getCLIEnvValue } from "../runtime/context.js";
+
+export interface RelativeArchiveUriResolution {
+  readonly inputUri: string;
+  readonly resolvedArchivePath: string;
+  readonly workingDirectory: string;
+}
+
 /** Apply Node path semantics at the CLI boundary, after Core parses URI syntax. */
 export function parseLocatedWikiGraphUri(uri: string): LocatedWikiGraphUri {
   const parsed = parsePortableLocatedWikiGraphUri(uri);
@@ -25,7 +33,7 @@ export function parseLocatedWikiGraphUri(uri: string): LocatedWikiGraphUri {
 export function formatWikiGraphCommandUri(
   archivePath: string,
   objectUri?: string,
-  cwd = process.cwd(),
+  cwd = getCLICwd(),
 ): string {
   let locator = archivePath;
   if (isAbsolute(archivePath)) {
@@ -41,8 +49,46 @@ export function formatWikiGraphCommandUri(
   return formatPortableWikiGraphCommandUri(locator, objectUri);
 }
 
+export function getRelativeArchiveUriResolution(
+  uri: string,
+): RelativeArchiveUriResolution | undefined {
+  let parsed: LocatedWikiGraphUri;
+  try {
+    parsed = parsePortableLocatedWikiGraphUri(uri);
+  } catch {
+    return undefined;
+  }
+
+  const locator = parsed.archivePath;
+  if (
+    locator === undefined ||
+    locator === "~" ||
+    locator.startsWith("~/") ||
+    locator.startsWith("wikg://lib/") ||
+    isAbsolute(locator)
+  ) {
+    return undefined;
+  }
+
+  const workingDirectory = getCLICwd();
+  return {
+    inputUri: uri,
+    resolvedArchivePath: resolve(workingDirectory, locator),
+    workingDirectory,
+  };
+}
+
 function resolveCLIArchivePath(locator: string): string {
-  if (locator === "~") return homedir();
-  if (locator.startsWith("~/")) return resolve(homedir(), locator.slice(2));
-  return resolve(locator);
+  if (locator === "~") return getCLIHomeDirectory();
+  if (locator.startsWith("~/")) {
+    return resolve(getCLIHomeDirectory(), locator.slice(2));
+  }
+  return resolve(getCLICwd(), locator);
+}
+
+function getCLIHomeDirectory(): string {
+  const environmentHome = getCLIEnvValue("HOME")?.trim();
+  return environmentHome === undefined || environmentHome === ""
+    ? homedir()
+    : environmentHome;
 }

--- a/packages/core/data/help/commands/library-predicate.jinja
+++ b/packages/core/data/help/commands/library-predicate.jinja
@@ -4,7 +4,7 @@ Command: {{ commandName }} {{ uri }} {{ predicate }}
 Library Predicate Command
 
 Target:
-  {{ uri }}
+  {{ displayUri }}
 
 Predicate:
   {{ predicate }}

--- a/packages/core/data/help/commands/predicate.jinja
+++ b/packages/core/data/help/commands/predicate.jinja
@@ -4,7 +4,7 @@ Command: {{ commandName }} <uri> {{ predicate }}
 URI Predicate Command
 
 Target:
-  {{ uri }}
+  {{ displayUri }}
 
 Predicate:
   {{ predicate }}

--- a/packages/core/data/help/commands/uri.jinja
+++ b/packages/core/data/help/commands/uri.jinja
@@ -4,7 +4,7 @@ Command: {{ commandName }} <uri>
 URI Command
 
 Target:
-  {{ uri }}
+  {{ displayUri }}
 
 {% if target.name == "archive-scope" %}
 URI type:

--- a/test/cli/sdk-runner.test.ts
+++ b/test/cli/sdk-runner.test.ts
@@ -114,6 +114,89 @@ describe("cli/sdk-runner", () => {
     }
   });
 
+  it("resolves relative archive child URIs from runner cwd", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "wikigraph-runner-cwd-"));
+    const stateDir = await mkdtemp(join(tmpdir(), "wikigraph-runner-state-"));
+
+    try {
+      const createResult = await runWikiGraphCLICaptured({
+        argv: ["wikg://book.wikg", "create"],
+        cwd,
+        stateDir,
+      });
+      const chapterResult = await runWikiGraphCLICaptured({
+        argv: ["wikg://book.wikg/chapter", "--depth", "0", "--json"],
+        cwd,
+        stateDir,
+      });
+
+      expect(createResult.exitCode).toBe(0);
+      expect(chapterResult.exitCode).toBe(0);
+      expect(JSON.parse(chapterResult.stdout)).toMatchObject({ objects: [] });
+      expect(chapterResult.stderr).toBe("");
+    } finally {
+      await rm(cwd, { force: true, recursive: true });
+      await rm(stateDir, { force: true, recursive: true });
+    }
+  });
+
+  it("uses the same home archive locator for archive roots and children", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "wikigraph-runner-cwd-"));
+    const home = await mkdtemp(join(tmpdir(), "wikigraph-runner-home-"));
+    const stateDir = await mkdtemp(join(tmpdir(), "wikigraph-runner-state-"));
+    const env = { HOME: home };
+
+    try {
+      const createResult = await runWikiGraphCLICaptured({
+        argv: ["wikg://~/book.wikg", "create"],
+        cwd,
+        env,
+        stateDir,
+      });
+      const chapterResult = await runWikiGraphCLICaptured({
+        argv: ["wikg://~/book.wikg/chapter", "--depth", "0", "--json"],
+        cwd,
+        env,
+        stateDir,
+      });
+
+      expect(createResult.exitCode).toBe(0);
+      expect(chapterResult.exitCode).toBe(0);
+      expect(JSON.parse(chapterResult.stdout)).toMatchObject({ objects: [] });
+      expect(chapterResult.stderr).toBe("");
+    } finally {
+      await rm(cwd, { force: true, recursive: true });
+      await rm(home, { force: true, recursive: true });
+      await rm(stateDir, { force: true, recursive: true });
+    }
+  });
+
+  it("explains relative archive URI resolution when the archive is missing", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "wikigraph-runner-cwd-"));
+    const stateDir = await mkdtemp(join(tmpdir(), "wikigraph-runner-state-"));
+
+    try {
+      const result = await runWikiGraphCLICaptured({
+        argv: ["wikg://missing book.wikg/chapter", "--depth", "0"],
+        cwd,
+        stateDir,
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain("File not found (ENOENT)");
+      expect(result.stderr).toContain(
+        "Archive URI `wikg://missing book.wikg/chapter` is relative to the current working directory",
+      );
+      expect(result.stderr).toContain(`  ${cwd}`);
+      expect(result.stderr).toContain(`  ${join(cwd, "missing book.wikg")}`);
+      expect(result.stderr).toContain("See: wg help uri");
+    } finally {
+      await rm(cwd, { force: true, recursive: true });
+      await rm(stateDir, { force: true, recursive: true });
+    }
+  });
+
   it("lets the core SDK and CLI runner use the same state dir in one process", async () => {
     const stateDir = await mkdtemp(join(tmpdir(), "wikigraph-shared-state-"));
 


### PR DESCRIPTION
## 变更

- 统一在 CLI 边界展开 Home 与相对 archive locator，修复 child/object URI 行为不一致
- 动态 URI help 统一执行 shell quoting，同时保留原始 Target 展示
- 相对 archive URI 找不到时输出工作目录、解析路径和帮助入口
- 增加 Home、相对 cwd、动态帮助及诊断回归测试

## 验证

- pnpm exec vitest run packages/cli/src/args/help.test.ts packages/cli/src/commands/archive-command/run/uri.test.ts test/cli/sdk-runner.test.ts --passWithNoTests
- pnpm verify
- pnpm test:run（155 files / 1001 tests）
- pnpm build