### PR TITLE
为 Source Artifact 增加稳定短 UID

### DIFF
--- a/docs/en/wikg-standard.md
+++ b/docs/en/wikg-standard.md
@@ -259,8 +259,11 @@ The file layout is small, but the archive carries several semantic layers:
 - Source layer: `texts/source/*.txt`, chapter serials, and source sentence
   records.
 - Source provenance: a source artifact identifies an imported PDF or EPUB by
-  its file SHA-256 and has the archive-root URI `wikg://artifact/<digest>`.
-  A fragment selects a stored location in that artifact: `#epubcfi(...)` for
+  its file SHA-256. Its default archive-local handle is
+  `wikg://artifact/<short-uid>`; the short UID starts with 12 digest characters
+  and lengthens on collision. `wikg://artifact/<sha256-digest>` remains valid
+  and the full digest is the portable content identity across archives. A
+  fragment selects a stored location in that artifact: `#epubcfi(...)` for
   EPUB, or `#page=<page>&bbox=<left>,<bottom>,<right>,<top>` for PDF. PDF pages
   are 1-based and bounding-box coordinates use the normalized `[0,1]`
   lower-left coordinate space. The artifact metadata and locator records live

--- a/docs/schema-upgrade.md
+++ b/docs/schema-upgrade.md
@@ -54,11 +54,12 @@ never stored them as important data.
 
 The v3 -> v4 archive upgrader adds the source provenance schema to
 `database.db`: `source_artifacts`, `source_locators`, `source_text_maps`, and
-their indexes. Locator fragments are persisted canonically and are unique
-within each source artifact. It preserves existing source/summary text and
-structured archive data; provenance tables are initialized in the extracted
-upgrade workspace and the resulting database is written back only by the
-explicit archive upgrader.
+their indexes. Each source artifact stores its full SHA-256 digest plus a
+unique archive-local short UID used by public handles. Locator fragments are
+persisted canonically and are unique within each source artifact. It preserves
+existing source/summary text and structured archive data; provenance tables are
+initialized in the extracted upgrade workspace and the resulting database is
+written back only by the explicit archive upgrader.
 
 Archive upgraders must refuse active coordinator state for the target archive
 and non-search-index overlays, because those can represent uncommitted important

--- a/docs/zh-CN/wikg-standard.md
+++ b/docs/zh-CN/wikg-standard.md
@@ -217,7 +217,7 @@ database.db-shm
 文件布局很小，但归档承载多个语义层：
 
 - Source layer：`texts/source/*.txt`、chapter serials 和 source sentence records。
-- Source provenance：source artifact 通过文件 SHA-256 标识导入的 PDF 或 EPUB，其归档根级 URI 为 `wikg://artifact/<digest>`。fragment 在 artifact 内选择已存位置：EPUB 使用 `#epubcfi(...)`，PDF 使用 `#page=<page>&bbox=<left>,<bottom>,<right>,<top>`。PDF 页码从 1 开始，bbox 使用左下角为原点的 `[0,1]` 归一化坐标。artifact 元数据与 locator 记录存放在 `database.db` 中；原始源文件不会存进归档。
+- Source provenance：source artifact 通过文件 SHA-256 标识导入的 PDF 或 EPUB，默认使用归档内的短地址 `wikg://artifact/<short-uid>`；短 UID 从 digest 的前 12 位开始，发生冲突时延长。完整形式 `wikg://artifact/<sha256-digest>` 仍然合法，完整 digest 是跨归档可移植的内容身份。fragment 在 artifact 内选择已存位置：EPUB 使用 `#epubcfi(...)`，PDF 使用 `#page=<page>&bbox=<left>,<bottom>,<right>,<top>`。PDF 页码从 1 开始，bbox 使用左下角为原点的 `[0,1]` 归一化坐标。artifact 元数据与 locator 记录存放在 `database.db` 中；原始源文件不会存进归档。
 - Source locator scope：`<chapter-uri>/source/locators` 将从 1 开始、闭区间的 Unicode 字符范围映射到 artifact locator URI。可选 fragment（如 `/source/locators#4..8`）先选择 source 句子，返回的字符范围相对于所选文本重新计数；未覆盖区间表示没有保存 locator。普通 source、evidence 与 query 结果仍专注于原文。
 - Reading Graph：`database.db` 中的 chunks、reading edges、snakes 和 sentence groups。
 - Knowledge Graph：`database.db` 中的 mentions、mention links、entity projections、triple projections 和 evidence references。

