### PR TITLE
修正 Query Readiness 与 FTS 恢复链

### DIFF
--- a/packages/cli/src/commands/archive-command/index.ts
+++ b/packages/cli/src/commands/archive-command/index.ts
@@ -26,6 +26,7 @@ import {
 import type { CLIArchiveArguments } from "../../args/index.js";
 import { loadCLIConfig } from "../../runtime/config.js";
 import { buildSearchIndexEmbeddingProvider } from "../../runtime/embedding.js";
+import { formatCliCommand } from "../../support/index.js";
 import { runConvertCommand } from "../convert.js";
 import { createArchive } from "./create.js";
 import { writeArchiveInspectReport } from "./inspect.js";
@@ -363,7 +364,14 @@ async function ensureArchiveQueryIndexCache(
         return;
       }
 
-      await rebuildArchiveSearchIndex(document, undefined, options);
+      try {
+        await rebuildArchiveSearchIndex(document, undefined, options);
+      } catch (error) {
+        if (isArchiveQueryNotReadyError(error)) {
+          throw createArchiveQueryNotReadyError(args, error.message);
+        }
+        throw error;
+      }
     },
     { searchIndexWritebackPolicy: "cache" },
   );
@@ -383,12 +391,43 @@ async function createScopedQueryArgs(
   });
 
   if (queryableChapters.length === 0) {
-    throw new Error(
+    throw createArchiveQueryNotReadyError(
+      args,
       "Wiki Graph query is not ready. No chapters in this scope have a current FTS artifact or source embedding artifact.",
     );
   }
 
   return { ...args, chapters: queryableChapters };
+}
+
+function createArchiveQueryNotReadyError(
+  args: Pick<CLIArchiveArguments, "archivePath">,
+  reason: string,
+): Error {
+  const buildCommand = formatCliCommand([
+    "wikg://local/job",
+    "add",
+    "--input",
+    args.archivePath,
+    "--task",
+    "index-fts",
+  ]);
+
+  return new Error(
+    [
+      reason,
+      "",
+      "Build local FTS artifacts without provider calls:",
+      `  ${buildCommand}`,
+      "",
+      "Help:",
+      "  wg help readiness",
+    ].join("\n"),
+  );
+}
+
+function isArchiveQueryNotReadyError(error: unknown): error is Error {
+  return error instanceof Error && error.name === "ArchiveQueryNotReadyError";
 }
 
 function applyChapterScope(

--- a/packages/cli/src/commands/archive-command/inspect.ts
+++ b/packages/cli/src/commands/archive-command/inspect.ts
@@ -70,13 +70,14 @@ interface InspectReport {
     readonly sourceWords: number;
     readonly summaryWords: number;
   };
-  readonly index: {
+  readonly localIndexCache: {
+    readonly blockedBy?: "missing-search-artifacts";
     readonly current: boolean;
     readonly fixCommand?: string;
     readonly impact?: string;
-    readonly querySupport: boolean;
     readonly resource?: string;
-    readonly status: "current" | "missing-or-outdated";
+    readonly status: "blocked" | "current" | "missing-or-outdated";
+    readonly syncAvailable: boolean;
   };
   readonly coverage: {
     readonly ftsIndexArtifact: InspectCoverage;
@@ -86,7 +87,17 @@ interface InspectReport {
     readonly summaryEmbeddingIndexArtifact: InspectCoverage;
     readonly sourceEmbeddingIndexArtifact: InspectCoverage;
   };
-  readonly queryBlockedChapters: readonly InspectChapterReference[];
+  readonly query: {
+    readonly ready: boolean;
+  };
+  readonly searchArtifacts: {
+    readonly blockedChapters: readonly InspectChapterReference[];
+    readonly fixCommand?: string;
+    readonly helpCommand: string;
+    readonly ready: boolean;
+    readonly resource?: string;
+    readonly status: "incomplete" | "ready";
+  };
   readonly retrievalGuidance: readonly string[];
   readonly improvements: readonly InspectImprovement[];
   readonly performanceHints: readonly GenerationPerformanceHint[];
@@ -118,7 +129,7 @@ async function createArchiveInspectReport(
   const [
     chapters,
     summaryWords,
-    ftsCurrent,
+    indexCacheCurrent,
     config,
     ftsArtifactCoverage,
     sourceEmbeddingArtifactCoverage,
@@ -169,19 +180,30 @@ async function createArchiveInspectReport(
     contentChapters,
     summaryEmbeddingArtifactCoverage,
   );
-  const queryBlockedChapters = contentChapters
-    .filter(
-      (chapter) =>
-        !ftsArtifactCovered.includes(chapter) &&
-        !sourceEmbeddingArtifactCovered.includes(chapter),
-    )
-    .map((chapter) => createInspectChapterReference(archiveUri, chapter));
+  const queryBlockedContentChapters = contentChapters.filter(
+    (chapter) =>
+      !ftsArtifactCovered.includes(chapter) &&
+      !sourceEmbeddingArtifactCovered.includes(chapter),
+  );
+  const queryBlockedChapters = queryBlockedContentChapters.map((chapter) =>
+    createInspectChapterReference(archiveUri, chapter),
+  );
+  const queryReady = queryBlockedChapters.length === 0;
+  const buildFtsCommand = formatCliCommand([
+    "wikg://local/job",
+    "add",
+    "--input",
+    scopeUri,
+    "--task",
+    "index-fts",
+  ]);
   const improvements = createInspectImprovements({
     archiveUri,
     concurrent,
     contentChapters,
-    ftsCurrent,
+    indexCacheCurrent,
     planningModel,
+    queryBlockedChapters: queryBlockedContentChapters,
     scopeUri,
     summaryCovered,
     knowledgeGraphCovered,
@@ -193,7 +215,10 @@ async function createArchiveInspectReport(
       ...improvements.map((improvement) => improvement.missingChapters ?? 0),
     ),
     concurrent,
-    hasGenerationWork: improvements.some(
+    hasJobWork: improvements.some(
+      (improvement) => improvement.planning !== undefined,
+    ),
+    hasRequestWork: improvements.some(
       (improvement) => improvement.planning !== undefined,
     ),
   });
@@ -213,18 +238,28 @@ async function createArchiveInspectReport(
       sourceWords,
       summaryWords,
     },
-    index: {
-      current: ftsCurrent,
-      ...(ftsCurrent
-        ? {}
-        : {
-            fixCommand: formatCliCommand([`${archiveUri}/index`, "sync"]),
+    localIndexCache: {
+      current: indexCacheCurrent,
+      ...(!queryReady
+        ? {
+            blockedBy: "missing-search-artifacts" as const,
             impact:
-              "The next archive query may need to sync index cache first.",
-            resource: "local CPU/disk time only; no provider calls.",
-          }),
-      querySupport: queryBlockedChapters.length === 0,
-      status: ftsCurrent ? "current" : "missing-or-outdated",
+              "The cache cannot be built until every content chapter has a current FTS or source embedding artifact.",
+          }
+        : indexCacheCurrent
+          ? {}
+          : {
+              fixCommand: formatCliCommand([`${archiveUri}/index`, "sync"]),
+              impact:
+                "The next archive query may need to sync index cache first.",
+              resource: "local CPU/disk time only; no provider calls.",
+            }),
+      status: !queryReady
+        ? "blocked"
+        : indexCacheCurrent
+          ? "current"
+          : "missing-or-outdated",
+      syncAvailable: queryReady && !indexCacheCurrent,
     },
     coverage: {
       ftsIndexArtifact: createInspectCoverage(
@@ -246,12 +281,27 @@ async function createArchiveInspectReport(
         contentChapters,
       ),
     },
-    queryBlockedChapters,
+    query: {
+      ready: queryReady,
+    },
+    searchArtifacts: {
+      blockedChapters: queryBlockedChapters,
+      ...(!queryReady
+        ? {
+            fixCommand: buildFtsCommand,
+            resource: "local CPU/disk time only; no provider calls.",
+          }
+        : {}),
+      helpCommand: "wg help readiness",
+      ready: queryReady,
+      status: queryReady ? "ready" : "incomplete",
+    },
     retrievalGuidance: formatRetrievalGuidance({
-      ftsCurrent,
+      indexCacheCurrent,
       knowledgeGraphCovered,
       readingGraphCovered,
       contentChapters,
+      queryReady,
       sourceWords,
     }),
     improvements,
@@ -285,15 +335,29 @@ function formatArchiveInspectText(report: InspectReport): string {
       `Source words: ${report.content.sourceWords}`,
       `Summary words: ${report.content.summaryWords}`,
       "",
-      "Index Cache",
-      `Status: ${report.index.current ? "current" : "missing or outdated"}`,
-      `Query support: ${report.index.querySupport ? "available" : "unavailable"}`,
-      ...(report.index.current
+      "Query Readiness",
+      `Status: ${report.query.ready ? "available" : "unavailable"}`,
+      `Search artifacts: ${report.searchArtifacts.status}`,
+      ...(report.searchArtifacts.ready
         ? []
         : [
-            `Impact: ${report.index.impact}`,
-            `Fix: ${report.index.fixCommand}`,
-            `Resource: ${report.index.resource}`,
+            `Fix: ${report.searchArtifacts.fixCommand}`,
+            `Resource: ${report.searchArtifacts.resource}`,
+            `Help: ${report.searchArtifacts.helpCommand}`,
+          ]),
+      "",
+      "Index Cache",
+      `Status: ${report.localIndexCache.status === "missing-or-outdated" ? "missing or outdated" : report.localIndexCache.status}`,
+      ...(report.localIndexCache.current
+        ? []
+        : [
+            `Impact: ${report.localIndexCache.impact}`,
+            ...(report.localIndexCache.fixCommand === undefined
+              ? []
+              : [`Fix: ${report.localIndexCache.fixCommand}`]),
+            ...(report.localIndexCache.resource === undefined
+              ? []
+              : [`Resource: ${report.localIndexCache.resource}`]),
           ]),
       "",
       "Coverage",
@@ -313,11 +377,11 @@ function formatArchiveInspectText(report: InspectReport): string {
       formatCoverageLine("Knowledge Graph", report.coverage.knowledgeGraph),
       formatCoverageLine("Summary Artifact", report.coverage.summary),
       `Summary note: ${report.help.summaryCoverage}`,
-      ...(report.queryBlockedChapters.length === 0
+      ...(report.searchArtifacts.blockedChapters.length === 0
         ? []
         : [
             "Query blockers: these chapters have neither FTS nor source embedding index artifacts:",
-            ...report.queryBlockedChapters.map(
+            ...report.searchArtifacts.blockedChapters.map(
               (chapter) =>
                 `- ${chapter.title === null ? "[untitled]" : chapter.title}: ${chapter.locatedUri}`,
             ),
@@ -456,8 +520,9 @@ function formatCoverageLine(label: string, coverage: InspectCoverage): string {
 
 function formatRetrievalGuidance(input: {
   readonly contentChapters: readonly InspectChapter[];
-  readonly ftsCurrent: boolean;
+  readonly indexCacheCurrent: boolean;
   readonly knowledgeGraphCovered: readonly InspectChapter[];
+  readonly queryReady: boolean;
   readonly readingGraphCovered: readonly InspectChapter[];
   readonly sourceWords: number;
 }): readonly string[] {
@@ -469,7 +534,9 @@ function formatRetrievalGuidance(input: {
   }
 
   const lines = [
-    `Query cache: ${input.ftsCurrent ? "current" : "missing or outdated; archive query can sync it from artifacts"}.`,
+    input.queryReady
+      ? `Query: available; local index cache is ${input.indexCacheCurrent ? "current" : "missing or outdated and can be synced from artifacts"}.`
+      : "Query: unavailable until every content chapter has a current FTS or source embedding artifact.",
   ];
 
   lines.push(
@@ -517,23 +584,15 @@ function createInspectImprovements(input: {
   readonly archiveUri: string;
   readonly concurrent: { readonly job: number; readonly request: number };
   readonly contentChapters: readonly InspectChapter[];
-  readonly ftsCurrent: boolean;
+  readonly indexCacheCurrent: boolean;
   readonly knowledgeGraphCovered: readonly InspectChapter[];
   readonly planningModel: string;
+  readonly queryBlockedChapters: readonly InspectChapter[];
   readonly readingGraphCovered: readonly InspectChapter[];
   readonly scopeUri: string;
   readonly summaryCovered: readonly InspectChapter[];
 }): readonly InspectImprovement[] {
   const improvements: InspectImprovement[] = [];
-
-  if (!input.ftsCurrent) {
-    improvements.push({
-      command: formatCliCommand([`${input.archiveUri}/index`, "sync"]),
-      recommendation:
-        "Sync the index cache from chapter index artifacts so query starts without a lazy cache rebuild.",
-      title: "Sync index cache",
-    });
-  }
 
   if (input.contentChapters.length === 0) {
     improvements.push({
@@ -548,6 +607,31 @@ function createInspectImprovements(input: {
       title: "Add source content",
     });
     return improvements;
+  }
+
+  if (input.queryBlockedChapters.length > 0) {
+    improvements.push({
+      command: formatCliCommand([
+        "wikg://local/job",
+        "add",
+        "--input",
+        input.scopeUri,
+        "--task",
+        "index-fts",
+      ]),
+      missingChapters: input.queryBlockedChapters.length,
+      missingWords: sumWords(input.queryBlockedChapters),
+      recommendation:
+        "Build local FTS artifacts to make this scope queryable. This does not call a provider.",
+      title: "Enable query with local FTS",
+    });
+  } else if (!input.indexCacheCurrent) {
+    improvements.push({
+      command: formatCliCommand([`${input.archiveUri}/index`, "sync"]),
+      recommendation:
+        "Sync the index cache from chapter index artifacts so query starts without a lazy cache rebuild.",
+      title: "Sync index cache",
+    });
   }
 
   improvements.push(

--- a/packages/cli/src/commands/queue/estimate.ts
+++ b/packages/cli/src/commands/queue/estimate.ts
@@ -21,6 +21,7 @@ export interface QueueAddEstimate {
   readonly planning: GenerationPlanningCost;
   readonly steps: readonly QueueAddEstimateStep[];
   readonly target: BuildJobTarget;
+  readonly usesProvider: boolean;
   readonly words: number;
 }
 
@@ -55,6 +56,7 @@ export function createQueueAddEstimate(input: {
     target: input.target,
   });
   const workChapters = Math.max(0, ...steps.map((step) => step.chapters));
+  const usesProvider = steps.some((step) => step.task !== "index-fts");
 
   return {
     chapters: input.chapters.length,
@@ -63,11 +65,13 @@ export function createQueueAddEstimate(input: {
     performanceHints: createGenerationPerformanceHints({
       chapters: workChapters,
       concurrent,
-      hasGenerationWork: steps.length > 0,
+      hasJobWork: steps.length > 0,
+      hasRequestWork: usesProvider,
     }),
     planning: sumGenerationPlanningCosts(model, steps),
     steps,
     target: input.target,
+    usesProvider,
     words,
   };
 }
@@ -222,7 +226,9 @@ export function formatQueueAddEstimateJSON(
 ): unknown {
   return {
     chapters: estimate.chapters,
-    concurrent: estimate.concurrent,
+    concurrent: estimate.usesProvider
+      ? estimate.concurrent
+      : { job: estimate.concurrent.job },
     includesPrerequisites: estimate.includesPrerequisites,
     performanceHints: estimate.performanceHints,
     steps: estimate.steps.map((step) => ({
@@ -237,7 +243,7 @@ export function formatQueueAddEstimateJSON(
     tokens: estimate.planning.tokens,
     waitSeconds: estimate.planning.timeSeconds,
     words: estimate.words,
-    model: estimate.planning.model,
+    ...(estimate.usesProvider ? { model: estimate.planning.model } : {}),
   };
 }
 
@@ -250,10 +256,10 @@ export function formatQueueAddEstimateLines(
     ...(estimate.includesPrerequisites
       ? ["  Includes prerequisite Reading Graph work where missing."]
       : []),
-    `  Model: ${estimate.planning.model}`,
+    ...(estimate.usesProvider ? [`  Model: ${estimate.planning.model}`] : []),
     `  Tokens: ${estimate.planning.tokens.input} input / ${estimate.planning.tokens.cacheableInput} cacheable input / ${estimate.planning.tokens.output} output`,
     `  Wait: ${formatGenerationPlanningDuration(estimate.planning.timeSeconds.min)}-${formatGenerationPlanningDuration(estimate.planning.timeSeconds.max)}`,
-    `  Current concurrency: job=${estimate.concurrent.job} request=${estimate.concurrent.request}`,
+    `  Current concurrency: job=${estimate.concurrent.job}${estimate.usesProvider ? ` request=${estimate.concurrent.request}` : ""}`,
     ...formatQueuePerformanceHintLines(estimate.performanceHints),
   ];
 }

--- a/packages/cli/src/commands/queue/output.ts
+++ b/packages/cli/src/commands/queue/output.ts
@@ -9,6 +9,7 @@ import {
 import {
   formatCLIJSON,
   formatCliCommand,
+  formatWikiGraphCommandUri,
   writeTextToStdout,
 } from "../../support/index.js";
 import {
@@ -261,6 +262,12 @@ export async function writeArchiveAddSummary(input: {
     readonly reason: string;
   }[];
 }): Promise<void> {
+  const jobsCommand = formatCliCommand(["wikg://local/job", "--json"]);
+  const verifyCommand = formatCliCommand([
+    formatWikiGraphCommandUri(input.archivePath),
+    "inspect",
+  ]);
+
   if (input.json) {
     await writeTextToStdout(
       formatCLIJSON({
@@ -273,6 +280,7 @@ export async function writeArchiveAddSummary(input: {
         ...(input.estimate === undefined
           ? {}
           : { estimate: formatQueueAddEstimateJSON(input.estimate) }),
+        ...(input.created.length === 0 ? {} : { jobsCommand, verifyCommand }),
         skipped: input.skipped.map((item) => ({
           chapterId: item.chapter.chapterId,
           chapter: formatChapterJSON(
@@ -303,6 +311,13 @@ export async function writeArchiveAddSummary(input: {
   }
   if (input.estimate !== undefined) {
     lines.push("", ...formatQueueAddEstimateLines(input.estimate));
+  }
+  if (input.created.length > 0) {
+    lines.push(
+      "",
+      `Jobs: ${jobsCommand}`,
+      `Verify after the jobs finish: ${verifyCommand}`,
+    );
   }
 
   await writeTextToStdout(`${lines.join("\n")}\n`);

--- a/packages/cli/src/runtime/planning.ts
+++ b/packages/cli/src/runtime/planning.ts
@@ -62,9 +62,10 @@ export function planGenerationTask(
 export function createGenerationPerformanceHints(input: {
   readonly chapters: number;
   readonly concurrent: GenerationConcurrency;
-  readonly hasGenerationWork: boolean;
+  readonly hasJobWork: boolean;
+  readonly hasRequestWork: boolean;
 }): readonly GenerationPerformanceHint[] {
-  if (!input.hasGenerationWork) {
+  if (!input.hasJobWork) {
     return [];
   }
 
@@ -77,7 +78,7 @@ export function createGenerationPerformanceHints(input: {
         ? 8
         : undefined;
 
-  if (recommendedRequest !== undefined) {
+  if (input.hasRequestWork && recommendedRequest !== undefined) {
     hints.push({
       command: `wg wikg://local/config/concurrent put request ${recommendedRequest}`,
       current: input.concurrent.request,
@@ -94,7 +95,7 @@ export function createGenerationPerformanceHints(input: {
       current: input.concurrent.job,
       kind: "job",
       message:
-        "Multiple chapters need generation and job concurrency is below 4. Raising it lets chapter jobs run in parallel.",
+        "Multiple chapters need work and job concurrency is below 4. Raising it lets chapter jobs run in parallel.",
       recommended: 4,
     });
   }

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -15,6 +15,7 @@ export {
   type WikiGraphTextStreamSessionOptions,
 } from "./app.js";
 export {
+  ArchiveQueryNotReadyError,
   findArchiveObjects,
   formatChapterId,
   formatEdgeId,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -229,6 +229,7 @@ export type {
 export { TOC_FILE_VERSION, parseSourceTextJsonl } from "./text/source/index.js";
 export type { BookMeta, ParsedSourceTextJsonl } from "./text/source/index.js";
 export {
+  ArchiveQueryNotReadyError,
   assertArchiveIndexArtifactsReady,
   buildArchiveIndexProjection,
   isArchiveSearchIndexCurrent,

--- a/packages/core/src/retrieval/query/archive-view/index-state.ts
+++ b/packages/core/src/retrieval/query/archive-view/index-state.ts
@@ -33,6 +33,10 @@ export interface ArchiveSearchIndexScopeOptions {
   readonly chapters?: readonly number[];
 }
 
+export class ArchiveQueryNotReadyError extends Error {
+  public override readonly name = "ArchiveQueryNotReadyError";
+}
+
 export async function rebuildArchiveSearchIndex(
   document: Document,
   progress?: SearchIndexProgressReporter,
@@ -175,7 +179,7 @@ export async function assertArchiveIndexArtifactsReady(
         : `${JSON.stringify(chapter.title)} (${chapter.uri})`,
     )
     .join(", ");
-  throw new Error(
+  throw new ArchiveQueryNotReadyError(
     `Wiki Graph query is not ready. Chapters ${chapterReferences} need a current FTS artifact or source embedding artifact before query.`,
   );
 }

--- a/packages/core/src/retrieval/query/archive-view/index.ts
+++ b/packages/core/src/retrieval/query/archive-view/index.ts
@@ -8,6 +8,7 @@ export {
 export type { ArchivePageOptions } from "./pages.js";
 
 export {
+  ArchiveQueryNotReadyError,
   clearDirtyArchiveSearchIndex,
   assertArchiveIndexArtifactsReady,
   buildArchiveIndexProjection,

--- a/packages/core/src/retrieval/query/index.ts
+++ b/packages/core/src/retrieval/query/index.ts
@@ -1,5 +1,6 @@
 export {
   findArchiveObjects,
+  ArchiveQueryNotReadyError,
   formatChapterId,
   formatEdgeId,
   formatNodeId,

--- a/test/cli/archive/mock.ts
+++ b/test/cli/archive/mock.ts
@@ -488,6 +488,7 @@ const archiveMockState = vi.hoisted(() => ({
     type: "triple",
   } satisfies ArchivePage,
   readCalls: [] as string[],
+  rebuildErrorMessage: undefined as string | undefined,
   serials: new Map([
     [1, { knowledgeGraphReady: true, topologyReady: true }],
     [2, { knowledgeGraphReady: false, topologyReady: false }],
@@ -520,7 +521,15 @@ vi.mock("wiki-graph-core", async (importOriginal) => {
       Promise.resolve(archiveMockState.ftsCurrent),
     ),
     listArchiveQueryableChapterIds: vi.fn(() => Promise.resolve([1, 2])),
-    rebuildArchiveSearchIndex: vi.fn(() => Promise.resolve()),
+    rebuildArchiveSearchIndex: vi.fn(() =>
+      archiveMockState.rebuildErrorMessage === undefined
+        ? Promise.resolve()
+        : Promise.reject(
+            Object.assign(new Error(archiveMockState.rebuildErrorMessage), {
+              name: "ArchiveQueryNotReadyError",
+            }),
+          ),
+    ),
     resolveWikiGraphLibraryArchivePath: vi.fn((uri: string) => {
       const archiveId = uri.split("/").at(-1) ?? "archive";
 
@@ -863,6 +872,7 @@ export function resetArchiveMockState(): void {
   };
   archiveMockState.inspectChapters = createDefaultInspectChapters();
   archiveMockState.readCalls.length = 0;
+  archiveMockState.rebuildErrorMessage = undefined;
   archiveMockState.serials = createDefaultInspectSerials();
   archiveMockState.summaryWords = 120;
   archiveMockState.convertCalls.length = 0;

--- a/test/cli/archive/object.test.ts
+++ b/test/cli/archive/object.test.ts
@@ -325,7 +325,7 @@ describe("cli/archive/object", () => {
     });
 
     const output = JSON.parse(archiveMockState.textWrites[0] ?? "") as {
-      readonly index?: { readonly fixCommand?: string };
+      readonly localIndexCache?: { readonly fixCommand?: string };
       readonly improvements?: readonly { readonly command?: string }[];
       readonly uri?: string;
     };
@@ -334,7 +334,7 @@ describe("cli/archive/object", () => {
       "/tmp/library/archive123.wikg",
     ]);
     expect(output.uri).toBe("wikg://lib/arc/archive123");
-    expect(output.index?.fixCommand).toBe(
+    expect(output.localIndexCache?.fixCommand).toBe(
       "wg wikg://lib/arc/archive123/index sync",
     );
     expect(archiveMockState.textWrites[0]).not.toContain(
@@ -448,11 +448,19 @@ describe("cli/archive/object", () => {
         sourceWords: 1200,
         summaryWords: 120,
       },
-      index: {
+      localIndexCache: {
         current: false,
         fixCommand: "wg wikg:///tmp/book.wikg/index sync",
-        querySupport: true,
         status: "missing-or-outdated",
+        syncAvailable: true,
+      },
+      query: {
+        ready: true,
+      },
+      searchArtifacts: {
+        blockedChapters: [],
+        ready: true,
+        status: "ready",
       },
       coverage: {
         knowledgeGraph: {
@@ -485,7 +493,7 @@ describe("cli/archive/object", () => {
     });
     expect(output.retrievalGuidance).toEqual(
       expect.arrayContaining([
-        "Query cache: missing or outdated; archive query can sync it from artifacts.",
+        "Query: available; local index cache is missing or outdated and can be synced from artifacts.",
       ]),
     );
     expect(output.improvements).toEqual(
@@ -541,16 +549,46 @@ describe("cli/archive/object", () => {
       json: true,
     });
 
-    expect(JSON.parse(archiveMockState.textWrites[0] ?? "")).toMatchObject({
-      queryBlockedChapters: [
-        {
-          chapterId: 2,
-          locatedUri: "wikg:///tmp/book.wikg/chapter/chapter-2",
-          title: "Missing chapter",
-          uri: "wikg://chapter/chapter-2",
-        },
-      ],
+    const report = JSON.parse(archiveMockState.textWrites[0] ?? "") as {
+      readonly improvements: readonly {
+        readonly command: string;
+        readonly title: string;
+      }[];
+    };
+    expect(report).toMatchObject({
+      localIndexCache: {
+        blockedBy: "missing-search-artifacts",
+        status: "blocked",
+        syncAvailable: false,
+      },
+      query: { ready: false },
+      searchArtifacts: {
+        blockedChapters: [
+          {
+            chapterId: 2,
+            locatedUri: "wikg:///tmp/book.wikg/chapter/chapter-2",
+            title: "Missing chapter",
+            uri: "wikg://chapter/chapter-2",
+          },
+        ],
+        fixCommand:
+          "wg wikg://local/job add --input wikg:///tmp/book.wikg --task index-fts",
+        ready: false,
+        status: "incomplete",
+      },
     });
+    expect(report.improvements[0]).toMatchObject({
+      command:
+        "wg wikg://local/job add --input wikg:///tmp/book.wikg --task index-fts",
+      title: "Enable query with local FTS",
+    });
+    expect(report.improvements.map((item) => item.command)).not.toContain(
+      "wg wikg:///tmp/book.wikg/index sync",
+    );
+
+    expect(archiveMockState.textWrites[0]).not.toContain(
+      "wikg:///tmp/book.wikg/index sync",
+    );
 
     archiveMockState.textWrites.length = 0;
     await runArchiveCommand({
@@ -560,6 +598,12 @@ describe("cli/archive/object", () => {
 
     expect(archiveMockState.textWrites[0]).toContain(
       "- Missing chapter: wikg:///tmp/book.wikg/chapter/chapter-2",
+    );
+    expect(archiveMockState.textWrites[0]).toContain(
+      "Fix: wg wikg://local/job add --input wikg:///tmp/book.wikg --task index-fts",
+    );
+    expect(archiveMockState.textWrites[0]).not.toContain(
+      "wikg:///tmp/book.wikg/index sync",
     );
   });
 

--- a/test/cli/archive/query.test.ts
+++ b/test/cli/archive/query.test.ts
@@ -87,6 +87,28 @@ describe("cli/archive/query", () => {
     });
   });
 
+  it("gives an executable local FTS recovery command when query is not ready", async () => {
+    archiveMockState.rebuildErrorMessage =
+      'Wiki Graph query is not ready. Chapters "Missing chapter" (wikg://chapter/chapter-2) need a current FTS artifact or source embedding artifact before query.';
+
+    await expect(
+      runArchiveCommand({
+        action: "search",
+        archivePath: "wikg:///tmp/My Book.wikg",
+        format: "text",
+        query: "RAG",
+      }),
+    ).rejects.toThrow(
+      [
+        "Build local FTS artifacts without provider calls:",
+        "  wg wikg://local/job add --input 'wikg:///tmp/My Book.wikg' --task index-fts",
+        "",
+        "Help:",
+        "  wg help readiness",
+      ].join("\n"),
+    );
+  });
+
   it("warns when search skips unindexed chapters", async () => {
     await runArchiveCommand({
       action: "search",

--- a/test/cli/queue.test.ts
+++ b/test/cli/queue.test.ts
@@ -697,6 +697,7 @@ describe("cli/queue", () => {
         target: "reading-graph",
         words: 800,
       },
+      jobsCommand: "wg wikg://local/job --json",
       skipped: [
         {
           chapter: {
@@ -708,7 +709,67 @@ describe("cli/queue", () => {
           reason: "planned",
         },
       ],
+      verifyCommand: "wg wikg://book.wikg inspect",
     });
+  });
+
+  it("keeps archive-wide local FTS output free of LLM details", async () => {
+    queueMockState.chapters = [
+      {
+        chapterId: 11,
+        stage: "sourced",
+        words: 400,
+      },
+      {
+        chapterId: 12,
+        stage: "sourced",
+        words: 800,
+      },
+    ];
+
+    await runQueueCommand({
+      action: "add",
+      archivePath: "book.wikg",
+      target: "index-fts",
+    });
+
+    const output = queueMockState.textWrites.join("");
+    expect(output).toContain("Work: index-fts over 2 chapters / 1200 words");
+    expect(output).toContain("Current concurrency: job=3");
+    expect(output).not.toContain("Model:");
+    expect(output).not.toContain("request=");
+    expect(output).not.toContain("LLM request concurrency");
+    expect(output).toContain("Jobs: wg wikg://local/job --json");
+    expect(output).toContain(
+      "Verify after the jobs finish: wg wikg://book.wikg inspect",
+    );
+  });
+
+  it("omits provider-only fields from archive-wide local FTS json", async () => {
+    queueMockState.chapters = [
+      {
+        chapterId: 12,
+        stage: "sourced",
+        words: 800,
+      },
+    ];
+
+    await runQueueCommand({
+      action: "add",
+      archivePath: "book.wikg",
+      json: true,
+      target: "index-fts",
+    });
+
+    const output = JSON.parse(queueMockState.textWrites.join("")) as {
+      readonly estimate: Record<string, unknown>;
+    };
+    expect(output.estimate).toMatchObject({
+      concurrent: { job: 3 },
+      target: "index-fts",
+    });
+    expect(output.estimate).not.toHaveProperty("model");
+    expect(output.estimate.concurrent).not.toHaveProperty("request");
   });
 
   it("suggests job concurrency for multi-chapter archive job add", async () => {


### PR DESCRIPTION
## 概要

- 将 inspect 中的 search artifacts、local index cache 与 query readiness 分层展示
- 缺少 artifact 时优先提供本地 index-fts 恢复命令，artifact 就绪后才建议 index sync
- 为 query readiness 错误补充可执行命令与帮助入口
- 清理纯 FTS 输出中的无关 LLM 信息，并补充批量任务查看和验收命令

## 验证

- pnpm verify
- pnpm test:run（155 files / 1007 tests）
- pnpm build

Closes #395