### PR TITLE
澄清 Chapter Source 生命周期帮助

### DIFF
--- a/packages/cli/src/args/help.test.ts
+++ b/packages/cli/src/args/help.test.ts
@@ -398,6 +398,10 @@ describe("cli/args/help", () => {
       "chapter-source-object",
       "wikg://book.wikg/chapter/part/source",
     );
+    const sourceRangeHelpText = renderUriHelpText(
+      "chapter-source-range-object",
+      "wikg://book.wikg/chapter/part/source#1..2",
+    );
     const sourceSetHelpText = renderUriPredicateHelpText(
       "chapter-source-object",
       "set",
@@ -413,6 +417,9 @@ describe("cli/args/help", () => {
     expect(chapterAddHelpText).toContain("non-empty UTF-8 plain text");
     expect(chapterAddHelpText).toContain("does not create a source-text map");
     expect(chapterAddHelpText).toContain("does not infer a");
+    expect(chapterAddHelpText).toContain(
+      "handles are opaque and are not derived from `--title`",
+    );
     expect(chapterHelpText).toContain(
       "wikg://book.wikg/chapter/part/state --help",
     );
@@ -426,6 +433,9 @@ describe("cli/args/help", () => {
     expect(sourceSetHelpText).toContain("Source input must not be empty");
     expect(sourceSetHelpText).toContain("Plain text writes source without");
     expect(sourceSetHelpText).toContain("File extensions are not inferred");
+    expect(sourceSetHelpText).toContain(
+      "does not replace source on a later-stage chapter",
+    );
     expect(sourceSetHelpText).toContain(
       "`sourceUnits` is the number of stored source processing fragments",
     );
@@ -453,6 +463,10 @@ describe("cli/args/help", () => {
       "<chapter-uri>/source/locators --json",
     );
     expect(sourceHelpText).toContain("containing `uri` and `text`");
+    expect(sourceHelpText).toContain(
+      "set: initialize source for a planned chapter",
+    );
+    expect(sourceRangeHelpText).toContain("current stored source revision");
     expect(sourceHelpText).toContain("/source/locators");
     expect(fileImportHelpText).toContain(
       "evidence cannot point back to a PDF page or EPUB CFI",

--- a/packages/core/data/help/commands/predicate.jinja
+++ b/packages/core/data/help/commands/predicate.jinja
@@ -140,6 +140,8 @@ Notes:
     format from the file name, and creates the chapter in the `source` stage.
   - This plain-text path does not create a source-text map or call an LLM
     provider. Read `{{ commandName }} help file-import` for source locators.
+  - Chapter handles are opaque and are not derived from `--title`; reuse the
+    returned `locatedUri` for later commands.
 
 Output:
   - Text output includes `Chapter`, the archive-relative handle, and `Located URI`, the complete target for later commands.

--- a/packages/core/data/help/commands/shared/chapter-source-set.jinja
+++ b/packages/core/data/help/commands/shared/chapter-source-set.jinja
@@ -15,6 +15,7 @@ Preconditions:
   - Read the chapter state and reset help before discarding data from a later-stage chapter.
 
 Behavior:
+  - Initializes source for a planned chapter; it does not replace source on a later-stage chapter.
   - Writes the complete source text and moves the chapter to `source`.
   - Does not generate Reading Graph data or a summary, and does not call an LLM provider.
   - With `--json`, prints the updated chapter status as one JSON object. `sourceUnits` is the number of stored source processing fragments, not the number of sentences.

--- a/packages/core/data/help/commands/uri.jinja
+++ b/packages/core/data/help/commands/uri.jinja
@@ -143,7 +143,7 @@ URI type:
 Default behavior:
   - `{{ commandName }} {{ uri }}` reads source text.
   - Source range fragments such as `#4..8` read sentence numbers 4 through 8, inclusive.
-  - Range fragments are read-only; `set` writes the complete source object.
+  - Range fragments are read-only; `set` fills the complete source object of a planned chapter.
   - Range sentence numbers are 1-based. `#1` is the first sentence; `#1..2` is the first two sentences.
   - Whole and ranged source reads print text by default. With `--json`, they return one object containing `uri` and `text`.
 
@@ -157,6 +157,7 @@ URI type:
 Default behavior:
   - `{{ commandName }} {{ uri }}` reads a structured source sentence range.
   - Range sentence numbers are 1-based. `#1` is the first sentence; `#1..2` is the first two sentences.
+  - Range numbers address the current stored source revision and may change after source is reset and written again.
   - Source range fragments support `--json`; the result contains `uri` and `text`.
 
 Use when:
@@ -477,6 +478,8 @@ Predicate commands:
   - set: replace this local config section with a JSON object. Help: {{ commandName }} {{ uri }} set --help
 {% elif target.name == "job-target-object" %}
   - set: change this local job target. Help: {{ commandName }} {{ uri }} set --help
+{% elif target.name == "chapter-source-object" %}
+  - set: initialize source for a planned chapter. Help: {{ commandName }} {{ uri }} set --help
 {% else %}
 {% if target.name == "metadata-object" %}
   - set: replace this metadata map. Help: {{ commandName }} {{ uri }} set --help


### PR DESCRIPTION
## Summary

- clarify that `source set` initializes a planned chapter rather than replacing later-stage source
- tell callers to reuse the opaque `locatedUri` returned by `chapter add`
- state that source range numbers belong to the current stored source revision

## Verification

- `pnpm test:run packages/cli/src/args/help.test.ts`
- `pnpm verify`
- exercised the affected URI help pages through `pnpm --filter wiki-graph dev`