--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -487,11 +487,24 @@ describe("cli/args/help", () => {
     expect(fileImportHelpText).toContain("OCR, layout analysis");
     expect(archiveCreateHelpText).toContain("wg help file-import");
     const locatorHelpText = renderHelpTopicText("source-locators");
-    expect(locatorHelpText).toContain("wikg://artifact/<digest>");
+    expect(locatorHelpText).toContain("wikg://artifact/<short-uid>");
+    expect(locatorHelpText).toContain("wikg://artifact/<sha256-digest>");
     expect(locatorHelpText).toContain("3..13 -> <artifact-locator-uri>");
     expect(locatorHelpText).toContain("Returned `range` values count Unicode");
     expect(locatorHelpText).toContain("<chapter-uri>/source/locators#4..8");
     expect(locatorHelpText).toContain("--limit <n>");
+    expect(
+      renderUriHelpText(
+        "artifact-object",
+        `wikg://book.wikg/artifact/${"a".repeat(12)}`,
+      ),
+    ).toContain("Source artifact object");
+    expect(
+      parseCLIArguments([
+        `wikg://lib/arc/archive123/artifact/${"a".repeat(12)}#epubcfi(/6/2!/4/2)`,
+        "--help",
+      ]),
+    ).toMatchObject({ kind: "help" });
     expect(
       renderUriHelpText(
         "artifact-object",
@@ -516,7 +529,7 @@ describe("cli/args/help", () => {
       `wikg://lib/arc/archive123/artifact/${"a".repeat(64)}`,
     );
     expect(libraryArtifactHelp).toContain(
-      "wikg://lib/arc/<archive-id>/artifact/<digest>",
+      "wikg://lib/arc/<archive-id>/artifact/<short-uid>",
     );
     expect(libraryArtifactHelp).not.toContain(
       "wikg://lib/arc/<archive-id>/entity",

--- a/packages/cli/src/args/uri/entry.ts
+++ b/packages/cli/src/args/uri/entry.ts
@@ -207,7 +207,7 @@ function classifyArchiveUriHelpTarget(uri: string): UriHelpTargetName {
   if (path === "index") {
     return "index-object";
   }
-  if (/^artifact\/[0-9a-f]{64}(?:#.+)?$/iu.test(path)) {
+  if (/^artifact\/[0-9a-f]{12,64}(?:#.+)?$/iu.test(path)) {
     return "artifact-object";
   }
   const chapterTarget = parseChapterTarget(objectUri);

--- a/packages/core/data/help/commands/uri.jinja
+++ b/packages/core/data/help/commands/uri.jinja
@@ -131,7 +131,7 @@ Default behavior:
   - Add a fragment such as `#4..8` to select source sentences 4 through 8 before listing their mappings.
   - Returned character ranges are 1-based, inclusive, and local to the selected source text.
   - Use `--limit <n>` for a bounded page, `{{ commandName }} next <cursor>` to continue, or `--all` for the complete collection.
-  - JSON and JSONL items have the shape `{"range":[1,23],"uri":"wikg://artifact/<digest>#..."}`.
+  - JSON and JSONL items have the shape `{"range":[1,23],"uri":"wikg://artifact/<short-uid>#..."}`.
 
 Use when:
   - You need to trace source text back to an imported PDF or EPUB location.
@@ -370,7 +370,7 @@ Library context:
   - Library archive shortcuts such as `wikg://lib/arc/<archive-id>/chapter` query or maintain one managed archive through its membership id.
   - Use a standalone archive URI or library archive shortcut for chapter maintenance writes.
 {% elif target.name == "artifact-object" %}
-  - A source artifact belongs to one archive. Use a library archive shortcut such as `wikg://lib/arc/<archive-id>/artifact/<digest>` to open it through library membership.
+  - A source artifact belongs to one archive. Use a library archive shortcut such as `wikg://lib/arc/<archive-id>/artifact/<short-uid>` to open it through library membership.
 {% elif target.name == "triple-scope" or target.name == "triple-object" %}
 {% if libraryContext.isLibraryWide %}
   - Library-wide scopes such as `wikg://lib/triple` use the aggregate library index.

--- a/packages/core/data/help/topics/source-locators.jinja
+++ b/packages/core/data/help/topics/source-locators.jinja
@@ -9,9 +9,14 @@ Purpose:
 
 Artifact URIs:
   - A source artifact identifies an imported PDF or EPUB by the SHA-256 digest
-    of its file bytes: `wikg://artifact/<digest>`.
-  - It belongs to the archive, not to one chapter. Add the archive locator when
-    opening a returned short URI.
+    of its file bytes. Output uses its stable archive-local short UID:
+    `wikg://artifact/<short-uid>`.
+  - A short UID starts with the first 12 digest characters and lengthens only
+    when needed for uniqueness. The full digest form remains valid:
+    `wikg://artifact/<sha256-digest>`.
+  - The short UID belongs to the archive, not to one chapter. Add the archive
+    locator when opening a returned short URI. Use the full `digest` from the
+    artifact details as its content identity across archives.
   - A fragment selects a location inside that artifact. PDF uses
     `#page=21&bbox=left,bottom,right,top`; EPUB uses `#epubcfi(...)`.
   - PDF pages are 1-based. Bounding boxes use normalized `[0,1]` coordinates
@@ -32,8 +37,8 @@ Locator scope:
 
 Reading details:
   {{ commandName }} <chapter-uri>/source/locators --json
-  {{ commandName }} wikg://book.wikg/artifact/<digest>
-  {{ commandName }} 'wikg://book.wikg/artifact/<digest>#page=21&bbox=0.1,0.2,0.9,0.35'
+  {{ commandName }} wikg://book.wikg/artifact/<short-uid>
+  {{ commandName }} 'wikg://book.wikg/artifact/<short-uid>#page=21&bbox=0.1,0.2,0.9,0.35'
 
 See also:
   - {{ commandName }} help file-import

--- a/packages/core/src/document/index.ts
+++ b/packages/core/src/document/index.ts
@@ -25,10 +25,13 @@ export type {
 } from "./directory/index.js";
 export { SCHEMA_SQL } from "./schema.js";
 export {
+  createSourceArtifactShortUid,
   formatSourceArtifactUri,
   formatSourceLocatorFragment,
   normalizeSourceArtifactDigest,
+  normalizeSourceArtifactReference,
   parseSourceLocatorFragment,
+  SOURCE_ARTIFACT_SHORT_UID_LENGTH,
 } from "./source-locator.js";
 export type { ParsedSourceLocatorFragment } from "./source-locator.js";
 export {

--- a/packages/core/src/document/schema.ts
+++ b/packages/core/src/document/schema.ts
@@ -1,4 +1,22 @@
-import type { Database } from "./database.js";
+import {
+  getNumber,
+  getOptionalString,
+  getString,
+  type Database,
+} from "./database.js";
+import { createSourceArtifactShortUid } from "./source-locator.js";
+
+const SOURCE_ARTIFACT_COLUMNS_SQL = `
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    digest BLOB NOT NULL UNIQUE,
+    short_uid TEXT NOT NULL UNIQUE
+      CHECK(length(short_uid) BETWEEN 12 AND 64)
+      CHECK(short_uid NOT GLOB '*[^0-9a-f]*')
+      CHECK(short_uid = substr(lower(hex(digest)), 1, length(short_uid))),
+    media_type TEXT NOT NULL,
+    name TEXT,
+    identifier TEXT
+`;
 
 export const SCHEMA_SQL = `
   CREATE TABLE IF NOT EXISTS serials (
@@ -294,15 +312,7 @@ export const SCHEMA_SQL = `
   ON text_sentence_records(kind, chapter_id, sentence_index);
 
   CREATE TABLE IF NOT EXISTS source_artifacts (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    digest BLOB NOT NULL UNIQUE,
-    short_uid TEXT NOT NULL UNIQUE
-      CHECK(length(short_uid) BETWEEN 12 AND 64)
-      CHECK(short_uid NOT GLOB '*[^0-9a-f]*')
-      CHECK(short_uid = substr(lower(hex(digest)), 1, length(short_uid))),
-    media_type TEXT NOT NULL,
-    name TEXT,
-    identifier TEXT
+${SOURCE_ARTIFACT_COLUMNS_SQL}
   );
 
   CREATE TABLE IF NOT EXISTS source_locators (
@@ -451,6 +461,7 @@ ${SEARCH_INDEX_TEXT_SENTENCE_RECORDS_COLUMNS_SQL}
 export async function initializeDocumentSchema(
   database: Database,
 ): Promise<void> {
+  await migrateSourceArtifactShortUids(database);
   await migrateSerialDocumentOrder(database);
   await ensureGraphBuildParameterTable(database);
   await migrateSerialStateRevision(database);
@@ -458,6 +469,102 @@ export async function initializeDocumentSchema(
   await migrateSerialStateGraphParameterHashes(database);
   await ensureSerialDocumentOrderIndex(database);
   await ensureGraphBuildParameterIndexes(database);
+}
+
+async function migrateSourceArtifactShortUids(
+  database: Database,
+): Promise<void> {
+  const columns = await listTableColumns(database, "source_artifacts");
+  if (columns.has("short_uid")) return;
+
+  const foreignKeysEnabled = await database.queryOne(
+    "PRAGMA foreign_keys",
+    undefined,
+    (row) => Number(row.foreign_keys) === 1,
+  );
+  if (foreignKeysEnabled === true) {
+    await database.execute("PRAGMA foreign_keys = OFF");
+  }
+
+  try {
+    await database.transaction(async () => {
+      const transactionColumns = await listTableColumns(
+        database,
+        "source_artifacts",
+      );
+      if (transactionColumns.has("short_uid")) return;
+
+      const artifacts = await database.queryAll(
+        `
+          SELECT id, digest, lower(hex(digest)) AS digest_hex,
+                 media_type, name, identifier
+          FROM source_artifacts
+          ORDER BY id
+        `,
+        undefined,
+        (row) => ({
+          digest: row.digest,
+          digestHex: getString(row, "digest_hex"),
+          id: getNumber(row, "id"),
+          identifier: getOptionalString(row, "identifier"),
+          mediaType: getString(row, "media_type"),
+          name: getOptionalString(row, "name"),
+        }),
+      );
+      const shortUids = new Set<string>();
+
+      await database.execute(`
+        CREATE TABLE source_artifacts_short_uid_migration (
+${SOURCE_ARTIFACT_COLUMNS_SQL}
+        )
+      `);
+      for (const artifact of artifacts) {
+        if (!(artifact.digest instanceof Uint8Array)) {
+          throw new TypeError("Expected source artifact digest to be binary");
+        }
+        const shortUid = createSourceArtifactShortUid(
+          artifact.digestHex,
+          shortUids,
+        );
+        await database.run(
+          `
+            INSERT INTO source_artifacts_short_uid_migration (
+              id, digest, short_uid, media_type, name, identifier
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+          `,
+          [
+            artifact.id,
+            artifact.digest,
+            shortUid,
+            artifact.mediaType,
+            artifact.name ?? null,
+            artifact.identifier ?? null,
+          ],
+        );
+        shortUids.add(shortUid);
+      }
+
+      await database.run("DROP TABLE source_artifacts");
+      await database.run(
+        "ALTER TABLE source_artifacts_short_uid_migration RENAME TO source_artifacts",
+      );
+      const foreignKeyErrors = await database.queryAll(
+        "PRAGMA foreign_key_check",
+        undefined,
+        (row) => row,
+      );
+      if (foreignKeyErrors.length > 0) {
+        throw new Error(
+          "Source artifact short UID migration broke a foreign key.",
+        );
+      }
+    });
+  } finally {
+    if (foreignKeysEnabled === true) {
+      await database.execute("PRAGMA foreign_keys = ON");
+    }
+  }
 }
 
 async function migrateSerialDocumentOrder(database: Database): Promise<void> {

--- a/packages/core/src/document/schema.ts
+++ b/packages/core/src/document/schema.ts
@@ -296,6 +296,10 @@ export const SCHEMA_SQL = `
   CREATE TABLE IF NOT EXISTS source_artifacts (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     digest BLOB NOT NULL UNIQUE,
+    short_uid TEXT NOT NULL UNIQUE
+      CHECK(length(short_uid) BETWEEN 12 AND 64)
+      CHECK(short_uid NOT GLOB '*[^0-9a-f]*')
+      CHECK(short_uid = substr(lower(hex(digest)), 1, length(short_uid))),
     media_type TEXT NOT NULL,
     name TEXT,
     identifier TEXT

--- a/packages/core/src/document/source-locator.ts
+++ b/packages/core/src/document/source-locator.ts
@@ -1,4 +1,7 @@
 const SOURCE_ARTIFACT_DIGEST_PATTERN = /^[0-9a-f]{64}$/iu;
+const SOURCE_ARTIFACT_REFERENCE_PATTERN = /^[0-9a-f]{12,64}$/iu;
+
+export const SOURCE_ARTIFACT_SHORT_UID_LENGTH = 12;
 
 export interface ParsedSourceLocatorFragment {
   readonly fragment: string;
@@ -16,13 +19,41 @@ export function normalizeSourceArtifactDigest(value: string): string {
   return value.toLowerCase();
 }
 
+export function normalizeSourceArtifactReference(value: string): string {
+  if (!SOURCE_ARTIFACT_REFERENCE_PATTERN.test(value)) {
+    throw new Error(
+      "Source artifact reference must be 12 to 64 hex characters.",
+    );
+  }
+
+  return value.toLowerCase();
+}
+
+export function createSourceArtifactShortUid(
+  digestValue: string,
+  existingShortUids: ReadonlySet<string>,
+): string {
+  const digest = normalizeSourceArtifactDigest(digestValue);
+
+  for (
+    let length = SOURCE_ARTIFACT_SHORT_UID_LENGTH;
+    length <= digest.length;
+    length += 1
+  ) {
+    const candidate = digest.slice(0, length);
+    if (!existingShortUids.has(candidate)) return candidate;
+  }
+
+  throw new Error(`Unable to allocate a unique short UID for ${digest}.`);
+}
+
 export function formatSourceArtifactUri(
-  digest: string,
+  reference: string,
   fragment?: string,
 ): string {
-  const normalizedDigest = normalizeSourceArtifactDigest(digest);
+  const normalizedReference = normalizeSourceArtifactReference(reference);
 
-  return `wikg://artifact/${normalizedDigest}${
+  return `wikg://artifact/${normalizedReference}${
     fragment === undefined ? "" : `#${fragment}`
   }`;
 }

--- a/packages/core/src/document/stores/source-provenance.test.ts
+++ b/packages/core/src/document/stores/source-provenance.test.ts
@@ -7,6 +7,72 @@ import { DirectoryDocument } from "../index.js";
 import { writeSerialSource } from "../../text/serial/source.js";
 
 describe("SourceProvenanceStore", () => {
+  it("persists exact stable short UIDs and extends only new collisions", async () => {
+    const path = await mkdtemp(join(tmpdir(), "wikigraph-source-provenance-"));
+    try {
+      const document = await DirectoryDocument.open(path);
+      try {
+        await document.openSession(async (opened) => {
+          const serialId = await opened.createSerial();
+          const first = "a".repeat(64);
+          const second = `${"a".repeat(12)}b${"1".repeat(51)}`;
+          const third = `${"a".repeat(12)}bc${"2".repeat(50)}`;
+
+          const replace = async (digests: readonly string[]) => {
+            await opened.sourceProvenance.replace(serialId, 1, {
+              artifacts: digests.map((digest) => ({
+                digest,
+                mediaType: "application/pdf",
+              })),
+              mappings: digests.map((digest, index) => ({
+                artifactDigest: digest,
+                locator: {
+                  bbox: [0, 0, 1, 1],
+                  pageIndex: index + 1,
+                },
+                sourceEnd: index + 1,
+                sourceStart: index,
+              })),
+            });
+          };
+
+          await replace([first]);
+          expect(
+            await opened.sourceProvenance.getArtifact(first),
+          ).toMatchObject({ digest: first, shortUid: "a".repeat(12) });
+
+          await replace([first, second]);
+          await replace([first, second, third]);
+
+          const artifacts = await opened.sourceProvenance.listArtifacts();
+          expect(
+            artifacts.map(({ digest, shortUid }) => ({ digest, shortUid })),
+          ).toStrictEqual([
+            { digest: first, shortUid: "a".repeat(12) },
+            { digest: second, shortUid: `${"a".repeat(12)}b` },
+            { digest: third, shortUid: `${"a".repeat(12)}bc` },
+          ]);
+          await expect(
+            opened.sourceProvenance.getArtifact("a".repeat(12)),
+          ).resolves.toMatchObject({ digest: first });
+          await expect(
+            opened.sourceProvenance.getArtifact(`${"a".repeat(12)}b`),
+          ).resolves.toMatchObject({ digest: second });
+          await expect(
+            opened.sourceProvenance.getArtifact(second),
+          ).resolves.toMatchObject({ shortUid: `${"a".repeat(12)}b` });
+          await expect(
+            opened.sourceProvenance.getArtifact(`${"a".repeat(12)}b1`),
+          ).resolves.toBeUndefined();
+        });
+      } finally {
+        await document.release();
+      }
+    } finally {
+      await rm(path, { force: true, recursive: true });
+    }
+  });
+
   it("replaces provenance atomically and removes unreferenced artifacts", async () => {
     const path = await mkdtemp(join(tmpdir(), "wikigraph-source-provenance-"));
     try {

--- a/packages/core/src/document/stores/source-provenance.ts
+++ b/packages/core/src/document/stores/source-provenance.ts
@@ -2,8 +2,10 @@ import { bytesToHex, hexToBytes } from "../../utils/bytes.js";
 import { getNumber, getOptionalString, getString } from "../database.js";
 import type { Database, SqlRow } from "../database.js";
 import {
+  createSourceArtifactShortUid,
   formatSourceLocatorFragment,
   normalizeSourceArtifactDigest,
+  normalizeSourceArtifactReference,
 } from "../source-locator.js";
 import type {
   SourceArtifactRecord,
@@ -21,31 +23,34 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
   }
 
   public async getArtifact(
-    digestValue: string,
+    referenceValue: string,
   ): Promise<SourceArtifactRecord | undefined> {
-    const digest = normalizeSourceArtifactDigest(digestValue);
+    const reference = normalizeSourceArtifactReference(referenceValue);
+    const byDigest = reference.length === 64;
 
     return await this.#database.queryOne(
       `
-        SELECT id, digest, media_type, name, identifier
+        SELECT id, digest, short_uid, media_type, name, identifier
         FROM source_artifacts
-        WHERE digest = ?
+        WHERE ${byDigest ? "digest" : "short_uid"} = ?
       `,
-      [hexToBytes(digest)],
+      [byDigest ? hexToBytes(reference) : reference],
       mapArtifactRecord,
     );
   }
 
   public async getLocator(
-    digestValue: string,
+    referenceValue: string,
     fragment: string,
   ): Promise<SourceLocatorRecord | undefined> {
-    const digest = normalizeSourceArtifactDigest(digestValue);
+    const reference = normalizeSourceArtifactReference(referenceValue);
+    const byDigest = reference.length === 64;
 
     return await this.#database.queryOne(
       `
         SELECT
           source_artifacts.digest AS digest,
+          source_artifacts.short_uid AS short_uid,
           source_artifacts.media_type AS media_type,
           source_artifacts.name AS name,
           source_artifacts.identifier AS identifier,
@@ -54,9 +59,10 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
         FROM source_locators
         JOIN source_artifacts
           ON source_artifacts.id = source_locators.artifact_id
-        WHERE source_artifacts.digest = ? AND source_locators.fragment = ?
+        WHERE source_artifacts.${byDigest ? "digest" : "short_uid"} = ?
+          AND source_locators.fragment = ?
       `,
-      [hexToBytes(digest), fragment],
+      [byDigest ? hexToBytes(reference) : reference, fragment],
       (row) => ({
         artifact: mapArtifactRecordWithoutId(row),
         fragment: getString(row, "fragment"),
@@ -68,7 +74,7 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
   public async listArtifacts(): Promise<SourceArtifactRecord[]> {
     return await this.#database.queryAll(
       `
-        SELECT id, digest, media_type, name, identifier
+        SELECT id, digest, short_uid, media_type, name, identifier
         FROM source_artifacts
         ORDER BY id
       `,
@@ -85,6 +91,7 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
           source_text_maps.source_start AS source_start,
           source_text_maps.source_end AS source_end,
           source_artifacts.digest AS digest,
+          source_artifacts.short_uid AS short_uid,
           source_artifacts.media_type AS media_type,
           source_artifacts.name AS name,
           source_artifacts.identifier AS identifier,
@@ -108,6 +115,7 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
             ...(identifier === undefined ? {} : { identifier }),
             mediaType: getString(row, "media_type"),
             ...(name === undefined ? {} : { name }),
+            shortUid: getString(row, "short_uid"),
           },
           fragment: getString(row, "fragment"),
           locator: parseLocator(getString(row, "value_json")),
@@ -130,6 +138,13 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
 
       if (input !== undefined) {
         const artifactIds = new Map<string, number>();
+        const existingShortUids = new Set(
+          await this.#database.queryAll(
+            `SELECT short_uid FROM source_artifacts`,
+            undefined,
+            (row) => getString(row, "short_uid"),
+          ),
+        );
 
         for (const artifact of input.artifacts) {
           const digest = normalizeSourceArtifactDigest(artifact.digest);
@@ -156,20 +171,26 @@ export class SourceProvenanceStore implements ReadonlySourceProvenanceStore {
           }
 
           if (existing === undefined) {
+            const shortUid = createSourceArtifactShortUid(
+              digest,
+              existingShortUids,
+            );
             await this.#database.run(
               `
                 INSERT INTO source_artifacts (
-                  digest, media_type, name, identifier
+                  digest, short_uid, media_type, name, identifier
                 )
-                VALUES (?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?)
               `,
               [
                 hexToBytes(digest),
+                shortUid,
                 artifact.mediaType,
                 artifact.name ?? null,
                 artifact.identifier ?? null,
               ],
             );
+            existingShortUids.add(shortUid);
             artifactIds.set(digest, await this.#database.getLastInsertRowId());
           } else {
             const existingMetadata = await this.#database.queryOne(
@@ -433,6 +454,7 @@ function mapArtifactRecordWithoutId(
     ...(identifier === undefined ? {} : { identifier }),
     mediaType: getString(row, "media_type"),
     ...(name === undefined ? {} : { name }),
+    shortUid: getString(row, "short_uid"),
   };
 }
 

--- a/packages/core/src/document/stores/types.ts
+++ b/packages/core/src/document/stores/types.ts
@@ -20,9 +20,9 @@ import type {
 } from "../types.js";
 
 export interface ReadonlySourceProvenanceStore {
-  getArtifact(digest: string): Promise<SourceArtifactRecord | undefined>;
+  getArtifact(reference: string): Promise<SourceArtifactRecord | undefined>;
   getLocator(
-    digest: string,
+    reference: string,
     fragment: string,
   ): Promise<SourceLocatorRecord | undefined>;
   listArtifacts(): Promise<SourceArtifactRecord[]>;

--- a/packages/core/src/document/types.ts
+++ b/packages/core/src/document/types.ts
@@ -85,6 +85,7 @@ export interface SourceArtifactInput {
 
 export interface SourceArtifactRecord extends SourceArtifactInput {
   readonly id: number;
+  readonly shortUid: string;
 }
 
 export interface SourceTextMappingInput {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -209,11 +209,14 @@ export type {
 } from "./storage/wikg/index.js";
 export {
   DirectoryDocument,
+  createSourceArtifactShortUid,
   formatSourceArtifactUri,
   formatSourceLocatorFragment,
   normalizeSourceArtifactDigest,
+  normalizeSourceArtifactReference,
   openSharedStateDatabase,
   parseSourceLocatorFragment,
+  SOURCE_ARTIFACT_SHORT_UID_LENGTH,
 } from "./document/index.js";
 export type {
   Database,

--- a/packages/core/src/retrieval/query/archive-view/pages.ts
+++ b/packages/core/src/retrieval/query/archive-view/pages.ts
@@ -285,23 +285,24 @@ async function readWikiGraphPage(
   switch (reference.type) {
     case "artifact": {
       const artifact = await document.sourceProvenance.getArtifact(
-        reference.digest,
+        reference.artifactReference,
       );
       if (artifact === undefined) {
         throw new Error(
-          `Source artifact ${formatSourceArtifactUri(reference.digest)} was not found in this archive.`,
+          `Source artifact ${formatSourceArtifactUri(reference.artifactReference)} was not found in this archive.`,
         );
       }
 
       if (reference.fragment === undefined) {
         return {
           digest: artifact.digest,
-          id: formatSourceArtifactUri(artifact.digest),
+          id: formatSourceArtifactUri(artifact.shortUid),
           ...(artifact.identifier === undefined
             ? {}
             : { identifier: artifact.identifier }),
           mediaType: artifact.mediaType,
           ...(artifact.name === undefined ? {} : { name: artifact.name }),
+          shortUid: artifact.shortUid,
           type: "artifact",
         };
       }
@@ -318,19 +319,20 @@ async function readWikiGraphPage(
       );
       if (locator === undefined) {
         throw new Error(
-          `Source locator ${formatSourceArtifactUri(artifact.digest, parsedLocator.fragment)} was not found in this archive.`,
+          `Source locator ${formatSourceArtifactUri(artifact.shortUid, parsedLocator.fragment)} was not found in this archive.`,
         );
       }
 
       return {
         digest: artifact.digest,
-        id: formatSourceArtifactUri(artifact.digest, parsedLocator.fragment),
+        id: formatSourceArtifactUri(artifact.shortUid, parsedLocator.fragment),
         ...(artifact.identifier === undefined
           ? {}
           : { identifier: artifact.identifier }),
         locator: locator.locator,
         mediaType: artifact.mediaType,
         ...(artifact.name === undefined ? {} : { name: artifact.name }),
+        shortUid: artifact.shortUid,
         type: "artifact",
       };
     }

--- a/packages/core/src/retrieval/query/archive-view/references.ts
+++ b/packages/core/src/retrieval/query/archive-view/references.ts
@@ -98,7 +98,7 @@ export function parseTextStreamRangeUri(uri: string):
 
 export type WikiGraphReference =
   | {
-      readonly digest: string;
+      readonly artifactReference: string;
       readonly fragment?: string;
       readonly type: "artifact";
     }
@@ -199,10 +199,13 @@ export function parseWikiGraphReference(uri: string): WikiGraphReference {
   switch (pathParts[0]) {
     case "artifact":
       if (pathParts.length === 2) {
-        const digest = pathParts[1];
-        if (digest !== undefined && /^[0-9a-f]{64}$/iu.test(digest)) {
+        const artifactReference = pathParts[1];
+        if (
+          artifactReference !== undefined &&
+          /^[0-9a-f]{12,64}$/iu.test(artifactReference)
+        ) {
           return {
-            digest: digest.toLowerCase(),
+            artifactReference: artifactReference.toLowerCase(),
             ...(hash === "" ? {} : { fragment: hash }),
             type: "artifact",
           };

--- a/packages/core/src/retrieval/query/archive-view/source-locators.ts
+++ b/packages/core/src/retrieval/query/archive-view/source-locators.ts
@@ -107,7 +107,7 @@ export async function createSourceLocatorRanges(
     if (end <= start) continue;
 
     const uri = formatSourceArtifactUri(
-      mapping.artifact.digest,
+      mapping.artifact.shortUid,
       mapping.fragment,
     );
     const previous = ranges.at(-1);

--- a/packages/core/src/retrieval/query/archive-view/types.ts
+++ b/packages/core/src/retrieval/query/archive-view/types.ts
@@ -275,6 +275,7 @@ export type ArchivePage = ArchiveLibrarySourceFields &
         readonly locator?: Readonly<Record<string, unknown>>;
         readonly mediaType: string;
         readonly name?: string;
+        readonly shortUid: string;
         readonly type: "artifact";
       }
     | {

--- a/packages/core/src/runtime/common/wiki-graph/uri.ts
+++ b/packages/core/src/runtime/common/wiki-graph/uri.ts
@@ -157,7 +157,7 @@ function optionalWikiGraphUriFragment(
 
   if (
     path.at(-2) === "artifact" &&
-    /^[0-9a-f]{64}$/iu.test(path.at(-1) ?? "")
+    /^[0-9a-f]{12,64}$/iu.test(path.at(-1) ?? "")
   ) {
     return { raw: fragment };
   }

--- a/packages/core/src/text/summary-build/snapshot/empty-stores.ts
+++ b/packages/core/src/text/summary-build/snapshot/empty-stores.ts
@@ -118,11 +118,11 @@ export class EmptySnapshotGraphBuildParameterStore implements ReadonlyGraphBuild
 }
 
 export class EmptySnapshotSourceProvenanceStore implements ReadonlySourceProvenanceStore {
-  public getArtifact(_digest: string): Promise<undefined> {
+  public getArtifact(_reference: string): Promise<undefined> {
     return Promise.resolve(undefined);
   }
 
-  public getLocator(_digest: string, _fragment: string): Promise<undefined> {
+  public getLocator(_reference: string, _fragment: string): Promise<undefined> {
     return Promise.resolve(undefined);
   }
 

--- a/test/cli/archive/source-ingestion.test.ts
+++ b/test/cli/archive/source-ingestion.test.ts
@@ -51,6 +51,7 @@ interface TocItemLike {
 describe("cli/archive/source-ingestion", () => {
   it("lists source locators separately and opens their artifact URIs", async () => {
     const digest = "a".repeat(64);
+    const shortUid = digest.slice(0, 12);
     const firstText = "😀 First source sentence. ";
     const secondText = "Second source sentence.";
     const secondStart = Array.from(firstText).length;
@@ -100,8 +101,8 @@ describe("cli/archive/source-ingestion", () => {
       );
 
       const wholeSource = await runJsonCLI(stateDir, [sourceUri, "--json"]);
-      const firstLocator = `wikg://artifact/${digest}#page=1&bbox=0,0,0.5,0.5`;
-      const secondLocator = `wikg://artifact/${digest}#page=2&bbox=0.5,0.5,1,1`;
+      const firstLocator = `wikg://artifact/${shortUid}#page=1&bbox=0,0,0.5,0.5`;
+      const secondLocator = `wikg://artifact/${shortUid}#page=2&bbox=0.5,0.5,1,1`;
       expect(wholeSource).not.toHaveProperty("locators");
       const wholePlain = await runWikiGraphCLICaptured({
         argv: [sourceUri],
@@ -153,7 +154,8 @@ describe("cli/archive/source-ingestion", () => {
         digest,
         mediaType: "application/pdf",
         name: "two-pages.pdf",
-        uri: `wikg://artifact/${digest}`,
+        shortUid,
+        uri: `wikg://artifact/${shortUid}`,
       });
       const locator = await runJsonCLI(stateDir, [
         `${archiveUri}/artifact/${digest}#page=1&bbox=0,0,0.5,0.5`,
@@ -163,6 +165,17 @@ describe("cli/archive/source-ingestion", () => {
         locator: { bbox: [0, 0, 0.5, 0.5], pageIndex: 1 },
         uri: firstLocator,
       });
+      await expect(
+        runJsonCLI(stateDir, [
+          `${archiveUri}/artifact/${shortUid}#page=1&bbox=0,0,0.5,0.5`,
+          "--json",
+        ]),
+      ).resolves.toMatchObject({ digest, shortUid, uri: firstLocator });
+      const unassignedPrefix = await runWikiGraphCLICaptured({
+        argv: [`${archiveUri}/artifact/${digest.slice(0, 13)}`, "--json"],
+        stateDir,
+      });
+      expect(unassignedPrefix.exitCode).toBe(1);
 
       const plain = await runWikiGraphCLICaptured({
         argv: [`${sourceUri}#2`],
@@ -311,6 +324,7 @@ describe("cli/archive/source-ingestion", () => {
     const epubDigest = createHash("sha256")
       .update(await readFile(LITTLE_PRINCE_EPUB_PATH))
       .digest("hex");
+    const epubShortUid = epubDigest.slice(0, 12);
     const generatedJsonl = parseJsonl(
       await readFile(LITTLE_PRINCE_JSONL_PATH, "utf8"),
     );
@@ -382,7 +396,7 @@ describe("cli/archive/source-ingestion", () => {
       };
       expect(firstLocator.range[0]).toBe(1);
       expect(firstLocator.uri).toContain(
-        `wikg://artifact/${epubDigest}#epubcfi(`,
+        `wikg://artifact/${epubShortUid}#epubcfi(`,
       );
       const sentenceLocatorPage = await runJsonCLI(stateDir, [
         `${chapterUri}/locators#1`,
@@ -397,7 +411,7 @@ describe("cli/archive/source-ingestion", () => {
       expect(sentenceLocators[0]?.range[0]).toBe(1);
       expect(
         sentenceLocators.every((locator) =>
-          locator.uri.includes(`wikg://artifact/${epubDigest}#epubcfi(`),
+          locator.uri.includes(`wikg://artifact/${epubShortUid}#epubcfi(`),
         ),
       ).toBe(true);
       const artifactLocator = await runJsonCLI(stateDir, [

--- a/test/core/document/source-locator.test.ts
+++ b/test/core/document/source-locator.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  createSourceArtifactShortUid,
   formatSourceArtifactUri,
   formatSourceLocatorFragment,
+  normalizeSourceArtifactReference,
   parseSourceLocatorFragment,
 } from "../../../packages/core/src/document/index.js";
 
@@ -36,6 +38,36 @@ describe("source locator URI", () => {
       locator: { cfi: fragment },
       mediaType: "application/epub+zip",
     });
+  });
+
+  it("allocates stable variable-length artifact short UIDs", () => {
+    const first = "a".repeat(64);
+    const second = `${"a".repeat(12)}b${"1".repeat(51)}`;
+    const third = `${"a".repeat(12)}bc${"2".repeat(50)}`;
+    const existing = new Set<string>();
+
+    const firstUid = createSourceArtifactShortUid(first, existing);
+    existing.add(firstUid);
+    const secondUid = createSourceArtifactShortUid(second, existing);
+    existing.add(secondUid);
+    const thirdUid = createSourceArtifactShortUid(third, existing);
+
+    expect(firstUid).toBe("a".repeat(12));
+    expect(secondUid).toBe(`${"a".repeat(12)}b`);
+    expect(thirdUid).toBe(`${"a".repeat(12)}bc`);
+    expect(formatSourceArtifactUri(secondUid)).toBe(
+      `wikg://artifact/${secondUid}`,
+    );
+    expect(normalizeSourceArtifactReference(second.toUpperCase())).toBe(second);
+  });
+
+  it("rejects artifact references that are not assigned-length candidates", () => {
+    expect(() => normalizeSourceArtifactReference("a".repeat(11))).toThrow(
+      "12 to 64 hex characters",
+    );
+    expect(() => normalizeSourceArtifactReference("g".repeat(12))).toThrow(
+      "12 to 64 hex characters",
+    );
   });
 
   it("rejects non-canonical or out-of-bounds PDF locations", () => {

--- a/test/core/retrieval/source-locators.test.ts
+++ b/test/core/retrieval/source-locators.test.ts
@@ -19,8 +19,9 @@ import { withTempDir } from "../../helpers/temp.js";
 describe("source locator ranges", () => {
   it("clips, rebases, merges adjacent locators, and preserves gaps", async () => {
     const digest = "a".repeat(64);
+    const shortUid = digest.slice(0, 12);
     const first = {
-      artifact: { digest, mediaType: "application/pdf" },
+      artifact: { digest, mediaType: "application/pdf", shortUid },
       fragment: "page=1&bbox=0,0,1,1",
       locator: { bbox: [0, 0, 1, 1], pageIndex: 1 },
       sourceRevision: 3,
@@ -48,11 +49,11 @@ describe("source locator ranges", () => {
       [
         {
           range: [1, 3],
-          uri: `wikg://artifact/${digest}#page=1&bbox=0,0,1,1`,
+          uri: `wikg://artifact/${shortUid}#page=1&bbox=0,0,1,1`,
         },
         {
           range: [5, 6],
-          uri: `wikg://artifact/${digest}#page=2&bbox=0.1,0.2,0.9,1`,
+          uri: `wikg://artifact/${shortUid}#page=2&bbox=0.1,0.2,0.9,1`,
         },
       ],
     );
@@ -72,6 +73,7 @@ describe("source locator ranges", () => {
   it("lists and paginates locator ranges for whole or selected source text", async () => {
     await withTempDir("wikigraph-source-locator-list-", async (path) => {
       const digest = "b".repeat(64);
+      const shortUid = digest.slice(0, 12);
       const firstText = "Alpha. ";
       const secondText = "Beta.";
       const parsed = parseSourceTextJsonl(
@@ -110,7 +112,7 @@ describe("source locator ranges", () => {
           items: [
             {
               range: [1, Array.from(firstText).length],
-              uri: `wikg://artifact/${digest}#page=1&bbox=0,0,1,0.5`,
+              uri: `wikg://artifact/${shortUid}#page=1&bbox=0,0,1,0.5`,
             },
           ],
           limit: 1,
@@ -136,7 +138,7 @@ describe("source locator ranges", () => {
                 Array.from(firstText).length + 1,
                 Array.from(firstText + secondText).length,
               ],
-              uri: `wikg://artifact/${digest}#page=1&bbox=0,0.5,1,1`,
+              uri: `wikg://artifact/${shortUid}#page=1&bbox=0,0.5,1,1`,
             },
           ],
           nextCursor: null,
@@ -150,7 +152,7 @@ describe("source locator ranges", () => {
           items: [
             {
               range: [1, Array.from(secondText).length],
-              uri: `wikg://artifact/${digest}#page=1&bbox=0,0.5,1,1`,
+              uri: `wikg://artifact/${shortUid}#page=1&bbox=0,0.5,1,1`,
             },
           ],
         });

--- a/test/core/runtime/common/wiki-graph-uri.test.ts
+++ b/test/core/runtime/common/wiki-graph-uri.test.ts
@@ -95,6 +95,15 @@ describe("wiki graph URI helpers", () => {
       protocol: "wikg",
       path: ["artifact", "a".repeat(64)],
     });
+    expect(
+      parseWikiGraphUriSyntax(
+        `wikg://artifact/${"a".repeat(12)}#epubcfi(/6/2!/4/2)`,
+      ),
+    ).toStrictEqual({
+      fragment: { raw: "epubcfi(/6/2!/4/2)" },
+      protocol: "wikg",
+      path: ["artifact", "a".repeat(12)],
+    });
     expect(() => parseWikiGraphUriSyntax("wikg://lib//arc")).toThrow(
       "empty path segment",
     );
@@ -128,6 +137,14 @@ describe("wiki graph URI helpers", () => {
     ).toStrictEqual({
       archivePath: "/file/book.wikg",
       objectUri: `wikg://artifact/${"b".repeat(64)}#page=2&bbox=0,0,1,1`,
+    });
+    expect(
+      parseLocatedWikiGraphUri(
+        `wikg://lib/arc/archive123/artifact/${"b".repeat(12)}#page=2&bbox=0,0,1,1`,
+      ),
+    ).toStrictEqual({
+      archivePath: "wikg://lib/arc/archive123",
+      objectUri: `wikg://artifact/${"b".repeat(12)}#page=2&bbox=0,0,1,1`,
     });
   });
 });

--- a/test/core/storage/schema-upgrade/index.test.ts
+++ b/test/core/storage/schema-upgrade/index.test.ts
@@ -47,7 +47,40 @@ import { withTempDir } from "../../../helpers/temp.js";
 describe("schema-upgrade", () => {
   it("upgrades a copied v3 archive and supports source provenance", async () => {
     await withFixture(async ({ archive, root }) => {
-      await removeV4SourceProvenanceSchema(archive, root);
+      const firstDigest = "a".repeat(64);
+      const secondDigest = `${"a".repeat(12)}b${"1".repeat(51)}`;
+      const thirdDigest = `${"a".repeat(12)}bc${"2".repeat(50)}`;
+      const fragments = [
+        "epubcfi(/6/2!/4/2)",
+        "epubcfi(/6/2!/4/4)",
+        "epubcfi(/6/2!/4/6)",
+      ] as const;
+      const seededArchive = new WikiGraphArchiveFile(archive);
+      await seededArchive.write(async (document) => {
+        await document.sourceProvenance.replace(
+          1,
+          await document.serials.getRevision(1),
+          {
+            artifacts: [firstDigest, secondDigest, thirdDigest].map(
+              (digest, index) => ({
+                digest,
+                identifier: `chapter-${index + 1}.xhtml`,
+                mediaType: "application/epub+zip",
+                name: "book.epub",
+              }),
+            ),
+            mappings: [firstDigest, secondDigest, thirdDigest].map(
+              (digest, index) => ({
+                artifactDigest: digest,
+                locator: { cfi: fragments[index]! },
+                sourceEnd: index + 1,
+                sourceStart: index,
+              }),
+            ),
+          },
+        );
+      });
+      await removeSourceArtifactShortUidColumn(archive, root);
       await rewriteManifest(archive, 3, true);
       const sourceBytes = await readFile(archive.path);
       const sourceToken = await readWikgArchiveMutationToken(archive);
@@ -120,54 +153,91 @@ describe("schema-upgrade", () => {
           name: "sqlite_autoindex_source_locators_1",
           unique: 1,
         });
+        await expect(
+          database.queryAll(
+            "PRAGMA foreign_key_check",
+            undefined,
+            (row) => row,
+          ),
+        ).resolves.toStrictEqual([]);
       } finally {
         await database.close();
       }
 
-      const digest = "c".repeat(64);
-      const fragment = "epubcfi(/6/2!/4/2)";
       const upgraded = new WikiGraphArchiveFile(upgradedArchive);
-      await upgraded.write(async (document) => {
-        await document.sourceProvenance.replace(
-          1,
-          await document.serials.getRevision(1),
-          {
-            artifacts: [
-              { digest, mediaType: "application/epub+zip", name: "book.epub" },
-            ],
-            mappings: [
-              {
-                artifactDigest: digest,
-                locator: { cfi: fragment },
-                sourceEnd: 7,
-                sourceStart: 0,
-              },
-            ],
-          },
-        );
-      });
       await upgraded.readDocument(async (document) => {
-        await expect(
-          document.sourceProvenance.getArtifact(digest),
-        ).resolves.toMatchObject({
-          digest,
-          mediaType: "application/epub+zip",
-          shortUid: digest.slice(0, 12),
-        });
-        await expect(
-          document.sourceProvenance.getArtifact(digest.slice(0, 12)),
-        ).resolves.toMatchObject({ digest });
-        await expect(
-          document.sourceProvenance.getLocator(digest, fragment),
-        ).resolves.toMatchObject({ fragment, locator: { cfi: fragment } });
-        await expect(
-          document.sourceProvenance.listMap(1),
-        ).resolves.toMatchObject([
+        expect(
+          (await document.sourceProvenance.listArtifacts()).map(
+            ({ digest, id, shortUid }) => ({ digest, id, shortUid }),
+          ),
+        ).toStrictEqual([
+          { digest: firstDigest, id: 1, shortUid: "a".repeat(12) },
           {
-            artifact: { digest, mediaType: "application/epub+zip" },
-            fragment,
-            sourceEnd: 7,
+            digest: secondDigest,
+            id: 2,
+            shortUid: `${"a".repeat(12)}b`,
+          },
+          {
+            digest: thirdDigest,
+            id: 3,
+            shortUid: `${"a".repeat(12)}bc`,
+          },
+        ]);
+        await expect(
+          document.sourceProvenance.getArtifact("a".repeat(12)),
+        ).resolves.toMatchObject({ digest: firstDigest });
+        await expect(
+          document.sourceProvenance.getArtifact(`${"a".repeat(12)}b`),
+        ).resolves.toMatchObject({ digest: secondDigest });
+        await expect(
+          document.sourceProvenance.getArtifact(secondDigest),
+        ).resolves.toMatchObject({ shortUid: `${"a".repeat(12)}b` });
+        await expect(
+          document.sourceProvenance.getArtifact(`${"a".repeat(12)}b1`),
+        ).resolves.toBeUndefined();
+        await expect(
+          document.sourceProvenance.getLocator(
+            `${"a".repeat(12)}bc`,
+            fragments[2],
+          ),
+        ).resolves.toMatchObject({
+          artifact: { digest: thirdDigest },
+          fragment: fragments[2],
+          locator: { cfi: fragments[2] },
+        });
+        expect(await document.sourceProvenance.listMap(1)).toMatchObject([
+          {
+            artifact: {
+              digest: firstDigest,
+              identifier: "chapter-1.xhtml",
+              mediaType: "application/epub+zip",
+              name: "book.epub",
+              shortUid: "a".repeat(12),
+            },
+            fragment: fragments[0],
+            locator: { cfi: fragments[0] },
+            sourceEnd: 1,
             sourceStart: 0,
+          },
+          {
+            artifact: {
+              digest: secondDigest,
+              identifier: "chapter-2.xhtml",
+              shortUid: `${"a".repeat(12)}b`,
+            },
+            fragment: fragments[1],
+            sourceEnd: 2,
+            sourceStart: 1,
+          },
+          {
+            artifact: {
+              digest: thirdDigest,
+              identifier: "chapter-3.xhtml",
+              shortUid: `${"a".repeat(12)}bc`,
+            },
+            fragment: fragments[2],
+            sourceEnd: 3,
+            sourceStart: 2,
           },
         ]);
       });
@@ -810,7 +880,7 @@ async function rewriteManifest(
   await nodeWikiGraphPlatform.zip.write(archive, entries);
 }
 
-async function removeV4SourceProvenanceSchema(
+async function removeSourceArtifactShortUidColumn(
   archive: NodeFile,
   root: string,
 ): Promise<void> {
@@ -825,9 +895,21 @@ async function removeV4SourceProvenanceSchema(
   const database = await Database.open(new NodeFile(databasePath));
   try {
     await database.execute(`
-      DROP TABLE source_text_maps;
-      DROP TABLE source_locators;
+      PRAGMA foreign_keys = OFF;
+      CREATE TABLE source_artifacts_legacy (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        digest BLOB NOT NULL UNIQUE,
+        media_type TEXT NOT NULL,
+        name TEXT,
+        identifier TEXT
+      );
+      INSERT INTO source_artifacts_legacy (
+        id, digest, media_type, name, identifier
+      )
+      SELECT id, digest, media_type, name, identifier
+      FROM source_artifacts;
       DROP TABLE source_artifacts;
+      ALTER TABLE source_artifacts_legacy RENAME TO source_artifacts;
     `);
   } finally {
     await database.close();

--- a/test/core/storage/schema-upgrade/index.test.ts
+++ b/test/core/storage/schema-upgrade/index.test.ts
@@ -88,6 +88,23 @@ describe("schema-upgrade", () => {
         readonly: true,
       });
       try {
+        const artifactColumns = await database.queryAll(
+          "PRAGMA table_info(source_artifacts)",
+          undefined,
+          (row) => ({ name: String(row.name), notNull: Number(row.notnull) }),
+        );
+        expect(artifactColumns).toContainEqual({
+          name: "short_uid",
+          notNull: 1,
+        });
+        const artifactIndexes = await database.queryAll(
+          "PRAGMA index_list(source_artifacts)",
+          undefined,
+          (row) => ({ name: String(row.name), unique: Number(row.unique) }),
+        );
+        expect(
+          artifactIndexes.filter((index) => index.unique === 1),
+        ).toHaveLength(2);
         const locatorColumns = await database.queryAll(
           "PRAGMA table_info(source_locators)",
           undefined,
@@ -132,7 +149,14 @@ describe("schema-upgrade", () => {
       await upgraded.readDocument(async (document) => {
         await expect(
           document.sourceProvenance.getArtifact(digest),
-        ).resolves.toMatchObject({ digest, mediaType: "application/epub+zip" });
+        ).resolves.toMatchObject({
+          digest,
+          mediaType: "application/epub+zip",
+          shortUid: digest.slice(0, 12),
+        });
+        await expect(
+          document.sourceProvenance.getArtifact(digest.slice(0, 12)),
+        ).resolves.toMatchObject({ digest });
         await expect(
           document.sourceProvenance.getLocator(digest, fragment),
         ).resolves.toMatchObject({ fragment, locator: { cfi: fragment } });


### PR DESCRIPTION
## 概要

- 为 archive 内 Source Artifact 持久化稳定的短 UID，默认 12 位，碰撞时仅扩展新 Artifact
- Core 与 CLI 同时支持精确短 UID 和完整 SHA-256 digest，并默认输出短 URI
- 完善现有 v3→v4 archive 迁移，保全既有 Artifact、Locator 与 Source Text Map
- 同步帮助文档与迁移、路由、展示回归测试

## 验证

- `pnpm verify`
- `pnpm test`（155 files / 1012 tests）
- `pnpm build`