### PR TITLE
统一 CLI 输出中的公开 Chapter URI

### DIFF
--- a/packages/cli/src/commands/archive-command/chapter.ts
+++ b/packages/cli/src/commands/archive-command/chapter.ts
@@ -100,19 +100,32 @@ export async function runArchiveChapterCommand(
       });
       return;
     case "build-index-artifact": {
-      const chapterId = await readArchiveDocument(
-        args.path,
-        async (document) =>
-          await resolveRequiredChapterPath(document, args.chapterPath),
-      );
+      const chapter = await readArchiveDocument(args.path, async (document) => {
+        const chapterId = await resolveRequiredChapterPath(
+          document,
+          args.chapterPath,
+        );
+        const matched = (await listChapters(document)).find(
+          (entry) => entry.chapterId === chapterId,
+        );
+
+        if (matched === undefined) {
+          throw new Error(`Chapter internal id ${chapterId} does not exist.`);
+        }
+        return matched;
+      });
       const job = await addBuildJob({
         archive: new NodeFile(args.path),
-        chapterId,
+        chapterId: chapter.chapterId,
         target: requireIndexArtifactTarget(args.indexArtifactTarget),
       });
 
       tryStartQueueWorker();
-      await writeJobSummary(job, { json: args.json ?? false, watch: true });
+      await writeJobSummary(job, {
+        chapter,
+        json: args.json ?? false,
+        watch: true,
+      });
       return;
     }
     case "delete-index-artifact":

--- a/packages/cli/src/commands/archive-command/inspect.ts
+++ b/packages/cli/src/commands/archive-command/inspect.ts
@@ -48,6 +48,13 @@ interface InspectCoverage {
   readonly totalWords: number;
 }
 
+interface InspectChapterReference {
+  readonly chapterId: number;
+  readonly locatedUri: string;
+  readonly title: string | null;
+  readonly uri: string;
+}
+
 interface InspectReport {
   readonly uri: string;
   readonly scope: {
@@ -79,7 +86,7 @@ interface InspectReport {
     readonly summaryEmbeddingIndexArtifact: InspectCoverage;
     readonly sourceEmbeddingIndexArtifact: InspectCoverage;
   };
-  readonly queryBlockedChapters: readonly number[];
+  readonly queryBlockedChapters: readonly InspectChapterReference[];
   readonly retrievalGuidance: readonly string[];
   readonly improvements: readonly InspectImprovement[];
   readonly performanceHints: readonly GenerationPerformanceHint[];
@@ -108,10 +115,6 @@ async function createArchiveInspectReport(
   args: CLIArchiveArguments,
 ): Promise<InspectReport> {
   const archiveUri = formatArchiveInspectCommandUri(args.archivePath);
-  const scopeUri =
-    args.chapterId === undefined
-      ? archiveUri
-      : `${archiveUri}/chapter/${args.chapterId}`;
   const [
     chapters,
     summaryWords,
@@ -129,6 +132,12 @@ async function createArchiveInspectReport(
     readIndexArtifactCoverage(document, "embedding-source", args.chapterId),
     readIndexArtifactCoverage(document, "embedding-summary", args.chapterId),
   ]);
+  const selectedChapter =
+    args.chapterId === undefined ? undefined : chapters[0];
+  const scopeUri =
+    selectedChapter === undefined
+      ? archiveUri
+      : formatInspectLocatedChapterUri(archiveUri, selectedChapter);
   const concurrent = {
     job: config.concurrent?.job ?? DEFAULT_GENERATION_JOB_CONCURRENCY,
     request:
@@ -166,7 +175,7 @@ async function createArchiveInspectReport(
         !ftsArtifactCovered.includes(chapter) &&
         !sourceEmbeddingArtifactCovered.includes(chapter),
     )
-    .map((chapter) => chapter.chapterId);
+    .map((chapter) => createInspectChapterReference(archiveUri, chapter));
   const improvements = createInspectImprovements({
     archiveUri,
     concurrent,
@@ -268,7 +277,7 @@ function formatArchiveInspectText(report: InspectReport): string {
     [
       "Archive Inspect",
       `URI: ${report.uri}`,
-      `Scope: ${report.scope.type === "archive" ? "archive" : `chapter ${report.scope.chapterId}`}`,
+      `Scope: ${report.scope.type === "archive" ? "archive" : report.uri}`,
       "",
       "Content",
       `Chapters: ${report.content.chapters.content} content / ${report.content.chapters.total} total`,
@@ -307,7 +316,11 @@ function formatArchiveInspectText(report: InspectReport): string {
       ...(report.queryBlockedChapters.length === 0
         ? []
         : [
-            `Query blockers: chapters ${report.queryBlockedChapters.join(", ")} have neither FTS nor source embedding index artifacts.`,
+            "Query blockers: these chapters have neither FTS nor source embedding index artifacts:",
+            ...report.queryBlockedChapters.map(
+              (chapter) =>
+                `- ${chapter.title === null ? "[untitled]" : chapter.title}: ${chapter.locatedUri}`,
+            ),
           ]),
       "",
       "Retrieval Guidance",
@@ -325,6 +338,25 @@ function formatArchiveInspectText(report: InspectReport): string {
           ]),
     ].join("\n") + "\n"
   );
+}
+
+function createInspectChapterReference(
+  archiveUri: string,
+  chapter: ChapterEntry,
+): InspectChapterReference {
+  return {
+    chapterId: chapter.chapterId,
+    locatedUri: formatInspectLocatedChapterUri(archiveUri, chapter),
+    title: chapter.title,
+    uri: chapter.uri,
+  };
+}
+
+function formatInspectLocatedChapterUri(
+  archiveUri: string,
+  chapter: Pick<ChapterEntry, "uri">,
+): string {
+  return `${archiveUri.replace(/\/+$/u, "")}/${chapter.uri.replace(/^wikg:\/\//u, "")}`;
 }
 
 async function readInspectChapters(

--- a/packages/cli/src/commands/queue/add.ts
+++ b/packages/cli/src/commands/queue/add.ts
@@ -37,7 +37,7 @@ export async function addArchiveJobs(
     readonly job: BuildJob;
   }> = [];
   const skipped: Array<{
-    readonly chapterId: number;
+    readonly chapter: ChapterEntry;
     readonly reason: string;
   }> = [];
 
@@ -55,7 +55,7 @@ export async function addArchiveJobs(
         }
         if (chapter.stage === "planned") {
           skipped.push({
-            chapterId: chapter.chapterId,
+            chapter,
             reason: "planned",
           });
           continue;
@@ -65,7 +65,7 @@ export async function addArchiveJobs(
           const summary = await document.readSummary(chapter.chapterId);
           if (summary === undefined || summary.trim() === "") {
             skipped.push({
-              chapterId: chapter.chapterId,
+              chapter,
               reason: "missing summary",
             });
             continue;
@@ -81,7 +81,7 @@ export async function addArchiveJobs(
           );
           if (artifact?.sourceRevision !== revision) {
             skipped.push({
-              chapterId: chapter.chapterId,
+              chapter,
               reason: "missing current FTS index artifact",
             });
             continue;
@@ -95,7 +95,7 @@ export async function addArchiveJobs(
           });
         } catch (error) {
           skipped.push({
-            chapterId: chapter.chapterId,
+            chapter,
             reason: error instanceof Error ? error.message : String(error),
           });
         }
@@ -104,6 +104,7 @@ export async function addArchiveJobs(
   );
 
   await writeArchiveAddSummary({
+    archivePath: args.archivePath!,
     created,
     ...(created.length === 0
       ? {}

--- a/packages/cli/src/commands/queue/index.ts
+++ b/packages/cli/src/commands/queue/index.ts
@@ -80,6 +80,7 @@ export async function runQueueCommand(args: CLIQueueArguments): Promise<void> {
         });
 
         await writeJobSummary(await addChapterJob(args, chapterId), {
+          chapter,
           estimate,
           json: args.json ?? false,
           watch: true,

--- a/packages/cli/src/commands/queue/output.ts
+++ b/packages/cli/src/commands/queue/output.ts
@@ -1,4 +1,10 @@
-import type { BuildJob, ChapterEntry } from "wiki-graph-core";
+import {
+  formatLocatedChapterUri,
+  listChapters,
+  WikiGraphArchiveFile,
+  type BuildJob,
+  type ChapterEntry,
+} from "wiki-graph-core";
 
 import {
   formatCLIJSON,
@@ -10,14 +16,25 @@ import {
   formatQueueAddEstimateLines,
   type QueueAddEstimate,
 } from "./estimate.js";
-import { getNodeResourcePath } from "../../runtime/node-platform.js";
+import { getNodeResourcePath, NodeFile } from "../../runtime/node-platform.js";
+
+interface JobChapterReference {
+  readonly locatedUri: string;
+  readonly title: string | null;
+  readonly uri: string;
+}
 
 export async function writeJobList(
   jobs: readonly BuildJob[],
   options: { readonly json: boolean },
 ): Promise<void> {
+  const chapters = await resolveJobChapters(jobs);
   if (options.json) {
-    await writeTextToStdout(formatCLIJSON({ items: jobs.map(formatJobJSON) }));
+    await writeTextToStdout(
+      formatCLIJSON({
+        items: jobs.map((job) => formatJobJSON(job, chapters.get(job.jobId))),
+      }),
+    );
     return;
   }
 
@@ -30,22 +47,23 @@ export async function writeJobList(
     `${formatJobListHeader()}\n${jobs
       .map(
         (job) =>
-          `${job.jobId.slice(0, 8).padEnd(8)} ${job.state.padEnd(9)} ${(job.currentStep ?? "-").padEnd(7)} ${job.target.padEnd(7)} ${job.chapterId.toString().padStart(7)} ${formatArchiveName(requireJobResourcePath(job, "archive", "archivePath"))}`,
+          `${job.jobId.slice(0, 8).padEnd(8)} ${job.state.padEnd(9)} ${(job.currentStep ?? "-").padEnd(7)} ${job.target.padEnd(7)} ${formatJobChapterListLabel(job, chapters.get(job.jobId))}`,
       )
       .join("\n")}\n`,
   );
 }
 
 function formatJobListHeader(): string {
-  return `${"JOB".padEnd(8)} ${"STATE".padEnd(9)} ${"STEP".padEnd(7)} ${"TARGET".padEnd(7)} ${"CHAPTER".padStart(7)} ARCHIVE`;
+  return `${"JOB".padEnd(8)} ${"STATE".padEnd(9)} ${"STEP".padEnd(7)} ${"TARGET".padEnd(7)} CHAPTER`;
 }
 
 export async function writeJobStatus(
   job: BuildJob,
   options: { readonly json: boolean },
 ): Promise<void> {
+  const chapter = await resolveJobChapter(job);
   if (options.json) {
-    await writeTextToStdout(formatCLIJSON(formatJobJSON(job)));
+    await writeTextToStdout(formatCLIJSON(formatJobJSON(job, chapter)));
     return;
   }
 
@@ -54,7 +72,8 @@ export async function writeJobStatus(
       `Job: ${job.jobId}`,
       `State: ${job.state}`,
       `Archive: ${requireJobResourcePath(job, "archive", "archivePath")}`,
-      `Chapter: ${job.chapterId}`,
+      `Chapter: ${formatJobChapterLabel(job, chapter)}`,
+      ...(chapter === undefined ? [] : [`Chapter URI: ${chapter.locatedUri}`]),
       `Target: ${job.target}`,
       `Step: ${job.currentStep ?? "-"}`,
       `Workspace: ${getJobResourcePath(job, "workspace", "workspacePath") ?? "-"}`,
@@ -65,12 +84,24 @@ export async function writeJobStatus(
   );
 }
 
-function formatJobJSON(job: BuildJob): Record<string, unknown> {
+function formatJobJSON(
+  job: BuildJob,
+  chapter?: JobChapterReference,
+): Record<string, unknown> {
   return {
     archiveKey: job.archiveKey,
     archivePath: getJobResourcePath(job, "archive", "archivePath"),
     cachePath: getJobResourcePath(job, "cache", "cachePath"),
     chapterId: job.chapterId,
+    ...(chapter === undefined
+      ? {}
+      : {
+          chapter: {
+            locatedUri: chapter.locatedUri,
+            title: chapter.title,
+            uri: chapter.uri,
+          },
+        }),
     createdAt: job.createdAt,
     ...(job.currentStep === undefined ? {} : { currentStep: job.currentStep }),
     ...(job.errorJSON === undefined ? {} : { errorJSON: job.errorJSON }),
@@ -162,14 +193,19 @@ export async function writeJobSummary(
   job: BuildJob,
   options: {
     readonly estimate?: QueueAddEstimate;
+    readonly chapter?: ChapterEntry;
     readonly json: boolean;
     readonly watch?: boolean;
   } = { json: false },
 ): Promise<void> {
+  const chapter =
+    options.chapter === undefined
+      ? await resolveJobChapter(job)
+      : createJobChapterReference(job, options.chapter);
   if (options.json) {
     await writeTextToStdout(
       formatCLIJSON({
-        ...formatJobJSON(job),
+        ...formatJobJSON(job, chapter),
         ...(formatJobQueuedNotice(job) === undefined
           ? {}
           : { notice: formatJobQueuedNotice(job) }),
@@ -191,7 +227,8 @@ export async function writeJobSummary(
 
   await writeTextToStdout(
     [
-      `Job ${job.jobId} ${job.state} ${job.target} chapter ${job.chapterId} ${requireJobResourcePath(job, "archive", "archivePath")}`,
+      `Job ${job.jobId} ${job.state} ${job.target} chapter ${formatJobChapterLabel(job, chapter)}`,
+      ...(chapter === undefined ? [] : [`Chapter URI: ${chapter.locatedUri}`]),
       ...(formatJobQueuedNotice(job) === undefined
         ? []
         : [formatJobQueuedNotice(job)!]),
@@ -212,6 +249,7 @@ export async function writeJobSummary(
 }
 
 export async function writeArchiveAddSummary(input: {
+  readonly archivePath: string;
   readonly created: readonly {
     readonly chapter: ChapterEntry;
     readonly job: BuildJob;
@@ -219,18 +257,29 @@ export async function writeArchiveAddSummary(input: {
   readonly estimate?: QueueAddEstimate;
   readonly json: boolean;
   readonly skipped: readonly {
-    readonly chapterId: number;
+    readonly chapter: ChapterEntry;
     readonly reason: string;
   }[];
 }): Promise<void> {
   if (input.json) {
     await writeTextToStdout(
       formatCLIJSON({
-        created: input.created.map((item) => formatJobJSON(item.job)),
+        created: input.created.map((item) =>
+          formatJobJSON(
+            item.job,
+            createJobChapterReference(item.job, item.chapter),
+          ),
+        ),
         ...(input.estimate === undefined
           ? {}
           : { estimate: formatQueueAddEstimateJSON(input.estimate) }),
-        skipped: input.skipped,
+        skipped: input.skipped.map((item) => ({
+          chapterId: item.chapter.chapterId,
+          chapter: formatChapterJSON(
+            createJobChapterReferenceFromPath(input.archivePath, item.chapter),
+          ),
+          reason: item.reason,
+        })),
       }),
     );
     return;
@@ -243,11 +292,14 @@ export async function writeArchiveAddSummary(input: {
 
   for (const job of input.created) {
     lines.push(
-      `Job ${job.job.jobId} ${job.job.state} ${job.job.target} chapter ${job.job.chapterId}`,
+      `Job ${job.job.jobId} ${job.job.state} ${job.job.target} chapter ${formatChapterLabel(job.chapter)}`,
+      `Chapter URI: ${createJobChapterReference(job.job, job.chapter).locatedUri}`,
     );
   }
   for (const skipped of input.skipped) {
-    lines.push(`Skipped chapter ${skipped.chapterId}: ${skipped.reason}`);
+    lines.push(
+      `Skipped chapter ${formatChapterLabel(skipped.chapter)}: ${skipped.reason}`,
+    );
   }
   if (input.estimate !== undefined) {
     lines.push("", ...formatQueueAddEstimateLines(input.estimate));
@@ -256,8 +308,113 @@ export async function writeArchiveAddSummary(input: {
   await writeTextToStdout(`${lines.join("\n")}\n`);
 }
 
-function formatArchiveName(path: string): string {
-  return path.split(/[\\/]/u).at(-1) ?? path;
+function formatJobChapterLabel(
+  job: BuildJob,
+  chapter: JobChapterReference | undefined,
+): string {
+  return chapter === undefined
+    ? `[unavailable; internal id ${job.chapterId}]`
+    : formatChapterLabel(chapter);
+}
+
+function formatJobChapterListLabel(
+  job: BuildJob,
+  chapter: JobChapterReference | undefined,
+): string {
+  return chapter === undefined
+    ? `[unavailable; internal id ${job.chapterId}]`
+    : `${chapter.title ?? "[untitled]"} ${chapter.locatedUri}`;
+}
+
+function formatChapterLabel(
+  chapter: Pick<JobChapterReference, "title" | "uri">,
+): string {
+  return chapter.title === null || chapter.title === undefined
+    ? chapter.uri
+    : `${JSON.stringify(chapter.title)} (${chapter.uri})`;
+}
+
+function formatChapterJSON(
+  chapter: JobChapterReference,
+): Record<string, unknown> {
+  return {
+    locatedUri: chapter.locatedUri,
+    title: chapter.title,
+    uri: chapter.uri,
+  };
+}
+
+function createJobChapterReference(
+  job: BuildJob,
+  chapter: ChapterEntry,
+): JobChapterReference {
+  return createJobChapterReferenceFromPath(
+    requireJobResourcePath(job, "archive", "archivePath"),
+    chapter,
+  );
+}
+
+function createJobChapterReferenceFromPath(
+  archivePath: string,
+  chapter: ChapterEntry,
+): JobChapterReference {
+  return {
+    locatedUri: formatLocatedChapterUri(archivePath, chapter.path),
+    title: chapter.title,
+    uri: chapter.uri,
+  };
+}
+
+async function resolveJobChapters(
+  jobs: readonly BuildJob[],
+): Promise<ReadonlyMap<string, JobChapterReference>> {
+  const jobsByArchive = new Map<string, BuildJob[]>();
+  for (const job of jobs) {
+    const archivePath = requireJobResourcePath(job, "archive", "archivePath");
+    const grouped = jobsByArchive.get(archivePath) ?? [];
+    grouped.push(job);
+    jobsByArchive.set(archivePath, grouped);
+  }
+  const entries = (
+    await Promise.all(
+      [...jobsByArchive].map(async ([archivePath, archiveJobs]) => {
+        try {
+          let chapters: readonly ChapterEntry[] = [];
+          await new WikiGraphArchiveFile(
+            new NodeFile(archivePath),
+          ).readDocument(async (document) => {
+            chapters = await listChapters(document);
+          });
+          const chaptersById = new Map(
+            chapters.map((chapter) => [chapter.chapterId, chapter]),
+          );
+
+          return archiveJobs.flatMap((job) => {
+            const chapter = chaptersById.get(job.chapterId);
+
+            return chapter === undefined
+              ? []
+              : [
+                  [
+                    job.jobId,
+                    createJobChapterReferenceFromPath(archivePath, chapter),
+                  ] as const,
+                ];
+          });
+        } catch {
+          return [];
+        }
+      }),
+    )
+  ).flat();
+
+  return new Map(entries);
+}
+
+async function resolveJobChapter(
+  job: BuildJob,
+): Promise<JobChapterReference | undefined> {
+  return (await resolveJobChapters([job])).get(job.jobId);
 }
 
 function getJobResourcePath(

--- a/packages/core/src/retrieval/query/archive-view/core.ts
+++ b/packages/core/src/retrieval/query/archive-view/core.ts
@@ -90,6 +90,12 @@ export async function readNodeSourceFragments(
   node: GraphNode,
 ): Promise<readonly ArchiveNodeSourceFragment[]> {
   const fragmentIds = await collectNodeSourceFragmentIds(document, node);
+  const chapters = new Map(
+    (await listChapters(document)).map((chapter) => [
+      chapter.chapterId,
+      chapter,
+    ]),
+  );
 
   return await Promise.all(
     fragmentIds.map(async ([chapterId, fragmentId]) => {
@@ -105,13 +111,16 @@ export async function readNodeSourceFragments(
       const firstSentence = fragmentSentences[0];
       const lastSentence = fragmentSentences[fragmentSentences.length - 1];
       const text = truncateSourceExcerpt(fragment.text);
+      const chapter = chapters.get(chapterId);
 
       return {
         id:
-          firstSentence === undefined || lastSentence === undefined
+          firstSentence === undefined ||
+          lastSentence === undefined ||
+          chapter === undefined
             ? fragment.id
             : formatTextStreamRangeUri(
-                chapterId,
+                chapter.path,
                 "source",
                 firstSentence.globalIndex,
                 lastSentence.globalIndex,

--- a/packages/core/src/retrieval/query/archive-view/evidence-hydration.ts
+++ b/packages/core/src/retrieval/query/archive-view/evidence-hydration.ts
@@ -1,13 +1,8 @@
 import type { ReadonlyDocument } from "../../../document/index.js";
 
 import { readEntitySearchEvidenceMentions } from "../search-cache/index.js";
-import {
-  isWikiGraphObjectUri,
-  mergeStringLists,
-  normalizeWikiGraphObjectUri,
-} from "./helpers.js";
-import { parseWikiGraphReference } from "./references.js";
-import type { WikiGraphReference } from "./references.js";
+import { mergeStringLists } from "./helpers.js";
+import { parseTextStreamRangeUri } from "./references.js";
 import { readTextStreamRange } from "./text-streams.js";
 import type {
   ArchiveFindHit,
@@ -171,7 +166,7 @@ async function hydrateTextStreamHitContext(
     return hit;
   }
 
-  const reference = parseTextStreamHitReference(hit.id);
+  const reference = parseTextStreamHitReference(hit);
 
   if (reference === undefined) {
     return hit;
@@ -194,20 +189,23 @@ async function hydrateTextStreamHitContext(
   };
 }
 
-function parseTextStreamHitReference(
-  uri: string,
-): Extract<WikiGraphReference, { readonly type: "text-stream" }> | undefined {
-  if (!isWikiGraphObjectUri(uri)) {
+function parseTextStreamHitReference(hit: ArchiveFindHit):
+  | {
+      readonly chapterId: number;
+      readonly endSentenceIndex: number;
+      readonly startSentenceIndex: number;
+      readonly stream: "source" | "summary";
+    }
+  | undefined {
+  if (hit.chapter === undefined) {
+    return undefined;
+  }
+  const reference = parseTextStreamRangeUri(hit.id);
+  if (reference === undefined) {
     return undefined;
   }
 
-  try {
-    const reference = parseWikiGraphReference(normalizeWikiGraphObjectUri(uri));
-
-    return reference.type === "text-stream" ? reference : undefined;
-  } catch {
-    return undefined;
-  }
+  return { ...reference, chapterId: hit.chapter };
 }
 
 async function coalesceTextStreamFindHits(
@@ -278,7 +276,7 @@ function parseSearchTextStreamHitRange(
     return undefined;
   }
 
-  const reference = parseTextStreamHitReference(hit.id);
+  const reference = parseTextStreamHitReference(hit);
 
   if (reference === undefined) {
     return undefined;

--- a/packages/core/src/retrieval/query/archive-view/find.ts
+++ b/packages/core/src/retrieval/query/archive-view/find.ts
@@ -242,6 +242,7 @@ export async function findChapters(
       ...(await findTextStreamSentences(
         document,
         chapter.chapterId,
+        chapter.path,
         "summary",
         title,
         search,
@@ -252,6 +253,7 @@ export async function findChapters(
       ...(await findTextStreamSentences(
         document,
         chapter.chapterId,
+        chapter.path,
         "source",
         title,
         search,
@@ -265,6 +267,7 @@ export async function findChapters(
 async function findTextStreamSentences(
   document: ReadonlyDocument,
   chapterId: number,
+  chapterPath: string,
   stream: ArchiveTextStreamKind,
   title: string,
   search: ArchiveTextSearch,
@@ -283,7 +286,7 @@ async function findTextStreamSentences(
         chapter: chapterId,
         field: stream,
         id: formatTextStreamRangeUri(
-          chapterId,
+          chapterPath,
           stream,
           sentence.globalIndex,
           sentence.globalIndex,

--- a/packages/core/src/retrieval/query/archive-view/index-state.test.ts
+++ b/packages/core/src/retrieval/query/archive-view/index-state.test.ts
@@ -224,7 +224,7 @@ describe("archive search index state", () => {
       await writeSourceChapter(document);
 
       await expect(assertArchiveIndexArtifactsReady(document)).rejects.toThrow(
-        "Wiki Graph query is not ready. Chapters 1 need a current FTS artifact or source embedding artifact before query.",
+        'Wiki Graph query is not ready. Chapters "Dense" (wikg://chapter/dense) need a current FTS artifact or source embedding artifact before query.',
       );
     });
   });
@@ -237,7 +237,7 @@ describe("archive search index state", () => {
       await replaceChapterSourceEmbeddingIndexArtifact(document, 2, provider);
 
       await expect(assertArchiveIndexArtifactsReady(document)).rejects.toThrow(
-        "Wiki Graph query is not ready. Chapters 1 need a current FTS artifact or source embedding artifact before query.",
+        'Wiki Graph query is not ready. Chapters "Unindexed" (wikg://chapter/unindexed) need a current FTS artifact or source embedding artifact before query.',
       );
       await expect(
         assertArchiveIndexArtifactsReady(document, { chapters: [2] }),
@@ -389,6 +389,7 @@ async function writeSourceChapters(
     await openedDocument.writeToc({
       items: titles.map((title, index) => ({
         children: [],
+        key: title.toLowerCase(),
         serialId: serialIds[index]!,
         title,
       })),

--- a/packages/core/src/retrieval/query/archive-view/index-state.ts
+++ b/packages/core/src/retrieval/query/archive-view/index-state.ts
@@ -164,9 +164,19 @@ export async function assertArchiveIndexArtifactsReady(
     return;
   }
 
-  const serials = blocked.map((record) => record.serialId).join(", ");
+  const blockedIds = new Set(blocked.map((record) => record.serialId));
+  const chapters = (await listChapters(document)).filter((chapter) =>
+    blockedIds.has(chapter.chapterId),
+  );
+  const chapterReferences = chapters
+    .map((chapter) =>
+      chapter.title === null
+        ? chapter.uri
+        : `${JSON.stringify(chapter.title)} (${chapter.uri})`,
+    )
+    .join(", ");
   throw new Error(
-    `Wiki Graph query is not ready. Chapters ${serials} need a current FTS artifact or source embedding artifact before query.`,
+    `Wiki Graph query is not ready. Chapters ${chapterReferences} need a current FTS artifact or source embedding artifact before query.`,
   );
 }
 

--- a/packages/core/src/retrieval/query/archive-view/pages.ts
+++ b/packages/core/src/retrieval/query/archive-view/pages.ts
@@ -340,12 +340,15 @@ async function readWikiGraphPage(
       throw new Error(
         `${displayUri} is a scope URI, not a readable object. Use ${displayUri}/title or ${displayUri}/state.`,
       );
-    case "chapter-title":
-      return await readArchivePage(
-        document,
-        formatChapterTitleId(reference.chapterId),
-        options,
-      );
+    case "chapter-title": {
+      const chapter = await requireChapter(document, reference.chapterId);
+
+      return {
+        id: displayUri,
+        title: chapter.title ?? `[chapter ${chapter.path}]`,
+        type: "chapter-title",
+      };
+    }
     case "chapter-state": {
       const details = await requireChapter(document, reference.chapterId);
       const targets = await createChapterState(document, details);

--- a/packages/core/src/retrieval/query/archive-view/references.ts
+++ b/packages/core/src/retrieval/query/archive-view/references.ts
@@ -1,4 +1,5 @@
 import type { ReadingEdgeRecord } from "../../../document/index.js";
+import { parseChapterPath } from "../../../document/chapter/path.js";
 import {
   parseWikiGraphUriSyntax,
   WIKI_GRAPH_URI_PREFIX,
@@ -36,11 +37,12 @@ export function formatFragmentId(serialId: number, fragmentId: number): string {
 }
 
 export function formatTextStreamRangeUri(
-  chapterPath: number | string,
+  chapterPath: string,
   stream: ArchiveTextStreamKind,
   startSentenceIndex: number,
   endSentenceIndex: number,
 ): string {
+  chapterPath = parseChapterPath(chapterPath);
   const startSentenceNumber = startSentenceIndex + 1;
   const endSentenceNumber = endSentenceIndex + 1;
   const hash =
@@ -49,6 +51,49 @@ export function formatTextStreamRangeUri(
       : `${startSentenceNumber}..${endSentenceNumber}`;
 
   return `wikg://chapter/${chapterPath}/${stream}#${hash}`;
+}
+
+export function parseTextStreamRangeUri(uri: string):
+  | {
+      readonly chapterPath: string;
+      readonly endSentenceIndex: number;
+      readonly startSentenceIndex: number;
+      readonly stream: ArchiveTextStreamKind;
+    }
+  | undefined {
+  uri = normalizeWikiGraphObjectUri(uri);
+  if (!isWikiGraphObjectUri(uri)) {
+    return undefined;
+  }
+
+  try {
+    const parsedUri = parseWikiGraphUriSyntax(uri);
+    const pathParts = parsedUri.path;
+    const stream = pathParts.at(-1);
+
+    if (
+      parsedUri.protocol !== "wikg" ||
+      pathParts[0] !== "chapter" ||
+      pathParts.length < 3 ||
+      (stream !== "source" && stream !== "summary")
+    ) {
+      return undefined;
+    }
+
+    const chapterPath = parseChapterPath(pathParts.slice(1, -1).join("/"));
+    const [startSentenceIndex, endSentenceIndex] = parseSentenceRange(
+      formatParsedFragment(parsedUri.fragment),
+    );
+
+    return {
+      chapterPath,
+      endSentenceIndex,
+      startSentenceIndex,
+      stream,
+    };
+  } catch {
+    return undefined;
+  }
 }
 
 export type WikiGraphReference =

--- a/packages/core/src/retrieval/query/archive-view/search/hydration.ts
+++ b/packages/core/src/retrieval/query/archive-view/search/hydration.ts
@@ -14,7 +14,7 @@ import {
 } from "../../../search-index/search/index.js";
 
 import { createSnippet, createNodePosition } from "../helpers.js";
-import { formatNodeId, formatTextStreamRangeUri } from "../references.js";
+import { formatNodeId } from "../references.js";
 import {
   createUnscoredEntityEvidenceMention,
   selectEntityLabel,
@@ -311,12 +311,7 @@ export async function hydrateSearchTextHit(
     chapter: hit.chapterId,
     ...createArchiveScopeFields(hit.archiveId),
     field: stream,
-    id: formatTextStreamRangeUri(
-      hit.chapterId,
-      stream,
-      range.startSentenceIndex,
-      range.endSentenceIndex,
-    ),
+    id: range.id,
     matchCount: 1,
     position: {
       chapter: hit.chapterId,

--- a/packages/core/src/retrieval/query/archive-view/source-evidence/read.ts
+++ b/packages/core/src/retrieval/query/archive-view/source-evidence/read.ts
@@ -1,7 +1,6 @@
 import type { ReadonlyDocument } from "../../../../document/index.js";
 import type { ChapterEntry } from "../../../../document/chapter/index.js";
 
-import { formatTextStreamRangeUri } from "../references.js";
 import { readTextStreamRange } from "../text-streams.js";
 import type { ArchiveEvidenceItem, EvidenceReadContext } from "../types.js";
 import { requireChapter } from "../core.js";
@@ -28,12 +27,7 @@ export async function createSourceEvidenceItem(
     chapterId,
     endSentenceIndex: range.endSentenceIndex,
     fragmentId: range.startSentenceIndex,
-    id: formatTextStreamRangeUri(
-      chapterId,
-      "source",
-      range.startSentenceIndex,
-      range.endSentenceIndex,
-    ),
+    id: range.id,
     locators: range.locators,
     ...(score === undefined ? {} : { score }),
     source: range.text,

--- a/packages/core/src/retrieval/query/archive-view/text-streams.ts
+++ b/packages/core/src/retrieval/query/archive-view/text-streams.ts
@@ -2,6 +2,10 @@ import type {
   ReadonlyDocument,
   ReadonlySerialTextStream,
 } from "../../../document/index.js";
+import {
+  listChapters,
+  type ChapterEntry,
+} from "../../../document/chapter/index.js";
 import { countTextWords } from "../../../utils/text-word-count.js";
 
 import { createSnippet } from "./helpers.js";
@@ -101,16 +105,15 @@ export async function readTextStreamRange(
   readonly text: string;
 }> {
   const index = await getTextStreamIndex(document, chapterId, stream, context);
+  const chapter = await getTextStreamChapter(document, chapterId, context);
   if (index.sentences.length === 0) {
-    throw new Error(
-      `Chapter ${formatChapterId(chapterId)} has no ${stream} text.`,
-    );
+    throw new Error(`Chapter ${chapter.uri} has no ${stream} text.`);
   }
 
   const lastSentenceIndex = index.sentences.length - 1;
   if (startSentenceIndex > lastSentenceIndex) {
     throw new Error(
-      `${stream} range ${formatTextStreamRangeUri(chapterId, stream, startSentenceIndex, endSentenceIndex)} is out of bounds. Last sentence number is ${lastSentenceIndex + 1}.`,
+      `${stream} range ${formatTextStreamRangeUri(chapter.path, stream, startSentenceIndex, endSentenceIndex)} is out of bounds. Last sentence number is ${lastSentenceIndex + 1}.`,
     );
   }
 
@@ -146,13 +149,37 @@ export async function readTextStreamRange(
 
   return {
     endSentenceIndex: end,
-    id: formatTextStreamRangeUri(chapterId, stream, start, end),
+    id: formatTextStreamRangeUri(chapter.path, stream, start, end),
     locators,
     ...(sourceEnd === undefined ? {} : { sourceEnd }),
     ...(sourceStart === undefined ? {} : { sourceStart }),
     startSentenceIndex: start,
     text,
   };
+}
+
+async function getTextStreamChapter(
+  document: ReadonlyDocument,
+  chapterId: number,
+  context: EvidenceReadContext,
+): Promise<ChapterEntry> {
+  let chapter = context.chapters.get(chapterId);
+
+  if (chapter === undefined) {
+    chapter = listChapters(document).then((chapters) => {
+      const matched = chapters.find((entry) => entry.chapterId === chapterId);
+
+      if (matched === undefined) {
+        throw new Error(
+          `Chapter ${formatChapterId(chapterId)} does not exist.`,
+        );
+      }
+      return matched;
+    });
+    context.chapters.set(chapterId, chapter);
+  }
+
+  return await chapter;
 }
 
 export async function readTextStreamText(

--- a/test/cli/archive/chapter.test.ts
+++ b/test/cli/archive/chapter.test.ts
@@ -43,6 +43,7 @@ const chapterMockState = vi.hoisted(() => ({
       uri: "wikg://chapter/a1b2c3d4e5f6",
     },
     {
+      chapterId: 2,
       childCount: 0,
       depth: 1,
       fragmentCount: 2,
@@ -444,7 +445,8 @@ describe("cli/archive-chapter", () => {
     ]);
     expect(chapterMockState.textWrites).toStrictEqual([
       [
-        "Job job-index-1 queued index-embedding-source chapter 2 /tmp/book.wikg",
+        'Job job-index-1 queued index-embedding-source chapter "Chapter 1" (wikg://chapter/a1b2c3d4e5f6/b2c3d4e5f6a1)',
+        "Chapter URI: wikg:///tmp/book.wikg/chapter/a1b2c3d4e5f6/b2c3d4e5f6a1",
         "Job is queued; the requested artifact or generated data is not ready until the job succeeds.",
         "Watch: wg wikg://local/job/job-index-1 watch",
         "",

--- a/test/cli/archive/mock.ts
+++ b/test/cli/archive/mock.ts
@@ -612,7 +612,17 @@ vi.mock("../../../packages/core/src/api/index.js", () => ({
   listArchiveCollection: vi.fn(() =>
     Promise.resolve(archiveMockState.collection),
   ),
-  listChapters: vi.fn(() => Promise.resolve(archiveMockState.inspectChapters)),
+  listChapters: vi.fn(() =>
+    Promise.resolve(
+      archiveMockState.inspectChapters.map((chapter) => ({
+        ...chapter,
+        documentOrder: chapter.chapterId,
+        key: `chapter-${chapter.chapterId}`,
+        path: `chapter-${chapter.chapterId}`,
+        uri: `wikg://chapter/chapter-${chapter.chapterId}`,
+      })),
+    ),
+  ),
   resolveChapterPathReadonly: vi.fn(
     (_document: unknown, chapterPath: string) => {
       const chapterId = Number(chapterPath);

--- a/test/cli/archive/object.test.ts
+++ b/test/cli/archive/object.test.ts
@@ -529,6 +529,40 @@ describe("cli/archive/object", () => {
     ]);
   });
 
+  it("reports query blockers with public, reopenable chapter URIs", async () => {
+    archiveMockState.indexArtifactCoverage["embedding-source"] =
+      archiveMockState.indexArtifactCoverage["embedding-source"].map(
+        (item) => ({ ...item, current: false }),
+      );
+
+    await runArchiveCommand({
+      action: "inspect",
+      archivePath: "/tmp/book.wikg",
+      json: true,
+    });
+
+    expect(JSON.parse(archiveMockState.textWrites[0] ?? "")).toMatchObject({
+      queryBlockedChapters: [
+        {
+          chapterId: 2,
+          locatedUri: "wikg:///tmp/book.wikg/chapter/chapter-2",
+          title: "Missing chapter",
+          uri: "wikg://chapter/chapter-2",
+        },
+      ],
+    });
+
+    archiveMockState.textWrites.length = 0;
+    await runArchiveCommand({
+      action: "inspect",
+      archivePath: "/tmp/book.wikg",
+    });
+
+    expect(archiveMockState.textWrites[0]).toContain(
+      "- Missing chapter: wikg:///tmp/book.wikg/chapter/chapter-2",
+    );
+  });
+
   it("inspects empty archive content without showing zero-percent coverage", async () => {
     archiveMockState.inspectChapters = [];
     archiveMockState.summaryWords = 0;

--- a/test/cli/archive/query.test.ts
+++ b/test/cli/archive/query.test.ts
@@ -32,6 +32,44 @@ describe("cli/archive/query", () => {
     );
   });
 
+  it("preserves the public chapter path in title page output", async () => {
+    vi.mocked(readArchivePage).mockResolvedValue({
+      id: "wikg://chapter/a1b2c3d4e5f6/title",
+      title: "Public chapter",
+      type: "chapter-title",
+    });
+
+    await runArchiveCommand({
+      action: "get",
+      archivePath: "wikg:///tmp/book.wikg/chapter/a1b2c3d4e5f6/title",
+      format: "json",
+      objectId: "wikg:///tmp/book.wikg/chapter/a1b2c3d4e5f6/title",
+    });
+
+    expect(readArchivePage).toHaveBeenCalledWith(
+      {},
+      "wikg://chapter/a1b2c3d4e5f6/title",
+      {},
+    );
+    expect(JSON.parse(archiveMockState.textWrites[0] ?? "")).toStrictEqual({
+      title: "Public chapter",
+      type: "chapter-title",
+      uri: "wikg://chapter/a1b2c3d4e5f6/title",
+    });
+
+    archiveMockState.textWrites.length = 0;
+    await runArchiveCommand({
+      action: "get",
+      archivePath: "wikg:///tmp/book.wikg/chapter/a1b2c3d4e5f6/title",
+      format: "text",
+      objectId: "wikg:///tmp/book.wikg/chapter/a1b2c3d4e5f6/title",
+    });
+
+    expect(archiveMockState.textWrites[0]).toContain(
+      "uri: wikg://chapter/a1b2c3d4e5f6/title",
+    );
+  });
+
   it("prints search hits as Wiki Graph URI objects", async () => {
     await runArchiveCommand({
       action: "search",

--- a/test/cli/queue.test.ts
+++ b/test/cli/queue.test.ts
@@ -315,7 +315,22 @@ vi.mock("../../packages/core/src/api/index.js", () => ({
     },
   ),
   listBuildJobs: vi.fn(() => Promise.resolve(queueMockState.jobs)),
-  listChapters: vi.fn(() => Promise.resolve(queueMockState.chapters)),
+  listChapters: vi.fn(() =>
+    Promise.resolve(
+      queueMockState.chapters.map((chapter) => ({
+        ...chapter,
+        childCount: 0,
+        depth: 0,
+        documentOrder: chapter.chapterId,
+        fragmentCount: chapter.stage === "planned" ? 0 : 1,
+        key: `chapter-${chapter.chapterId}`,
+        path: `chapter-${chapter.chapterId}`,
+        title: `Chapter ${chapter.chapterId}`,
+        tocPath: [`chapter-${chapter.chapterId}`],
+        uri: `wikg://chapter/chapter-${chapter.chapterId}`,
+      })),
+    ),
+  ),
   pauseBuildJob: vi.fn(),
   readBuildJobEvents: vi.fn(() => Promise.resolve(queueMockState.events)),
   resolveChapterPathReadonly: vi.fn(
@@ -684,6 +699,11 @@ describe("cli/queue", () => {
       },
       skipped: [
         {
+          chapter: {
+            locatedUri: "wikg://book.wikg/chapter/chapter-11",
+            title: "Chapter 11",
+            uri: "wikg://chapter/chapter-11",
+          },
           chapterId: 11,
           reason: "planned",
         },
@@ -837,7 +857,7 @@ describe("cli/queue", () => {
     });
 
     expect(queueMockState.textWrites).toStrictEqual([
-      "JOB      STATE     STEP    TARGET  CHAPTER ARCHIVE\njob-1-fu running   reading-summary reading-summary      12 book.wikg\n",
+      "JOB      STATE     STEP    TARGET  CHAPTER\njob-1-fu running   reading-summary reading-summary Chapter 12 wikg:///books/book.wikg/chapter/chapter-12\n",
     ]);
   });
 
@@ -879,6 +899,11 @@ describe("cli/queue", () => {
         {
           archiveKey: "archive-key",
           archivePath: "/books/book.wikg",
+          chapter: {
+            locatedUri: "wikg:///books/book.wikg/chapter/chapter-12",
+            title: "Chapter 12",
+            uri: "wikg://chapter/chapter-12",
+          },
           chapterId: 12,
           createdAt: 1,
           eventsPath: "events.ndjson",

--- a/test/core/retrieval/query/archive-view/collection.test.ts
+++ b/test/core/retrieval/query/archive-view/collection.test.ts
@@ -141,7 +141,7 @@ describe("archive/query/archive-view/collection", () => {
           expect.arrayContaining([
             "wikg://chapter/second/title",
             "node:200",
-            "wikg://chapter/2/summary#1",
+            "wikg://chapter/second/summary#1",
             "wikg://triple/Q1/mentions/Q2",
           ]),
         );
@@ -196,7 +196,7 @@ describe("archive/query/archive-view/collection", () => {
         expect(entityWithEvidence?.type).toBe("entity");
         expect(entityWithEvidence?.evidence?.shown).toBe(1);
         expect(entityWithEvidence?.evidence?.sources[0]?.id).toBe(
-          "wikg://chapter/2/source#1",
+          "wikg://chapter/second/source#1",
         );
       } finally {
         await document.release();

--- a/test/core/retrieval/query/archive-view/evidence.test.ts
+++ b/test/core/retrieval/query/archive-view/evidence.test.ts
@@ -151,7 +151,7 @@ describe("archive/query/archive-view/evidence", () => {
         );
 
         expect(firstPage.items.map((item) => item.id)).toStrictEqual([
-          "wikg://chapter/1/source#1..2",
+          "wikg://chapter/introduction/source#1..2",
         ]);
         expect(firstPage.nextCursor).not.toBeNull();
 
@@ -168,7 +168,7 @@ describe("archive/query/archive-view/evidence", () => {
         );
 
         expect(secondPage.items.map((item) => item.id)).toStrictEqual([
-          "wikg://chapter/1/source#3..4",
+          "wikg://chapter/introduction/source#3..4",
         ]);
         expect(secondPage.nextCursor).toBeNull();
       } finally {
@@ -267,7 +267,7 @@ describe("archive/query/archive-view/evidence", () => {
         ).resolves.toMatchObject({
           items: [
             {
-              id: "wikg://chapter/1/source#1..3",
+              id: "wikg://chapter/introduction/source#1..3",
               source:
                 "An LLM Wiki exposes pages, links, and source fragments to agents.朱元璋知道了这个消息，随后亲自来到洪都。Source-only archives should be searchable.",
               type: "source",
@@ -281,7 +281,7 @@ describe("archive/query/archive-view/evidence", () => {
         ).resolves.toMatchObject({
           items: [
             {
-              id: "wikg://chapter/1/source#1",
+              id: "wikg://chapter/introduction/source#1",
               source:
                 "An LLM Wiki exposes pages, links, and source fragments to agents.",
               type: "source",
@@ -293,7 +293,7 @@ describe("archive/query/archive-view/evidence", () => {
         ).resolves.toMatchObject({
           items: [
             {
-              id: "wikg://chapter/1/source#1..3",
+              id: "wikg://chapter/introduction/source#1..3",
               type: "source",
             },
           ],
@@ -303,7 +303,7 @@ describe("archive/query/archive-view/evidence", () => {
         ).resolves.toMatchObject({
           items: [
             {
-              id: "wikg://chapter/1/source#1..3",
+              id: "wikg://chapter/introduction/source#1..3",
               type: "source",
             },
           ],
@@ -315,7 +315,7 @@ describe("archive/query/archive-view/evidence", () => {
             shown: 1,
             sources: [
               {
-                id: "wikg://chapter/1/source#1..3",
+                id: "wikg://chapter/introduction/source#1..3",
                 type: "source",
               },
             ],
@@ -335,7 +335,7 @@ describe("archive/query/archive-view/evidence", () => {
             shown: 1,
             sources: [
               {
-                id: "wikg://chapter/1/source#1..3",
+                id: "wikg://chapter/introduction/source#1..3",
                 type: "source",
               },
             ],
@@ -402,7 +402,7 @@ describe("archive/query/archive-view/evidence", () => {
                 shown: 1,
                 sources: [
                   {
-                    id: "wikg://chapter/1/source#1..3",
+                    id: "wikg://chapter/introduction/source#1..3",
                   },
                 ],
                 total: 1,
@@ -431,7 +431,7 @@ describe("archive/query/archive-view/evidence", () => {
         ).resolves.toMatchObject({
           items: [
             {
-              id: "wikg://chapter/1/source#3..6",
+              id: "wikg://chapter/introduction/source#3..6",
               source:
                 "Source-only archives should be searchable.First unrelated fragment sentence.Second fragment mentions Augustine.Third unrelated fragment sentence.",
               type: "source",
@@ -446,7 +446,7 @@ describe("archive/query/archive-view/evidence", () => {
         ).resolves.toMatchObject({
           items: [
             {
-              id: "wikg://chapter/1/source#1..5",
+              id: "wikg://chapter/introduction/source#1..5",
               type: "source",
             },
           ],
@@ -494,7 +494,7 @@ describe("archive/query/archive-view/evidence", () => {
         );
 
         expect(evidence.items.map((item) => item.id)).toStrictEqual([
-          "wikg://chapter/1/source#1..3",
+          "wikg://chapter/introduction/source#1..3",
         ]);
         expect(evidence.items[0]?.score).toBeGreaterThan(0);
       } finally {
@@ -521,7 +521,14 @@ describe("archive/query/archive-view/evidence", () => {
           );
           await draft.commit();
           await openedDocument.writeToc({
-            items: [{ children: [], serialId: 1, title: "Triple evidence" }],
+            items: [
+              {
+                children: [],
+                key: "triple-evidence",
+                serialId: 1,
+                title: "Triple evidence",
+              },
+            ],
             version: 1,
           });
           await openedDocument.mentions.saveMany([
@@ -583,7 +590,14 @@ describe("archive/query/archive-view/evidence", () => {
           draft.addSentence("Alpha beta beta beta appears later.", 6);
           await draft.commit();
           await openedDocument.writeToc({
-            items: [{ children: [], serialId: 1, title: "Evidence" }],
+            items: [
+              {
+                children: [],
+                key: "ranked-evidence",
+                serialId: 1,
+                title: "Evidence",
+              },
+            ],
             version: 1,
           });
           await openedDocument.mentions.saveMany([
@@ -616,8 +630,8 @@ describe("archive/query/archive-view/evidence", () => {
         );
 
         expect(evidence.items.map((item) => item.id)).toStrictEqual([
-          "wikg://chapter/1/source#3",
-          "wikg://chapter/1/source#1",
+          "wikg://chapter/ranked-evidence/source#3",
+          "wikg://chapter/ranked-evidence/source#1",
         ]);
       } finally {
         await document.release();

--- a/test/core/retrieval/query/archive-view/graph-search.test.ts
+++ b/test/core/retrieval/query/archive-view/graph-search.test.ts
@@ -57,7 +57,7 @@ describe("archive/query/archive-view/graph search", () => {
               shown: 1,
               sources: [
                 expect.objectContaining({
-                  id: "wikg://chapter/1/source#1..3",
+                  id: "wikg://chapter/introduction/source#1..3",
                   source:
                     "An LLM Wiki exposes pages, links, and source fragments to agents.朱元璋知道了这个消息，随后亲自来到洪都。Source-only archives should be searchable.",
                 }),
@@ -543,7 +543,7 @@ describe("archive/query/archive-view/graph search", () => {
         expect(triple?.evidence?.total).toBe(1);
         expect(triple?.evidence?.sources).toStrictEqual([
           expect.objectContaining({
-            id: "wikg://chapter/1/source#1..3",
+            id: "wikg://chapter/introduction/source#1..3",
             source:
               "An LLM Wiki exposes pages, links, and source fragments to agents.朱元璋知道了这个消息，随后亲自来到洪都。Source-only archives should be searchable.",
           }),
@@ -645,7 +645,9 @@ describe("archive/query/archive-view/graph search", () => {
         const sourceHit = result.items.find(
           (item) => item.type === "source" && item.field === "source",
         );
-        expect(sourceHit?.id).toMatch(/^wikg:\/\/chapter\/1\/source#/u);
+        expect(sourceHit?.id).toMatch(
+          /^wikg:\/\/chapter\/introduction\/source#/u,
+        );
         expect(sourceHit).toMatchObject({
           field: "source",
           missingTerms: [],

--- a/test/core/retrieval/query/archive-view/pages.test.ts
+++ b/test/core/retrieval/query/archive-view/pages.test.ts
@@ -228,7 +228,7 @@ describe("archive/query/archive-view/pages", () => {
 
         expect(result.items).toContainEqual(
           expect.objectContaining({
-            id: "wikg://chapter/1/summary#1",
+            id: "wikg://chapter/introduction/summary#1",
             type: "summary",
           }),
         );
@@ -354,19 +354,26 @@ describe("archive/query/archive-view/pages", () => {
 
           await draft.commit();
           await openedDocument.writeToc({
-            items: [{ children: [], serialId: 1, title: "Numbered" }],
+            items: [
+              {
+                children: [],
+                key: "numbered",
+                serialId: 1,
+                title: "Numbered",
+              },
+            ],
             version: 1,
           });
         });
 
         const page = await readArchivePage(
           document,
-          "wikg://chapter/1/source#11..13",
+          "wikg://chapter/numbered/source#11..13",
         );
 
         expect(page).toMatchObject({
           fragment: {
-            id: "wikg://chapter/1/source#11..13",
+            id: "wikg://chapter/numbered/source#11..13",
             text: ["Sentence 10", "Sentence 11", "Sentence 12"].join(""),
           },
           type: "fragment",
@@ -409,7 +416,7 @@ describe("archive/query/archive-view/pages", () => {
         await expect(
           readArchivePage(document, "wikg://chapter/1/source#100..100"),
         ).rejects.toThrow(
-          "source range wikg://chapter/1/source#100 is out of bounds. Last sentence number is 3.",
+          "source range wikg://chapter/introduction/source#100 is out of bounds. Last sentence number is 3.",
         );
       } finally {
         await document.release();
@@ -435,7 +442,7 @@ describe("archive/query/archive-view/pages", () => {
         );
         expect(page.id).toBe("node:100");
         expect(page.sourceFragments[0]?.id).toBe(
-          "wikg://chapter/1/source#1..3",
+          "wikg://chapter/introduction/source#1..3",
         );
         expect(page.sourceFragments[0]?.text).toContain(
           "An LLM Wiki exposes pages",
@@ -462,7 +469,7 @@ describe("archive/query/archive-view/pages", () => {
           throw new Error("Expected node page");
         }
         expect(page.sourceFragments[0]?.id).toBe(
-          "wikg://chapter/1/source#1..3",
+          "wikg://chapter/introduction/source#1..3",
         );
         expect(page.sourceFragments[0]?.text).toContain(
           "Source-only archives should be searchable.",
@@ -556,12 +563,12 @@ describe("archive/query/archive-view/pages", () => {
           "wikg://chapter/second-in-id-first-in-document/title",
         ]);
         expect(evidence.items.map((item) => item.id)).toStrictEqual([
-          "wikg://chapter/2/source#1",
-          "wikg://chapter/1/source#1",
+          "wikg://chapter/second-in-id-first-in-document/source#1",
+          "wikg://chapter/first-in-id-second-in-document/source#1",
         ]);
         expect(evidenceReverse.items.map((item) => item.id)).toStrictEqual([
-          "wikg://chapter/1/source#1",
-          "wikg://chapter/2/source#1",
+          "wikg://chapter/first-in-id-second-in-document/source#1",
+          "wikg://chapter/second-in-id-first-in-document/source#1",
         ]);
       } finally {
         await document.release();

--- a/test/core/retrieval/query/archive-view/pages.test.ts
+++ b/test/core/retrieval/query/archive-view/pages.test.ts
@@ -40,6 +40,13 @@ describe("archive/query/archive-view/pages", () => {
           type: "chapter-title",
         });
         await expect(
+          readArchivePage(document, "wikg://chapter/introduction/title"),
+        ).resolves.toStrictEqual({
+          id: "wikg://chapter/introduction/title",
+          title: "Introduction",
+          type: "chapter-title",
+        });
+        await expect(
           readArchivePage(document, "wikg://chapter/1/state"),
         ).resolves.toStrictEqual({
           id: "wikg://chapter/1/state",

--- a/test/core/retrieval/query/archive-view/search-controls.test.ts
+++ b/test/core/retrieval/query/archive-view/search-controls.test.ts
@@ -35,7 +35,7 @@ describe("archive/query/archive-view/search controls", () => {
         expect(result.items).toContainEqual(
           expect.objectContaining({
             field: "source",
-            id: "wikg://chapter/1/source#2",
+            id: "wikg://chapter/introduction/source#2",
             type: "source",
           }),
         );
@@ -64,7 +64,7 @@ describe("archive/query/archive-view/search controls", () => {
         expect(result.items).toStrictEqual([
           expect.objectContaining({
             chapter: 1,
-            id: "wikg://chapter/1/source#1",
+            id: "wikg://chapter/introduction/source#1",
             position: { chapter: 1, sentence: 0 },
             type: "source",
           }),

--- a/test/core/retrieval/query/archive-view/text-search.test.ts
+++ b/test/core/retrieval/query/archive-view/text-search.test.ts
@@ -68,7 +68,7 @@ describe("archive/query/archive-view/text search", () => {
         expect(result.items).toContainEqual(
           expect.objectContaining({
             field: "source",
-            id: "wikg://chapter/1/source#1..3",
+            id: "wikg://chapter/introduction/source#1..3",
             position: {
               chapter: 1,
               sentence: 0,
@@ -77,6 +77,15 @@ describe("archive/query/archive-view/text search", () => {
           }),
         );
         const sourceHit = result.items.find((item) => item.type === "source");
+        if (sourceHit === undefined) {
+          throw new Error("Expected source search hit");
+        }
+        await expect(
+          readArchivePage(document, sourceHit.id),
+        ).resolves.toMatchObject({
+          id: sourceHit.id,
+          type: "fragment",
+        });
         expect(sourceHit?.locators).toStrictEqual({
           [`1..${Array.from(sourceHit?.snippet ?? "").length}`]: `wikg://artifact/${"a".repeat(64)}#epubcfi(/6/2!/4/2)`,
         });
@@ -111,7 +120,14 @@ describe("archive/query/archive-view/text search", () => {
             .getSerialFragments(1)
             .writeTextStream(sourceText);
           await openedDocument.writeToc({
-            items: [{ children: [], serialId: 1, title: "Chapter 1" }],
+            items: [
+              {
+                children: [],
+                key: "rendered-source",
+                serialId: 1,
+                title: "Chapter 1",
+              },
+            ],
             version: 1,
           });
         });
@@ -167,7 +183,14 @@ describe("archive/query/archive-view/text search", () => {
             version: 1,
           });
           await openedDocument.writeToc({
-            items: [{ children: [], serialId: 1, title: "Chapter 1" }],
+            items: [
+              {
+                children: [],
+                key: "coalesced-source",
+                serialId: 1,
+                title: "Chapter 1",
+              },
+            ],
             version: 1,
           });
         });
@@ -178,7 +201,7 @@ describe("archive/query/archive-view/text search", () => {
         expect(result.items).toStrictEqual([
           expect.objectContaining({
             field: "source",
-            id: "wikg://chapter/1/source#1..3",
+            id: "wikg://chapter/coalesced-source/source#1..3",
             snippet:
               "# Test NoteAlice studies graph retrieval.Bob cites Alice in a research note.",
             type: "source",
@@ -208,7 +231,9 @@ describe("archive/query/archive-view/text search", () => {
         const sourceHit = result.items.find(
           (item) => item.type === "source" && item.field === "source",
         );
-        expect(sourceHit?.id).toMatch(/^wikg:\/\/chapter\/1\/source#/u);
+        expect(sourceHit?.id).toMatch(
+          /^wikg:\/\/chapter\/introduction\/source#/u,
+        );
         expect(sourceHit).toMatchObject({
           field: "source",
           type: "source",
@@ -305,6 +330,7 @@ describe("archive/query/archive-view/text search", () => {
             items: [
               {
                 children: [],
+                key: "ranking",
                 serialId: 1,
                 title: "Ranking",
               },
@@ -320,8 +346,8 @@ describe("archive/query/archive-view/text search", () => {
         });
 
         expect(result.items.map((item) => item.id)).toStrictEqual([
-          "wikg://chapter/1/source#2",
-          "wikg://chapter/1/source#1",
+          "wikg://chapter/ranking/source#2",
+          "wikg://chapter/ranking/source#1",
         ]);
         expect(result.items[0]?.score).toBeGreaterThan(
           result.items[1]?.score ?? 0,


### PR DESCRIPTION
## 概要

- 统一搜索、evidence 与 source/summary range 的公开 Chapter URI，使用 TOC opaque path
- 为 Job、readiness 与 inspect 输出补充可识别标题及可直接操作的 URI
- 保证 plain、JSON、JSONL 和 Open short URIs 提示中的 URI 可重新打开
- 修复 direct chapter title 页面回落到内部 numeric chapterId 的问题

## 验证

- `pnpm verify`
- 6 个相关测试文件，138 tests passed
- 完整实现阶段测试：155 files，999 tests passed
- `pnpm build`
- 真实临时 archive 验证 title 的 plain/JSON URI 可重新定位

无 schema 改动。